### PR TITLE
cli: fix bug in pivot for postings without tag

### DIFF
--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -92,7 +92,7 @@ pivot tag j = j{jtxns = map pivotTrans . jtxns $ j}
   pivotTrans t = t{tpostings = map pivotPosting . tpostings $ t}
   pivotPosting p
     | Just (_ , value) <- tagTuple = p{paccount = value, porigin = Just $ originalPosting p}
-    | _                <- tagTuple = p{paccount = T.pack ""}
+    | _                <- tagTuple = p{paccount = T.pack "", porigin = Just $ originalPosting p}
    where tagTuple = find ((tag ==) . fst) . postingAllImplicitTags $ p
 
 -- | Apply the anonymisation transformation on a journal, if option is present

--- a/tests/misc/pivot.test
+++ b/tests/misc/pivot.test
@@ -54,6 +54,20 @@ hledger -f- --pivot TAG reg '^Account2$' '^fun$' not:hidden
                                 value                       -1 EUR         1 EUR
 >>>=0
 
+# We should be able to query on original account names
+hledger -f- --pivot expenses reg not:liabilities
+<<<
+2017/1/1 prepay
+    assets           $1500  ; expenses:a
+    assets            $100  ; expenses:b
+    assets              $5  ; expenses:c
+    liabilities     $-1605
+>>>
+2017/01/01 prepay               a                            $1500         $1500
+                                b                             $100         $1600
+                                c                               $5         $1605
+>>>=0
+
 # pivot for implicit tag desc (technical sample)
 hledger -f- --pivot description reg -M
 <<<


### PR DESCRIPTION
Without this fix for postings without tag query checked effective account which is always empty text ("").