### PR TITLE
Add --pivot option

### DIFF
--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -115,6 +115,7 @@ inputflags = [
  ,flagReq ["rules-file"]  (\s opts -> Right $ setopt "rules-file" s opts) "RFILE" "CSV conversion rules file (default: FILE.rules)"
  ,flagReq ["alias"]  (\s opts -> Right $ setopt "alias" s opts)  "OLD=NEW" "display accounts named OLD as NEW"
  ,flagNone ["ignore-assertions"] (setboolopt "ignore-assertions") "ignore any balance assertions in the journal"
+ ,flagReq ["pivot"]  (\s opts -> Right $ setopt "pivot" s opts)  "TAG" "Replace the accounts of postings with TAG by TAG:<value>"
  ]
 
 -- | Common report-related flags: --period, --cost, etc.

--- a/hledger/doc/examples.m4.md
+++ b/hledger/doc/examples.m4.md
@@ -65,3 +65,19 @@ $ hledger print desc:shop                 # show transactions with shop in the d
 $ hledger activity -W                     # show transaction counts per week as a bar chart
 ```
 
+With the journal
+
+```journal
+2016/02/16 Member Fee Payment John Doe
+    assets:bank account                                   2 EUR
+    income:member fees                                  -2 EUR
+      ; member: John Doe
+```
+
+the --pivot comand will output the following:
+
+```shells
+$ hledger bal --pivot member
+    2 EUR  assets:bank account
+   -2 EUR  member:John Doe
+```

--- a/hledger/doc/options.m4.md
+++ b/hledger/doc/options.m4.md
@@ -104,6 +104,10 @@ Both of these must be written after the command name.
 `-B --cost                    `
 : show amounts in their cost price's commodity
 
+`--pivot TAG
+: will transform the journal before any other processing by replacing the account name of every posting having the tag TAG with content VALUE by the  account name "TAG:VALUE".
+: The TAG will only match if it is a full-length match. The pivot will only happen if the TAG is on a posting, not if it is on the transaction. If the tag value is a multi:level:account:name the new account name will be "TAG:multi:level:account:name".
+
 ## Multiple files
 
 One may specify the `--file FILE` option multiple times. This is equivalent to

--- a/tests/misc/pivot.test
+++ b/tests/misc/pivot.test
@@ -1,0 +1,40 @@
+# --pivot tests
+
+# check pivot with print
+hledger -f- --pivot TAG print
+<<<
+2016/02/16 Test Transaction
+    Account1                                   2 EUR
+    Account2                                  -2 EUR
+    ; TAG: value
+>>>
+2016/02/16 Test Transaction
+    Account1          2 EUR
+    TAG:value        -2 EUR
+    ; TAG: value
+
+>>>=0
+
+# check pivot with bal
+hledger -f- --pivot member bal --no-total
+<<<
+2016/02/16 Member Fee Payment John Doe
+    assets:bank account                                   2 EUR
+    income:member fees                                  -2 EUR
+      ; member: John Doe
+>>>
+               2 EUR  assets:bank account
+              -2 EUR  member:John Doe
+>>>=0
+
+# check with another example
+hledger -f- --pivot budget bal --no-total
+<<<
+2016/02/16 Donation Freifunk
+    assets:bank account                                   2 EUR
+    income:donations                                  -2 EUR
+      ; budget: Freifunk
+>>>
+               2 EUR  assets:bank account
+              -2 EUR  budget:Freifunk
+>>>=0


### PR DESCRIPTION
Hey,
I found the --pivot from the original ledger to be very useful, so I reimplemented it for hledger. I am fairly new at haskell, so feel free to criticize my code in any way you can imagine. If you would like to include the feature in hledger I am open to modify the pull request according to your wishes.

The option --pivot TAG will change

    2016/02/16 Test Transaction
        Account1                                   2 EUR
        Account2                                  -2 EUR
          ; TAG: value

to

    2016/02/16 Test Transaction
        Account1  2 EUR
        TAG:value  -2 EUR
          ; TAG: value

while this run of hledger. (Node: This differs slightly from the original ledger, where --pivot will instead create the posting `TAG:value:Account2  -2 EUR`. One could consider renaming or offering both features.)

Greetings,
Malte