### PR TITLE
Apply ModifierTransaction's from journal during hledger-rewrite.

### DIFF
--- a/bin/hledger-rewrite.hs
+++ b/bin/hledger-rewrite.hs
@@ -5,6 +5,7 @@
   --package megaparsec
   --package text
 -}
+{-# LANGUAGE LambdaCase #-}
 {-
 
 hledger-rewrite [PATTERNS] --add-posting "ACCT  AMTEXPR" ...
@@ -27,7 +28,6 @@ Related: https://github.com/simonmichael/hledger/issues/99
 TODO:
 - should allow regex matching and interpolating matched name in replacement
 - should apply all matching rules to a transaction, not just one
-- should apply the rule for each matched posting within a transaction, if there's more than one
 - should be possible to use this on unbalanced entries, eg while editing one
 
 -}
@@ -57,6 +57,17 @@ cmdmode = (defCommandMode ["hledger-rewrite"]) {
     }
   }
 
+modifierTransactionFromOpts :: RawOpts -> ModifierTransaction
+modifierTransactionFromOpts opts = txn where
+    exprs = addPostingExprsFromOpts opts :: [PostingExpr]
+    postings = flip map exprs $ \case
+        (acct, AmountLiteral s) -> acct `post'`  amountp' s
+        (acct, AmountMultiplier n) -> acct `post'` amount { acommodity = T.pack "*", aquantity = n }
+    txn = ModifierTransaction { mtvalueexpr = T.empty, mtpostings = postings }
+
+post' :: AccountName -> Amount -> Posting
+post' acct amt = (accountNameWithoutPostingType acct `post` amt) { ptype = accountNamePostingType acct }
+
 type PostingExpr = (AccountName, AmountExpr)
 
 data AmountExpr = AmountLiteral String | AmountMultiplier Quantity deriving (Show)
@@ -80,32 +91,32 @@ amountexprp =
     ,AmountLiteral <$> many anyChar
     ]
 
-amountExprRenderer :: Query -> AmountExpr -> (Transaction -> MixedAmount)
-amountExprRenderer q aex =
-  case aex of
-    AmountLiteral s    -> const (mamountp' s)
-    AmountMultiplier n -> (`divideMixedAmount` (1 / n)) . (`firstAmountMatching` q)
-  where
-    firstAmountMatching :: Transaction -> Query -> MixedAmount
-    firstAmountMatching t q = pamount $ head $ filter (q `matchesPosting`) $ tpostings t
 
-rewriteTransaction :: Transaction -> [(AccountName, Transaction -> MixedAmount)] -> Transaction
-rewriteTransaction t addps = t{tpostings=tpostings t ++ map (uncurry (generatePosting t)) addps}
-  where
-    generatePosting :: Transaction -> AccountName -> (Transaction -> MixedAmount) -> Posting
-    generatePosting t acct amtfn = nullposting{paccount     = accountNameWithoutPostingType acct
-                                              ,ptype        = accountNamePostingType acct
-                                              ,pamount      = amtfn t
-                                              ,ptransaction = Just t
-                                              }
+postingScale :: Posting -> Maybe Quantity
+postingScale p =
+    case amounts $ pamount p of
+        [a] | acommodity a == T.pack "*" -> Just $ aquantity a
+        _ -> Nothing
+
+runModifierPosting :: Posting -> (Posting -> Posting)
+runModifierPosting p' =
+    case postingScale p' of
+        Nothing -> \p -> p' { ptransaction = ptransaction p }
+        Just n -> \p -> p' { pamount = pamount p `divideMixedAmount` (1/n), ptransaction = ptransaction p }
+
+runModifierTransaction :: Query -> ModifierTransaction -> (Transaction -> Transaction)
+runModifierTransaction q mod = modifier where
+    mods = map runModifierPosting $ mtpostings mod
+    generatePostings ps = [mod p | p <- ps, q `matchesPosting` p, mod <- mods]
+    modifier t@Transaction{ tpostings = ps } = t { tpostings = ps ++ generatePostings ps }
 
 main = do
   opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} <- getCliOpts cmdmode
   d <- getCurrentDay
   let q = queryFromOpts d ropts
-      addps = [(a, amountExprRenderer q aex) | (a, aex) <- addPostingExprsFromOpts rawopts]
+      mod = modifierTransactionFromOpts rawopts
   withJournalDo opts $ \opts j@Journal{jtxns=ts} -> do
     -- rewrite matched transactions
