### PR TITLE
Adding "--value"/"-V" option for balancesheet/incomestatement/cashflow and register

### DIFF
--- a/hledger/Hledger/Cli/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Balancesheet.hs
@@ -11,6 +11,7 @@ module Hledger.Cli.Balancesheet (
  ,tests_Hledger_Cli_Balancesheet
 ) where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Text.Lazy.IO as LT
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
@@ -28,6 +29,7 @@ balancesheetmode = (defCommandMode $ ["balancesheet"]++aliases) {
      groupUnnamed = [
       flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
      ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
+     ,flagNone ["value","V"] (setboolopt "value") "show amounts as their current market value in their default valuation commodity"
      ]
     ,groupHidden = []
     ,groupNamed = [generalflagsgroup1]
@@ -41,18 +43,23 @@ balancesheet CliOpts{reportopts_=ropts} j = do
   -- let lines = case lineFormatFromOpts ropts of Left err, Right ...
   d <- getCurrentDay
   let q = queryFromOpts d (withoutBeginDate ropts)
+      valuedate = fromMaybe d $ queryEndDate False $ queryFromOpts d ropts
       assetreport@(_,assets)          = balanceReport ropts (And [q, journalAssetAccountQuery j]) j
       liabilityreport@(_,liabilities) = balanceReport ropts (And [q, journalLiabilityAccountQuery j]) j
       total = assets + liabilities
+      convertReport | value_ ropts = balanceReportValue j valuedate
+                    | otherwise    = id
+      convertTotal  | value_ ropts = mixedAmountValue j valuedate
+                    | otherwise    = id
   LT.putStr $ [lt|Balance Sheet
 
 Assets:
-#{balanceReportAsText ropts assetreport}
+#{balanceReportAsText ropts (convertReport assetreport)}
 Liabilities:
-#{balanceReportAsText ropts liabilityreport}
+#{balanceReportAsText ropts (convertReport liabilityreport)}
 Total:
 --------------------
-#{padleft 20 $ showMixedAmountWithoutPrice total}
+#{padleft 20 $ showMixedAmountWithoutPrice (convertTotal total)}
 |]
 
 withoutBeginDate :: ReportOpts -> ReportOpts

--- a/hledger/Hledger/Cli/Cashflow.hs
+++ b/hledger/Hledger/Cli/Cashflow.hs
@@ -14,6 +14,7 @@ module Hledger.Cli.Cashflow (
  ,tests_Hledger_Cli_Cashflow
 ) where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Text.Lazy.IO as LT
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
@@ -31,6 +32,7 @@ cashflowmode = (defCommandMode ["cashflow","cf"]) {
      groupUnnamed = [
       flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
      ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
+     ,flagNone ["value","V"] (setboolopt "value") "show amounts as their current market value in their default valuation commodity"
      ]
     ,groupHidden = []
     ,groupNamed = [generalflagsgroup1]
@@ -43,18 +45,23 @@ cashflow CliOpts{reportopts_=ropts} j = do
   -- let lines = case lineFormatFromOpts ropts of Left err, Right ...
   d <- getCurrentDay
   let q = queryFromOpts d ropts
+      valuedate = fromMaybe d $ queryEndDate False $ queryFromOpts d ropts
       cashreport@(_,total) = balanceReport ropts (And [q, journalCashAccountQuery j]) j
       -- operatingreport@(_,operating) = balanceReport ropts (And [q, journalOperatingAccountMatcher j]) j
       -- investingreport@(_,investing) = balanceReport ropts (And [q, journalInvestingAccountMatcher j]) j
       -- financingreport@(_,financing) = balanceReport ropts (And [q, journalFinancingAccountMatcher j]) j
       -- total = operating + investing + financing
+      convertReport | value_ ropts = balanceReportValue j valuedate
+                    | otherwise    = id
+      convertTotal  | value_ ropts = mixedAmountValue j valuedate
+                    | otherwise    = id
   LT.putStr $ [lt|Cashflow Statement
 
 Cash flows:
-#{balanceReportAsText ropts cashreport}
+#{balanceReportAsText ropts (convertReport cashreport)}
 Total:
 --------------------
-#{padleft 20 $ showMixedAmountWithoutPrice total}
+#{padleft 20 $ showMixedAmountWithoutPrice (convertTotal total)}
 |]
 
 tests_Hledger_Cli_Cashflow :: Test

--- a/hledger/Hledger/Cli/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Incomestatement.hs
@@ -11,6 +11,7 @@ module Hledger.Cli.Incomestatement (
  ,tests_Hledger_Cli_Incomestatement
 ) where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Text.Lazy.IO as LT
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
@@ -28,6 +29,7 @@ incomestatementmode = (defCommandMode $ ["incomestatement"]++aliases) {
      groupUnnamed = [
       flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
      ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
+     ,flagNone ["value","V"] (setboolopt "value") "show amounts as their current market value in their default valuation commodity"
      ]
     ,groupHidden = []
     ,groupNamed = [generalflagsgroup1]
@@ -40,18 +42,23 @@ incomestatement :: CliOpts -> Journal -> IO ()
 incomestatement CliOpts{reportopts_=ropts} j = do
   d <- getCurrentDay
   let q = queryFromOpts d ropts
+      valuedate = fromMaybe d $ queryEndDate False $ queryFromOpts d ropts
       incomereport@(_,income)    = balanceReport ropts (And [q, journalIncomeAccountQuery j]) j
       expensereport@(_,expenses) = balanceReport ropts (And [q, journalExpenseAccountQuery j]) j
       total = income + expenses
+      convertReport | value_ ropts = balanceReportValue j valuedate
+                    | otherwise    = id
+      convertTotal  | value_ ropts = mixedAmountValue j valuedate
+                    | otherwise    = id
   LT.putStr $ [lt|Income Statement
 
 Revenues:
-#{balanceReportAsText ropts incomereport}
+#{balanceReportAsText ropts (convertReport incomereport)}
 Expenses:
-#{balanceReportAsText ropts expensereport}
+#{balanceReportAsText ropts (convertReport expensereport)}
 Total:
 --------------------
-#{padleft 20 $ showMixedAmountWithoutPrice total}
+#{padleft 20 $ showMixedAmountWithoutPrice (convertTotal total)}
 |]
 
 tests_Hledger_Cli_Incomestatement :: Test


### PR DESCRIPTION
Let me know if this is in the spirit of the library/utility! :)

I tried my best to adhere to the style that I saw used across the library, but feel free to tell me if there are any stylistic inconsistencies!

I see some potential for refactoring out balancesheet/incomestatement/cashflow commands, too, and would be willing to do it if you think that it'd be helpful to do so.
