### PR TITLE
Added a simple 'showMarketPrice' function to show market price directives in a journal-compatible way

### DIFF
--- a/hledger-lib/Hledger/Data.hs
+++ b/hledger-lib/Hledger/Data.hs
@@ -15,6 +15,7 @@ module Hledger.Data (
                module Hledger.Data.Dates,
                module Hledger.Data.Journal,
                module Hledger.Data.Ledger,
+               module Hledger.Data.MarketPrice,
                module Hledger.Data.Period,
                module Hledger.Data.Posting,
                module Hledger.Data.RawOptions,
@@ -34,6 +35,7 @@ import Hledger.Data.Commodity
 import Hledger.Data.Dates
 import Hledger.Data.Journal
 import Hledger.Data.Ledger
+import Hledger.Data.MarketPrice
 import Hledger.Data.Period
 import Hledger.Data.Posting
 import Hledger.Data.RawOptions
@@ -50,6 +52,7 @@ tests_Hledger_Data = TestList
     ,tests_Hledger_Data_Amount
     ,tests_Hledger_Data_Commodity
     ,tests_Hledger_Data_Journal
+    ,tests_Hledger_Data_MarketPrice
     ,tests_Hledger_Data_Ledger
     ,tests_Hledger_Data_Posting
     -- ,tests_Hledger_Data_RawOptions

--- a/hledger-lib/Hledger/Data/MarketPrice.hs
+++ b/hledger-lib/Hledger/Data/MarketPrice.hs
@@ -12,18 +12,22 @@ are thousands separated by comma, significant decimal places and so on.
 
 -}
 
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings, LambdaCase #-}
 
 module Hledger.Data.MarketPrice
 where
 import qualified Data.Text as T
--- import Test.HUnit
+import Test.HUnit
 
 import Hledger.Data.Amount
-import Hledger.Data.Types
 import Hledger.Data.Dates
+import Hledger.Data.Types
+-- import Hledger.Read.JournalReader
 import Hledger.Utils
+import Hledger.Utils.Parse
 
+-- | Get the string representation of an market price, based on its
+-- commodity's display settings.
 showMarketPrice :: MarketPrice -> String
 showMarketPrice mp = unwords
     [ "P"
@@ -31,3 +35,12 @@ showMarketPrice mp = unwords
     , T.unpack (mpcommodity mp)
     , (showAmount . setAmountPrecision maxprecision) (mpamount mp)
     ]
+
+tests_Hledger_Data_MarketPrice = TestList $
+  [
+    -- this test needs Hledger.Read.JournalReader, which causes cyclic imports?
+    -- "showParsedMarketPrice" ~: do
+    --   let mp = parseWithState mempty marketpricedirectivep "P 2017/01/30 BTC $922.83"
+    --       mpString = (fmap . fmap) showMarketPrice mp
+    --   mpString `is` (Just (Right "P 2017/01/30 BTC $922.83"))
+  ]

--- a/hledger-lib/Hledger/Data/MarketPrice.hs
+++ b/hledger-lib/Hledger/Data/MarketPrice.hs
@@ -16,18 +16,18 @@ are thousands separated by comma, significant decimal places and so on.
 
 module Hledger.Data.MarketPrice
 where
-import Data.Time.Format
 import qualified Data.Text as T
 -- import Test.HUnit
 
 import Hledger.Data.Amount
 import Hledger.Data.Types
+import Hledger.Data.Dates
 import Hledger.Utils
 
 showMarketPrice :: MarketPrice -> String
 showMarketPrice mp = unwords
     [ "P"
-    , formatTime defaultTimeLocale "%0Y/%m/%d" (mpdate mp)
+    , showDate (mpdate mp)
     , T.unpack (mpcommodity mp)
     , (showAmount . setAmountPrecision maxprecision) (mpamount mp)
     ]

--- a/hledger-lib/Hledger/Data/MarketPrice.hs
+++ b/hledger-lib/Hledger/Data/MarketPrice.hs
@@ -6,10 +6,6 @@ published by a stock exchange or the foreign exchange market.  Some
 commands (balance, currently) can use this information to show the market
 value of things at a given date.
 
