### PR TITLE
Budgeting addon to simulate behavior of C++ ledger with option --budget

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,3 +1,4 @@
+hledger-budget
 hledger-chart
 hledger-check-dates
 hledger-dupes

--- a/bin/hledger-budget.hs
+++ b/bin/hledger-budget.hs
@@ -1,0 +1,57 @@
+#!/usr/bin/env stack
+{- stack runghc --verbosity info
+  --package hledger-lib
+  --package hledger
+  --package text
+-}
+{-# LANGUAGE OverloadedStrings #-}
+import Data.List
+import System.Console.CmdArgs
+import Hledger.Cli
+import Hledger.Cli.Main (mainmode)
+import Hledger.Data.AutoTransaction
+
+actions :: [(Mode RawOpts, CliOpts -> IO ())]
+actions =
+    [ (manmode, man)
+    , (infomode, info')
+    , (balancemode, flip withJournalDo' balance)
+    , (balancesheetmode, flip withJournalDo' balancesheet)
+    , (cashflowmode, flip withJournalDo' cashflow)
+    , (incomestatementmode, flip withJournalDo' incomestatement)
+    , (registermode, flip withJournalDo' register)
+    , (printmode, flip withJournalDo' print')
+    ]
+
+cmdmode :: Mode RawOpts
+cmdmode = (mainmode [])
+    { modeNames = ["hledger-budget"]
+    , modeGroupModes = Group
+        { groupUnnamed = map fst actions
+        , groupNamed = []
+        , groupHidden = []
+        }
+    }
+
+journalBalanceTransactions' :: CliOpts -> Journal -> IO Journal
+journalBalanceTransactions' opts j = do
+    let assrt = not $ ignore_assertions_ opts
+    either error' return $ journalBalanceTransactions assrt j
+
+withJournalDo' :: CliOpts -> (CliOpts -> Journal -> IO ()) -> IO ()
+withJournalDo' opts = withJournalDo opts . wrapper where
+    wrapper f opts' j = f opts' =<< journalBalanceTransactions' opts' j{ jtxns = ts' } where
+        -- use original transactions as input for journalBalanceTransactions to re-infer balances/prices
+        modifier = originalTransaction . foldr (flip (.) . fmap txnTieKnot . runModifierTransaction Any) id mtxns
+        mtxns = jmodifiertxns j
+        ts' = map modifier $ jtxns j
+
+main :: IO ()
+main = do
+    rawopts <- fmap decodeRawOpts . processArgs $ cmdmode
+    opts <- rawOptsToCliOpts rawopts
+    let cmd = command_ opts
+    case find (\e -> cmd `elem` modeNames (fst e)) actions of
+        Just (amode, _) | "h" `elem` map fst (rawopts_ opts) -> print amode
+        Just (_, action) -> action opts
+        Nothing -> print cmdmode

--- a/bin/hledger-budget.hs
+++ b/bin/hledger-budget.hs
@@ -5,6 +5,17 @@
   --package text
 -}
 {-# LANGUAGE OverloadedStrings #-}
+{-
+
+hledger-budget REPORT-COMMAND [--no-offset] [--no-buckets] [OPTIONS...]
+
+Perform some subset of reports available in core hledger but process automated
+and periodic transactions. Also simplify tree of accounts to ease view of
+"budget buckets".
+
+This addon tries to simulate behavior of "ledger --budget".
+
+-}
 import Control.Arrow (first)
 import Data.Maybe
 import Data.List

--- a/hledger/doc/commands.m4.md
+++ b/hledger/doc/commands.m4.md
@@ -1014,6 +1014,133 @@ update according to list of input files specified via `--file` options and
 Be careful. Whole transaction being re-formatted in a style of output from
 `hledger print`.
 
+## budget
+This tool helps to get reports useful for planning and tracking the budget.
+
+For people familiar with [`ledger`
+budgeting](http://www.ledger-cli.org/3.0/doc/ledger3.html#Budgeting) may
+consider this tool as an alias to `ledger --budget`.
+
+With this tool you may either use so called periodic transactions that being
+issued with each new period or use a family of approaches with automated
+transactions. You may want to look at [budgeting section of
+plaintextaccounting](http://plaintextaccounting.org/#budgeting).
+
+Periodic transaction that being interpreted by this tool may look like:
+
+```ledger
+~ monthly from 2017/3
+    income:salary  $-4,000.00
+    expenses:taxes  $1,000
+    expenses:housing:rent  $1,200
+    expenses:grocery  $400
+    expenses:leisure  $200
+    expenses:health  $200
+    expenses  $100
+    assets:savings
+```
+
+Header of such entries starts with `'~'` (tilde symbol) following by an
+interval with an effect period when transactions should be injected.
+
+Effect of declaring such periodic transaction is:
+
+- Transactions will be injected at the beginning of each period. I.e. for
+  monthly it will always refer to 1st day of month.
+- Injected transaction will have inverted amounts to offset existing associated
+  expenses. I.e. for this example negative balance indicates how much you have
+  within your budget and positive amounts indicates how far you off from your
+  budget.
+- Set of accounts across of all periodic transactions will form kinda buckets
+  where rest of the accounts will be sorted into. Each account not mentioned in
+  any of periodic transaction will be dropped without changing of balance for
+  parent account. I.e. for this example postings for `expenses:leisure:movie`
+  will contribute to the  balance of `expenses:leisure` only in reports.
+
+Note that beside a periodic transaction all automated transactions will be
+handled in a similar way how they are handled in `rewrite` command.
+
+### Bucketing
+It is very common to have more expense accounts than budget
+"envelopes"/"buckets". For this reason all periodic transactions are treated as
+a source of information about your budget "buckets".
+
+I.e. example from previous section will build a sub-tree of accounts that look like
+
+```
+assets:savings
+expenses
+  taxes
+  housing:rent
+  grocery
+  leisure
+  health
+income:salary
+```
+
+All accounts used in your transactions journal files will be classified
+according to that tree to contribute to an appropriate bucket of budget.
+
+Everything else will be collected under virtual account `<unbucketed>` to give
+you an idea of what parts of your accounts tree is not budgeted. For example
+`liabilities` will contributed to that entry.
+
+### Reports
+You can use `budget` command to produce next reports:
+
+- `balance` - the most important one to track how you follow your budget. If
+  you use month-based budgeting you may want to use `--monthly` and
+  `--row-total` option to see how you are doing through the months. You also
+  may find it useful to add `--tree` option to see aggregated totals per
+  intermediate node of accounts tree.
+- `register` - might be useful if you want to see long history (ex. `--weekly`)
+  that is too wide to fit into your terminal.
+- `print` - this is mostly to check what actually happens. But you may use it
+  if you prefer to generate budget transactions and store it in a separate
+  journal for some less popular budgeting scheme.
+
+### Extra options for reports
+You may tweak behavior of this command with additional options `--no-offset` and `--no-bucketing`.
+
+- Don't use these options if your budgeting schema includes both periodic
+  transactions, and "bucketing". Unless you want to figure out how your
+  budgeting might look like. You may find helpful values of average column from
+  report
+
+```shell
+$ hledger budget -- bal --period 'monthly to last month' --no-offset --average
+```
+
+- Use `--no-offset` and `--no-bucketing` if your schema fully relies on
+  automated transactions and hand-crafted budgeting transactions. In this mode
+  only automated transactions will be processed. I.e. when you journal looks
+  something like
+
+```ledger
+= ^expenses:food
+  budget:gifts  *-1
+  assets:budget  *1
+
+2017/1/1 Budget for Jan
+  assets:bank  $-1000
+  budget:gifts  $200
+  budget:misc
+```
+
+- Use `--no-bucketing` only if you want to produce a valid journal. For example
+  when you want to pass it as an input for other `hledger` command. Most people
+  will find this useless.
+
+### Recommendations
+- Automated transaction should follow same rules that usual transactions follow
+  (i.e. keep balance for real and balanced virtual postings).
+- Don't change the balance of real asset and liability accounts for which you
+  usually put assertions. Keep in mind that `hledger` do not apply modification
+  transactions.
+- In periodic transactions to offset your budget use either top-level account
+  like `Assets` or introduce a "virtual" one like `Assets:Bank:Budget` that
+  will be a child to the one you want to offset.
+
 ## ui
 Curses-style interface, see [hledger-ui](hledger-ui.html).
 

--- a/tests/bin/budget.test
+++ b/tests/bin/budget.test
@@ -115,6 +115,7 @@ runghc ../../bin/hledger-budget.hs reg -f -
 >>>=0
 
 # Periodical transactions within journal being applied with inverted sign in amounts
+# As well, accounts from periodic transaction being used for bucketing
 runghc ../../bin/hledger-budget.hs bal -f - --no-total -DH expenses
 <<<
 ~ daily from 2016/12/31
@@ -133,7 +134,7 @@ runghc ../../bin/hledger-budget.hs bal -f - --no-total -DH expenses
     expenses:fee  *-0.008  ; cash withdraw fee
 
 2016/12/31
-    expenses:housing  $600
+    expenses:housing:rent  $600
     assets:cash
 
 2017/1/1
@@ -159,6 +160,106 @@ Ending balances (historical) in 2016/12/26-2017/01/04:
  expenses:grocery ||        $-50        $-50        $-50        $-50        $-50        $-50     $-20.00     $-70.00     $-70.00     $-70.00 
  expenses:housing ||       $-250       $-250       $-250       $-250       $-250     $350.00     $350.00     $100.00     $100.00     $100.00 
  expenses:leisure ||        $-20        $-20        $-20        $-20        $-20        $-20      $-5.00     $-25.00     $-25.00     $-25.00 
+
+>>>2
+>>>=0
+
+# We still can disable bucketing keeping rewrites and budget offset
+runghc ../../bin/hledger-budget.hs bal -f - --no-total --no-buckets -DH expenses
+<<<
+~ daily from 2016/12/31
+    expenses:food  $8
+    assets
+
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
+
+2016/12/31
+    expenses:housing:rent  $600
+    assets:bank
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    assets:bank
+>>>
+Ending balances (historical) in 2016/12/31-2017/01/01:
+
+                       ||  2016/12/31  2017/01/01 
+=======================++=========================
+ expenses:fee          ||           0          $1 
+ expenses:food         ||         $-8          $4 
+ expenses:grocery      ||           0         $30 
+ expenses:housing:rent ||        $600        $600 
+ expenses:leisure      ||           0         $15 
+
+>>>2
+>>>=0
+
+# We can disable offset keeping rewrites and bucketing
+# Note that original account names used for query
+runghc ../../bin/hledger-budget.hs bal -f - --no-total --no-offset -DH expenses
+<<<
+~ daily from 2016/12/31
+    expenses:food  $8
+    assets
+
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
+
+2016/12/31
+    expenses:housing:rent  $600
+    assets:bank
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    assets:bank
+>>>
+Ending balances (historical) in 2016/12/31-2017/01/01:
+
+               ||  2016/12/31  2017/01/01 
+===============++=========================
+ <unbucketed>  ||        $600        $646 
+ expenses:food ||           0         $20 
+
+>>>2
+>>>=0
+
+# We can keep just rewrites
+runghc ../../bin/hledger-budget.hs bal -f - --no-total --no-buckets --no-offset -DH expenses
+<<<
+~ daily from 2016/12/31
+    expenses:food  $8
+    assets
+
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
+
+2016/12/31
+    expenses:housing:rent  $600
+    assets:bank
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    assets:bank
+>>>
+Ending balances (historical) in 2016/12/31-2017/01/01:
+
+                       ||  2016/12/31  2017/01/01 
+=======================++=========================
+ expenses:fee          ||           0          $1 
+ expenses:food         ||           0         $20 
+ expenses:grocery      ||           0         $30 
+ expenses:housing:rent ||        $600        $600 
+ expenses:leisure      ||           0         $15 
 
 >>>2
 >>>=0

--- a/tests/bin/budget.test
+++ b/tests/bin/budget.test
@@ -113,3 +113,52 @@ runghc ../../bin/hledger-budget.hs reg -f -
                                 assets:bank                  $0.40             0
 >>>2
 >>>=0
+
+# Periodical transactions within journal being applied with inverted sign in amounts
+runghc ../../bin/hledger-budget.hs bal -f - --no-total -DH expenses
+<<<
+~ daily from 2016/12/31
+    expenses:food  $8
+    assets
+
+~ weekly
+    expenses:leisure  $20
+    expenses:grocery  $50
+    expenses:housing  $250
+    expenses:fee  $10
+    assets
+
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
+
+2016/12/31
+    expenses:housing  $600
+    assets:cash
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    assets:cash
+
+2017/1/2
+    assets:cash  $200.00
+    assets:bank
+
+2017/1/4
+    assets:cash  $100.00
+    assets:bank
+>>>
+Ending balances (historical) in 2016/12/26-2017/01/04:
+
+                  ||  2016/12/26  2016/12/27  2016/12/28  2016/12/29  2016/12/30  2016/12/31  2017/01/01  2017/01/02  2017/01/03  2017/01/04 
+==================++=========================================================================================================================
+ expenses:fee     ||        $-10        $-10        $-10        $-10        $-10        $-10        $-10     $-18.40     $-18.40     $-17.60 
+ expenses:food    ||           0           0           0           0           0         $-8       $4.00      $-4.00     $-12.00     $-20.00 
+ expenses:grocery ||        $-50        $-50        $-50        $-50        $-50        $-50     $-20.00     $-70.00     $-70.00     $-70.00 
+ expenses:housing ||       $-250       $-250       $-250       $-250       $-250     $350.00     $350.00     $100.00     $100.00     $100.00 
+ expenses:leisure ||        $-20        $-20        $-20        $-20        $-20        $-20      $-5.00     $-25.00     $-25.00     $-25.00 
+
+>>>2
+>>>=0

--- a/tests/bin/budget.test
+++ b/tests/bin/budget.test
@@ -1,0 +1,115 @@
+# Test budget addon
+
+# Rewrite rules within journal always applied
+runghc ../../bin/hledger-budget.hs bal -f - --no-total -DH budget
+<<<
+= ^assets:bank$ date:2017/1 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; cash withdraw fee
+= ^expenses:housing
+    (budget:housing)  *-1
+= ^expenses:grocery ^expenses:food
+    (budget:food)  *-1
+
+2016/12/31
+    expenses:housing  $600
+    assets:cash
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    assets:cash
+
+2017/1/2
+    assets:cash  $200.00
+    assets:bank
+
+2017/2/1
+    assets:cash  $100.00
+    assets:bank
+
+; order with normal entries doesn't matter
+; but relative order matters to refer-rewritten transactions
+= ^expenses not:housing not:grocery not:food
+    (budget:misc)  *-1
+>>>
+Ending balances (historical) in 2016/12/31-2017/01/02:
+
+                ||  2016/12/31  2017/01/01  2017/01/02 
+================++=====================================
+ budget:food    ||           0     $-50.00     $-50.00 
+ budget:housing ||    $-600.00    $-600.00    $-600.00 
+ budget:misc    ||           0     $-15.00     $-16.60 
+
+>>>2
+>>>=0
+
+# Rewrite rules can chain one another according to order of definition
+runghc ../../bin/hledger-budget.hs reg -f -
+<<<
+
+; unfortunately date override in posting comment doesn't work
+
+= liabilities:credit amt:<0 date:2016/12
+    liabilities:credit  *-1  ; [2017/1/1]
+    assets:bank  *1  ; [2017/1/1]
+
+= liabilities:credit amt:<0 date:2017/1
+    liabilities:credit  *-1  ; [2017/2/1]
+    assets:bank  *1  ; [2017/2/1]
+
+= liabilities:credit amt:<0 date:2017/2
+    liabilities:credit  *-1  ; [2017/3/1]
+    assets:bank  *1  ; [2017/3/1]
+
+= assets:bank date:2017/2 amt:<0
+    assets:bank  *0.008
+    expenses:fee  *-0.008  ; :salary-card: cash withdraw fee
+
+= expenses:fee tag:salary-card date:2017-2017/12/26
+    income:compensate  *-0.5
+    assets:bank  *0.5  ; compensation from employer
+
+2016/12/31
+    expenses:housing  $600
+    liabilities:credit
+
+2017/1/1
+    expenses:food  $20
+    expenses:leisure  $15
+    expenses:grocery  $30
+    liabilities:credit
+
+2017/1/2
+    assets:cash  $200.00
+    liabilities:credit
+
+2017/2/1
+    assets:cash  $100.00
+    liabilities:credit
+>>>
+2016/12/31                      expenses:housing           $600.00       $600.00
+                                liabilities:credit        $-600.00             0
+                                liabilities:credit         $600.00       $600.00
+                                assets:bank               $-600.00             0
+2017/01/01                      expenses:food               $20.00        $20.00
+                                expenses:leisure            $15.00        $35.00
+                                expenses:grocery            $30.00        $65.00
+                                liabilities:credit         $-65.00             0
+                                liabilities:credit          $65.00        $65.00
+                                assets:bank                $-65.00             0
+2017/01/02                      assets:cash                $200.00       $200.00
+                                liabilities:credit        $-200.00             0
+                                liabilities:credit         $200.00       $200.00
+                                assets:bank               $-200.00             0
+2017/02/01                      assets:cash                $100.00       $100.00
+                                liabilities:credit        $-100.00             0
+                                liabilities:credit         $100.00       $100.00
+                                assets:bank               $-100.00             0
+                                assets:bank                 $-0.80        $-0.80
+                                expenses:fee                 $0.80             0
+                                income:compensate           $-0.40        $-0.40
+                                assets:bank                  $0.40             0
+>>>2
+>>>=0


### PR DESCRIPTION
Until we'll get a better budgeting solution let's borrow one from C++ ledger approach.
- Modification transactions are active like in `hledger-rewrite`. If you like to fill budget buckets/envelopes manually.
- Periodic transactions inject `Budget transaction`s on a range of journal prepending any transaction in original journal. Can be disabled with `--no-offset` when you just need bucketing feature.
- Shrink tree of account to a smaller one according to account names used postings of periodic transactions.

Differences from C++ ledger:
- Posting match expression in modification transaction uses the syntax of queries of command-line.
- Period expression uses the syntax of `--period` option. I had to change keywords to lowercase.
- Order of postings in periodic transactions doesn't matter. Bucketing is done in a bit more natural way in accordance with accounts tree. 

Note that first argument of this addon should always be some subset of a `hledger` commands. Currently supported ones:
- `balance` - obvious.
- `register` - still useful with options like `-p 'monthly in 2017'`.
- `print` - mostly for debugging purposes.
- `balancesheet`, `incomestatement`, `cashflow` - doubtful.

Also be careful with automated transactions because they may result in balance assertion failures. Rules of thumb:
- Modifier transaction should follow same rules that usual transactions follow (i.e. keep balance for real and balanced virtual postings).
- Don't change the balance of real asset and liability accounts for which you usually put assertions. Keep in mind that `hledger` do not apply modification transactions.
- In periodic transactions to offset your budget use either top-level account like `Assets` or introduce a "virtual" one like `Assets:Bank:Budget` that will be a child to the one you want to offset.

P.S. With `--no-offset` and `--no-buckets` it might be considered as a resolution of #99 .