### PR TITLE
rewrite: inherit dates, change application order

### DIFF
--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -92,7 +92,7 @@ pivot tag j = j{jtxns = map pivotTrans . jtxns $ j}
   pivotTrans t = t{tpostings = map pivotPosting . tpostings $ t}
   pivotPosting p
     | Just (_ , value) <- tagTuple = p{paccount = value, porigin = Just $ originalPosting p}
-    | _                <- tagTuple = p{paccount = T.pack ""}
+    | _                <- tagTuple = p{paccount = T.pack "", porigin = Just $ originalPosting p}
    where tagTuple = find ((tag ==) . fst) . postingAllImplicitTags $ p
 
 -- | Apply the anonymisation transformation on a journal, if option is present

--- a/tests/bin/rewrite.test
+++ b/tests/bin/rewrite.test
@@ -35,7 +35,7 @@ runghc ../../bin/hledger-rewrite.hs -f- expenses:gifts --add-posting '(budget:gi
 
 2016/1/1 gift
     assets:cash     $-15
-    expenses:gifts
+    expenses:gifts  ; [1/2]
 >>>
 2016/01/01 withdraw
     assets:cash           $20
@@ -43,8 +43,8 @@ runghc ../../bin/hledger-rewrite.hs -f- expenses:gifts --add-posting '(budget:gi
 
 2016/01/01 gift
     assets:cash             $-15
-    expenses:gifts
-    (budget:gifts)          $-15
+    expenses:gifts      ; [1/2]
+    (budget:gifts)          $-15    ; [2016/01/02]
 
 >>>2
 >>>=0
@@ -83,9 +83,12 @@ runghc ../../bin/hledger-rewrite.hs -f- assets:bank and 'amt:<0' --add-posting '
 # Rewrite rule within journal
 runghc ../../bin/hledger-rewrite.hs -f- date:2017/1  --add-posting 'Here comes Santa  $0'
 <<<
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
 = ^expenses:housing
     (budget:housing)  *-1
-= ^expenses:grocery or ^expenses:food
+= ^expenses:grocery ^expenses:food
     (budget:food)  *-1
 
 2016/12/31
@@ -106,12 +109,10 @@ runghc ../../bin/hledger-rewrite.hs -f- date:2017/1  --add-posting 'Here comes S
     assets:cash  $100.00
     assets:bank
 
+; order with normal entries doesn't matter
+; but relative order matters to refer-rewritten transactions
 = ^expenses not:housing not:grocery not:food
     (budget:misc)  *-1
-
-= ^assets:bank$ date:2017/1 amt:<0
-    assets:bank  *0.008
-    expenses:fee  *-0.008  ; cash withdraw fee
 >>>
 2016/12/31
     expenses:housing       $600.00
@@ -126,9 +127,9 @@ runghc ../../bin/hledger-rewrite.hs -f- date:2017/1  --add-posting 'Here comes S
     Here comes Santa             0
     Here comes Santa             0
     Here comes Santa             0
-    (budget:misc)          $-15.00
     (budget:food)          $-20.00
     (budget:food)          $-30.00
+    (budget:misc)          $-15.00
 
 2017/01/02
     assets:cash            $200.00

--- a/tests/misc/pivot.test
+++ b/tests/misc/pivot.test
@@ -54,6 +54,20 @@ hledger -f- --pivot TAG reg '^Account2$' '^fun$' not:hidden
                                 value                       -1 EUR         1 EUR
 >>>=0
 
+# We should be able to query on original account names
+hledger -f- --pivot expenses reg not:liabilities
+<<<
+2017/1/1 prepay
+    assets           $1500  ; expenses:a
+    assets            $100  ; expenses:b
+    assets              $5  ; expenses:c
+    liabilities     $-1605
+>>>
+2017/01/01 prepay               a                            $1500         $1500
+                                b                             $100         $1600
+                                c                               $5         $1605
+>>>=0
+
 # pivot for implicit tag desc (technical sample)
 hledger -f- --pivot description reg -M
 <<<


### PR DESCRIPTION
For budgeting it is important to inherit actual date of posting if it
differs from date of transaction. These dates will be added
as a separate line of comment.

More natural order of rewrites is when result of first defined one is
available for all next rewrites.