### PR TITLE
Support vty 0.7

### DIFF
--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -22,7 +22,7 @@ import Data.Monoid
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
 import qualified Data.Vector as V
-import Graphics.Vty
+import Graphics.Vty (Event(..),Key(..))
 import Lens.Micro.Platform
 import System.Console.ANSI
 import System.FilePath (takeFileName)

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -13,7 +13,7 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.Monoid
 import Data.Time.Calendar (Day)
-import Graphics.Vty hiding (char, string)-- (Event(..))
+import Graphics.Vty (Event(..),Key(..))
 import Text.Parsec
 
 import Hledger.Cli hiding (progname,prognameandversion,green)

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -18,7 +18,7 @@ import Data.Maybe
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
 import qualified Data.Vector as V
-import Graphics.Vty
+import Graphics.Vty (Event(..),Key(..))
 import Brick
 import Brick.Widgets.List
 import Brick.Widgets.Edit

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -14,7 +14,7 @@ import Data.List
 import Data.Monoid
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
-import Graphics.Vty
+import Graphics.Vty (Event(..),Key(..))
 import Brick
 import Brick.Widgets.List (listMoveTo)
 import Brick.Widgets.Border (borderAttr)

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -40,7 +40,7 @@ module Hledger.UI.UITypes where
 
 import Data.Monoid
 import Data.Time.Calendar (Day)
-import Graphics.Vty
+import Graphics.Vty (Event)
 import Brick
 import Brick.Widgets.List
 import Brick.Widgets.Edit (Editor)

--- a/hledger-ui/Hledger/UI/UIUtils.hs
+++ b/hledger-ui/Hledger/UI/UIUtils.hs
@@ -13,7 +13,7 @@ import Brick.Widgets.Dialog
 import Brick.Widgets.Edit
 import Data.List
 import Data.Monoid
-import Graphics.Vty
+import Graphics.Vty (Event(..),Key(..),Color,Attr,currentAttr)
 import Lens.Micro.Platform
 import System.Process
 

--- a/hledger-ui/hledger-ui.cabal
+++ b/hledger-ui/hledger-ui.cabal
@@ -78,7 +78,7 @@ executable hledger-ui
     , text-zipper >= 0.4 && < 0.5
     , transformers
     , vector
-    , vty >= 5.2 && < 5.6
+    , vty >= 5.2 && < 5.8
   if flag(threaded)
     ghc-options: -threaded
   if flag(old-locale)

--- a/hledger-ui/package.yaml
+++ b/hledger-ui/package.yaml
@@ -83,7 +83,7 @@ executables:
       - text-zipper >= 0.4 && < 0.5
       - transformers
       - vector
-      - vty >= 5.2 && < 5.6
+      - vty >= 5.2 && < 5.8
     when:
       - condition: flag(threaded)
         ghc-options: -threaded


### PR DESCRIPTION
The explicit exports are necessary to prevent ambiguity errors with `Mode` and `setMode` in `vty`. I have to admit that I didn’t get around to testing vty 0.6 (which was previously excluded by the bounds) but it works with vty 0.7.