-thing we are tracking, and some display preferences that tell how to
-display 'Amount's of the commodity - is the symbol on the left or right,
-are thousands separated by comma, significant decimal places and so on.
-
 -}
 
 {-# LANGUAGE OverloadedStrings, LambdaCase #-}
@@ -22,9 +18,6 @@ import Test.HUnit
 import Hledger.Data.Amount
 import Hledger.Data.Dates
 import Hledger.Data.Types
--- import Hledger.Read.JournalReader
-import Hledger.Utils
-import Hledger.Utils.Parse
 
 -- | Get the string representation of an market price, based on its
 -- commodity's display settings.
@@ -36,11 +29,4 @@ showMarketPrice mp = unwords
     , (showAmount . setAmountPrecision maxprecision) (mpamount mp)
     ]
 
-tests_Hledger_Data_MarketPrice = TestList $
-  [
-    -- this test needs Hledger.Read.JournalReader, which causes cyclic imports?
-    -- "showParsedMarketPrice" ~: do
-    --   let mp = parseWithState mempty marketpricedirectivep "P 2017/01/30 BTC $922.83"
-    --       mpString = (fmap . fmap) showMarketPrice mp
-    --   mpString `is` (Just (Right "P 2017/01/30 BTC $922.83"))
-  ]
+tests_Hledger_Data_MarketPrice = TestList []

--- a/hledger-lib/Hledger/Data/MarketPrice.hs
+++ b/hledger-lib/Hledger/Data/MarketPrice.hs
@@ -1,0 +1,33 @@
+{-|
+
+A 'MarketPrice' represents a historical exchange rate between two
+commodities. (Ledger calls them historical prices.) For example, prices
+published by a stock exchange or the foreign exchange market.  Some
+commands (balance, currently) can use this information to show the market
+value of things at a given date.
+
+thing we are tracking, and some display preferences that tell how to
+display 'Amount's of the commodity - is the symbol on the left or right,
+are thousands separated by comma, significant decimal places and so on.
+
+-}
+
+{-# LANGUAGE LambdaCase #-}
+
+module Hledger.Data.MarketPrice
+where
+import Data.Time.Format
+import qualified Data.Text as T
+-- import Test.HUnit
+
+import Hledger.Data.Amount
+import Hledger.Data.Types
+import Hledger.Utils
+
+showMarketPrice :: MarketPrice -> String
+showMarketPrice mp = unwords
+    [ "P"
+    , formatTime defaultTimeLocale "%0Y/%m/%d" (mpdate mp)
+    , T.unpack (mpcommodity mp)
+    , (showAmount . setAmountPrecision maxprecision) (mpamount mp)
+    ]

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -624,6 +624,12 @@ test_postingp = do
 
 tests_Hledger_Read_JournalReader = TestList $ concat [
     -- test_numberp
+    [
+    "showParsedMarketPrice" ~: do
+      let mp = parseWithState mempty marketpricedirectivep "P 2017/01/30 BTC $922.83\n"
+          mpString = (fmap . fmap) showMarketPrice mp
+      mpString `is` (Just (Right "P 2017/01/30 BTC $922.83"))
+    ]
  ]
 
 {- old hunit tests

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -110,6 +110,7 @@ library
       Hledger.Data.Dates
       Hledger.Data.Journal
       Hledger.Data.Ledger
+      Hledger.Data.MarketPrice
       Hledger.Data.Period
       Hledger.Data.StringFormat
       Hledger.Data.Posting

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -91,6 +91,7 @@ library:
   - Hledger.Data.Dates
   - Hledger.Data.Journal
   - Hledger.Data.Ledger
+  - Hledger.Data.MarketPrice
   - Hledger.Data.Period
   - Hledger.Data.StringFormat
   - Hledger.Data.Posting


### PR DESCRIPTION
Not too big a deal!  Not sure if it's worth an entire module.  Tried writing tests (parse and re-show), but couldn't get it to work cleanly without cyclic imports.

By the way, I noticed that hledger parses market price directives with "full" datetimes, but throws away the times.   Would it be worthwhile to modify the `MarketPrice` type to also include a full datetime, potentially, as well, if it was given one?