### PR TITLE
remove the tooltip from the hledger-web journal screen.

### DIFF
--- a/hledger-web/Handler/Common.hs
+++ b/hledger-web/Handler/Common.hs
@@ -401,7 +401,7 @@ journalTransactionsReportAsHtml _ vd (_,items) = [hamlet|
    itemAsHtml VD{..} (n, _, _, _, (t, _, split, _, amt, _)) = [hamlet|
 <tr.item.#{evenodd}.#{firstposting}>
  <td.date>#{date}
- <td.description colspan=2 title="#{show t}">#{elideRight 60 desc}
+ <td.description colspan=2>#{elideRight 60 desc}
  <td.amount align=right>
   $if showamt
    #{mixedAmountAsHtml amt}


### PR DESCRIPTION
info shown on the page is the same as that shown in the tooltip.  So removing this saves us a few bytes of page size.  
