### PR TITLE
rewrite: support for replace and comment

### DIFF
--- a/bin/hledger-rewrite.hs
+++ b/bin/hledger-rewrite.hs
@@ -155,6 +155,10 @@ https://github.com/simonmichael/hledger/issues/99
   |]
   [flagReq ["add-posting"] (\s opts -> Right $ setopt "add-posting" s opts) "'ACCT  AMTEXPR'"
            "add a posting to ACCT, which may be parenthesised. AMTEXPR is either a literal amount, or *N which means the transaction's first matched amount multiplied by N (a decimal number). Two spaces separate ACCT and AMTEXPR."
+  ,flagReq ["txn-comment"] (\s opts -> Right $ setopt "txn-comment" s opts) "'COMMENT'"
+           "add transaction comment."
+  ,flagNone ["replace"] (setboolopt "replace-posting")
+           "replace/delete original posting from transaction."
   ,flagNone ["diff"] (setboolopt "diff") "generate diff suitable as an input for patch tool"
   ]
   [generalflagsgroup1]
@@ -193,7 +197,12 @@ modifierTransactionFromOpts :: RawOpts -> IO ModifierTransaction
 modifierTransactionFromOpts opts = do
     postings <- mapM (postingp' . stripquotes . T.pack) $ listofstringopt "add-posting" opts
     return
-        ModifierTransaction { mtvalueexpr = T.empty, mtpostings = postings }
+        ModifierTransaction { mtvalueexpr = T.empty
+                            , mtcomment = T.intercalate "\n" $
+                                map T.pack (listofstringopt "txn-comment" opts)
+
+                            , mtreplace = boolopt "replace-posting" opts
+                            , mtpostings = postings }
 
 outputFromOpts :: RawOpts -> (CliOpts -> Journal -> Journal -> IO ())
 outputFromOpts opts

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -240,6 +240,8 @@ instance NFData Transaction
 
 data ModifierTransaction = ModifierTransaction {
       mtvalueexpr :: Text,
+      mtcomment   :: Text,      -- ^ transaction's comment lines to be added
+      mtreplace   :: Bool,      -- ^ 'True' for replacing matched postings
       mtpostings  :: [Posting]
     } deriving (Eq,Typeable,Data,Generic)
 

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -412,7 +412,7 @@ modifiertransactionp = do
   lift (many spacenonewline)
   valueexpr <- T.pack <$> lift restofline
   postings <- postingsp Nothing
-  return $ ModifierTransaction valueexpr postings
+  return $ ModifierTransaction valueexpr "" False postings
 
 periodictransactionp :: MonadIO m => ErroringJournalParser m PeriodicTransaction
 periodictransactionp = do

--- a/tests/bin/rewrite.test
+++ b/tests/bin/rewrite.test
@@ -248,3 +248,55 @@
 +    assets:bank              $-5
 >>>2
 >>>=0
+
+# Split price with VAT
+runghc ../../bin/hledger-rewrite.hs -f- ^expenses:food --replace --add-posting 'expense:food  *0.8  ; VAT:none' --add-posting 'expenses:taxes  *0.2  ; VAT:explicit'
+<<<
+2016/1/1
+    expenses:food  $10
+    assets:bank
+
+2016/1/2
+    expenses:food
+    assets:bank  $-20
+>>>
+2016/01/01
+    assets:bank
+    expense:food                $8    ; VAT:none
+    expenses:taxes              $2    ; VAT:explicit
+
+2016/01/02
+    assets:bank               $-20
+    expense:food               $16    ; VAT:none
+    expenses:taxes              $4    ; VAT:explicit
+
+>>>2
+>>>=0
+
+# Comment transaction
+runghc ../../bin/hledger-rewrite.hs -f- desc:Starbucks 'amt:>0' --txn-comment 'discounts:10%' --add-posting 'expenses:discount  *-0.2' --add-posting 'assets:bank  *0.2'
+<<<
+2016/1/1 Starbucks
+    expenses:snacks  $5
+    assets:bank
+
+2016/1/2 Starbucks
+    expenses:snacks
+    assets:bank  $-15
+>>>
+2016/01/01 Starbucks
+    ; discounts:10%
+    expenses:snacks                $5
+    assets:bank
+    expenses:discount             $-1
+    assets:bank                    $1
+
+2016/01/02 Starbucks
+    ; discounts:10%
+    expenses:snacks
+    assets:bank                  $-15
+    expenses:discount             $-3
+    assets:bank                    $3
+
+>>>2
+>>>=0


### PR DESCRIPTION
With `--replace` it is possible to drop original posting from
transaction.

With `--txn-comment` it is possible to add transaction-level comment.