### PR TITLE
Improve the performance of post summation

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -86,6 +86,7 @@ module Hledger.Data.Amount (
   isZeroMixedAmount,
   isReallyZeroMixedAmount,
   isReallyZeroMixedAmountCost,
+  sumMixedAmounts,
   -- ** rendering
   showMixedAmount,
   showMixedAmountOneLine,
@@ -102,6 +103,7 @@ module Hledger.Data.Amount (
 ) where
 
 import Data.Char (isDigit)
+import Data.Coerce (coerce)
 import Data.Decimal (roundTo)
 import Data.Function (on)
 import Data.List
@@ -358,6 +360,13 @@ missingmixedamt = Mixed [missingamt]
 -- | Convert amounts in various commodities into a normalised MixedAmount.
 mixed :: [Amount] -> MixedAmount
 mixed = normaliseMixedAmount . Mixed
+
+-- | This is a more efficient version of sum
+sumMixedAmounts :: [MixedAmount] -> MixedAmount
+sumMixedAmounts = normaliseMixedAmount . combineMixedAmounts
+  where combineMixedAmounts :: [MixedAmount] -> MixedAmount
+        combineMixedAmounts =
+          Mixed . concat . (coerce :: [MixedAmount] -> [[Amount]])
 
 -- | Simplify a mixed amount's component amounts:
 --

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -121,7 +121,7 @@ accountNamesFromPostings :: [Posting] -> [AccountName]
 accountNamesFromPostings = nub . map paccount
 
 sumPostings :: [Posting] -> MixedAmount
-sumPostings = sum . map pamount
+sumPostings = sumMixedAmounts . map pamount
 
 -- | Get a posting's (primary) date - it's own primary date if specified,
 -- otherwise the parent transaction's primary date, or the null date if

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -391,7 +391,7 @@ priceInferrerFor t pt = inferprice
     pmixedamounts  = map pamount postings
     pamounts       = concatMap amounts pmixedamounts
     pcommodities   = map acommodity pamounts
-    sumamounts     = amounts $ sum pmixedamounts -- sum normalises to one amount per commodity & price
+    sumamounts     = amounts $ sumMixedAmounts pmixedamounts -- sum normalises to one amount per commodity & price
     sumcommodities = map acommodity sumamounts
     sumprices      = filter (/=NoPrice) $ map aprice sumamounts
     caninferprices = length sumcommodities == 2 && null sumprices


### PR DESCRIPTION
This improves the performance on my example query from `300ms` on average to `290ms` (where the performance is bound by parsing and checking for balanced transactions). This is sadly a bit less than I hoped for but if we find a few of these small improvements it can definitely help a lot.