### PR TITLE
txnTieKnot fix (~10% memory reduce)

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,4 +1,6 @@
+hledger-chart
 hledger-check-dates
+hledger-dupes
 hledger-equity
 hledger-print-unique
 hledger-register-match

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -489,7 +489,8 @@ transactionDate2 t = fromMaybe (tdate t) $ tdate2 t
 -- | Ensure a transaction's postings refer back to it, so that eg
 -- relatedPostings works right.
 txnTieKnot :: Transaction -> Transaction
-txnTieKnot t@Transaction{tpostings=ps} = t{tpostings=map (postingSetTransaction t) ps}
+txnTieKnot t@Transaction{tpostings=ps} = t' where
+    t' = t{tpostings=map (postingSetTransaction t') ps}
 
 -- | Ensure a transaction's postings do not refer back to it, so that eg
 -- recursiveSize and GHCI's :sprint work right.


### PR DESCRIPTION
```
HEAD is now at d657374a... doc: note an issue with balance assertions & multiple -f options
(pts/33/rxvt-unicode-256color) nikolay@ony [0]  2017-01-16 16:57:56
~/contrib/hledger
zsh% stack build --ghc-options=-O2 >& /dev/null && stack exec -- hledger -f examples/10000x1000x10.journal bal > /dev/null +RTS -s
   3,115,009,192 bytes allocated in the heap
     287,039,088 bytes copied during GC
      37,426,776 bytes maximum residency (11 sample(s))
       2,516,552 bytes maximum slop
             105 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      6013 colls,     0 par    0.211s   0.218s     0.0000s    0.0073s
  Gen  1        11 colls,     0 par    0.108s   0.108s     0.0098s    0.0348s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    1.047s  (  1.048s elapsed)
  GC      time    0.319s  (  0.326s elapsed)
  EXIT    time    0.005s  (  0.005s elapsed)
  Total   time    1.407s  (  1.379s elapsed)

  Alloc rate    2,974,608,614 bytes per MUT second

  Productivity  77.3% of total user, 78.9% of total elapsed

gc_alloc_block_sync: 0
whitehole_spin: 0
gen[0].sync: 0
gen[1].sync: 0
(pts/33/rxvt-unicode-256color) nikolay@ony [0]  2017-01-16 16:59:06
~/contrib/hledger
zsh% git checkout master                                                                                                          
Previous HEAD position was d657374a... doc: note an issue with balance assertions & multiple -f options
Switched to branch 'master'
Your branch is ahead of 'upstream/master' by 2 commits.
  (use "git push" to publish your local commits)
(pts/33/rxvt-unicode-256color) nikolay@ony [0]  2017-01-16 16:59:14
~/contrib/hledger
zsh% stack build --ghc-options=-O2 >& /dev/null && stack exec -- hledger -f examples/10000x1000x10.journal bal > /dev/null +RTS -s
   3,113,489,064 bytes allocated in the heap
     277,260,720 bytes copied during GC
      33,713,872 bytes maximum residency (11 sample(s))
       2,516,552 bytes maximum slop
              91 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      6011 colls,     0 par    0.214s   0.214s     0.0000s    0.0005s
  Gen  1        11 colls,     0 par    0.094s   0.094s     0.0085s    0.0306s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    1.063s  (  1.066s elapsed)
  GC      time    0.308s  (  0.308s elapsed)
  EXIT    time    0.004s  (  0.004s elapsed)
  Total   time    1.410s  (  1.379s elapsed)

  Alloc rate    2,928,641,916 bytes per MUT second

  Productivity  78.1% of total user, 79.9% of total elapsed

gc_alloc_block_sync: 0
whitehole_spin: 0
gen[0].sync: 0
gen[1].sync: 0
```