-    let j' = j{jtxns=map (\t -> if q `matchesTransaction` t then rewriteTransaction t addps else t) ts}
+    let j' = j{jtxns=map (runModifierTransaction q mod) ts}
     -- run the print command, showing all transactions
     print' opts{reportopts_=ropts{query_=""}} j'

--- a/tests/bin/rewrite.test
+++ b/tests/bin/rewrite.test
@@ -1,7 +1,7 @@
 # Tests for rewrite addon
 
 # Add proportional income tax (from documentation)
-runghc ../../bin/hledger-rewrite.hs -f- ^income --add-posting '(liabilities:tax)  *.33'
+runghc ../../bin/hledger-rewrite.hs -f- ^income --add-posting '(liabilities:tax)  *.33  ; income tax'
 <<<
 2016/1/1 paycheck
     income:remuneration     $-100
@@ -16,8 +16,8 @@ runghc ../../bin/hledger-rewrite.hs -f- ^income --add-posting '(liabilities:tax)
     income:remuneration         $-100
     income:donations             $-15
     assets:bank
-    (liabilities:tax)            $-33
-    (liabilities:tax)             $-5
+    (liabilities:tax)            $-33    ; income tax
+    (liabilities:tax)             $-5    ; income tax
 
 2016/01/01 withdraw
     assets:cash           $20

--- a/tests/bin/rewrite.test
+++ b/tests/bin/rewrite.test
@@ -5,6 +5,7 @@ runghc ../../bin/hledger-rewrite.hs -f- ^income --add-posting '(liabilities:tax)
 <<<
 2016/1/1 paycheck
     income:remuneration     $-100
+    income:donations         $-15
     assets:bank
 
 2016/1/1 withdraw
@@ -13,8 +14,10 @@ runghc ../../bin/hledger-rewrite.hs -f- ^income --add-posting '(liabilities:tax)
 >>>
 2016/01/01 paycheck
     income:remuneration         $-100
+    income:donations             $-15
     assets:bank
     (liabilities:tax)            $-33
+    (liabilities:tax)             $-5
 
 2016/01/01 withdraw
     assets:cash           $20

--- a/tests/bin/rewrite.test
+++ b/tests/bin/rewrite.test
@@ -79,3 +79,69 @@ runghc ../../bin/hledger-rewrite.hs -f- assets:bank and 'amt:<0' --add-posting '
 
 >>>2
 >>>=0
+
+# Rewrite rule within journal
+runghc ../../bin/hledger-rewrite.hs -f- date:2017/1  --add-posting 'Here comes Santa  $0'
+<<<
+= ^expenses:housing
+    (budget:housing)  *-1
+= ^expenses:grocery or ^expenses:food
+    (budget:food)  *-1
+
+2016/12/31
+    expenses:housing  $600
+    assets:cash
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    assets:cash
+
+2017/1/2
+    assets:cash  $200.00
+    assets:bank
+
+2017/2/1
+    assets:cash  $100.00
+    assets:bank
+
+= ^expenses not:housing not:grocery not:food
+    (budget:misc)  *-1
+
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
+>>>
+2016/12/31
+    expenses:housing       $600.00
+    assets:cash
+
+2017/01/01
+    expenses:food           $20.00
+    expenses:leisure        $15.00
+    expenses:grocery        $30.00
+    assets:cash
+    Here comes Santa             0
+    Here comes Santa             0
+    Here comes Santa             0
+    Here comes Santa             0
+    (budget:misc)          $-15.00
+    (budget:food)          $-20.00
+    (budget:food)          $-30.00
+
+2017/01/02
+    assets:cash            $200.00
+    assets:bank
+    Here comes Santa             0
+    Here comes Santa             0
+    assets:bank             $-1.60
+    expenses:fee             $1.60    ; cash withdraw fee
+    (budget:misc)           $-1.60
+
+2017/02/01
+    assets:cash       $100.00
+    assets:bank
+
+>>>2
+>>>=0


### PR DESCRIPTION
Probably the most natural usage would be `hledger rewrite -f rewrites.hledger`. See tests for examples.

Currently no compatibility with C++ `ledger` expressions. Same for posting values. Commodity `*` is used to identify relative amounts to posting.

*Note*: users who migrated from C++ `ledger` probably want to move their automated transactions into a separate file to avoid unintentional rewrites. Maybe we should add option to control application of automated transactions from journal.