### PR TITLE
Alternative to hledgerCommandMode

### DIFF
--- a/bin/hledger-rewrite.hs
+++ b/bin/hledger-rewrite.hs
@@ -6,6 +6,7 @@
   --package megaparsec
   --package text
   --package Diff
+  --package data-default
 -}
 
 {-# LANGUAGE OverloadedStrings, LambdaCase, DeriveTraversable, ViewPatterns, QuasiQuotes #-}
@@ -14,6 +15,7 @@ import Control.Monad.Writer
 import Data.List (sortOn, foldl')
 import Data.String.Here
 import qualified Data.Text as T
+import Data.Default
 -- hledger lib, cli and cmdargs utils
 import Hledger.Cli hiding (outputflags)
 -- more utils for parsing
@@ -26,7 +28,7 @@ import qualified Data.Algorithm.Diff as D
 import Hledger.Data.AutoTransaction (runModifierTransaction)
 
 ------------------------------------------------------------------------------
-cmdmode = hledgerCommandMode
+cmdmode = templateCommandMode
   [here| rewrite
 Print all transactions, adding custom postings to the matched ones.
 
@@ -149,13 +151,16 @@ See also:
 https://github.com/simonmichael/hledger/issues/99
 
   |]
-  [flagReq ["add-posting"] (\s opts -> Right $ setopt "add-posting" s opts) "'ACCT  AMTEXPR'"
-           "add a posting to ACCT, which may be parenthesised. AMTEXPR is either a literal amount, or *N which means the transaction's first matched amount multiplied by N (a decimal number). Two spaces separate ACCT and AMTEXPR."
-  ,flagNone ["diff"] (setboolopt "diff") "generate diff suitable as an input for patch tool"
-  ]
-  [generalflagsgroup1]
-  []
-  ([], Just $ argsFlag "[QUERY] --add-posting \"ACCT  AMTEXPR\" ...")
+  `addModeFlags` def
+    { groupUnnamed =
+        [flagReq ["add-posting"] (\s opts -> Right $ setopt "add-posting" s opts) "'ACCT  AMTEXPR'"
+                "add a posting to ACCT, which may be parenthesised. AMTEXPR is either a literal amount, or *N which means the transaction's first matched amount multiplied by N (a decimal number). Two spaces separate ACCT and AMTEXPR."
+        ,flagNone ["diff"] (setboolopt "diff") "generate diff suitable as an input for patch tool"
+        ]
+    , groupNamed = [generalflagsgroup1]
+    }
+  `addModeRemainingArgs`
+    [argsFlag "[QUERY] --add-posting \"ACCT  AMTEXPR\" ..."]
 ------------------------------------------------------------------------------
 
 -- TODO regex matching and interpolating matched name in replacement

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -22,6 +22,10 @@ module Hledger.Cli.CliOptions (
   defCommandMode,
   quickAddonCommandMode,
   hledgerCommandMode,
+  templateCommandMode,
+  addModeFlags,
+  addModeArgs,
+  addModeRemainingArgs,
   argsFlag,
   showModeUsage,
   withAliases,
@@ -266,6 +270,44 @@ hledgerCommandMode tmpl ungroupedflags groupedflags hiddenflags args =
         ,modeArgs = args
         }
 
+-- | Build a cmdarg mode suitable for a hledger add-on command,
+-- from a help template. Use 'addModeFlags', 'addModeArgs', and
+-- 'addModeRemainingArgs' to declare flags and arguments.
+templateCommandMode :: HelpTemplate -> Mode RawOpts
+templateCommandMode tmpl = hledgerCommandMode tmpl [] [] [] ([], Nothing)
+
+-- | Extend cmdarg mode with a group of flags
+addModeFlags :: Mode a -> Group (Flag a) -> Mode a
+mode `addModeFlags` newFlags = mode' where
+    mode' = mode { modeGroupFlags = groupFlags' }
+    groupFlags = modeGroupFlags mode
+    groupFlags' = groupFlags
+        { groupUnnamed = groupUnnamed groupFlags ++ groupUnnamed newFlags
+        , groupNamed = namedFlags'
+        , groupHidden = groupHidden groupFlags ++ groupHidden newFlags
+        }
+    namedFlags = groupNamed groupFlags
+    namedFlags' = foldr injectKeyedList namedFlags (groupNamed newFlags)
+    injectKeyedList :: Eq a => (a, [b]) -> [(a, [b])] -> [(a, [b])]
+    injectKeyedList (k, xs) zs =
+        case ((k ==) . fst) `partition` zs of
+            ([z], zs') -> (fst z, snd z ++ xs) : zs'
+            _ -> (k, xs) : zs
+
+-- | Extend cmdarg mode with a positional parameters description
+addModeArgs :: Mode a -> [Arg a] -> Mode a
+addModeArgs mode newArgs = mode { modeArgs = (args ++ newArgs, marg) } where
+    (args, marg) = modeArgs mode
+
+-- | Extend cmdarg mode with an parameters description with a last one catching
+-- all of the remaining arguments
+addModeRemainingArgs :: Mode a -> [Arg a] -> Mode a
+addModeRemainingArgs mode [] = mode
+addModeRemainingArgs mode remArgs = mode { modeArgs = (args', marg') } where
+    args' = args ++ init remArgs
+    marg' = Just $ last remArgs
+    (args, _) = modeArgs mode
+
 -- | Built-in descriptions for some of the known addons.
 standardAddonsHelp :: [(String,String)]
 standardAddonsHelp = [
@@ -350,6 +392,7 @@ data CliOpts = CliOpts {
  } deriving (Show, Data, Typeable)
 
 instance Default CliOpts where def = defcliopts
+instance Default (Group a) where def = Group def def def
 
 defcliopts :: CliOpts
 defcliopts = CliOpts


### PR DESCRIPTION
That's a nice idea to parse help template and use part of information from there. Now it is pretty close to [`docopt`](http://hackage.haskell.org/package/docopt). `hledger` can't use `docopt` as it is due to lack of ability to re-use flags in sub commands and add-ons.

`hledgerCommandMode` helps to get rid of that nasty code for modifying result of `defCommandMode`. But it have 5-6 required parameters two of which even have same type.

Suggestion is to introduce "combinators" that are not available in [`cmdargs`](http://hackage.haskell.org/package/cmdargs) and actively use [`def`](http://hackage.haskell.org/package/data-default-0.7.1.1/docs/Data-Default.html#v:def).

This is a sample. More changes after getting agreement that move to more readable codebase.

**Comments to resolve:**

- [ ] Use names `with*` instad of `addMode*`.
- [ ] Evaluate use of `Monoid`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simonmichael/hledger/502)
<!-- Reviewable:end -->
