### PR TITLE
Normalize amount in infereBalancingAmount

### DIFF
--- a/tests/journal/commodities.test
+++ b/tests/journal/commodities.test
@@ -32,3 +32,18 @@ hledger -f- balance
 --------------------
                    0
 >>>=0
+
+# 4. autobalance with prices
+hledger -f- print
+<<<
+2016/1/1
+    saving-card  $-105
+    snacks  95 EUR @@ $100
+    Equity:Unbalanced
+>>>
+2016/01/01
+    saving-card                 $-105
+    snacks             95 EUR @@ $100
+    Equity:Unbalanced              $5
+
+>>>=0


### PR DESCRIPTION
This fixes issue exposed by a fix for simonmichael/hledger#465

```
2016/1/1
    saving-card  $-105
    snacks  95 EUR @@ $100
    Equity:Unbalanced  ; absence of $5 here triggers strange behavior
```

Before
```
2016/01/01
    saving-card                 $-105
    snacks             95 EUR @@ $100
    Equity:Unbalanced            $105    ; absence of $5 here triggers strange behavior
    Equity:Unbalanced           $-100    ; absence of $5 here triggers strange behavior
```
Now:
```
2016/01/01
    saving-card                 $-105
    snacks             95 EUR @@ $100
    Equity:Unbalanced              $5    ; absence of $5 here triggers strange behavior
```