### PR TITLE
Ignore dist-newstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ shake
 test.hs
 */doc/*.[0-9].md
 */doc/*.info
+dist-newstyle/


### PR DESCRIPTION
This is the replacement for `dist` when using `cabal new-build`. Since I have started to use it for some things, I got annoyed by having a dirty `git status`.

If you want, I can also add a `cabal.project` which is similar to `stack.yaml` but doesn’t contain something like a resolver so even if you don’t use it, it shouldn’t require a lot of maintenance effort. 

I wanted to leave that decision separate from ignoring `dist-newstyle` (which I want to have either way) so I didn’t add the cabal.project directly.