### PR TITLE
Fix a few spaceleaks

### DIFF
--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -64,7 +64,7 @@ accountsFromPostings ps =
     acctamts = [(paccount p,pamount p) | p <- ps]
     grouped = groupBy (\a b -> fst a == fst b) $ sort $ acctamts
     counted = [(a, length acctamts) | acctamts@((a,_):_) <- grouped]
-    summed = map (\as@((aname,_):_) -> (aname, sum $ map snd as)) grouped -- always non-empty
+    summed = map (\as@((aname,_):_) -> (aname, sumStrict $ map snd as)) grouped -- always non-empty
     nametree = treeFromPaths $ map (expandAccountName . fst) summed
     acctswithnames = nameTreeToAccount "root" nametree
     acctswithnumps = mapAccounts setnumps    acctswithnames where setnumps    a = a{anumpostings=fromMaybe 0 $ lookup (aname a) counted}

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -435,7 +435,7 @@ tests_normaliseMixedAmountSquashPricesForDisplay = [
 -- rendering helper.
 sumSimilarAmountsUsingFirstPrice :: [Amount] -> Amount
 sumSimilarAmountsUsingFirstPrice [] = nullamt
-sumSimilarAmountsUsingFirstPrice as = (sum as){aprice=aprice $ head as}
+sumSimilarAmountsUsingFirstPrice as = (sumStrict as){aprice=aprice $ head as}
 
 -- -- | Sum same-commodity amounts. If there were different prices, set
 -- -- the price to a special marker indicating "various". Only used as a

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -584,8 +584,8 @@ journalBalanceTransactionsST assrt j createStore storeIn extract =
     flip R.runReaderT (Env bals (storeIn txStore) assrt $
                        Just $ jinferredcommodities j) $ do
       dated <- fmap snd . sortBy (comparing fst) . concat
-             <$> mapM discriminateByDate (jtxns j)
-      mapM checkInferAndRegisterAmounts dated
+             <$> mapM' discriminateByDate (jtxns j)
+      mapM' checkInferAndRegisterAmounts dated
     lift $ extract txStore
   where size = genericLength $ journalPostings j
 
@@ -759,7 +759,7 @@ canonicalStyleFrom ss@(first:_) =
   where
     mgrps = maybe Nothing Just $ headMay $ catMaybes $ map asdigitgroups ss
     -- precision is maximum of all precisions
-    prec = maximum $ map asprecision ss
+    prec = maximumStrict $ map asprecision ss
     mdec  = Just $ headDef '.' $ catMaybes $ map asdecimalpoint ss
     -- precision is that of first amount with a decimal point
     -- (mdec, prec) =
@@ -842,8 +842,8 @@ journalDateSpan secondary j
     | null ts   = DateSpan Nothing Nothing
     | otherwise = DateSpan (Just earliest) (Just $ addDays 1 latest)
     where
-      earliest = minimum dates
-      latest   = maximum dates
+      earliest = minimumStrict dates
+      latest   = maximumStrict dates
       dates    = pdates ++ tdates
       tdates   = map (if secondary then transactionDate2 else tdate) ts
       pdates   = concatMap (catMaybes . map (if secondary then (Just . postingDate2) else pdate) . tpostings) ts

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -126,7 +126,7 @@ accountNamesFromPostings :: [Posting] -> [AccountName]
 accountNamesFromPostings = nub . map paccount
 
 sumPostings :: [Posting] -> MixedAmount
-sumPostings = sum . map pamount
+sumPostings = sumStrict . map pamount
 
 -- | Remove all prices of a posting
 removePrices :: Posting -> Posting

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -393,10 +393,10 @@ inferBalancingAmount update t@Transaction{tpostings=ps}
            return t{tpostings=postings}
   where
     printerr s = intercalate "\n" [s, showTransactionUnelided t]
-    ((amountfulrealps, amountlessrealps), realsum) =
-      (partition hasAmount (realPostings t), sum $ map pamount amountfulrealps)
-    ((amountfulbvps, amountlessbvps), bvsum)       =
-      (partition hasAmount (balancedVirtualPostings t), sum $ map pamount amountfulbvps)
+    (amountfulrealps, amountlessrealps) = partition hasAmount (realPostings t)
+    realsum = sumStrict $ map pamount amountfulrealps
+    (amountfulbvps, amountlessbvps) = partition hasAmount (balancedVirtualPostings t)
+    bvsum = sumStrict $ map pamount amountfulbvps
     inferamount p@Posting{ptype=RegularPosting}
      | not (hasAmount p) = updateAmount p realsum
     inferamount p@Posting{ptype=BalancedVirtualPosting}
@@ -460,7 +460,7 @@ priceInferrerFor t pt = inferprice
     pmixedamounts  = map pamount postings
     pamounts       = concatMap amounts pmixedamounts
     pcommodities   = map acommodity pamounts
-    sumamounts     = amounts $ sum pmixedamounts -- sum normalises to one amount per commodity & price
+    sumamounts     = amounts $ sumStrict pmixedamounts -- sum normalises to one amount per commodity & price
     sumcommodities = map acommodity sumamounts
     sumprices      = filter (/=NoPrice) $ map aprice sumamounts
     caninferprices = length sumcommodities == 2 && null sumprices

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -130,7 +130,7 @@ instance NFData Price
 data AmountStyle = AmountStyle {
       ascommodityside   :: Side,                 -- ^ does the symbol appear on the left or the right ?
       ascommodityspaced :: Bool,                 -- ^ space between symbol and quantity ?
-      asprecision       :: Int,                  -- ^ number of digits displayed after the decimal point
+      asprecision       :: !Int,                 -- ^ number of digits displayed after the decimal point
       asdecimalpoint    :: Maybe Char,           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
       asdigitgroups     :: Maybe DigitGroupStyle -- ^ style for displaying digit groups, if any
 } deriving (Eq,Ord,Read,Show,Typeable,Data,Generic)

--- a/hledger/Hledger/Cli/Register.hs
+++ b/hledger/Hledger/Cli/Register.hs
@@ -90,8 +90,8 @@ postingsReportItemAsCsvRecord (_, _, _, p, b) = [idx,date,desc,acct,amt,bal]
 postingsReportAsText :: CliOpts -> PostingsReport -> String
 postingsReportAsText opts (_,items) = unlines $ map (postingsReportItemAsText opts amtwidth balwidth) items
   where
-    amtwidth = maximum $ 12 : map (strWidth . showMixedAmount . itemamt) items
-    balwidth = maximum $ 12 : map (strWidth . showMixedAmount . itembal) items
+    amtwidth = maximumStrict $ 12 : map (strWidth . showMixedAmount . itemamt) items
+    balwidth = maximumStrict $ 12 : map (strWidth . showMixedAmount . itembal) items
     itemamt (_,_,_,Posting{pamount=a},_) = a
     itembal (_,_,_,_,a) = a
 


### PR DESCRIPTION
This is the result of applying Neil Mitchell’s trick of limiting the stack size to hledger.

Let me break down the different changes:
- `sum`, `maximum` and `minimum` use `foldl` instead of `foldl'` which can leak memory.
- Since `asprecision` is rarely evaluated this is responsible for another spaceleak.
- Lastly `sequence` is sort of a false positive so I mostly made the change here to be able to use the trick. Looking at [benchmarks](http://www.joachim-breitner.de/blog/684-Constructing_a_list_in_a_monad_revisited) it seems like this difference list based version is slightly faster on small lists but is slower on bigger lists.

Here are the benchmark results:

**before**

```
Benchmark bench: RUNNING...
Benchmarking hledger in /home/moritz/code/haskell/hledger/baseline/hledger with criterion
benchmarking read bench/10000x1000x10.journal
time                 1.992 s    (1.990 s .. 1.995 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.987 s    (1.986 s .. 1.988 s)
std dev              1.392 ms   (0.0 s .. 1.543 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking print
time                 1.599 s    (1.583 s .. 1.607 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.612 s    (1.606 s .. 1.614 s)
std dev              5.457 ms   (0.0 s .. 6.127 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking register
time                 2.203 s    (2.161 s .. 2.261 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.159 s    (2.131 s .. 2.173 s)
std dev              24.04 ms   (0.0 s .. 24.94 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking balance
time                 209.6 ms   (204.6 ms .. 214.6 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 208.9 ms   (208.1 ms .. 211.0 ms)
std dev              1.625 ms   (24.09 μs .. 2.165 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking stats
time                 195.6 ms   (189.5 ms .. 201.6 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 197.3 ms   (194.6 ms .. 201.5 ms)
std dev              4.471 ms   (2.152 ms .. 6.746 ms)
variance introduced by outliers: 14% (moderately inflated)
```

**after**

```
Benchmark bench: RUNNING...
Benchmarking hledger in /home/moritz/code/haskell/hledger/hledger with criterion
benchmarking read bench/10000x1000x10.journal
time                 1.852 s    (1.817 s .. 1.903 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.846 s    (1.834 s .. 1.854 s)
std dev              11.56 ms   (0.0 s .. 13.28 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking print
time                 1.602 s    (1.589 s .. 1.609 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.607 s    (1.606 s .. 1.607 s)
std dev              352.9 μs   (0.0 s .. 407.5 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking register
time                 2.143 s    (2.050 s .. 2.223 s)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 2.135 s    (2.121 s .. 2.146 s)
std dev              17.79 ms   (0.0 s .. 19.60 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking balance
time                 204.6 ms   (196.1 ms .. 209.5 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 204.5 ms   (202.2 ms .. 206.1 ms)
std dev              2.434 ms   (1.329 ms .. 3.665 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking stats
time                 190.3 ms   (182.7 ms .. 195.5 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 190.9 ms   (188.6 ms .. 194.4 ms)
std dev              3.729 ms   (696.3 μs .. 5.146 ms)
variance introduced by outliers: 14% (moderately inflated)
```

Memory usage doesn’t seem to be significantly impacted (although it looks like it goes slightly down with this patch).
