### PR TITLE
Add a cabal.project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ test.hs
 */doc/*.[0-9].md
 */doc/*.info
 dist-newstyle/
+cabal.project.local
+*~

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: hledger-lib
+          hledger
+          hledger-ui
+          hledger-web
+          hledger-api


### PR DESCRIPTION
I also snuck some ignores in there. `*~` is for backup files created by emacs and `cabal.project.local` contains *temporary* changes to things like ghc-options so it should never be commited.