### PR TITLE
Upgrade to regex-compat-tdfa to squelch Unicode problems

### DIFF
--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -67,7 +67,7 @@ library
                  ,old-time
                  ,parsec
                  ,pretty-show
-                 ,regex-compat == 0.95.*
+                 ,regex-compat-tdfa == 0.95.*
                  ,regexpr >= 0.5.1
                  ,safe >= 0.2
                  ,split >= 0.1 && < 0.3
@@ -98,7 +98,7 @@ test-suite tests
                , old-time
                , parsec
                , pretty-show
-               , regex-compat
+               , regex-compat-tdfa
                , regexpr
                , safe
                , split

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -159,7 +159,7 @@ test-suite tests
                , parsec
                , pretty-show
                , process
-               , regex-compat
+               , regex-compat-tdfa
                , regexpr
                , safe
                , shakespeare-text


### PR DESCRIPTION
regex-compat is notoriously poor at supporting non-ASCII character sets. I have a UTF-8 encoded .csv file containing Unicode (a Unicode pound sign, in particular) and this seemed to cause hledger some difficulties:

```
$ hledger print --rules-file "Paypal.rules" -f "Paypal.csv"
using conversion rules file /Users/mbolingbroke/Dropbox/Finances/ledger/Paypal.rules
hledger: user error (Text.Regex.Posix.String died: (ReturnCode 17,"illegal byte sequence"))
```

After recompiling hledger-lib/hledger with regex-compat-tdfa instead, this was solved painlessly:

```
$ hledger print --rules-file "Paypal.rules" -f "Paypal.csv"
using conversion rules file /Users/mbolingbroke/Dropbox/Finances/ledger/Paypal.rules
```
