### PR TITLE
hledger-web: Fixes keyboard shortcut for adding a transaction. 

### DIFF
--- a/hledger-web/Handler/JournalR.hs
+++ b/hledger-web/Handler/JournalR.hs
@@ -34,7 +34,7 @@ getJournalR = do
   hledgerLayout vd "journal" [hamlet|
        <h2#contenttitle>#{title}
        <!-- p>Journal entries record movements of commodities between accounts. -->
-       <a#addformlink role="button" style="cursor:pointer;" data-toggle="modal" data-target="#addmodal"  title="Add a new transaction to the journal" style="margin-top:1em;">Add a transaction
+       <a#addformlink role="button" style="cursor:pointer;" onClick="addformReset(true);" data-toggle="modal" data-target="#addmodal"  title="Add a new transaction to the journal" style="margin-top:1em;">Add a transaction
        ^{maincontent}
      |]
 

--- a/hledger-web/static/hledger.js
+++ b/hledger-web/static/hledger.js
@@ -6,7 +6,7 @@
 $(document).ready(function() {
 
   // show add form if ?add=1
-  if ($.url.param('add')) { addformShow(showmsg=true); }
+  if ($.url.param('add')) { addformShow(true); }
 
   // sidebar account hover handlers
   $('#sidebar td a').mouseenter(function(){ $(this).parent().addClass('mouseover'); });
@@ -127,7 +127,7 @@ function registerChartClick(ev, pos, item) {
 // ADD FORM
 
 function addformShow(showmsg) {
-  showmsg = typeof showmsg !== 'undefined' ? a : false;
+  showmsg = typeof showmsg !== 'undefined' ? showmsg : false;
   addformReset(showmsg);
   $('#addmodal')
     .on('shown.bs.modal', function (e) {
@@ -138,7 +138,7 @@ function addformShow(showmsg) {
 
 // Make sure the add form is empty and clean for display.
 function addformReset(showmsg) {
-  showmsg = typeof showmsg !== 'undefined' ? a : false;
+  showmsg = typeof showmsg !== 'undefined' ? showmsg : false;
   if ($('form#addform').length > 0) {
     if (!showmsg) $('div#message').html('');
     $('form#addform')[0].reset();


### PR DESCRIPTION
This error happens in Chrome and in Firefox too.

See pull request #251. 

The link 'Add a transaction' is working because it is triggered by bootstrap `data-toggle=modal data-target="#addmodal`. The keyboard follows another path because it resets the form before calling `modal` on `$("#addmodal")`.. that helped discover that the link 'Add a transaction' does not clean the form in fact. :)

Should I leave it like this? Should I clean the form after clicking 'Add transaction' ? I think the best would be:
 - Put a link on the form (below the 'X') to clean the fields.
 - (Possibly) do not clean the form when pressing 'a'.