### PR TITLE
handle multiple -f parameters sensibly

### DIFF
--- a/data/alias.journal
+++ b/data/alias.journal
@@ -1,0 +1,2 @@
+alias expenses	= equity:draw:personal
+alias assets = assets:personal

--- a/data/business.journal
+++ b/data/business.journal
@@ -1,0 +1,4 @@
+2014/1/1
+    expenses:office supplies  $1
+    assets:business checking
+

--- a/data/personal.journal
+++ b/data/personal.journal
@@ -1,0 +1,4 @@
+2014/1/2
+    expenses:food  $1
+    assets:cash
+

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1060,6 +1060,12 @@ With the `--depth N` option, commands like [account](#account), [balance](#balan
 and [register](#register) will show only the uppermost accounts in the account
 tree, down to level N. Use this when you want a summary with less detail.
 
+### Multiple files
+
+One may specify the `--file FILE` option multiple times. This is equivalent to
+concatenating the files to standard input and passing `--file -`, except that
+the add command functions normally and adds entries to the first specified file.
+
 ## Queries
 
 One of hledger's strengths is being able to quickly report on precise subsets of your data.\

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -256,7 +256,7 @@ main = do
 
       -- internal commands
       | cmd == "activity"        = withJournalDo opts histogram       `orShowHelp` activitymode
-      | cmd == "add"             = (journalFilePathFromOpts opts >>= ensureJournalFileExists >> withJournalDo opts add) `orShowHelp` addmode
+      | cmd == "add"             = (journalFilePathFromOpts opts >>= (ensureJournalFileExists . head) >> withJournalDo opts add) `orShowHelp` addmode
       | cmd == "accounts"        = withJournalDo opts accounts        `orShowHelp` accountsmode
       | cmd == "balance"         = withJournalDo opts balance         `orShowHelp` balancemode
       | cmd == "balancesheet"    = withJournalDo opts balancesheet    `orShowHelp` balancesheetmode

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -68,7 +68,7 @@ withJournalDo opts cmd = do
   -- to let the add command work.
   rulespath <- rulesFilePathFromOpts opts
   journalpath <- journalFilePathFromOpts opts
-  ej <- readJournalFile Nothing rulespath (not $ ignore_assertions_ opts) (head journalpath)
+  ej <- readJournalFiles Nothing rulespath (not $ ignore_assertions_ opts) journalpath
   either error' (cmd opts . journalApplyAliases (aliasesFromOpts opts)) ej
 
 -- | Write some output to stdout or to a file selected by --output-file.

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -68,7 +68,7 @@ withJournalDo opts cmd = do
   -- to let the add command work.
   rulespath <- rulesFilePathFromOpts opts
   journalpath <- journalFilePathFromOpts opts
-  ej <- readJournalFile Nothing rulespath (not $ ignore_assertions_ opts) journalpath
+  ej <- readJournalFile Nothing rulespath (not $ ignore_assertions_ opts) (head journalpath)
   either error' (cmd opts . journalApplyAliases (aliasesFromOpts opts)) ej
 
 -- | Write some output to stdout or to a file selected by --output-file.

--- a/tests/cli/alias.journal
+++ b/tests/cli/alias.journal
@@ -1,0 +1,1 @@
+../../data/alias.journal

--- a/tests/cli/business.journal
+++ b/tests/cli/business.journal
@@ -1,0 +1,1 @@
+../../data/business.journal

--- a/tests/cli/multiple-files.test
+++ b/tests/cli/multiple-files.test
@@ -1,0 +1,39 @@
+# 1. all data files on the command line should be read
+hledgerdev inc -f personal.journal -f business.journal
+>>>
+Income Statement
+
+Revenues:
+--------------------
+                   0
+
+Expenses:
+                  $2  expenses
+                  $1    food
+                  $1    office supplies
+--------------------
+                  $2
+
+Total:
+--------------------
+                  $2
+>>>2
+>>>=0
+
+# 2. aliases in files should only apply to later files
+hledgerdev print -f personal.journal -f business.journal -f alias.journal -f personal.journal
+>>>
+2014/01/01
+    expenses:office supplies            $1
+    assets:business checking           $-1
+
+2014/01/02
+    expenses:food            $1
+    assets:cash             $-1
+
+2014/01/02
+    equity:draw:personal:food            $1
+    assets:personal:cash                $-1
+
+>>>2
+>>>=0

--- a/tests/cli/personal.journal
+++ b/tests/cli/personal.journal
@@ -1,0 +1,1 @@
+../../data/personal.journal


### PR DESCRIPTION
Fixes bug #165, though instead of `hledger inc -f file1 file2` it is `hledger inc -f file1 -f file2`: the former would interfere with specifying patterns on the command line.

Notes:

This did make the API slightly redundant, exporting both readJournalFiles and readJournalFile. (I have a version without readJournalFile, but the web frontend isn't tested.)

The first file is added to journalFilePaths with the contents of all the files and I haven't looked exhaustively for bugs that may cause, but I suspect it might only be parser error messages with the wrong file name. That looks like a problem to be solved along side the include file parsing one (hledger-lib/Hledger/Read/CsvReader.hs:812).

The important possible bug that I came up with was fine though: `hledger add -f file1 -f file2` behaves sensibly, matching on all input files and appending to the first.