### PR TITLE
Update default year directive to allow optional month

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -143,6 +143,7 @@ instance Monoid Journal where
   mempty = nulljournal
   mappend j1 j2 = Journal {
      jparsedefaultyear          = jparsedefaultyear          j2
+    ,jparsedefaultmonth         = jparsedefaultmonth         j2
     ,jparsedefaultcommodity     = jparsedefaultcommodity     j2
     ,jparseparentaccounts       = jparseparentaccounts       j2
     ,jparsealiases              = jparsealiases              j2
@@ -163,6 +164,7 @@ instance Monoid Journal where
 nulljournal :: Journal
 nulljournal = Journal {
    jparsedefaultyear          = Nothing
+  ,jparsedefaultmonth         = Nothing
   ,jparsedefaultcommodity     = Nothing
   ,jparseparentaccounts       = []
   ,jparsealiases              = []

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -143,7 +143,6 @@ instance Monoid Journal where
   mempty = nulljournal
   mappend j1 j2 = Journal {
      jparsedefaultyear          = jparsedefaultyear          j2
-    ,jparsedefaultmonth         = jparsedefaultmonth         j2
     ,jparsedefaultcommodity     = jparsedefaultcommodity     j2
     ,jparseparentaccounts       = jparseparentaccounts       j2
     ,jparsealiases              = jparsealiases              j2
@@ -164,7 +163,6 @@ instance Monoid Journal where
 nulljournal :: Journal
 nulljournal = Journal {
    jparsedefaultyear          = Nothing
-  ,jparsedefaultmonth         = Nothing
   ,jparsedefaultcommodity     = Nothing
   ,jparseparentaccounts       = []
   ,jparsealiases              = []

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -224,6 +224,8 @@ instance NFData MarketPrice
 
 type Year = Integer
 
+type Month = Int
+
 -- | A Journal, containing transactions and various other things.
 -- The basic data model for hledger.
 --
@@ -237,6 +239,7 @@ type Year = Integer
 data Journal = Journal {
   -- parsing-related data
    jparsedefaultyear      :: (Maybe Year)                          -- ^ the current default year, specified by the most recent Y directive (or current date)
+  ,jparsedefaultmonth     :: (Maybe Month)                         -- ^ the current default month, specified by the most recent Y directive containing month part (or current date)
   ,jparsedefaultcommodity :: (Maybe (CommoditySymbol,AmountStyle)) -- ^ the current default commodity and its format, specified by the most recent D directive
   ,jparseparentaccounts   :: [AccountName]                         -- ^ the current stack of parent account names, specified by apply account directives
   ,jparsealiases          :: [AccountAlias]                        -- ^ the current account name aliases in effect, specified by alias directives (& options ?)

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -238,8 +238,7 @@ type Month = Int
 --
 data Journal = Journal {
   -- parsing-related data
-   jparsedefaultyear      :: (Maybe Year)                          -- ^ the current default year, specified by the most recent Y directive (or current date)
-  ,jparsedefaultmonth     :: (Maybe Month)                         -- ^ the current default month, specified by the most recent Y directive containing month part (or current date)
+   jparsedefaultyear      :: (Maybe (Year,Maybe Month))            -- ^ the current default year/month, specified by the most recent Y directive (or current date)
   ,jparsedefaultcommodity :: (Maybe (CommoditySymbol,AmountStyle)) -- ^ the current default commodity and its format, specified by the most recent D directive
   ,jparseparentaccounts   :: [AccountName]                         -- ^ the current stack of parent account names, specified by apply account directives
   ,jparsealiases          :: [AccountAlias]                        -- ^ the current account name aliases in effect, specified by alias directives (& options ?)

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -215,6 +215,7 @@ includedirectivep = do
 newJournalWithParseStateFrom :: Journal -> Journal
 newJournalWithParseStateFrom j = mempty{
    jparsedefaultyear      = jparsedefaultyear j
+  ,jparsedefaultmonth     = jparsedefaultmonth j
   ,jparsedefaultcommodity = jparsedefaultcommodity j
   ,jparseparentaccounts   = jparseparentaccounts j
   ,jparsealiases          = jparsealiases j
@@ -358,12 +359,18 @@ endtagdirectivep = do
 
 defaultyeardirectivep :: ErroringJournalParser ()
 defaultyeardirectivep = do
-  char 'Y' <?> "default year"
+  char 'Y' <?> "default year and optionally month"
   many spacenonewline
   y <- many1 digit
+  m <- optionMaybe $ char '/' >> many1 digit
   let y' = read y
   failIfInvalidYear y
   setYear y'
+  case m of Just mval -> (do
+                           let m' = read mval
+                           failIfInvalidMonth mval
+                           setMonth m')
+            Nothing   -> sequence_ []
 
 defaultcommoditydirectivep :: ErroringJournalParser ()
 defaultcommoditydirectivep = do

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -215,7 +215,6 @@ includedirectivep = do
 newJournalWithParseStateFrom :: Journal -> Journal
 newJournalWithParseStateFrom j = mempty{
    jparsedefaultyear      = jparsedefaultyear j
-  ,jparsedefaultmonth     = jparsedefaultmonth j
   ,jparsedefaultcommodity = jparsedefaultcommodity j
   ,jparseparentaccounts   = jparseparentaccounts j
   ,jparsealiases          = jparsealiases j
@@ -364,13 +363,11 @@ defaultyeardirectivep = do
   y <- many1 digit
   m <- optionMaybe $ char '/' >> many1 digit
   let y' = read y
+  let m' = fmap read m
   failIfInvalidYear y
-  setYear y'
-  case m of Just mval -> (do
-                           let m' = read mval
-                           failIfInvalidMonth mval
-                           setMonth m')
+  case m of Just mval -> failIfInvalidMonth mval
             Nothing   -> sequence_ []
+  setYear (y',m')
 
 defaultcommoditydirectivep :: ErroringJournalParser ()
 defaultcommoditydirectivep = do

--- a/hledger-lib/doc/hledger_journal.5.m4.md
+++ b/hledger-lib/doc/hledger_journal.5.m4.md
@@ -93,9 +93,9 @@ it will be inferred.
 
 Within a journal file, transaction dates use Y/M/D (or Y-M-D or Y.M.D)
 Leading zeros are optional.
-The year may be omitted, in which case it will be inferred from the context - the current transaction, the default year set with a
+Year/month may be omitted, in which case they will be inferred from the context - the current transaction, default values set with a
 [default year directive](#default-year), or the current date when the command is run.
-Some examples: `2010/01/31`, `1/31`, `2010-01-31`, `2010.1.31`.
+Some examples: `2010/01/31`, `1/31`, `2010-01-31`, `2010.1.31`, `29`.
 
 ### Secondary dates
 
@@ -668,8 +668,8 @@ The commodity (and the sample amount's display format) will be applied to all su
 
 ### Default year
 
-You can set a default year to be used for subsequent dates which don't
-specify a year. This is a line beginning with `Y` followed by the year. Eg:
+You can set a default year/month to be used for subsequent dates which don't
+specify a year/month. This is a line beginning with `Y` followed by the year and optionally a month. Eg:
 
 ```journal
 Y2009      ; set default year to 2009
@@ -686,6 +686,12 @@ Y2010      ; change default year to 2010
 
 1/31       ; equivalent to 2010/1/31
   expenses  1
+  assets
+  
+Y2016/01   ; change default year to 2016 and month to 01
+
+12         ; equivalent to 2016/01/12
+  expanses  1
   assets
 ```
 

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -131,6 +131,11 @@ tests_Hledger_Cli = TestList
     tdate (head $ jtxns j) `is` fromGregorian 2009 1 1
     return ()
 
+  ,"default year and month" ~: do
+    j <- readJournal Nothing Nothing True Nothing defaultyearmonth_journal_txt >>= either error' return
+    tdate (head $ jtxns j) `is` fromGregorian 2009 7 1
+    return ()
+
   ,"show dollars" ~: showAmount (usd 1) ~?= "$1.00"
 
   ,"show hours" ~: showAmount (hrs 1) ~?= "1.00h"
@@ -195,6 +200,15 @@ defaultyear_journal_txt = T.unlines
  ["Y2009"
  ,""
  ,"01/01 A"
+ ,"    a  $1"
+ ,"    b"
+ ]
+
+defaultyearmonth_journal_txt :: Text
+defaultyearmonth_journal_txt = T.unlines
+ ["Y2009/07"
+ ,""
+ ,"01 A"
  ,"    a  $1"
  ,"    b"
  ]


### PR DESCRIPTION
This adds possibility to specify default month in `Y` directive.
Example usage:

```
Y2016/07

01 a transaction
  ...
```

Transaction date here is 2016/07/01.

Related issue: #362 
