### PR TITLE
Default to serving API only on loopback interface

### DIFF
--- a/hledger-api/hledger-api.hs
+++ b/hledger-api/hledger-api.hs
@@ -97,7 +97,8 @@ serveApi p d f j = do
   printf "Starting web api http://localhost:%d/api/v1 for %s\n" p f
   printf "and file server  http://localhost:%d        for %s/\n" p d
   printf "Press ctrl-c to quit\n"
-  Warp.run p $
+  let settings = setPort p $ setHost "127.0.0.1" defaultSettings
+  Warp.runSettings settings $
     logStdout $
     hledgerApiApp d j
 


### PR DESCRIPTION
Before, hledger-api was binding on *4 (any IPv4 address), so anyone on the local network could access the API and the files it was serving.

Switch this to only listening on the loopback interface, so only the local machine can request the data (more secure-by-default). You can still put it behind a reverse proxy if you want to expose it.

We can discuss whether there should be another command line argument for host, if you like? I'm easy - just lean away from command line arguments unless we have a use case for them, and I'm not sure we do here yet?