### PR TITLE
Added .btn-default to unify buttons across browsers

### DIFF
--- a/hledger-web/Foundation.hs
+++ b/hledger-web/Foundation.hs
@@ -382,7 +382,7 @@ addform _ vd@VD{..} = [hamlet|
          |]
        | otherwise = [hamlet|
           <td #addbtncell style="text-align:right;">
-           <button type=submit .btn .btn-lg name=submit>add
+           <button type=submit .btn .btn-default .btn-lg name=submit>add
            $if length filepaths > 1
             <br>
             <span class="input-lg">to:

--- a/hledger-web/Handler/Common.hs
+++ b/hledger-web/Handler/Common.hs
@@ -114,8 +114,8 @@ searchform VD{..} = [hamlet|
       <a role=button .btn .close style="position:absolute; right:0; padding-right:.1em; padding-left:.1em; margin-right:.1em; margin-left:.1em; font-size:24px;" href="@{here}" title="Clear search terms">&times;
      <input .form-control style="font-size:18px; padding-bottom:2px;" name=q value=#{q} title="Enter hledger search patterns to filter the data below">
     <td width="1%" style="white-space:nowrap;">
-     <button .btn style="font-size:18px;" type=submit title="Apply search terms">Search
-     <button .btn style="font-size:18px;" type=button data-toggle="modal" data-target="#helpmodal" title="Show search and general help">?
+     <button .btn .btn-default style="font-size:18px;" type=submit title="Apply search terms">Search
+     <button .btn .btn-default style="font-size:18px;" type=button data-toggle="modal" data-target="#helpmodal" title="Show search and general help">?
 |]
  where
   filtering = not $ null q


### PR DESCRIPTION
By overriding the default brower-styles using the class `btn-default`, the buttons on hldeger-web are now rendered the same on all browsers. It also gives the interface a cleaner look
![before_after](https://cloud.githubusercontent.com/assets/1364576/19285578/d4bdffc8-8ffa-11e6-84fc-d5761e657373.png)
