### PR TITLE
lib: use all 76 doctests

### DIFF
--- a/hledger-lib/.ghci
+++ b/hledger-lib/.ghci
@@ -1,1 +1,2 @@
 :set prompt "hledger-lib> "
+:set -optP-include -optPdist/build/autogen/cabal_macros.h

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables, PackageImports #-}
 {-|
 
 Easy regular expression helpers, currently based on regex-tdfa. These should:
@@ -51,7 +51,7 @@ import Data.Array
 import Data.Char
 import Data.List (foldl')
 import Data.MemoUgly (memo)
-import Text.Regex.TDFA (
+import "regex-tdfa" Text.Regex.TDFA (
   Regex, CompOption(..), ExecOption(..), defaultCompOpt, defaultExecOpt,
   makeRegexOpts, AllMatches(getAllMatches), match, (=~), MatchText
   )

--- a/hledger-lib/tests/doctests.hs
+++ b/hledger-lib/tests/doctests.hs
@@ -1,6 +1,9 @@
 import Test.DocTest
 
-main = doctest [
-   "Hledger/Read/JournalReader.hs"
-  ,"Hledger/Data/Dates.hs"
-  ]
+main = do
+  let dist = "dist"
+  doctest [
+    "-optP-include"
+    ,"-optP" ++ dist ++ "/build/autogen/cabal_macros.h"
+    ,"Hledger.hs"
+    ]


### PR DESCRIPTION
Add some work-around for preprocessor into `doctest.hs` and `.ghci`.