### PR TITLE
fix the haddock for amounts

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -434,9 +434,9 @@ sumSimilarAmountsUsingFirstPrice :: [Amount] -> Amount
 sumSimilarAmountsUsingFirstPrice [] = nullamt
 sumSimilarAmountsUsingFirstPrice as = (sum as){aprice=aprice $ head as}
 
--- | Sum same-commodity amounts. If there were different prices, set
--- the price to a special marker indicating "various". Only used as a
--- rendering helper.
+-- -- | Sum same-commodity amounts. If there were different prices, set
+-- -- the price to a special marker indicating "various". Only used as a
+-- -- rendering helper.
 -- sumSimilarAmountsNotingPriceDifference :: [Amount] -> Amount
 -- sumSimilarAmountsNotingPriceDifference [] = nullamt
 -- sumSimilarAmountsNotingPriceDifference as = undefined


### PR DESCRIPTION
The haddocks for `amounts` are a bit broken, see [here](https://hackage.haskell.org/package/hledger-lib-0.27.1/docs/Hledger-Data-Amount.html#v:amounts).