### PR TITLE
Refactoring balancesheet/incomestatement/cashflow, bringing to feature parity with 'balance'

### DIFF
--- a/doc/lib.m4
+++ b/doc/lib.m4
@@ -148,6 +148,10 @@ m4_define({{_reportingoptions_}}, {{
 : convert amounts to their cost at transaction time
 (using the [transaction price](journal.html#transaction-prices), if any)
 
+`-V --value`
+: convert amounts to their market value on the report end date
+(using the most recent applicable [market price](journal.html#market-prices), if any)
+
 `--pivot TAGNAME`
 : organize reports by some tag's value instead of by account
 

--- a/hledger-api/doc/hledger-api.1.info
+++ b/hledger-api/doc/hledger-api.1.info
@@ -1,32 +1,30 @@
-This is hledger-api/doc/hledger-api.1.info, produced by makeinfo
-version 4.8 from stdin.
+This is hledger-api.1.info, produced by makeinfo version 5.2 from stdin.
 
 
-File: hledger-api.1.info,  Node: Top,  Up: (dir)
+File: hledger-api.1.info,  Node: Top,  Next: OPTIONS,  Up: (dir)
 
 hledger-api(1) hledger-api dev
 ******************************
 
 hledger-api is a simple web API server, intended to support client-side
-web apps operating on hledger data. It comes with a series of simple
+web apps operating on hledger data.  It comes with a series of simple
 client-side app examples, which drive its evolution.
 
    Like hledger, it reads data from one or more files in hledger
-journal, timeclock, timedot, or CSV format specified with `-f', or
-`$LEDGER_FILE', or `$HOME/.hledger.journal' (on windows, perhaps
-`C:/Users/USER/.hledger.journal'). For more about this see hledger(1),
+journal, timeclock, timedot, or CSV format specified with '-f', or
+'$LEDGER_FILE', or '$HOME/.hledger.journal' (on windows, perhaps
+'C:/Users/USER/.hledger.journal').  For more about this see hledger(1),
 hledger_journal(5) etc.
 
    The server listens on IP address 127.0.0.1, accessible only to local
-requests, by default. You can change this with `--host', eg `--host
-0.0.0.0' to listen on all addresses. Note there is no other access
+requests, by default.  You can change this with '--host', eg '--host
+0.0.0.0' to listen on all addresses.  Note there is no other access
 control, so you will need to hide hledger-api behind an authenticating
-proxy if you want to restrict access. You can change the TCP port
-(default: 8001) with `-p PORT'.
+proxy if you want to restrict access.  You can change the TCP port
+(default: 8001) with '-p PORT'.
 
-   If invoked as `hledger-api --swagger', instead of starting a server
+   If invoked as 'hledger-api --swagger', instead of starting a server
 the API docs will be printed in Swagger 2.0 format.
-
 * Menu:
 
 * OPTIONS::
@@ -37,56 +35,57 @@ File: hledger-api.1.info,  Node: OPTIONS,  Prev: Top,  Up: Top
 1 OPTIONS
 *********
 
-Note: if invoking hledger-api as a hledger subcommand, write `--'
-before options as shown above.
+Note: if invoking hledger-api as a hledger subcommand, write '--' before
+options as shown above.
 
-`-d --static-dir=DIR'
-     serve files from a different directory (default: `.')
+'-d --static-dir=DIR'
 
-`-p --port=PORT'
+     serve files from a different directory (default: '.')
+'-p --port=PORT'
+
      use a different TCP port (default: 8001)
+'--swagger'
 
-`--swagger'
      print API docs in Swagger 2.0 format, and exit
 
    hledger general options:
 
-`-h'
-     show general usage (or after COMMAND, the command's usage)
+'-h'
 
-`--help'
+     show general usage (or after COMMAND, the command's usage)
+'--help'
+
      show the current program's manual as plain text (or after an add-on
      COMMAND, the add-on's manual)
+'--man'
 
-`--man'
      show the current program's manual with man
+'--info'
 
-`--info'
      show the current program's manual with info
+'--version'
 
-`--version'
      show version
+'--debug[=N]'
 
-`--debug[=N]'
      show debug output (levels 1-9, default: 1)
+'-f FILE --file=FILE'
 
-`-f FILE --file=FILE'
-     use a different input file. For stdin, use -
+     use a different input file.  For stdin, use -
+'--rules-file=RULESFILE'
 
-`--rules-file=RULESFILE'
      Conversion rules file to use when reading CSV (default: FILE.rules)
+'--alias=OLD=NEW'
 
-`--alias=OLD=NEW'
      display accounts named OLD as NEW
+'-I --ignore-assertions'
 
-`-I --ignore-assertions'
      ignore any failing balance assertions in the journal
-
 
 
 Tag Table:
-Node: Top90
-Node: OPTIONS1216
-Ref: #options1303
+Node: Top74
+Node: OPTIONS1220
+Ref: #options1307
 
 End Tag Table

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -19,6 +19,7 @@ module Hledger.Reports.BalanceReport (
   balanceReport,
   balanceReportValue,
   mixedAmountValue,
+  amountValue,
   flatShowsExclusiveBalance,
 
   -- * Tests

--- a/hledger-lib/doc/hledger_csv.5.info
+++ b/hledger-lib/doc/hledger_csv.5.info
@@ -1,23 +1,21 @@
-This is hledger-lib/doc/hledger_csv.5.info, produced by makeinfo
-version 4.8 from stdin.
+This is hledger_csv.5.info, produced by makeinfo version 5.2 from stdin.
 
 
-File: hledger_csv.5.info,  Node: Top,  Up: (dir)
+File: hledger_csv.5.info,  Node: Top,  Next: CSV RULES,  Up: (dir)
 
 hledger_csv(5) hledger dev
 **************************
 
 hledger can read CSV files, converting each CSV record into a journal
 entry (transaction), if you provide some conversion hints in a "rules
-file". This file should be named like the CSV file with an additional
-`.rules' suffix (eg: `mybank.csv.rules'); or, you can specify the file
-with `--rules-file PATH'. hledger will create it if necessary, with
-some default rules which you'll need to adjust. At minimum, the rules
-file must specify the `date' and `amount' fields. For an example, see
+file".  This file should be named like the CSV file with an additional
+'.rules' suffix (eg: 'mybank.csv.rules'); or, you can specify the file
+with '--rules-file PATH'.  hledger will create it if necessary, with
+some default rules which you'll need to adjust.  At minimum, the rules
+file must specify the 'date' and 'amount' fields.  For an example, see
 How to read CSV files.
 
    To learn about _exporting_ CSV, see CSV output.
-
 * Menu:
 
 * CSV RULES::
@@ -30,8 +28,7 @@ File: hledger_csv.5.info,  Node: CSV RULES,  Next: TIPS,  Prev: Top,  Up: Top
 ***********
 
 The following six kinds of rule can appear in the rules file, in any
-order. Blank lines and lines beginning with `#' or `;' are ignored.
-
+order.  Blank lines and lines beginning with '#' or ';' are ignored.
 * Menu:
 
 * skip::
@@ -47,11 +44,10 @@ File: hledger_csv.5.info,  Node: skip,  Next: date-format,  Up: CSV RULES
 1.1 skip
 ========
 
-`skip'_`N'_
+'skip'_'N'_
 
-   Skip this number of CSV records at the beginning. You'll need this
-whenever your CSV data contains header lines. Eg:
-
+   Skip this number of CSV records at the beginning.  You'll need this
+whenever your CSV data contains header lines.  Eg:
 
 # ignore the first CSV line
 skip 1
@@ -62,25 +58,21 @@ File: hledger_csv.5.info,  Node: date-format,  Next: field list,  Prev: skip,  U
 1.2 date-format
 ===============
 
-`date-format'_`DATEFMT'_
+'date-format'_'DATEFMT'_
 
-   When your CSV date fields are not formatted like `YYYY/MM/DD' (or
-`YYYY-MM-DD' or `YYYY.MM.DD'), you'll need to specify the format.
+   When your CSV date fields are not formatted like 'YYYY/MM/DD' (or
+'YYYY-MM-DD' or 'YYYY.MM.DD'), you'll need to specify the format.
 DATEFMT is a strptime-like date parsing pattern, which must parse the
-date field values completely. Examples:
-
+date field values completely.  Examples:
 
 # for dates like "6/11/2013":
 date-format %-d/%-m/%Y
 
-
 # for dates like "11/06/2013":
 date-format %m/%d/%Y
 
-
 # for dates like "2013-Nov-06":
 date-format %Y-%h-%d
-
 
 # for dates like "11/6/2013 11:32 PM":
 date-format %-m/%-d/%Y %l:%M %p
@@ -91,15 +83,13 @@ File: hledger_csv.5.info,  Node: field list,  Next: field assignment,  Prev: dat
 1.3 field list
 ==============
 
-`fields'_`FIELDNAME1'_, _`FIELDNAME2'_...
+'fields'_'FIELDNAME1'_, _'FIELDNAME2'_...
 
    This (a) names the CSV fields, in order (names may not contain
 whitespace; uninteresting names may be left blank), and (b) assigns them
 to journal entry fields if you use any of these standard field names:
-`date', `date2', `status', `code', `description', `comment',
-`account1', `account2', `amount', `amount-in', `amount-out',
-`currency'. Eg:
-
+'date', 'date2', 'status', 'code', 'description', 'comment', 'account1',
+'account2', 'amount', 'amount-in', 'amount-out', 'currency'.  Eg:
 
 # use the 1st, 2nd and 4th CSV fields as the entry's date, description and amount,
 # and give the 7th and 8th fields meaningful names for later reference:
@@ -115,16 +105,14 @@ File: hledger_csv.5.info,  Node: field assignment,  Next: conditional block,  Pr
 1.4 field assignment
 ====================
 
-_`ENTRYFIELDNAME'_ _`FIELDVALUE'_
+_'ENTRYFIELDNAME'_ _'FIELDVALUE'_
 
    This sets a journal entry field (one of the standard names above) to
 the given text value, which can include CSV field values interpolated by
-name (`%CSVFIELDNAME') or 1-based position (`%N'). Eg:
-
+name ('%CSVFIELDNAME') or 1-based position ('%N').  Eg:
 
 # set the amount to the 4th CSV field with "USD " prepended
 amount USD %4
-
 
 # combine three fields to make a comment (containing two tags)
 comment note: %somefield - %anotherfield, date: %1
@@ -138,27 +126,25 @@ File: hledger_csv.5.info,  Node: conditional block,  Next: include,  Prev: field
 1.5 conditional block
 =====================
 
-`if' _`PATTERN'_
-_`FIELDASSIGNMENTS'_...
+'if' _'PATTERN'_
+    _'FIELDASSIGNMENTS'_...
 
-   `if'
-_`PATTERN'_
-_`PATTERN'_...
-_`FIELDASSIGNMENTS'_...
+   'if'
+_'PATTERN'_
+_'PATTERN'_...
+    _'FIELDASSIGNMENTS'_...
 
    This applies one or more field assignments, only to those CSV records
-matched by one of the PATTERNs. The patterns are case-insensitive
+matched by one of the PATTERNs.  The patterns are case-insensitive
 regular expressions which match anywhere within the whole CSV record
-(it's not yet possible to match within a specific field). When there are
-multiple patterns they can be written on separate lines, unindented. The
-field assignments are on separate lines indented by at least one space.
-Examples:
-
+(it's not yet possible to match within a specific field).  When there
+are multiple patterns they can be written on separate lines, unindented.
+The field assignments are on separate lines indented by at least one
+space.  Examples:
 
 # if the CSV record contains "groceries", set account2 to "expenses:groceries"
 if groceries
  account2 expenses:groceries
-
 
 # if the CSV record contains any of these patterns, set account2 and comment as shown
 if
@@ -174,12 +160,11 @@ File: hledger_csv.5.info,  Node: include,  Prev: conditional block,  Up: CSV RUL
 1.6 include
 ===========
 
-`include'_`RULESFILE'_
+'include'_'RULESFILE'_
 
-   Include another rules file at this point. `RULESFILE' is either an
+   Include another rules file at this point.  'RULESFILE' is either an
 absolute file path or a path relative to the current file's directory.
 Eg:
-
 
 # rules reused with several CSV files
 include common.rules
@@ -190,42 +175,41 @@ File: hledger_csv.5.info,  Node: TIPS,  Prev: CSV RULES,  Up: Top
 2 TIPS
 ******
 
-Each generated journal entry will have two postings, to `account1' and
-`account2' respectively. Currently it's not possible to generate
+Each generated journal entry will have two postings, to 'account1' and
+'account2' respectively.  Currently it's not possible to generate
 entries with more than two postings.
 
    If the CSV has debit/credit amounts in separate fields, assign to the
-`amount-in' and `amount-out' pseudo fields instead of `amount'.
+'amount-in' and 'amount-out' pseudo fields instead of 'amount'.
 
    If the CSV has the currency in a separate field, assign that to the
-`currency' pseudo field which will be automatically prepended to the
-amount. (Or you can do the same thing with a field assignment.)
+'currency' pseudo field which will be automatically prepended to the
+amount.  (Or you can do the same thing with a field assignment.)
 
    If an amount value is parenthesised, it will be de-parenthesised and
 sign-flipped automatically.
 
-   The generated journal entries will be sorted by date. The original
+   The generated journal entries will be sorted by date.  The original
 order of same-day entries will be preserved, usually.
-
 
 
 Tag Table:
-Node: Top90
-Node: CSV RULES795
-Ref: #csv-rules901
-Node: skip1144
-Ref: #skip1240
-Node: date-format1411
-Ref: #date-format1540
-Node: field list2049
-Ref: #field-list2188
-Node: field assignment2883
-Ref: #field-assignment3040
-Node: conditional block3545
-Ref: #conditional-block3701
-Node: include4588
-Ref: #include4699
-Node: TIPS4930
-Ref: #tips5014
+Node: Top74
+Node: CSV RULES800
+Ref: #csv-rules906
+Node: skip1149
+Ref: #skip1245
+Node: date-format1417
+Ref: #date-format1546
+Node: field list2052
+Ref: #field-list2191
+Node: field assignment2886
+Ref: #field-assignment3043
+Node: conditional block3547
+Ref: #conditional-block3703
+Node: include4599
+Ref: #include4710
+Node: TIPS4941
+Ref: #tips5025
 
 End Tag Table

--- a/hledger-lib/doc/hledger_csv.5.txt
+++ b/hledger-lib/doc/hledger_csv.5.txt
@@ -124,27 +124,27 @@ CSV RULES
               include common.rules
 
 TIPS
-       Each generated journal entry will have two postings,  to  account1  and
+       Each  generated  journal  entry will have two postings, to account1 and
        account2 respectively.  Currently it's not possible to generate entries
        with more than two postings.
 
-       If the CSV has debit/credit amounts in separate fields, assign  to  the
+       If  the  CSV has debit/credit amounts in separate fields, assign to the
        amount-in and amount-out pseudo fields instead of amount.
 
-       If  the  CSV  has  the currency in a separate field, assign that to the
-       currency pseudo field which will  be  automatically  prepended  to  the
+       If the CSV has the currency in a separate field,  assign  that  to  the
+       currency  pseudo  field  which  will  be automatically prepended to the
        amount.  (Or you can do the same thing with a field assignment.)
 
-       If  an  amount  value is parenthesised, it will be de-parenthesised and
+       If an amount value is parenthesised, it will  be  de-parenthesised  and
        sign-flipped automatically.
 
-       The generated journal entries will be sorted  by  date.   The  original
+       The  generated  journal  entries  will be sorted by date.  The original
        order of same-day entries will be preserved, usually.
 
 
 
 REPORTING BUGS
-       Report  bugs at http://bugs.hledger.org (or on the #hledger IRC channel
+       Report bugs at http://bugs.hledger.org (or on the #hledger IRC  channel
        or hledger mail list)
 
 
@@ -158,7 +158,7 @@ COPYRIGHT
 
 
 SEE ALSO
-       hledger(1),     hledger-ui(1),     hledger-web(1),      hledger-api(1),
+       hledger(1),      hledger-ui(1),     hledger-web(1),     hledger-api(1),
        hledger_csv(5), hledger_journal(5), hledger_timeclock(5), hledger_time-
        dot(5), ledger(1)
 

--- a/hledger-lib/doc/hledger_journal.5.info
+++ b/hledger-lib/doc/hledger_journal.5.info
@@ -1,32 +1,31 @@
-This is hledger-lib/doc/hledger_journal.5.info, produced by makeinfo
-version 4.8 from stdin.
+This is hledger_journal.5.info, produced by makeinfo version 5.2 from
+stdin.
 
 
-File: hledger_journal.5.info,  Node: Top,  Up: (dir)
+File: hledger_journal.5.info,  Node: Top,  Next: FILE FORMAT,  Up: (dir)
 
 hledger_journal(5) hledger dev
 ******************************
 
 hledger's usual data source is a plain text file containing journal
-entries in hledger journal format. This file represents a standard
-accounting general journal. I use file names ending in `.journal', but
-that's not required. The journal file contains a number of transaction
+entries in hledger journal format.  This file represents a standard
+accounting general journal.  I use file names ending in '.journal', but
+that's not required.  The journal file contains a number of transaction
 entries, each describing a transfer of money (or any commodity) between
 two or more named accounts, in a simple format readable by both hledger
 and humans.
 
    hledger's journal format is a compatible subset, mostly, of ledger's
 journal format, so hledger can work with compatible ledger journal files
-as well. It's safe, and encouraged, to run both hledger and ledger on
+as well.  It's safe, and encouraged, to run both hledger and ledger on
 the same journal file, eg to validate the results you're getting.
 
    You can use hledger without learning any more about this file; just
-use the add or web commands to create and update it. Many users, though,
-also edit the journal file directly with a text editor, perhaps assisted
-by the helper modes for emacs or vim.
+use the add or web commands to create and update it.  Many users,
+though, also edit the journal file directly with a text editor, perhaps
+assisted by the helper modes for emacs or vim.
 
    Here's an example:
-
 
 ; A sample journal file. This is a comment.
 
@@ -82,31 +81,26 @@ File: hledger_journal.5.info,  Node: Transactions,  Next: Dates,  Up: FILE FORMA
 1.1 Transactions
 ================
 
-Transactions are represented by journal entries. Each begins with a
+Transactions are represented by journal entries.  Each begins with a
 simple date in column 0, followed by three optional fields with spaces
 between them:
 
-   * a status flag, which can be empty or `!' or `*' (meaning
+   * a status flag, which can be empty or '!' or '*' (meaning
      "uncleared", "pending" and "cleared", or whatever you want)
-
    * a transaction code (eg a check number),
-
    * and/or a description
 
-   then some number of postings, of some amount to some account. Each
+   then some number of postings, of some amount to some account.  Each
 posting is on its own line, consisting of:
 
    * indentation of one or more spaces (or tabs)
-
-   * optionally, a `!' or `*' status flag followed by a space
-
+   * optionally, a '!' or '*' status flag followed by a space
    * an account name, optionally containing single spaces
-
    * optionally, two or more spaces or tabs followed by an amount
 
    Usually there are two or more postings, though one or none is also
-possible. The posting amounts within a transaction must always balance,
-ie add up to 0. Optionally one amount can be left blank, in which case
+possible.  The posting amounts within a transaction must always balance,
+ie add up to 0.  Optionally one amount can be left blank, in which case
 it will be inferred.
 
 
@@ -128,11 +122,11 @@ File: hledger_journal.5.info,  Node: Simple dates,  Next: Secondary dates,  Up: 
 ------------------
 
 Within a journal file, transaction dates use Y/M/D (or Y-M-D or Y.M.D)
-Leading zeros are optional. The year may be omitted, in which case it
+Leading zeros are optional.  The year may be omitted, in which case it
 will be inferred from the context - the current transaction, the default
 year set with a default year directive, or the current date when the
-command is run. Some examples: `2010/01/31', `1/31', `2010-01-31',
-`2010.1.31'.
+command is run.  Some examples: '2010/01/31', '1/31', '2010-01-31',
+'2010.1.31'.
 
 
 File: hledger_journal.5.info,  Node: Secondary dates,  Next: Posting dates,  Prev: Simple dates,  Up: Dates
@@ -141,40 +135,37 @@ File: hledger_journal.5.info,  Node: Secondary dates,  Next: Posting dates,  Pre
 ---------------------
 
 Real-life transactions sometimes involve more than one date - eg the
-date you write a cheque, and the date it clears in your bank. When you
+date you write a cheque, and the date it clears in your bank.  When you
 want to model this, eg for more accurate balances, you can specify
-individual posting dates, which I recommend. Or, you can use the
+individual posting dates, which I recommend.  Or, you can use the
 secondary dates (aka auxiliary/effective dates) feature, supported for
 compatibility with Ledger.
 
    A secondary date can be written after the primary date, separated by
-an equals sign. The primary date, on the left, is used by default; the
-secondary date, on the right, is used when the `--date2' flag is
-specified (`--aux-date' or `--effective' also work).
+an equals sign.  The primary date, on the left, is used by default; the
+secondary date, on the right, is used when the '--date2' flag is
+specified ('--aux-date' or '--effective' also work).
 
    The meaning of secondary dates is up to you, but it's best to follow
-a consistent rule. Eg write the bank's clearing date as primary, and
+a consistent rule.  Eg write the bank's clearing date as primary, and
 when needed, the date the transaction was initiated as secondary.
 
-   Here's an example. Note that a secondary date will use the year of
+   Here's an example.  Note that a secondary date will use the year of
 the primary date if unspecified.
-
 
 2010/2/23=2/19 movie ticket
   expenses:cinema                   $10
   assets:checking
 
-
 $ hledger register checking
 2010/02/23 movie ticket         assets:checking                $-10         $-10
-
 
 $ hledger register checking --date2
 2010/02/19 movie ticket         assets:checking                $-10         $-10
 
    Secondary dates require some effort; you must use them consistently
 in your journal entries and remember whether to use or not use the
-`--date2' flag for your reports. They are included in hledger for
+'--date2' flag for your reports.  They are included in hledger for
 Ledger compatibility, but posting dates are a more powerful and less
 confusing alternative.
 
@@ -186,34 +177,31 @@ File: hledger_journal.5.info,  Node: Posting dates,  Prev: Secondary dates,  Up:
 
 You can give individual postings a different date from their parent
 transaction, by adding a posting comment containing a tag (see below)
-like `date:DATE'. This is probably the best way to control posting
-dates precisely. Eg in this example the expense should appear in May
+like 'date:DATE'.  This is probably the best way to control posting
+dates precisely.  Eg in this example the expense should appear in May
 reports, and the deduction from checking should be reported on 6/1 for
 easy bank reconciliation:
-
 
 2015/5/30
     expenses:food     $10   ; food purchased on saturday 5/30
     assets:checking         ; bank cleared it on monday, date:6/1
 
-
 $ hledger -f t.j register food
 2015/05/30                      expenses:food                  $10           $10
-
 
 $ hledger -f t.j register checking
 2015/06/01                      assets:checking               $-10          $-10
 
    DATE should be a simple date; if the year is not specified it will
-use the year of the transaction's date. You can set the secondary date
-similarly, with `date2:DATE2'. The `date:' or `date2:' tags must have a
-valid simple date value if they are present, eg a `date:' tag with no
+use the year of the transaction's date.  You can set the secondary date
+similarly, with 'date2:DATE2'.  The 'date:' or 'date2:' tags must have a
+valid simple date value if they are present, eg a 'date:' tag with no
 value is not allowed.
 
    Ledger's earlier, more compact bracketed date syntax is also
-supported: `[DATE]', `[DATE=DATE2]' or `[=DATE2]'. hledger will attempt
-to parse any square-bracketed sequence of the `0123456789/-.='
-characters in this way. With this syntax, DATE infers its year from the
+supported: '[DATE]', '[DATE=DATE2]' or '[=DATE2]'.  hledger will attempt
+to parse any square-bracketed sequence of the '0123456789/-.='
+characters in this way.  With this syntax, DATE infers its year from the
 transaction and DATE2 infers its year from DATE.
 
 
@@ -223,12 +211,13 @@ File: hledger_journal.5.info,  Node: Account names,  Next: Amounts,  Prev: Dates
 =================
 
 Account names typically have several parts separated by a full colon,
-from which hledger derives a hierarchical chart of accounts. They can be
-anything you like, but in finance there are traditionally five top-level
-accounts: `assets', `liabilities', `income', `expenses', and `equity'.
+from which hledger derives a hierarchical chart of accounts.  They can
+be anything you like, but in finance there are traditionally five
+top-level accounts: 'assets', 'liabilities', 'income', 'expenses', and
+'equity'.
 
-   Account names may contain single spaces, eg: `assets:accounts
-receivable'. Because of this, they must always be followed by *two or
+   Account names may contain single spaces, eg: 'assets:accounts
+receivable'.  Because of this, they must always be followed by *two or
 more spaces* (or newline).
 
    Account names can be aliased.
@@ -239,58 +228,53 @@ File: hledger_journal.5.info,  Node: Amounts,  Next: Virtual Postings,  Prev: Ac
 1.4 Amounts
 ===========
 
-After the account name, there is usually an amount. Important: between
+After the account name, there is usually an amount.  Important: between
 account name and amount, there must be *two or more spaces*.
 
    Amounts consist of a number and (usually) a currency symbol or
-commodity name. Some examples:
+commodity name.  Some examples:
 
-   `2.00001'
-`$1'
-`4000 AAPL'
-`3 "green apples"'
-`-$1,000,000.00'
-`INR 9,99,99,999.00'
-`EUR -2.000.000,00'
+   '2.00001'
+'$1'
+'4000 AAPL'
+'3 "green apples"'
+'-$1,000,000.00'
+'INR 9,99,99,999.00'
+'EUR -2.000.000,00'
 
    As you can see, the amount format is somewhat flexible:
 
    * amounts are a number (the "quantity") and optionally a currency
      symbol/commodity name (the "commodity").
-
    * the commodity is a symbol, word, or phrase, on the left or right,
-     with or without a separating space. If the commodity contains
+     with or without a separating space.  If the commodity contains
      numbers, spaces or non-word punctuation it must be enclosed in
      double quotes.
-
    * negative amounts with a commodity on the left can have the minus
      sign before or after it
-
    * digit groups (thousands, or any other grouping) can be separated by
      commas (in which case period is used for decimal point) or periods
      (in which case comma is used for decimal point)
 
    You can use any of these variations when recording data, but when
 hledger displays amounts, it will choose a consistent format for each
-commodity. (Except for price amounts, which are always formatted as
-written). The display format is chosen as follows:
+commodity.  (Except for price amounts, which are always formatted as
+written).  The display format is chosen as follows:
 
    * if there is a commodity directive specifying the format, that is
      used
-
    * otherwise the format is inferred from the first posting amount in
-     that commodity in the journal, and the precision (number of
-     decimal places) will be the maximum from all posting amounts in
-     that commmodity
-
-   * or if there are no such amounts in the journal, a default format
-     is used (like `$1000.00').
+     that commodity in the journal, and the precision (number of decimal
+     places) will be the maximum from all posting amounts in that
+     commmodity
+   * or if there are no such amounts in the journal, a default format is
+     used (like '$1000.00').
 
    Price amounts and amounts in D directives usually don't affect amount
-format inference, but in some situations they can do so indirectly. (Eg
+format inference, but in some situations they can do so indirectly.  (Eg
 when D's default commodity is applied to a commodity-less amount, or
 when an amountless posting is balanced using a price's commodity, or
-when -V is used.) If you find this causing problems, set the desired
+when -V is used.)  If you find this causing problems, set the desired
 format with a commodity directive.
 
 
@@ -303,23 +287,20 @@ When you parenthesise the account name in a posting, we call that a
 _virtual posting_, which means:
 
    * it is ignored when checking that the transaction is balanced
-
-   * it is excluded from reports when the `--real/-R' flag is used, or
-     the `real:1' query.
+   * it is excluded from reports when the '--real/-R' flag is used, or
+     the 'real:1' query.
 
    You could use this, eg, to set an account's opening balance without
-needing to use the `equity:opening balances' account:
-
+needing to use the 'equity:opening balances' account:
 
 1/1 special unbalanced posting to set initial balance
   (assets:checking)   $1000
 
    When the account name is bracketed, we call it a _balanced virtual
-posting_. This is like an ordinary virtual posting except the balanced
+posting_.  This is like an ordinary virtual posting except the balanced
 virtual postings in a transaction must balance to 0, like the real
-postings (but separately from them). Balanced virtual postings are also
-excluded by `--real/-R' or `real:1'.
-
+postings (but separately from them).  Balanced virtual postings are also
+excluded by '--real/-R' or 'real:1'.
 
 1/1 buy food with cash, and update some budget-tracking subaccounts elsewhere
   expenses:food                   $10
@@ -327,7 +308,7 @@ excluded by `--real/-R' or `real:1'.
   [assets:checking:available]     $10
   [assets:checking:budget:food]  $-10
 
-   Virtual postings have some legitimate uses, but those are few. You
+   Virtual postings have some legitimate uses, but those are few.  You
 can usually find an equivalent journal entry using real postings, which
 is more correct and provides better error checking.
 
@@ -337,11 +318,10 @@ File: hledger_journal.5.info,  Node: Balance Assertions,  Next: Balance Assignme
 1.6 Balance Assertions
 ======================
 
-hledger supports Ledger-style balance assertions in journal files. These
-look like `=EXPECTEDBALANCE' following a posting's amount. Eg in this
-example we assert the expected dollar balance in accounts a and b after
-each posting:
-
+hledger supports Ledger-style balance assertions in journal files.
+These look like '=EXPECTEDBALANCE' following a posting's amount.  Eg in
+this example we assert the expected dollar balance in accounts a and b
+after each posting:
 
 2013/1/1
   a   $1  =$1
@@ -352,12 +332,11 @@ each posting:
   b  $-1  =$-2
 
    After reading a journal file, hledger will check all balance
-assertions and report an error if any of them fail. Balance assertions
+assertions and report an error if any of them fail.  Balance assertions
 can protect you from, eg, inadvertently disrupting reconciled balances
-while cleaning up old entries. You can disable them temporarily with the
-`--ignore-assertions' flag, which can be useful for troubleshooting or
-for reading Ledger files.
-
+while cleaning up old entries.  You can disable them temporarily with
+the '--ignore-assertions' flag, which can be useful for troubleshooting
+or for reading Ledger files.
 * Menu:
 
 * Assertions and ordering::
@@ -374,17 +353,17 @@ File: hledger_journal.5.info,  Node: Assertions and ordering,  Next: Assertions 
 -----------------------------
 
 hledger sorts an account's postings and assertions first by date and
-then (for postings on the same day) by parse order. Note this is
+then (for postings on the same day) by parse order.  Note this is
 different from Ledger, which sorts assertions only by parse order.
 (Also, Ledger assertions do not see the accumulated effect of repeated
 postings to the same account within a transaction.)
 
    So, hledger balance assertions keep working if you reorder
-differently-dated transactions within the journal. But if you reorder
+differently-dated transactions within the journal.  But if you reorder
 same-dated transactions or postings, assertions might break and require
-updating. This order dependence does bring an advantage: precise control
-over the order of postings and assertions within a day, so you can
-assert intra-day balances.
+updating.  This order dependence does bring an advantage: precise
+control over the order of postings and assertions within a day, so you
+can assert intra-day balances.
 
 
 File: hledger_journal.5.info,  Node: Assertions and included files,  Next: Assertions and multiple -f options,  Prev: Assertions and ordering,  Up: Balance Assertions
@@ -392,8 +371,8 @@ File: hledger_journal.5.info,  Node: Assertions and included files,  Next: Asser
 1.6.2 Assertions and included files
 -----------------------------------
 
-With included files, things are a little more complicated. Including
-preserves the ordering of postings and assertions. If you have multiple
+With included files, things are a little more complicated.  Including
+preserves the ordering of postings and assertions.  If you have multiple
 postings to an account on the same day, split across different files,
 and you also want to assert the account's balance on the same day,
 you'll have to put the assertion in the right file.
@@ -405,7 +384,7 @@ File: hledger_journal.5.info,  Node: Assertions and multiple -f options,  Next: 
 ----------------------------------------
 
 Balance assertions don't work well across files specified with multiple
--f options. Use include or concatenate the files instead.
+-f options.  Use include or concatenate the files instead.
 
 
 File: hledger_journal.5.info,  Node: Assertions and commodities,  Next: Assertions and subaccounts,  Prev: Assertions and multiple -f options,  Up: Balance Assertions
@@ -415,14 +394,15 @@ File: hledger_journal.5.info,  Node: Assertions and commodities,  Next: Assertio
 
 The asserted balance must be a simple single-commodity amount, and in
 fact the assertion checks only this commodity's balance within the
-(possibly multi-commodity) account balance. We could call this a partial
-balance assertion. This is compatible with Ledger, and makes it possible
-to make assertions about accounts containing multiple commodities.
+(possibly multi-commodity) account balance.  We could call this a
+partial balance assertion.  This is compatible with Ledger, and makes it
+possible to make assertions about accounts containing multiple
+commodities.
 
    To assert each commodity's balance in such a multi-commodity account,
-you can add multiple postings (with amount 0 if necessary). But note
+you can add multiple postings (with amount 0 if necessary).  But note
 that no matter how many assertions you add, you can't be sure the
-account does not contain some unexpected commodity. (We'll add support
+account does not contain some unexpected commodity.  (We'll add support
 for this kind of total balance assertion if there's demand.)
 
 
@@ -432,8 +412,7 @@ File: hledger_journal.5.info,  Node: Assertions and subaccounts,  Next: Assertio
 --------------------------------
 
 Balance assertions do not count the balance from subaccounts; they check
-the posted account's exclusive balance. For example:
-
+the posted account's exclusive balance.  For example:
 
 1/1
   checking:fund   1 = 1  ; post to this subaccount, its balance is now 1
@@ -442,7 +421,6 @@ the posted account's exclusive balance. For example:
 
    The balance report's flat mode shows these exclusive balances more
 clearly:
-
 
 $ hledger bal checking --flat
                    1  checking
@@ -457,7 +435,8 @@ File: hledger_journal.5.info,  Node: Assertions and virtual postings,  Prev: Ass
 -------------------------------------
 
 Balance assertions are checked against all postings, both real and
-virtual. They are not affected by the `--real/-R' flag or `real:' query.
+virtual.  They are not affected by the '--real/-R' flag or 'real:'
+query.
 
 
 File: hledger_journal.5.info,  Node: Balance Assignments,  Next: Prices,  Prev: Balance Assertions,  Up: FILE FORMAT
@@ -465,12 +444,11 @@ File: hledger_journal.5.info,  Node: Balance Assignments,  Next: Prices,  Prev: 
 1.7 Balance Assignments
 =======================
 
-Ledger-style balance assignments are also supported. These are like
+Ledger-style balance assignments are also supported.  These are like
 balance assertions, but with no posting amount on the left side of the
 equals sign; instead it is calculated automatically so as to satisfy the
-assertion. This can be a convenience during data entry, eg when setting
+assertion.  This can be a convenience during data entry, eg when setting
 opening balances:
-
 
 ; starting a new journal, set asset account balances
 2016/1/1 opening balances
@@ -481,7 +459,6 @@ opening balances:
 
    or when adjusting a balance to reality:
 
-
 ; no cash left; update balance, record any untracked spending as a generic expense
 2016/1/15
   assets:cash    = $0
@@ -490,7 +467,7 @@ opening balances:
    The calculated amount depends on the account's balance in the
 commodity at that point (which depends on the previously-dated postings
 of the commodity to that account since the last balance assertion or
-assignment). Note that using balance assignments makes your journal a
+assignment).  Note that using balance assignments makes your journal a
 little less explicit; to know the exact amount posted, you have to run
 hledger or do the calculations yourself, instead of just reading it.
 
@@ -512,44 +489,39 @@ File: hledger_journal.5.info,  Node: Transaction prices,  Next: Market prices,  
 ------------------------
 
 Within a transaction posting, you can record an amount's price in
-another commodity. This can be used to document the cost (for a
+another commodity.  This can be used to document the cost (for a
 purchase), or selling price (for a sale), or the exchange rate that was
-used, for this transaction. These transaction prices are fixed, and do
+used, for this transaction.  These transaction prices are fixed, and do
 not change over time.
 
    Amounts with transaction prices can be displayed in the transaction
-price's commodity, by using the `--cost/-B' flag supported by most
+price's commodity, by using the '--cost/-B' flag supported by most
 hledger commands (mnemonic: "cost Basis").
 
    There are several ways to record a transaction price:
 
-  1. Write the unit price (aka exchange rate), as `@ UNITPRICE' after
+  1. Write the unit price (aka exchange rate), as '@ UNITPRICE' after
      the amount:
-
 
      2009/1/1
        assets:foreign currency   €100 @ $1.35  ; one hundred euros at $1.35 each
        assets:cash
 
-  2. Or write the total price, as `@@ TOTALPRICE' after the amount:
-
+  2. Or write the total price, as '@@ TOTALPRICE' after the amount:
 
      2009/1/1
        assets:foreign currency   €100 @@ $135  ; one hundred euros at $135 for the lot
        assets:cash
 
-  3. Or let hledger infer the price so as to balance the transaction. To
-     permit this, you must fully specify all posting amounts, and their
-     sum must have a non-zero amount in exactly two commodities:
-
+  3. Or let hledger infer the price so as to balance the transaction.
+     To permit this, you must fully specify all posting amounts, and
+     their sum must have a non-zero amount in exactly two commodities:
 
      2009/1/1
        assets:foreign currency   €100          ; one hundred euros
        assets:cash              $-135          ; exchanged for $135
 
-
    With any of the above examples we get:
-
 
 $ hledger print -B
 2009/01/01
@@ -566,26 +538,25 @@ File: hledger_journal.5.info,  Node: Market prices,  Prev: Transaction prices,  
 -------------------
 
 Market prices are not tied to a particular transaction; they represent
-historical exchange rates between two commodities. (Ledger calls them
-historical prices.) For example, the prices published by a stock
-exchange or the foreign exchange market. Some commands (balance,
+historical exchange rates between two commodities.  (Ledger calls them
+historical prices.)  For example, the prices published by a stock
+exchange or the foreign exchange market.  Some commands (balance,
 currently) can use this information to show the market value of things
 at a given date.
 
    To record market prices, use P directives in the main journal or in
-an included file. Their format is:
-
+an included file.  Their format is:
 
 P DATE COMMODITYBEINGPRICED UNITPRICE
 
-   DATE is a simple date as usual. COMMODITYBEINGPRICED is the symbol of
-the commodity being priced. UNITPRICE is an ordinary amount (symbol and
-quantity) in a second commodity, specifying the unit price or conversion
-rate for the first commodity in terms of the second, on the given date.
+   DATE is a simple date as usual.  COMMODITYBEINGPRICED is the symbol
+of the commodity being priced.  UNITPRICE is an ordinary amount (symbol
+and quantity) in a second commodity, specifying the unit price or
+conversion rate for the first commodity in terms of the second, on the
+given date.
 
    For example, the following directives say that one euro was worth
 1.35 US dollars during 2009, and $1.40 from 2010 onward:
-
 
 P 2009/1/1 € $1.35
 P 2010/1/1 € $1.40
@@ -596,21 +567,20 @@ File: hledger_journal.5.info,  Node: Comments,  Next: Tags,  Prev: Prices,  Up: 
 1.9 Comments
 ============
 
-Lines in the journal beginning with a semicolon (`;') or hash (`#') or
-asterisk (`*') are comments, and will be ignored.  (Asterisk comments
+Lines in the journal beginning with a semicolon (';') or hash ('#') or
+asterisk ('*') are comments, and will be ignored.  (Asterisk comments
 make it easy to treat your journal like an org-mode outline in emacs.)
 
-   Also, anything between `comment' and `end comment' directives is a
-(multi-line) comment. If there is no `end comment', the comment extends
+   Also, anything between 'comment' and 'end comment' directives is a
+(multi-line) comment.  If there is no 'end comment', the comment extends
 to the end of the file.
 
    You can attach comments to a transaction by writing them after the
 description and/or indented on the following lines (before the
-postings). Similarly, you can attach comments to an individual posting
+postings).  Similarly, you can attach comments to an individual posting
 by writing them after the amount and/or indented on the following lines.
 
    Some examples:
-
 
 # a journal comment
 
@@ -643,12 +613,10 @@ transactions, which you can then search or pivot on.
    A simple tag is a word (which may contain hyphens) followed by a full
 colon, written inside a transaction or posting comment line:
 
-
 2017/1/16 bought groceries    ; sometag:
 
    Tags can have a value, which is the text after the colon, up to the
 next comma or end of line, with leading/trailing whitespace removed:
-
 
     expenses:food    $10   ; a-posting-tag: the tag value
 
@@ -656,22 +624,18 @@ next comma or end of line, with leading/trailing whitespace removed:
 newlines.  Ending at commas means you can write multiple short tags on
 one line, comma separated:
 
-
     assets:checking       ; a comment containing tag1:, tag2: some value ...
 
    Here,
 
-   * "`a comment containing'" is just comment text, not a tag
-
-   * "`tag1'" is a tag with no value
-
-   * "`tag2'" is another tag, whose value is "`some value ...'"
+   * "'a comment containing'" is just comment text, not a tag
+   * "'tag1'" is a tag with no value
+   * "'tag2'" is another tag, whose value is "'some value ...'"
 
    Tags in a transaction comment affect the transaction and all of its
-postings, while tags in a posting comment affect only that posting. For
-example, the following transaction has three tags (`A', `TAG2',
-`third-tag') and the posting has four (those plus `posting-tag'):
-
+postings, while tags in a posting comment affect only that posting.  For
+example, the following transaction has three tags ('A', 'TAG2',
+'third-tag') and the posting has four (those plus 'posting-tag'):
 
 1/1 a transaction  ; A:, TAG2:
     ; third-tag: a third transaction tag, <- with a value
@@ -679,7 +643,6 @@ example, the following transaction has three tags (`A', `TAG2',
 
    Tags are like Ledger's metadata feature, except hledger's tag values
 are simple strings.
-
 * Menu:
 
 * Implicit tags::
@@ -692,18 +655,15 @@ File: hledger_journal.5.info,  Node: Implicit tags,  Up: Tags
 
 Some predefined "implicit" tags are also provided:
 
-   * `code' - the transaction's code field
+   * 'code' - the transaction's code field
+   * 'description' - the transaction's description
+   * 'payee' - the part of description before '|', or all of it
+   * 'note' - the part of description after '|', or all of it
 
-   * `description' - the transaction's description
-
-   * `payee' - the part of description before `|', or all of it
-
-   * `note' - the part of description after `|', or all of it
-
-   `payee' and `note' support descriptions written in a special `PAYEE
-| NOTE' format, accessing the parts before and after the pipe character
-respectively. For descriptions not containing a pipe character they are
-the same as `description'.
+   'payee' and 'note' support descriptions written in a special 'PAYEE |
+NOTE' format, accessing the parts before and after the pipe character
+respectively.  For descriptions not containing a pipe character they are
+the same as 'description'.
 
 
 File: hledger_journal.5.info,  Node: Directives,  Prev: Tags,  Up: FILE FORMAT
@@ -729,21 +689,17 @@ File: hledger_journal.5.info,  Node: Account aliases,  Next: account directive, 
 ----------------------
 
 You can define aliases which rewrite your account names (after reading
-the journal, before generating reports). hledger's account aliases can
+the journal, before generating reports).  hledger's account aliases can
 be useful for:
 
    * expanding shorthand account names to their full form, allowing
      easier data entry and a less verbose journal
-
    * adapting old journals to your current chart of accounts
-
    * experimenting with new account organisations, like a new hierarchy
      or combining two accounts into one
-
    * customising reports
 
    See also How to use account aliases.
-
 * Menu:
 
 * Basic aliases::
@@ -757,21 +713,19 @@ File: hledger_journal.5.info,  Node: Basic aliases,  Next: Regex aliases,  Up: A
 1.11.1.1 Basic aliases
 ......................
 
-To set an account alias, use the `alias' directive in your journal
-file. This affects all subsequent journal entries in the current file or
-its included files. The spaces around the = are optional:
-
+To set an account alias, use the 'alias' directive in your journal file.
+This affects all subsequent journal entries in the current file or its
+included files.  The spaces around the = are optional:
 
 alias OLD = NEW
 
-   Or, you can use the `--alias 'OLD=NEW'' option on the command line.
-This affects all entries. It's useful for trying out aliases
+   Or, you can use the '--alias 'OLD=NEW'' option on the command line.
+This affects all entries.  It's useful for trying out aliases
 interactively.
 
-   OLD and NEW are full account names. hledger will replace any
-occurrence of the old account name with the new one. Subaccounts are
+   OLD and NEW are full account names.  hledger will replace any
+occurrence of the old account name with the new one.  Subaccounts are
 also affected.  Eg:
-
 
 alias checking = assets:bank:wells fargo:checking
 # rewrites "checking" to "assets:bank:wells fargo:checking", or "checking:a" to "assets:bank:wells fargo:checking:a"
@@ -783,21 +737,19 @@ File: hledger_journal.5.info,  Node: Regex aliases,  Next: Multiple aliases,  Pr
 ......................
 
 There is also a more powerful variant that uses a regular expression,
-indicated by the forward slashes. (This was the default behaviour in
+indicated by the forward slashes.  (This was the default behaviour in
 hledger 0.24-0.25):
-
 
 alias /REGEX/ = REPLACEMENT
 
-   or `--alias '/REGEX/=REPLACEMENT''.
+   or '--alias '/REGEX/=REPLACEMENT''.
 
-   REGEX is a case-insensitive regular expression. Anywhere it matches
+   REGEX is a case-insensitive regular expression.  Anywhere it matches
 inside an account name, the matched part will be replaced by
 REPLACEMENT. If REGEX contains parenthesised match groups, these can be
 referenced by the usual numeric backreferences in REPLACEMENT. Note,
 currently regular expression aliases may cause noticeable slow-downs.
-(And if you use Ledger on your hledger file, they will be ignored.) Eg:
-
+(And if you use Ledger on your hledger file, they will be ignored.)  Eg:
 
 alias /^(.+):bank:([^:]+)(.*)/ = \1:\2 \3
 # rewrites "assets:bank:wells fargo:checking" to  "assets:wells fargo checking"
@@ -809,14 +761,13 @@ File: hledger_journal.5.info,  Node: Multiple aliases,  Next: end aliases,  Prev
 .........................
 
 You can define as many aliases as you like using directives or
-command-line options. Aliases are recursive - each alias sees the result
-of applying previous ones. (This is different from Ledger, where aliases
-are non-recursive by default). Aliases are applied in the following
-order:
+command-line options.  Aliases are recursive - each alias sees the
+result of applying previous ones.  (This is different from Ledger, where
+aliases are non-recursive by default).  Aliases are applied in the
+following order:
 
   1. alias directives, most recently seen first (recent directives take
      precedence over earlier ones; directives not yet seen are ignored)
-
   2. alias options, in the order they appear on the command line
 
 
@@ -825,9 +776,8 @@ File: hledger_journal.5.info,  Node: end aliases,  Prev: Multiple aliases,  Up: 
 1.11.1.4 end aliases
 ....................
 
-You can clear (forget) all currently defined aliases with the `end
+You can clear (forget) all currently defined aliases with the 'end
 aliases' directive:
-
 
 end aliases
 
@@ -837,10 +787,9 @@ File: hledger_journal.5.info,  Node: account directive,  Next: apply account dir
 1.11.2 account directive
 ------------------------
 
-The `account' directive predefines account names, as in Ledger and
-Beancount. This may be useful for your own documentation; hledger
+The 'account' directive predefines account names, as in Ledger and
+Beancount.  This may be useful for your own documentation; hledger
 doesn't make use of it yet.
-
 
 ; account ACCT
 ;   OPTIONAL COMMENTS/TAGS...
@@ -860,9 +809,8 @@ File: hledger_journal.5.info,  Node: apply account directive,  Next: Multi-line 
 ------------------------------
 
 You can specify a parent account which will be prepended to all accounts
-within a section of the journal. Use the `apply account' and `end apply
+within a section of the journal.  Use the 'apply account' and 'end apply
 account' directives like so:
-
 
 apply account home
 
@@ -874,14 +822,12 @@ end apply account
 
    which is equivalent to:
 
-
 2010/01/01
     home:food           $10
     home:cash          $-10
 
-   If `end apply account' is omitted, the effect lasts to the end of
-the file. Included files are also affected, eg:
-
+   If 'end apply account' is omitted, the effect lasts to the end of the
+file.  Included files are also affected, eg:
 
 apply account business
 include biz.journal
@@ -889,7 +835,7 @@ end apply account
 apply account personal
 include personal.journal
 
-   Prior to hledger 1.0, legacy `account' and `end' spellings were also
+   Prior to hledger 1.0, legacy 'account' and 'end' spellings were also
 supported.
 
 
@@ -898,8 +844,8 @@ File: hledger_journal.5.info,  Node: Multi-line comments,  Next: commodity direc
 1.11.4 Multi-line comments
 --------------------------
 
-A line containing just `comment' starts a multi-line comment, and a
-line containing just `end comment' ends it. See comments.
+A line containing just 'comment' starts a multi-line comment, and a line
+containing just 'end comment' ends it.  See comments.
 
 
 File: hledger_journal.5.info,  Node: commodity directive,  Next: Default commodity,  Prev: Multi-line comments,  Up: Directives
@@ -907,13 +853,11 @@ File: hledger_journal.5.info,  Node: commodity directive,  Next: Default commodi
 1.11.5 commodity directive
 --------------------------
 
-The `commodity' directive predefines commodities (currently this is
-just informational), and also it may define the display format for
-amounts in this commodity (overriding the automatically inferred
-format).
+The 'commodity' directive predefines commodities (currently this is just
+informational), and also it may define the display format for amounts in
+this commodity (overriding the automatically inferred format).
 
    It may be written on a single line, like this:
-
 
 ; commodity EXAMPLEAMOUNT
 
@@ -922,10 +866,9 @@ format).
 ; separating thousands with comma.
 commodity 1,000.0000 AAAA
 
-   or on multiple lines, using the "format" subdirective. In this case
+   or on multiple lines, using the "format" subdirective.  In this case
 the commodity symbol appears twice and should be the same in both
 places:
-
 
 ; commodity SYMBOL
 ;   format EXAMPLEAMOUNT
@@ -943,11 +886,10 @@ File: hledger_journal.5.info,  Node: Default commodity,  Next: Default year,  Pr
 ------------------------
 
 The D directive sets a default commodity (and display format), to be
-used for amounts without a commodity symbol (ie, plain numbers). (Note
-this differs from Ledger's default commodity directive.) The commodity
+used for amounts without a commodity symbol (ie, plain numbers).  (Note
+this differs from Ledger's default commodity directive.)  The commodity
 and display format will be applied to all subsequent commodity-less
 amounts, or until the next D directive.
-
 
 # commodity-less amounts should be treated as dollars
 # (and displayed with symbol on the left, thousands separators and two decimal places)
@@ -964,9 +906,8 @@ File: hledger_journal.5.info,  Node: Default year,  Next: Including other files,
 -------------------
 
 You can set a default year to be used for subsequent dates which don't
-specify a year. This is a line beginning with `Y' followed by the year.
+specify a year.  This is a line beginning with 'Y' followed by the year.
 Eg:
-
 
 Y2009      ; set default year to 2009
 
@@ -993,13 +934,12 @@ File: hledger_journal.5.info,  Node: Including other files,  Prev: Default year,
 You can pull in the content of additional journal files by writing an
 include directive, like this:
 
-
 include path/to/file.journal
 
    If the path does not begin with a slash, it is relative to the
-current file. Glob patterns (`*') are not currently supported.
+current file.  Glob patterns ('*') are not currently supported.
 
-   The `include' directive can only be used in journal files. It can
+   The 'include' directive can only be used in journal files.  It can
 include journal, timeclock or timedot files, but not CSV files.
 
 
@@ -1009,8 +949,8 @@ File: hledger_journal.5.info,  Node: EDITOR SUPPORT,  Prev: FILE FORMAT,  Up: To
 ****************
 
 Add-on modes exist for various text editors, to make working with
-journal files easier. They add colour, navigation aids and helpful
-commands. For hledger users who edit the journal file directly (the
+journal files easier.  They add colour, navigation aids and helpful
+commands.  For hledger users who edit the journal file directly (the
 majority), using one of these modes is quite recommended.
 
    These were written with Ledger in mind, but also work with hledger
@@ -1022,83 +962,82 @@ Sublime Text      https://github.com/ledger/ledger/wiki/Using-Sublime-Text
 Textmate          https://github.com/ledger/ledger/wiki/Using-TextMate-2
 Text Wrangler     https://github.com/ledger/ledger/wiki/Editing-Ledger-files-with-TextWrangler
 
-
 
 Tag Table:
-Node: Top94
-Node: FILE FORMAT2284
-Ref: #file-format2410
-Node: Transactions2593
-Ref: #transactions2713
-Node: Dates3656
-Ref: #dates3784
-Node: Simple dates3849
-Ref: #simple-dates3977
-Node: Secondary dates4341
-Ref: #secondary-dates4497
-Node: Posting dates6057
-Ref: #posting-dates6188
-Node: Account names7559
-Ref: #account-names7698
-Node: Amounts8183
-Ref: #amounts8321
-Node: Virtual Postings10420
-Ref: #virtual-postings10581
-Node: Balance Assertions11801
-Ref: #balance-assertions11978
-Node: Assertions and ordering12873
-Ref: #assertions-and-ordering13061
-Node: Assertions and included files13758
-Ref: #assertions-and-included-files14001
-Node: Assertions and multiple -f options14332
-Ref: #assertions-and-multiple--f-options14588
-Node: Assertions and commodities14719
-Ref: #assertions-and-commodities14956
-Node: Assertions and subaccounts15648
-Ref: #assertions-and-subaccounts15882
-Node: Assertions and virtual postings16404
-Ref: #assertions-and-virtual-postings16613
-Node: Balance Assignments16754
-Ref: #balance-assignments16923
-Node: Prices18041
-Ref: #prices18174
-Node: Transaction prices18225
-Ref: #transaction-prices18370
-Node: Market prices19950
-Ref: #market-prices20085
-Node: Comments21054
-Ref: #comments21176
-Node: Tags22288
-Ref: #tags22408
-Node: Implicit tags23843
-Ref: #implicit-tags23951
-Node: Directives24470
-Ref: #directives24585
-Node: Account aliases24778
-Ref: #account-aliases24924
-Node: Basic aliases25526
-Ref: #basic-aliases25671
-Node: Regex aliases26359
-Ref: #regex-aliases26529
-Node: Multiple aliases27299
-Ref: #multiple-aliases27473
-Node: end aliases27969
-Ref: #end-aliases28111
-Node: account directive28213
-Ref: #account-directive28395
-Node: apply account directive28691
-Ref: #apply-account-directive28889
-Node: Multi-line comments29549
-Ref: #multi-line-comments29741
-Node: commodity directive29868
-Ref: #commodity-directive30054
-Node: Default commodity30927
-Ref: #default-commodity31102
-Node: Default year31638
-Ref: #default-year31805
-Node: Including other files32228
-Ref: #including-other-files32387
-Node: EDITOR SUPPORT32783
-Ref: #editor-support32903
+Node: Top78
+Node: FILE FORMAT2292
+Ref: #file-format2418
+Node: Transactions2601
+Ref: #transactions2721
+Node: Dates3663
+Ref: #dates3791
+Node: Simple dates3856
+Ref: #simple-dates3984
+Node: Secondary dates4350
+Ref: #secondary-dates4506
+Node: Posting dates6069
+Ref: #posting-dates6200
+Node: Account names7574
+Ref: #account-names7713
+Node: Amounts8200
+Ref: #amounts8338
+Node: Virtual Postings10439
+Ref: #virtual-postings10600
+Node: Balance Assertions11820
+Ref: #balance-assertions11997
+Node: Assertions and ordering12893
+Ref: #assertions-and-ordering13081
+Node: Assertions and included files13781
+Ref: #assertions-and-included-files14024
+Node: Assertions and multiple -f options14357
+Ref: #assertions-and-multiple--f-options14613
+Node: Assertions and commodities14745
+Ref: #assertions-and-commodities14982
+Node: Assertions and subaccounts15678
+Ref: #assertions-and-subaccounts15912
+Node: Assertions and virtual postings16433
+Ref: #assertions-and-virtual-postings16642
+Node: Balance Assignments16784
+Ref: #balance-assignments16953
+Node: Prices18072
+Ref: #prices18205
+Node: Transaction prices18256
+Ref: #transaction-prices18401
+Node: Market prices19978
+Ref: #market-prices20113
+Node: Comments21086
+Ref: #comments21208
+Node: Tags22321
+Ref: #tags22441
+Node: Implicit tags23870
+Ref: #implicit-tags23978
+Node: Directives24495
+Ref: #directives24610
+Node: Account aliases24803
+Ref: #account-aliases24949
+Node: Basic aliases25548
+Ref: #basic-aliases25693
+Node: Regex aliases26383
+Ref: #regex-aliases26553
+Node: Multiple aliases27324
+Ref: #multiple-aliases27498
+Node: end aliases27996
+Ref: #end-aliases28138
+Node: account directive28239
+Ref: #account-directive28421
+Node: apply account directive28717
+Ref: #apply-account-directive28915
+Node: Multi-line comments29574
+Ref: #multi-line-comments29766
+Node: commodity directive29894
+Ref: #commodity-directive30080
+Node: Default commodity30952
+Ref: #default-commodity31127
+Node: Default year31664
+Ref: #default-year31831
+Node: Including other files32254
+Ref: #including-other-files32413
+Node: EDITOR SUPPORT32810
+Ref: #editor-support32930
 
 End Tag Table

--- a/hledger-lib/doc/hledger_journal.5.txt
+++ b/hledger-lib/doc/hledger_journal.5.txt
@@ -7,23 +7,23 @@ NAME
        Journal - hledger's default file format, representing a General Journal
 
 DESCRIPTION
-       hledger's usual data source is a plain  text  file  containing  journal
-       entries  in  hledger  journal  format.  This file represents a standard
-       accounting general journal.  I use file names ending in  .journal,  but
+       hledger's  usual  data  source  is a plain text file containing journal
+       entries in hledger journal format.  This  file  represents  a  standard
+       accounting  general  journal.  I use file names ending in .journal, but
        that's not required.  The journal file contains a number of transaction
        entries, each describing a transfer of money (or any commodity) between
        two or more named accounts, in a simple format readable by both hledger
        and humans.
 
-       hledger's journal format is a compatible subset,  mostly,  of  ledger's
-       journal  format,  so  hledger  can  work with compatible ledger journal
-       files as well.  It's safe, and encouraged,  to  run  both  hledger  and
+       hledger's  journal  format  is a compatible subset, mostly, of ledger's
+       journal format, so hledger can  work  with  compatible  ledger  journal
+       files  as  well.   It's  safe,  and encouraged, to run both hledger and
        ledger on the same journal file, eg to validate the results you're get-
        ting.
 
        You can use hledger without learning any more about this file; just use
-       the  add  or web commands to create and update it.  Many users, though,
-       also edit the  journal  file  directly  with  a  text  editor,  perhaps
+       the add or web commands to create and update it.  Many  users,  though,
+       also  edit  the  journal  file  directly  with  a  text editor, perhaps
        assisted by the helper modes for emacs or vim.
 
        Here's an example:
@@ -53,18 +53,18 @@ DESCRIPTION
 
 FILE FORMAT
    Transactions
-       Transactions  are  represented  by journal entries.  Each begins with a
-       simple date in column 0, followed by three optional fields with  spaces
+       Transactions are represented by journal entries.  Each  begins  with  a
+       simple  date in column 0, followed by three optional fields with spaces
        between them:
 
-       o a  status  flag,  which  can be empty or ! or * (meaning "uncleared",
+       o a status flag, which can be empty or !  or  *  (meaning  "uncleared",
          "pending" and "cleared", or whatever you want)
 
        o a transaction code (eg a check number),
 
        o and/or a description
 
-       then some number of postings, of some amount  to  some  account.   Each
+       then  some  number  of  postings, of some amount to some account.  Each
        posting is on its own line, consisting of:
 
        o indentation of one or more spaces (or tabs)
@@ -76,34 +76,34 @@ FILE FORMAT
        o optionally, two or more spaces or tabs followed by an amount
 
        Usually there are two or more postings, though one or none is also pos-
-       sible.  The posting amounts within a transaction must  always  balance,
+       sible.   The  posting amounts within a transaction must always balance,
        ie add up to 0.  Optionally one amount can be left blank, in which case
        it will be inferred.
 
    Dates
    Simple dates
-       Within a journal file, transaction dates use Y/M/D (or Y-M-D or  Y.M.D)
-       Leading  zeros are optional.  The year may be omitted, in which case it
-       will be inferred from  the  context  -  the  current  transaction,  the
-       default  year  set  with  a default year directive, or the current date
-       when the command is run.  Some examples: 2010/01/31, 1/31,  2010-01-31,
+       Within  a journal file, transaction dates use Y/M/D (or Y-M-D or Y.M.D)
+       Leading zeros are optional.  The year may be omitted, in which case  it
+       will  be  inferred  from  the  context  -  the current transaction, the
+       default year set with a default year directive,  or  the  current  date
+       when  the command is run.  Some examples: 2010/01/31, 1/31, 2010-01-31,
        2010.1.31.
 
    Secondary dates
-       Real-life  transactions  sometimes  involve more than one date - eg the
+       Real-life transactions sometimes involve more than one date  -  eg  the
        date you write a cheque, and the date it clears in your bank.  When you
-       want  to  model  this,  eg  for more accurate balances, you can specify
-       individual posting dates, which I recommend.  Or, you can use the  sec-
-       ondary  dates  (aka  auxiliary/effective  dates) feature, supported for
+       want to model this, eg for more  accurate  balances,  you  can  specify
+       individual  posting dates, which I recommend.  Or, you can use the sec-
+       ondary dates (aka auxiliary/effective  dates)  feature,  supported  for
        compatibility with Ledger.
 
        A secondary date can be written after the primary date, separated by an
-       equals  sign.   The  primary date, on the left, is used by default; the
-       secondary date, on the right, is used when the --date2 flag  is  speci-
+       equals sign.  The primary date, on the left, is used  by  default;  the
+       secondary  date,  on the right, is used when the --date2 flag is speci-
        fied (--aux-date or --effective also work).
 
-       The  meaning of secondary dates is up to you, but it's best to follow a
-       consistent rule.  Eg write the bank's clearing  date  as  primary,  and
+       The meaning of secondary dates is up to you, but it's best to follow  a
+       consistent  rule.   Eg  write  the bank's clearing date as primary, and
        when needed, the date the transaction was initiated as secondary.
 
        Here's an example.  Note that a secondary date will use the year of the
@@ -119,18 +119,18 @@ FILE FORMAT
               $ hledger register checking --date2
               2010/02/19 movie ticket         assets:checking                $-10         $-10
 
-       Secondary dates require some effort; you must use them consistently  in
+       Secondary  dates require some effort; you must use them consistently in
        your journal entries and remember whether to use or not use the --date2
        flag for your reports.  They are included in hledger for Ledger compat-
-       ibility,  but  posting  dates  are  a  more powerful and less confusing
+       ibility, but posting dates are  a  more  powerful  and  less  confusing
        alternative.
 
    Posting dates
-       You can give individual postings a different  date  from  their  parent
-       transaction,  by  adding a posting comment containing a tag (see below)
+       You  can  give  individual  postings a different date from their parent
+       transaction, by adding a posting comment containing a tag  (see  below)
        like date:DATE.  This is probably the best way to control posting dates
-       precisely.   Eg  in  this  example  the  expense  should  appear in May
-       reports, and the deduction from checking should be reported on 6/1  for
+       precisely.  Eg in  this  example  the  expense  should  appear  in  May
+       reports,  and the deduction from checking should be reported on 6/1 for
        easy bank reconciliation:
 
               2015/5/30
@@ -143,23 +143,23 @@ FILE FORMAT
               $ hledger -f t.j register checking
               2015/06/01                      assets:checking               $-10          $-10
 
-       DATE  should be a simple date; if the year is not specified it will use
-       the year of the transaction's date.  You can  set  the  secondary  date
-       similarly,  with  date2:DATE2.   The  date:  or date2: tags must have a
-       valid simple date value if they are present, eg a  date:  tag  with  no
+       DATE should be a simple date; if the year is not specified it will  use
+       the  year  of  the  transaction's date.  You can set the secondary date
+       similarly, with date2:DATE2.  The date: or  date2:  tags  must  have  a
+       valid  simple  date  value  if they are present, eg a date: tag with no
        value is not allowed.
 
        Ledger's earlier, more compact bracketed date syntax is also supported:
-       [DATE], [DATE=DATE2] or [=DATE2].  hledger will attempt  to  parse  any
+       [DATE],  [DATE=DATE2]  or  [=DATE2].  hledger will attempt to parse any
        square-bracketed sequence of the 0123456789/-.= characters in this way.
-       With this syntax, DATE infers its year from the transaction  and  DATE2
+       With  this  syntax, DATE infers its year from the transaction and DATE2
        infers its year from DATE.
 
    Account names
-       Account  names  typically have several parts separated by a full colon,
-       from which hledger derives a hierarchical chart of accounts.  They  can
-       be  anything  you  like,  but  in  finance there are traditionally five
-       top-level accounts: assets, liabilities, income, expenses, and  equity.
+       Account names typically have several parts separated by a  full  colon,
+       from  which hledger derives a hierarchical chart of accounts.  They can
+       be anything you like, but  in  finance  there  are  traditionally  five
+       top-level accounts: assets, liabilities, income, expenses, and equity.
 
        Account  names  may  contain single spaces, eg: assets:accounts receiv-
        able.  Because of this, they must always be followed  by  two  or  more
@@ -206,31 +206,31 @@ FILE FORMAT
 
        o if there is a commodity directive specifying the format, that is used
 
-       o otherwise the format is inferred from the  first  posting  amount  in
-         that  commodity  in the journal, and the precision (number of decimal
+       o otherwise  the  format  is  inferred from the first posting amount in
+         that commodity in the journal, and the precision (number  of  decimal
          places) will be the maximum from all posting amounts in that commmod-
          ity
 
-       o or  if  there are no such amounts in the journal, a default format is
+       o or if there are no such amounts in the journal, a default  format  is
          used (like $1000.00).
 
-       Price amounts and amounts in D directives usually don't  affect  amount
-       format  inference,  but  in  some situations they can do so indirectly.
-       (Eg when D's default commodity is applied to a  commodity-less  amount,
+       Price  amounts  and amounts in D directives usually don't affect amount
+       format inference, but in some situations they  can  do  so  indirectly.
+       (Eg  when  D's default commodity is applied to a commodity-less amount,
        or when an amountless posting is balanced using a price's commodity, or
-       when -V is used.) If you find this causing problems,  set  the  desired
+       when  -V  is  used.) If you find this causing problems, set the desired
        format with a commodity directive.
 
    Virtual Postings
-       When  you  parenthesise  the  account name in a posting, we call that a
+       When you parenthesise the account name in a posting,  we  call  that  a
        virtual posting, which means:
 
        o it is ignored when checking that the transaction is balanced
 
-       o it is excluded from reports when the --real/-R flag is used,  or  the
+       o it  is  excluded from reports when the --real/-R flag is used, or the
          real:1 query.
 
-       You  could  use  this,  eg, to set an account's opening balance without
+       You could use this, eg, to set an  account's  opening  balance  without
        needing to use the equity:opening balances account:
 
               1/1 special unbalanced posting to set initial balance
@@ -238,8 +238,8 @@ FILE FORMAT
 
        When the account name is bracketed, we call it a balanced virtual post-
        ing.  This is like an ordinary virtual posting except the balanced vir-
-       tual postings in a transaction must balance to 0, like the  real  post-
-       ings  (but  separately  from them).  Balanced virtual postings are also
+       tual  postings  in a transaction must balance to 0, like the real post-
+       ings (but separately from them).  Balanced virtual  postings  are  also
        excluded by --real/-R or real:1.
 
               1/1 buy food with cash, and update some budget-tracking subaccounts elsewhere
@@ -249,13 +249,13 @@ FILE FORMAT
                 [assets:checking:budget:food]  $-10
 
        Virtual postings have some legitimate uses, but those are few.  You can
-       usually  find an equivalent journal entry using real postings, which is
+       usually find an equivalent journal entry using real postings, which  is
        more correct and provides better error checking.
 
    Balance Assertions
-       hledger supports Ledger-style  balance  assertions  in  journal  files.
-       These  look  like =EXPECTEDBALANCE following a posting's amount.  Eg in
-       this example we assert the expected dollar balance in accounts a and  b
+       hledger  supports  Ledger-style  balance  assertions  in journal files.
+       These look like =EXPECTEDBALANCE following a posting's amount.   Eg  in
+       this  example we assert the expected dollar balance in accounts a and b
        after each posting:
 
               2013/1/1
@@ -267,31 +267,31 @@ FILE FORMAT
                 b  $-1  =$-2
 
        After reading a journal file, hledger will check all balance assertions
-       and report an error if any of them fail.  Balance assertions  can  pro-
-       tect  you  from, eg, inadvertently disrupting reconciled balances while
-       cleaning up old entries.  You can disable  them  temporarily  with  the
-       --ignore-assertions  flag,  which  can be useful for troubleshooting or
+       and  report  an error if any of them fail.  Balance assertions can pro-
+       tect you from, eg, inadvertently disrupting reconciled  balances  while
+       cleaning  up  old  entries.   You can disable them temporarily with the
+       --ignore-assertions flag, which can be useful  for  troubleshooting  or
        for reading Ledger files.
 
    Assertions and ordering
-       hledger sorts an account's postings and assertions first  by  date  and
-       then  (for postings on the same day) by parse order.  Note this is dif-
+       hledger  sorts  an  account's postings and assertions first by date and
+       then (for postings on the same day) by parse order.  Note this is  dif-
        ferent from Ledger, which sorts assertions only by parse order.  (Also,
-       Ledger  assertions  do not see the accumulated effect of repeated post-
+       Ledger assertions do not see the accumulated effect of  repeated  post-
        ings to the same account within a transaction.)
 
-       So, hledger balance assertions keep  working  if  you  reorder  differ-
-       ently-dated  transactions  within  the  journal.   But  if  you reorder
+       So,  hledger  balance  assertions  keep  working if you reorder differ-
+       ently-dated transactions  within  the  journal.   But  if  you  reorder
        same-dated transactions or postings, assertions might break and require
-       updating.   This order dependence does bring an advantage: precise con-
+       updating.  This order dependence does bring an advantage: precise  con-
        trol over the order of postings and assertions within a day, so you can
        assert intra-day balances.
 
    Assertions and included files
-       With  included  files, things are a little more complicated.  Including
-       preserves the ordering of postings and assertions.  If you have  multi-
-       ple  postings  to  an  account  on the same day, split across different
-       files, and you also want to assert the account's balance  on  the  same
+       With included files, things are a little more  complicated.   Including
+       preserves  the ordering of postings and assertions.  If you have multi-
+       ple postings to an account on the  same  day,  split  across  different
+       files,  and  you  also want to assert the account's balance on the same
        day, you'll have to put the assertion in the right file.
 
    Assertions and multiple -f options
@@ -299,21 +299,21 @@ FILE FORMAT
        -f options.  Use include or concatenate the files instead.
 
    Assertions and commodities
-       The asserted balance must be a simple single-commodity amount,  and  in
-       fact  the  assertion  checks  only  this commodity's balance within the
-       (possibly multi-commodity) account balance.  We could call this a  par-
-       tial  balance  assertion.  This is compatible with Ledger, and makes it
+       The  asserted  balance must be a simple single-commodity amount, and in
+       fact the assertion checks only  this  commodity's  balance  within  the
+       (possibly  multi-commodity) account balance.  We could call this a par-
+       tial balance assertion.  This is compatible with Ledger, and  makes  it
        possible to make assertions about accounts containing multiple commodi-
        ties.
 
-       To  assert  each commodity's balance in such a multi-commodity account,
-       you can add multiple postings (with amount 0 if necessary).   But  note
-       that  no  matter  how  many  assertions  you add, you can't be sure the
+       To assert each commodity's balance in such a  multi-commodity  account,
+       you  can  add multiple postings (with amount 0 if necessary).  But note
+       that no matter how many assertions you  add,  you  can't  be  sure  the
        account does not contain some unexpected commodity.  (We'll add support
        for this kind of total balance assertion if there's demand.)
 
    Assertions and subaccounts
-       Balance  assertions  do  not  count  the balance from subaccounts; they
+       Balance assertions do not count  the  balance  from  subaccounts;  they
        check the posted account's exclusive balance.  For example:
 
               1/1
@@ -321,7 +321,7 @@ FILE FORMAT
                 checking        1 = 1  ; post to the parent account, its exclusive balance is now 1
                 equity
 
-       The balance report's flat mode  shows  these  exclusive  balances  more
+       The  balance  report's  flat  mode  shows these exclusive balances more
        clearly:
 
               $ hledger bal checking --flat
@@ -335,10 +335,10 @@ FILE FORMAT
        tual.  They are not affected by the --real/-R flag or real: query.
 
    Balance Assignments
-       Ledger-style balance assignments are also supported.   These  are  like
-       balance  assertions, but with no posting amount on the left side of the
-       equals sign; instead it is calculated automatically so  as  to  satisfy
-       the  assertion.   This  can be a convenience during data entry, eg when
+       Ledger-style  balance  assignments  are also supported.  These are like
+       balance assertions, but with no posting amount on the left side of  the
+       equals  sign;  instead  it is calculated automatically so as to satisfy
+       the assertion.  This can be a convenience during data  entry,  eg  when
        setting opening balances:
 
               ; starting a new journal, set asset account balances
@@ -356,27 +356,27 @@ FILE FORMAT
                 expenses:misc
 
        The calculated amount depends on the account's balance in the commodity
-       at  that  point  (which depends on the previously-dated postings of the
-       commodity to that account since the last balance assertion  or  assign-
+       at that point (which depends on the previously-dated  postings  of  the
+       commodity  to  that account since the last balance assertion or assign-
        ment).  Note that using balance assignments makes your journal a little
        less explicit; to know the exact amount posted, you have to run hledger
        or do the calculations yourself, instead of just reading it.
 
    Prices
    Transaction prices
-       Within  a  transaction  posting,  you  can  record an amount's price in
-       another commodity.  This can be used to document the cost (for  a  pur-
-       chase),  or  selling  price (for a sale), or the exchange rate that was
+       Within a transaction posting, you  can  record  an  amount's  price  in
+       another  commodity.   This can be used to document the cost (for a pur-
+       chase), or selling price (for a sale), or the exchange  rate  that  was
        used, for this transaction.  These transaction prices are fixed, and do
        not change over time.
 
-       Amounts  with  transaction  prices  can be displayed in the transaction
-       price's commodity, by  using  the  --cost/-B  flag  supported  by  most
+       Amounts with transaction prices can be  displayed  in  the  transaction
+       price's  commodity,  by  using  the  --cost/-B  flag  supported by most
        hledger commands (mnemonic: "cost Basis").
 
        There are several ways to record a transaction price:
 
-       1. Write  the  unit price (aka exchange rate), as @ UNITPRICE after the
+       1. Write the unit price (aka exchange rate), as @ UNITPRICE  after  the
           amount:
 
                   2009/1/1
@@ -390,7 +390,7 @@ FILE FORMAT
                     assets:cash
 
        3. Or let hledger infer the price so as to balance the transaction.  To
-          permit  this,  you must fully specify all posting amounts, and their
+          permit this, you must fully specify all posting amounts,  and  their
           sum must have a non-zero amount in exactly two commodities:
 
                   2009/1/1
@@ -404,38 +404,38 @@ FILE FORMAT
                   assets:foreign currency       $135.00
                   assets:cash                  $-135.00
 
-       Example use for transaction prices: recording the effective  conversion
+       Example  use for transaction prices: recording the effective conversion
        rate of purchases made in a foreign currency.
 
    Market prices
-       Market  prices are not tied to a particular transaction; they represent
-       historical exchange rates between two commodities.  (Ledger calls  them
-       historical  prices.)  For  example,  the  prices  published  by a stock
-       exchange or the foreign exchange market.  Some commands (balance,  cur-
-       rently)  can use this information to show the market value of things at
+       Market prices are not tied to a particular transaction; they  represent
+       historical  exchange rates between two commodities.  (Ledger calls them
+       historical prices.) For  example,  the  prices  published  by  a  stock
+       exchange  or the foreign exchange market.  Some commands (balance, cur-
+       rently) can use this information to show the market value of things  at
        a given date.
 
-       To record market prices, use P directives in the main journal or in  an
+       To  record market prices, use P directives in the main journal or in an
        included file.  Their format is:
 
               P DATE COMMODITYBEINGPRICED UNITPRICE
 
-       DATE  is a simple date as usual.  COMMODITYBEINGPRICED is the symbol of
-       the commodity being priced.  UNITPRICE is an  ordinary  amount  (symbol
-       and  quantity) in a second commodity, specifying the unit price or con-
-       version rate for the first commodity in terms of  the  second,  on  the
+       DATE is a simple date as usual.  COMMODITYBEINGPRICED is the symbol  of
+       the  commodity  being  priced.  UNITPRICE is an ordinary amount (symbol
+       and quantity) in a second commodity, specifying the unit price or  con-
+       version  rate  for  the  first commodity in terms of the second, on the
        given date.
 
-       For  example, the following directives say that one euro was worth 1.35
+       For example, the following directives say that one euro was worth  1.35
        US dollars during 2009, and $1.40 from 2010 onward:
 
               P 2009/1/1  $1.35
               P 2010/1/1  $1.40
 
    Comments
-       Lines in the journal beginning with a semicolon  (;)  or  hash  (#)  or
-       asterisk  (*)  are  comments,  and will be ignored.  (Asterisk comments
-       make it easy to treat your journal like an org-mode outline in  emacs.)
+       Lines  in  the  journal  beginning  with a semicolon (;) or hash (#) or
+       asterisk (*) are comments, and will  be  ignored.   (Asterisk  comments
+       make it easy to treat your journal like an org-mode outline in emacs.)
 
        Also,   anything  between  comment  and  end comment  directives  is  a
        (multi-line) comment.  If there is no end comment, the comment  extends
@@ -551,27 +551,27 @@ FILE FORMAT
        Or, you can use the --alias 'OLD=NEW' option on the command line.  This
        affects all entries.  It's useful for trying out aliases interactively.
 
-       OLD and NEW are full account names.  hledger will  replace  any  occur-
-       rence  of  the old account name with the new one.  Subaccounts are also
+       OLD  and  NEW  are full account names.  hledger will replace any occur-
+       rence of the old account name with the new one.  Subaccounts  are  also
        affected.  Eg:
 
               alias checking = assets:bank:wells fargo:checking
               # rewrites "checking" to "assets:bank:wells fargo:checking", or "checking:a" to "assets:bank:wells fargo:checking:a"
 
    Regex aliases
-       There is also a more powerful variant that uses a  regular  expression,
-       indicated  by  the forward slashes.  (This was the default behaviour in
+       There  is  also a more powerful variant that uses a regular expression,
+       indicated by the forward slashes.  (This was the default  behaviour  in
        hledger 0.24-0.25):
 
               alias /REGEX/ = REPLACEMENT
 
        or --alias '/REGEX/=REPLACEMENT'.
 
-       REGEX is a case-insensitive regular expression.   Anywhere  it  matches
-       inside  an  account name, the matched part will be replaced by REPLACE-
-       MENT.  If REGEX contains parenthesised match groups, these can be  ref-
+       REGEX  is  a  case-insensitive regular expression.  Anywhere it matches
+       inside an account name, the matched part will be replaced  by  REPLACE-
+       MENT.   If REGEX contains parenthesised match groups, these can be ref-
        erenced by the usual numeric backreferences in REPLACEMENT.  Note, cur-
-       rently regular expression  aliases  may  cause  noticeable  slow-downs.
+       rently  regular  expression  aliases  may  cause noticeable slow-downs.
        (And if you use Ledger on your hledger file, they will be ignored.) Eg:
 
               alias /^(.+):bank:([^:]+)(.*)/ = \1:\2 \3
@@ -729,7 +729,6 @@ EDITOR SUPPORT
 
        These  were  written  with  Ledger  in mind, but also work with hledger
        files:
-
 
        Emacs              http://www.ledger-cli.org/3.0/doc/ledger-mode.html
        Vim                https://github.com/ledger/ledger/wiki/Get-

--- a/hledger-lib/doc/hledger_timeclock.5.info
+++ b/hledger-lib/doc/hledger_timeclock.5.info
@@ -1,5 +1,5 @@
-This is hledger-lib/doc/hledger_timeclock.5.info, produced by makeinfo
-version 4.8 from stdin.
+This is hledger_timeclock.5.info, produced by makeinfo version 5.2 from
+stdin.
 
 
 File: hledger_timeclock.5.info,  Node: Top,  Up: (dir)
@@ -7,13 +7,12 @@ File: hledger_timeclock.5.info,  Node: Top,  Up: (dir)
 hledger_timeclock(5) hledger dev
 ********************************
 
-hledger can read timeclock files. As with Ledger, these are (a subset
+hledger can read timeclock files.  As with Ledger, these are (a subset
 of) timeclock.el's format, containing clock-in and clock-out entries as
-in the example below. The date is a simple date. The time format is
-HH:MM[:SS][+-ZZZZ]. Seconds and timezone are optional. The timezone, if
+in the example below.  The date is a simple date.  The time format is
+HH:MM[:SS][+-ZZZZ]. Seconds and timezone are optional.  The timezone, if
 present, must be four digits and is ignored (currently the time is
 always interpreted as a local time).
-
 
 i 2015/03/30 09:00:00 some:account name  optional description after two spaces
 o 2015/03/30 09:20:00
@@ -21,10 +20,9 @@ i 2015/03/31 22:21:45 another account
 o 2015/04/01 02:00:34
 
    hledger treats each clock-in/clock-out pair as a transaction posting
-some number of hours to an account. Or if the session spans more than
-one day, it is split into several transactions, one for each day. For
-the above time log, `hledger print' generates these journal entries:
-
+some number of hours to an account.  Or if the session spans more than
+one day, it is split into several transactions, one for each day.  For
+the above time log, 'hledger print' generates these journal entries:
 
 $ hledger -f t.timeclock print
 2015/03/30 * optional description after two spaces
@@ -38,7 +36,6 @@ $ hledger -f t.timeclock print
 
    Here is a sample.timeclock to download and some queries to try:
 
-
 $ hledger -f sample.timeclock balance                               # current time balances
 $ hledger -f sample.timeclock register -p 2009/3                    # sessions in march 2009
 $ hledger -f sample.timeclock register -p weekly --depth 1 --empty  # time summary by week
@@ -50,18 +47,16 @@ $ hledger -f sample.timeclock register -p weekly --depth 1 --empty  # time summa
 
    * at the command line, use these bash aliases:
 
-
      alias ti="echo i `date '+%Y-%m-%d %H:%M:%S'` \$* >>$TIMELOG"
      alias to="echo o `date '+%Y-%m-%d %H:%M:%S'` >>$TIMELOG"
 
-   * or use the old `ti' and `to' scripts in the ledger 2.x repository.
+   * or use the old 'ti' and 'to' scripts in the ledger 2.x repository.
      These rely on a "timeclock" executable which I think is just the
      ledger 2 executable renamed.
 
 
-
 
 Tag Table:
-Node: Top96
+Node: Top80
 
 End Tag Table

--- a/hledger-lib/doc/hledger_timeclock.5.txt
+++ b/hledger-lib/doc/hledger_timeclock.5.txt
@@ -7,11 +7,11 @@ NAME
        Timeclock - the time logging format of timeclock.el, as read by hledger
 
 DESCRIPTION
-       hledger can read timeclock files.  As with Ledger, these are (a  subset
+       hledger  can read timeclock files.  As with Ledger, these are (a subset
        of) timeclock.el's format, containing clock-in and clock-out entries as
-       in the example below.  The date is a simple date.  The time  format  is
-       HH:MM[:SS][+-ZZZZ].   Seconds and timezone are optional.  The timezone,
-       if present, must be four digits and is ignored (currently the  time  is
+       in  the  example below.  The date is a simple date.  The time format is
+       HH:MM[:SS][+-ZZZZ].  Seconds and timezone are optional.  The  timezone,
+       if  present,  must be four digits and is ignored (currently the time is
        always interpreted as a local time).
 
               i 2015/03/30 09:00:00 some:account name  optional description after two spaces
@@ -19,9 +19,9 @@ DESCRIPTION
               i 2015/03/31 22:21:45 another account
               o 2015/04/01 02:00:34
 
-       hledger  treats  each  clock-in/clock-out pair as a transaction posting
-       some number of hours to an account.  Or if the session spans more  than
-       one  day, it is split into several transactions, one for each day.  For
+       hledger treats each clock-in/clock-out pair as  a  transaction  posting
+       some  number of hours to an account.  Or if the session spans more than
+       one day, it is split into several transactions, one for each day.   For
        the above time log, hledger print generates these journal entries:
 
               $ hledger -f t.timeclock print
@@ -42,7 +42,7 @@ DESCRIPTION
 
        To generate time logs, ie to clock in and clock out, you could:
 
-       o use emacs and  the  built-in  timeclock.el,  or  the  extended  time-
+       o use  emacs  and  the  built-in  timeclock.el,  or  the extended time-
          clock-x.el and perhaps the extras in ledgerutils.el
 
        o at the command line, use these bash aliases:
@@ -51,13 +51,13 @@ DESCRIPTION
                 alias to="echo o `date '+%Y-%m-%d %H:%M:%S'` >>$TIMELOG"
 
        o or use the old ti and to scripts in the ledger 2.x repository.  These
-         rely on a "timeclock" executable which I think is just the  ledger  2
+         rely  on  a "timeclock" executable which I think is just the ledger 2
          executable renamed.
 
 
 
 REPORTING BUGS
-       Report  bugs at http://bugs.hledger.org (or on the #hledger IRC channel
+       Report bugs at http://bugs.hledger.org (or on the #hledger IRC  channel
        or hledger mail list)
 
 
@@ -71,7 +71,7 @@ COPYRIGHT
 
 
 SEE ALSO
-       hledger(1),     hledger-ui(1),     hledger-web(1),      hledger-api(1),
+       hledger(1),      hledger-ui(1),     hledger-web(1),     hledger-api(1),
        hledger_csv(5), hledger_journal(5), hledger_timeclock(5), hledger_time-
        dot(5), ledger(1)
 

--- a/hledger-lib/doc/hledger_timedot.5.info
+++ b/hledger-lib/doc/hledger_timedot.5.info
@@ -1,24 +1,23 @@
-This is hledger-lib/doc/hledger_timedot.5.info, produced by makeinfo
-version 4.8 from stdin.
+This is hledger_timedot.5.info, produced by makeinfo version 5.2 from
+stdin.
 
 
-File: hledger_timedot.5.info,  Node: Top,  Up: (dir)
+File: hledger_timedot.5.info,  Node: Top,  Next: FILE FORMAT,  Up: (dir)
 
 hledger_timedot(5) hledger dev
 ******************************
 
 Timedot is a plain text format for logging dated, categorised quantities
-(eg time), supported by hledger. It is convenient for approximate and
+(eg time), supported by hledger.  It is convenient for approximate and
 retroactive time logging, eg when the real-time clock-in/out required
-with a timeclock file is too precise or too interruptive. It can be
+with a timeclock file is too precise or too interruptive.  It can be
 formatted like a bar chart, making clear at a glance where time was
 spent.
 
    Though called "timedot", the format does not specify the commodity
-being logged, so could represent other dated, quantifiable things. Eg
+being logged, so could represent other dated, quantifiable things.  Eg
 you could record a single-entry journal of financial transactions,
 perhaps slightly more conveniently than with hledger_journal(5) format.
-
 * Menu:
 
 * FILE FORMAT::
@@ -29,25 +28,23 @@ File: hledger_timedot.5.info,  Node: FILE FORMAT,  Prev: Top,  Up: Top
 1 FILE FORMAT
 *************
 
-A timedot file contains a series of day entries. A day entry begins with
-a date, and is followed by category/quantity pairs, one per line. Dates
-are hledger-style simple dates (see hledger_journal(5)). Categories are
-hledger-style account names, optionally indented. There must be at least
-two spaces between the category and the quantity. Quantities can be
-written in two ways:
+A timedot file contains a series of day entries.  A day entry begins
+with a date, and is followed by category/quantity pairs, one per line.
+Dates are hledger-style simple dates (see hledger_journal(5)).
+Categories are hledger-style account names, optionally indented.  There
+must be at least two spaces between the category and the quantity.
+Quantities can be written in two ways:
 
-  1. a series of dots (period characters). Each dot represents "a
-     quarter" - eg, a quarter hour. Spaces can be used to group dots
+  1. a series of dots (period characters).  Each dot represents "a
+     quarter" - eg, a quarter hour.  Spaces can be used to group dots
      into hours, for easier counting.
 
-  2. a number (integer or decimal), representing "units" - eg, hours. A
-     good alternative when dots are cumbersome. (A number also can
+  2. a number (integer or decimal), representing "units" - eg, hours.  A
+     good alternative when dots are cumbersome.  (A number also can
      record negative quantities.)
 
-
-   Blank lines and lines beginning with #, ; or * are ignored. An
+   Blank lines and lines beginning with #, ; or * are ignored.  An
 example:
-
 
 # on this day, 6h was spent on client work, 1.5h on haskell FOSS work, etc.
 2016/2/1
@@ -61,7 +58,6 @@ biz:research  .
 
    Or with numbers:
 
-
 2016/2/3
 inc:client1   4
 fos:hledger   3
@@ -69,14 +65,12 @@ biz:research  1
 
    Reporting:
 
-
 $ hledger -f t.timedot print date:2016/2/2
 2016/02/02 *
     (inc:client1)          2.00
 
 2016/02/02 *
     (biz:research)          0.25
-
 
 $ hledger -f t.timedot bal --daily --tree
 Balance changes in 2016/02/01-2016/02/03:
@@ -93,14 +87,12 @@ Balance changes in 2016/02/01-2016/02/03:
 ------------++----------------------------------------
             ||         7.75         2.25         8.00
 
-   I prefer to use period for separating account components. We can make
-this work with an account alias:
-
+   I prefer to use period for separating account components.  We can
+make this work with an account alias:
 
 2016/2/4
 fos.hledger.timedot  4
 fos.ledger           ..
-
 
 $ hledger -f t.timedot --alias /\\./=: bal date:2016/2/4
                 4.50  fos
@@ -111,11 +103,10 @@ $ hledger -f t.timedot --alias /\\./=: bal date:2016/2/4
 
    Here is a sample.timedot.
 
-
 
 Tag Table:
-Node: Top94
-Node: FILE FORMAT876
-Ref: #file-format979
+Node: Top78
+Node: FILE FORMAT882
+Ref: #file-format985
 
 End Tag Table

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -204,6 +204,7 @@ test-suite doctests
       Hledger.Data.Dates
       Hledger.Data.Journal
       Hledger.Data.Ledger
+      Hledger.Data.MarketPrice
       Hledger.Data.Period
       Hledger.Data.Posting
       Hledger.Data.RawOptions
@@ -303,6 +304,7 @@ test-suite hunittests
       Hledger.Data.Dates
       Hledger.Data.Journal
       Hledger.Data.Ledger
+      Hledger.Data.MarketPrice
       Hledger.Data.Period
       Hledger.Data.Posting
       Hledger.Data.RawOptions

--- a/hledger-ui/Hledger/UI/UIOptions.hs
+++ b/hledger-ui/Hledger/UI/UIOptions.hs
@@ -39,7 +39,6 @@ uiflags = [
   -- ,flagReq ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "with --flat, omit this many leading account name components"
   -- ,flagReq  ["format"] (\s opts -> Right $ setopt "format" s opts) "FORMATSTR" "use this custom line format"
   -- ,flagNone ["no-elide"] (\opts -> setboolopt "no-elide" opts) "don't compress empty parent accounts on one line"
-  ,flagNone ["value","V"] (setboolopt "value") "show amounts as their current market value in their default valuation commodity (accounts screen)"
  ]
 
 --uimode :: Mode [([Char], [Char])]

--- a/hledger-ui/doc/hledger-ui.1
+++ b/hledger-ui/doc/hledger-ui.1
@@ -63,12 +63,6 @@ show period balances (changes) at startup instead of historical balances
 show full account names, unindented
 .RS
 .RE
-.TP
-.B \f[C]\-V\ \-\-value\f[]
-show amounts as their current market value in their default valuation
-commodity (accounts screen only)
-.RS
-.RE
 .PP
 hledger general options:
 .TP
@@ -205,6 +199,12 @@ show items with zero amount, normally hidden
 .B \f[C]\-B\ \-\-cost\f[]
 convert amounts to their cost at transaction time (using the transaction
 price, if any)
+.RS
+.RE
+.TP
+.B \f[C]\-V\ \-\-value\f[]
+convert amounts to their market value on the report end date (using the
+most recent applicable market price, if any)
 .RS
 .RE
 .TP

--- a/hledger-ui/doc/hledger-ui.1.info
+++ b/hledger-ui/doc/hledger-ui.1.info
@@ -1,24 +1,22 @@
-This is hledger-ui/doc/hledger-ui.1.info, produced by makeinfo version
-4.8 from stdin.
+This is hledger-ui.1.info, produced by makeinfo version 5.2 from stdin.
 
 
-File: hledger-ui.1.info,  Node: Top,  Up: (dir)
+File: hledger-ui.1.info,  Node: Top,  Next: OPTIONS,  Up: (dir)
 
 hledger-ui(1) hledger-ui dev
 ****************************
 
 hledger-ui is hledger's curses-style interface, providing an efficient
 full-window text UI for viewing accounts and transactions, and some
-limited data entry capability. It is easier than hledger's command-line
+limited data entry capability.  It is easier than hledger's command-line
 interface, and sometimes quicker and more convenient than the web
 interface.
 
    Like hledger, it reads data from one or more files in hledger
-journal, timeclock, timedot, or CSV format specified with `-f', or
-`$LEDGER_FILE', or `$HOME/.hledger.journal' (on windows, perhaps
-`C:/Users/USER/.hledger.journal'). For more about this see hledger(1),
+journal, timeclock, timedot, or CSV format specified with '-f', or
+'$LEDGER_FILE', or '$HOME/.hledger.journal' (on windows, perhaps
+'C:/Users/USER/.hledger.journal').  For more about this see hledger(1),
 hledger_journal(5) etc.
-
 * Menu:
 
 * OPTIONS::
@@ -31,121 +29,124 @@ File: hledger-ui.1.info,  Node: OPTIONS,  Next: KEYS,  Prev: Top,  Up: Top
 1 OPTIONS
 *********
 
-Note: if invoking hledger-ui as a hledger subcommand, write `--' before
+Note: if invoking hledger-ui as a hledger subcommand, write '--' before
 options as shown above.
 
    Any QUERYARGS are interpreted as a hledger search query which filters
 the data.
 
-`--watch'
+'--watch'
+
      watch for data and date changes and reload automatically
+'--theme=default|terminal|greenterm'
 
-`--theme=default|terminal|greenterm'
      use this custom display theme
+'--register=ACCTREGEX'
 
-`--register=ACCTREGEX'
      start in the (first) matched account's register screen
+'--change'
 
-`--change'
      show period balances (changes) at startup instead of historical
      balances
+'--flat'
 
-`--flat'
      show full account names, unindented
-
-`-V --value'
-     show amounts as their current market value in their default
-     valuation commodity (accounts screen only)
 
    hledger general options:
 
-`-h'
-     show general usage (or after COMMAND, the command's usage)
+'-h'
 
-`--help'
+     show general usage (or after COMMAND, the command's usage)
+'--help'
+
      show the current program's manual as plain text (or after an add-on
      COMMAND, the add-on's manual)
+'--man'
 
-`--man'
      show the current program's manual with man
+'--info'
 
-`--info'
      show the current program's manual with info
+'--version'
 
-`--version'
      show version
+'--debug[=N]'
 
-`--debug[=N]'
      show debug output (levels 1-9, default: 1)
+'-f FILE --file=FILE'
 
-`-f FILE --file=FILE'
-     use a different input file. For stdin, use -
+     use a different input file.  For stdin, use -
+'--rules-file=RULESFILE'
 
-`--rules-file=RULESFILE'
      Conversion rules file to use when reading CSV (default: FILE.rules)
+'--alias=OLD=NEW'
 
-`--alias=OLD=NEW'
      display accounts named OLD as NEW
+'-I --ignore-assertions'
 
-`-I --ignore-assertions'
      ignore any failing balance assertions in the journal
 
    hledger reporting options:
 
-`-b --begin=DATE'
+'-b --begin=DATE'
+
      include postings/txns on or after this date
+'-e --end=DATE'
 
-`-e --end=DATE'
      include postings/txns before this date
+'-D --daily'
 
-`-D --daily'
      multiperiod/multicolumn report by day
+'-W --weekly'
 
-`-W --weekly'
      multiperiod/multicolumn report by week
+'-M --monthly'
 
-`-M --monthly'
      multiperiod/multicolumn report by month
+'-Q --quarterly'
 
-`-Q --quarterly'
      multiperiod/multicolumn report by quarter
+'-Y --yearly'
 
-`-Y --yearly'
      multiperiod/multicolumn report by year
+'-p --period=PERIODEXP'
 
-`-p --period=PERIODEXP'
      set start date, end date, and/or reporting interval all at once
      (overrides the flags above)
+'--date2'
 
-`--date2'
      show, and match with -b/-e/-p/date:, secondary dates instead
+'-C --cleared'
 
-`-C --cleared'
      include only cleared postings/txns
+'--pending'
 
-`--pending'
      include only pending postings/txns
+'-U --uncleared'
 
-`-U --uncleared'
      include only uncleared (and pending) postings/txns
+'-R --real'
 
-`-R --real'
      include only non-virtual postings
+'--depth=N'
 
-`--depth=N'
      hide accounts/postings deeper than N
+'-E --empty'
 
-`-E --empty'
      show items with zero amount, normally hidden
+'-B --cost'
 
-`-B --cost'
      convert amounts to their cost at transaction time (using the
      transaction price, if any)
+'-V --value'
 
-`--pivot TAGNAME'
+     convert amounts to their market value on the report end date (using
+     the most recent applicable market price, if any)
+'--pivot TAGNAME'
+
      organize reports by some tag's value instead of by account
+'--anon'
 
-`--anon'
      show anonymized accounts and payees
 
 
@@ -154,57 +155,57 @@ File: hledger-ui.1.info,  Node: KEYS,  Next: SCREENS,  Prev: OPTIONS,  Up: Top
 2 KEYS
 ******
 
-`?' shows a help dialog listing all keys. (Some of these also appear in
-the quick help at the bottom of each screen.) Press `?' again (or
-`ESCAPE', or `LEFT') to close it. The following keys work on most
+'?' shows a help dialog listing all keys.  (Some of these also appear in
+the quick help at the bottom of each screen.)  Press '?' again (or
+'ESCAPE', or 'LEFT') to close it.  The following keys work on most
 screens:
 
-   The cursor keys navigate: `right' (or `enter') goes deeper, `left'
-returns to the previous screen, `up'/`down'/`page up'/`page
-down'/`home'/`end' move up and down through lists. Vi-style
-`h'/`j'/`k'/`l' movement keys are also supported. A tip: movement speed
+   The cursor keys navigate: 'right' (or 'enter') goes deeper, 'left'
+returns to the previous screen, 'up'/'down'/'page up'/'page
+down'/'home'/'end' move up and down through lists.  Vi-style
+'h'/'j'/'k'/'l' movement keys are also supported.  A tip: movement speed
 is limited by your keyboard repeat rate, to move faster you may want to
-adjust it. (If you're on a mac, the Karabiner app is one way to do
+adjust it.  (If you're on a mac, the Karabiner app is one way to do
 that.)
 
    With shift pressed, the cursor keys adjust the report period,
 limiting the transactions to be shown (by default, all are shown).
-`shift-down/up' steps downward and upward through these standard report
-period durations: year, quarter, month, week, day. Then,
-`shift-left/right' moves to the previous/next period. `t' sets the
-report period to today. With the `--watch' option, when viewing a
+'shift-down/up' steps downward and upward through these standard report
+period durations: year, quarter, month, week, day.  Then,
+'shift-left/right' moves to the previous/next period.  't' sets the
+report period to today.  With the '--watch' option, when viewing a
 "current" period (the current day, week, month, quarter, or year), the
-period will move automatically to track the current date. To set a
-non-standard period, you can use `/' and a `date:' query.
+period will move automatically to track the current date.  To set a
+non-standard period, you can use '/' and a 'date:' query.
 
-   `/' lets you set a general filter query limiting the data shown,
-using the same query terms as in hledger and hledger-web. While editing
-the query, you can use CTRL-a/e/d/k, BS, cursor keys; press `ENTER' to
-set it, or `ESCAPE'to cancel. There are also keys for quickly adjusting
+   '/' lets you set a general filter query limiting the data shown,
+using the same query terms as in hledger and hledger-web.  While editing
+the query, you can use CTRL-a/e/d/k, BS, cursor keys; press 'ENTER' to
+set it, or 'ESCAPE'to cancel.  There are also keys for quickly adjusting
 some common filters like account depth and cleared/uncleared (see
-below). `BACKSPACE' or `DELETE' removes all filters, showing all
+below).  'BACKSPACE' or 'DELETE' removes all filters, showing all
 transactions.
 
-   `ESCAPE' removes all filters and jumps back to the top screen. Or,
+   'ESCAPE' removes all filters and jumps back to the top screen.  Or,
 it cancels a minibuffer edit or help dialog in progress.
 
-   `g' reloads from the data file(s) and updates the current screen and
-any previous screens. (With large files, this could cause a noticeable
+   'g' reloads from the data file(s) and updates the current screen and
+any previous screens.  (With large files, this could cause a noticeable
 pause.)
 
-   `I' toggles balance assertion checking. Disabling balance assertions
+   'I' toggles balance assertion checking.  Disabling balance assertions
 temporarily can be useful for troubleshooting.
 
-   `a' runs command-line hledger's add command, and reloads the updated
-file. This allows some basic data entry.
+   'a' runs command-line hledger's add command, and reloads the updated
+file.  This allows some basic data entry.
 
-   `E' runs $HLEDGER_UI_EDITOR, or $EDITOR, or a default (`emacsclient
--a "" -nw') on the journal file. With some editors (emacs, vi), the
+   'E' runs $HLEDGER_UI_EDITOR, or $EDITOR, or a default ('emacsclient
+-a "" -nw') on the journal file.  With some editors (emacs, vi), the
 cursor will be positioned at the current transaction when invoked from
 the register and transaction screens, and at the error location (if
 possible) when invoked from the error screen.
 
-   `q' quits the application.
+   'q' quits the application.
 
    Additional screen-specific keys are described below.
 
@@ -227,45 +228,45 @@ File: hledger-ui.1.info,  Node: Accounts screen,  Next: Register screen,  Up: SC
 3.1 Accounts screen
 ===================
 
-This is normally the first screen displayed. It lists accounts and their
-balances, like hledger's balance command. By default, it shows all
-accounts and their latest ending balances (including the balances of
-subaccounts). if you specify a query on the command line, it shows just
+This is normally the first screen displayed.  It lists accounts and
+their balances, like hledger's balance command.  By default, it shows
+all accounts and their latest ending balances (including the balances of
+subaccounts).  if you specify a query on the command line, it shows just
 the matched accounts and the balances from matched transactions.
 
    Account names are normally indented to show the hierarchy (tree
 mode).  To see less detail, set a depth limit by pressing a number key,
-`1' to `9'. `0' shows even less detail, collapsing all accounts to a
-single total. `-' and `+' (or `=') decrease and increase the depth
-limit. To remove the depth limit, set it higher than the maximum
-account depth, or press `ESCAPE'.
+'1' to '9'.  '0' shows even less detail, collapsing all accounts to a
+single total.  '-' and '+' (or '=') decrease and increase the depth
+limit.  To remove the depth limit, set it higher than the maximum
+account depth, or press 'ESCAPE'.
 
-   `F' toggles flat mode, in which accounts are shown as a flat list,
-with their full names. In this mode, account balances exclude
+   'F' toggles flat mode, in which accounts are shown as a flat list,
+with their full names.  In this mode, account balances exclude
 subaccounts, except for accounts at the depth limit (as with hledger's
 balance command).
 
-   `H' toggles between showing historical balances or period balances.
+   'H' toggles between showing historical balances or period balances.
 Historical balances (the default) are ending balances at the end of the
 report period, taking into account all transactions before that date
 (filtered by the filter query if any), including transactions before the
-start of the report period. In other words, historical balances are what
-you would see on a bank statement for that account (unless disturbed by
-a filter query). Period balances ignore transactions before the report
-start date, so they show the change in balance during the report period.
-They are more useful eg when viewing a time log.
+start of the report period.  In other words, historical balances are
+what you would see on a bank statement for that account (unless
+disturbed by a filter query).  Period balances ignore transactions
+before the report start date, so they show the change in balance during
+the report period.  They are more useful eg when viewing a time log.
 
-   `C' toggles cleared mode, in which uncleared transactions and
-postings are not shown. `U' toggles uncleared mode, in which only
+   'C' toggles cleared mode, in which uncleared transactions and
+postings are not shown.  'U' toggles uncleared mode, in which only
 uncleared transactions/postings are shown.
 
-   `R' toggles real mode, in which virtual postings are ignored.
+   'R' toggles real mode, in which virtual postings are ignored.
 
-   `Z' toggles nonzero mode, in which only accounts with nonzero
+   'Z' toggles nonzero mode, in which only accounts with nonzero
 balances are shown (hledger-ui shows zero items by default, unlike
 command-line hledger).
 
-   Press `right' or `enter' to view an account's transactions register.
+   Press 'right' or 'enter' to view an account's transactions register.
 
 
 File: hledger-ui.1.info,  Node: Register screen,  Next: Transaction screen,  Prev: Accounts screen,  Up: SCREENS
@@ -274,44 +275,42 @@ File: hledger-ui.1.info,  Node: Register screen,  Next: Transaction screen,  Pre
 ===================
 
 This screen shows the transactions affecting a particular account, like
-a check register. Each line represents one transaction and shows:
+a check register.  Each line represents one transaction and shows:
 
-   * the other account(s) involved, in abbreviated form. (If there are
-     both real and virtual postings, it shows only the accounts
-     affected by real postings.)
+   * the other account(s) involved, in abbreviated form.  (If there are
+     both real and virtual postings, it shows only the accounts affected
+     by real postings.)
 
    * the overall change to the current account's balance; positive for
      an inflow to this account, negative for an outflow.
 
    * the running historical total or period total for the current
-     account, after the transaction. This can be toggled with `H'.
-     Similar to the accounts screen, the historical total is affected
-     by transactions (filtered by the filter query) before the report
-     start date, while the period total is not. If the historical total
-     is not disturbed by a filter query, it will be the running
-     historical balance you would see on a bank register for the
-     current account.
-
+     account, after the transaction.  This can be toggled with 'H'.
+     Similar to the accounts screen, the historical total is affected by
+     transactions (filtered by the filter query) before the report start
+     date, while the period total is not.  If the historical total is
+     not disturbed by a filter query, it will be the running historical
+     balance you would see on a bank register for the current account.
 
    If the accounts screen was in tree mode, the register screen will
 include transactions from both the current account and its subaccounts.
 If the accounts screen was in flat mode, and a non-depth-clipped account
 was selected, the register screen will exclude transactions from
-subaccounts. In other words, the register always shows the transactions
-responsible for the period balance shown on the accounts screen. As on
-the accounts screen, this can be toggled with `F'.
+subaccounts.  In other words, the register always shows the transactions
+responsible for the period balance shown on the accounts screen.  As on
+the accounts screen, this can be toggled with 'F'.
 
-   `C' toggles cleared mode, in which uncleared transactions and
-postings are not shown. `U' toggles uncleared mode, in which only
+   'C' toggles cleared mode, in which uncleared transactions and
+postings are not shown.  'U' toggles uncleared mode, in which only
 uncleared transactions/postings are shown.
 
-   `R' toggles real mode, in which virtual postings are ignored.
+   'R' toggles real mode, in which virtual postings are ignored.
 
-   `Z' toggles nonzero mode, in which only transactions posting a
+   'Z' toggles nonzero mode, in which only transactions posting a
 nonzero change are shown (hledger-ui shows zero items by default, unlike
 command-line hledger).
 
-   Press `right' (or `enter') to view the selected transaction in
+   Press 'right' (or 'enter') to view the selected transaction in
 detail.
 
 
@@ -329,11 +328,11 @@ description, comments, along with all of its account postings are shown.
 Simple transactions have two postings, but there can be more (or in
 certain cases, fewer).
 
-   `up' and `down' will step through all transactions listed in the
-previous account register screen. In the title bar, the numbers in
-parentheses show your position within that account register. They will
+   'up' and 'down' will step through all transactions listed in the
+previous account register screen.  In the title bar, the numbers in
+parentheses show your position within that account register.  They will
 vary depending on which account register you came from (remember most
-transactions appear in multiple account registers). The #N number
+transactions appear in multiple account registers).  The #N number
 preceding them is the transaction's position within the complete
 unfiltered journal, which is a more stable id (at least until the next
 reload).
@@ -345,27 +344,26 @@ File: hledger-ui.1.info,  Node: Error screen,  Prev: Transaction screen,  Up: SC
 ================
 
 This screen will appear if there is a problem, such as a parse error,
-when you press g to reload. Once you have fixed the problem, press g
-again to reload and resume normal operation. (Or, you can press escape
+when you press g to reload.  Once you have fixed the problem, press g
+again to reload and resume normal operation.  (Or, you can press escape
 to cancel the reload attempt.)
-
 
 
 Tag Table:
-Node: Top88
-Node: OPTIONS823
-Ref: #options922
-Node: KEYS3611
-Ref: #keys3708
-Node: SCREENS6278
-Ref: #screens6365
-Node: Accounts screen6455
-Ref: #accounts-screen6585
-Node: Register screen8623
-Ref: #register-screen8780
-Node: Transaction screen10668
-Ref: #transaction-screen10828
-Node: Error screen11695
-Ref: #error-screen11819
+Node: Top73
+Node: OPTIONS825
+Ref: #options924
+Node: KEYS3631
+Ref: #keys3728
+Node: SCREENS6316
+Ref: #screens6403
+Node: Accounts screen6493
+Ref: #accounts-screen6623
+Node: Register screen8672
+Ref: #register-screen8829
+Node: Transaction screen10718
+Ref: #transaction-screen10878
+Node: Error screen11748
+Ref: #error-screen11872
 
 End Tag Table

--- a/hledger-ui/doc/hledger-ui.1.m4.md
+++ b/hledger-ui/doc/hledger-ui.1.m4.md
@@ -69,10 +69,6 @@ Any QUERYARGS are interpreted as a hledger search query which filters the data.
 `--flat`
 : show full account names, unindented
 
-`-V --value`
-: show amounts as their current market value in their default valuation commodity
-(accounts screen only)
-
 hledger general options:
 
 _generaloptions_

--- a/hledger-ui/doc/hledger-ui.1.txt
+++ b/hledger-ui/doc/hledger-ui.1.txt
@@ -50,15 +50,11 @@ OPTIONS
 
        --flat show full account names, unindented
 
-       -V --value
-              show amounts as their current market value in their default val-
-              uation commodity (accounts screen only)
-
        hledger general options:
 
        -h     show general usage (or after COMMAND, the command's usage)
 
-       --help show the current program's manual as plain  text  (or  after  an
+       --help show  the  current  program's  manual as plain text (or after an
               add-on COMMAND, the add-on's manual)
 
        --man  show the current program's manual with man
@@ -75,7 +71,7 @@ OPTIONS
               use a different input file.  For stdin, use -
 
        --rules-file=RULESFILE
-              Conversion   rules  file  to  use  when  reading  CSV  (default:
+              Conversion  rules  file  to  use  when  reading  CSV   (default:
               FILE.rules)
 
        --alias=OLD=NEW
@@ -108,7 +104,7 @@ OPTIONS
               multiperiod/multicolumn report by year
 
        -p --period=PERIODEXP
-              set start date, end date, and/or reporting interval all at  once
+              set  start date, end date, and/or reporting interval all at once
               (overrides the flags above)
 
        --date2
@@ -133,8 +129,12 @@ OPTIONS
               show items with zero amount, normally hidden
 
        -B --cost
-              convert  amounts  to  their  cost at transaction time (using the
+              convert amounts to their cost at  transaction  time  (using  the
               transaction price, if any)
+
+       -V --value
+              convert  amounts  to  their  market value on the report end date
+              (using the most recent applicable market price, if any)
 
        --pivot TAGNAME
               organize reports by some tag's value instead of by account

--- a/hledger-web/doc/hledger-web.1
+++ b/hledger-web/doc/hledger-web.1
@@ -258,6 +258,12 @@ price, if any)
 .RS
 .RE
 .TP
+.B \f[C]\-V\ \-\-value\f[]
+convert amounts to their market value on the report end date (using the
+most recent applicable market price, if any)
+.RS
+.RE
+.TP
 .B \f[C]\-\-pivot\ TAGNAME\f[]
 organize reports by some tag\[aq]s value instead of by account
 .RS

--- a/hledger-web/doc/hledger-web.1.info
+++ b/hledger-web/doc/hledger-web.1.info
@@ -1,69 +1,68 @@
-This is hledger-web/doc/hledger-web.1.info, produced by makeinfo
-version 4.8 from stdin.
+This is hledger-web.1.info, produced by makeinfo version 5.2 from stdin.
 
 
-File: hledger-web.1.info,  Node: Top,  Up: (dir)
+File: hledger-web.1.info,  Node: Top,  Next: OPTIONS,  Up: (dir)
 
 hledger-web(1) hledger-web dev
 ******************************
 
-hledger-web is hledger's web interface. It starts a simple web
+hledger-web is hledger's web interface.  It starts a simple web
 application for browsing and adding transactions, and optionally opens
-it in a web browser window if possible. It provides a more user-friendly
-UI than the hledger CLI or hledger-ui interface, showing more at once
-(accounts, the current account register, balance charts) and allowing
-history-aware data entry, interactive searching, and bookmarking.
+it in a web browser window if possible.  It provides a more
+user-friendly UI than the hledger CLI or hledger-ui interface, showing
+more at once (accounts, the current account register, balance charts)
+and allowing history-aware data entry, interactive searching, and
+bookmarking.
 
    hledger-web also lets you share a ledger with multiple users, or even
-the public web. There is no access control, so if you need that you
-should put it behind a suitable web proxy. As a small protection against
-data loss when running an unprotected instance, it writes a numbered
-backup of the main journal file (only ?) on every edit.
+the public web.  There is no access control, so if you need that you
+should put it behind a suitable web proxy.  As a small protection
+against data loss when running an unprotected instance, it writes a
+numbered backup of the main journal file (only ?)  on every edit.
 
    Like hledger, it reads data from one or more files in hledger
-journal, timeclock, timedot, or CSV format specified with `-f', or
-`$LEDGER_FILE', or `$HOME/.hledger.journal' (on windows, perhaps
-`C:/Users/USER/.hledger.journal'). For more about this see hledger(1),
+journal, timeclock, timedot, or CSV format specified with '-f', or
+'$LEDGER_FILE', or '$HOME/.hledger.journal' (on windows, perhaps
+'C:/Users/USER/.hledger.journal').  For more about this see hledger(1),
 hledger_journal(5) etc.
 
    By default, hledger-web starts the web app in "transient mode" and
-also opens it in your default web browser if possible. In this mode the
+also opens it in your default web browser if possible.  In this mode the
 web app will keep running for as long as you have it open in a browser
 window, and will exit after two minutes of inactivity (no requests and
-no browser windows viewing it). With `--serve', it just runs the web
+no browser windows viewing it).  With '--serve', it just runs the web
 app without exiting, and logs requests to the console.
 
    By default the server listens on IP address 127.0.0.1, accessible
-only to local requests. You can use `--host' to change this, eg `--host
+only to local requests.  You can use '--host' to change this, eg '--host
 0.0.0.0' to listen on all configured addresses.
 
-   Similarly, use `--port' to set a TCP port other than 5000, eg if you
+   Similarly, use '--port' to set a TCP port other than 5000, eg if you
 are running multiple hledger-web instances.
 
-   You can use `--base-url' to change the protocol, hostname, port and
+   You can use '--base-url' to change the protocol, hostname, port and
 path that appear in hyperlinks, useful eg for integrating hledger-web
-within a larger website. The default is `http://HOST:PORT/' using the
-server's configured host address and TCP port (or `http://HOST' if PORT
+within a larger website.  The default is 'http://HOST:PORT/' using the
+server's configured host address and TCP port (or 'http://HOST' if PORT
 is 80).
 
-   With `--file-url' you can set a different base url for static files,
+   With '--file-url' you can set a different base url for static files,
 eg for better caching or cookie-less serving on high performance
 websites.
 
    Note there is no built-in access control (aside from listening on
-127.0.0.1 by default). So you will need to hide hledger-web behind an
+127.0.0.1 by default).  So you will need to hide hledger-web behind an
 authenticating proxy (such as apache or nginx) if you want to restrict
 who can see and add entries to your journal.
 
    Command-line options and arguments may be used to set an initial
-filter on the data. This is not shown in the web UI, but it will be
+filter on the data.  This is not shown in the web UI, but it will be
 applied in addition to any search query entered there.
 
    With journal and timeclock files (but not CSV files, currently) the
 web app detects changes made by other means and will show the new data
-on the next request. If a change makes the file unparseable, hledger-web
-will show an error until the file has been fixed.
-
+on the next request.  If a change makes the file unparseable,
+hledger-web will show an error until the file has been fixed.
 * Menu:
 
 * OPTIONS::
@@ -74,125 +73,131 @@ File: hledger-web.1.info,  Node: OPTIONS,  Prev: Top,  Up: Top
 1 OPTIONS
 *********
 
-Note: if invoking hledger-web as a hledger subcommand, write `--'
-before options as shown above.
+Note: if invoking hledger-web as a hledger subcommand, write '--' before
+options as shown above.
 
-`--serve'
+'--serve'
+
      serve and log requests, don't browse or auto-exit
+'--host=IPADDR'
 
-`--host=IPADDR'
      listen on this IP address (default: 127.0.0.1)
+'--port=PORT'
 
-`--port=PORT'
      listen on this TCP port (default: 5000)
+'--base-url=URL'
 
-`--base-url=URL'
      set the base url (default: http://IPADDR:PORT). You would change
      this when sharing over the network, or integrating within a larger
      website.
+'--file-url=URL'
 
-`--file-url=URL'
-     set the static files url (default: BASEURL/static). hledger-web
+     set the static files url (default: BASEURL/static).  hledger-web
      normally serves static files itself, but if you wanted to serve
-     them from another server for efficiency, you would set the url
-     with this.
+     them from another server for efficiency, you would set the url with
+     this.
 
    hledger general options:
 
-`-h'
-     show general usage (or after COMMAND, the command's usage)
+'-h'
 
-`--help'
+     show general usage (or after COMMAND, the command's usage)
+'--help'
+
      show the current program's manual as plain text (or after an add-on
      COMMAND, the add-on's manual)
+'--man'
 
-`--man'
      show the current program's manual with man
+'--info'
 
-`--info'
      show the current program's manual with info
+'--version'
 
-`--version'
      show version
+'--debug[=N]'
 
-`--debug[=N]'
      show debug output (levels 1-9, default: 1)
+'-f FILE --file=FILE'
 
-`-f FILE --file=FILE'
-     use a different input file. For stdin, use -
+     use a different input file.  For stdin, use -
+'--rules-file=RULESFILE'
 
-`--rules-file=RULESFILE'
      Conversion rules file to use when reading CSV (default: FILE.rules)
+'--alias=OLD=NEW'
 
-`--alias=OLD=NEW'
      display accounts named OLD as NEW
+'-I --ignore-assertions'
 
-`-I --ignore-assertions'
      ignore any failing balance assertions in the journal
 
    hledger reporting options:
 
-`-b --begin=DATE'
+'-b --begin=DATE'
+
      include postings/txns on or after this date
+'-e --end=DATE'
 
-`-e --end=DATE'
      include postings/txns before this date
+'-D --daily'
 
-`-D --daily'
      multiperiod/multicolumn report by day
+'-W --weekly'
 
-`-W --weekly'
      multiperiod/multicolumn report by week
+'-M --monthly'
 
-`-M --monthly'
      multiperiod/multicolumn report by month
+'-Q --quarterly'
 
-`-Q --quarterly'
      multiperiod/multicolumn report by quarter
+'-Y --yearly'
 
-`-Y --yearly'
      multiperiod/multicolumn report by year
+'-p --period=PERIODEXP'
 
-`-p --period=PERIODEXP'
      set start date, end date, and/or reporting interval all at once
      (overrides the flags above)
+'--date2'
 
-`--date2'
      show, and match with -b/-e/-p/date:, secondary dates instead
+'-C --cleared'
 
-`-C --cleared'
      include only cleared postings/txns
+'--pending'
 
-`--pending'
      include only pending postings/txns
+'-U --uncleared'
 
-`-U --uncleared'
      include only uncleared (and pending) postings/txns
+'-R --real'
 
-`-R --real'
      include only non-virtual postings
+'--depth=N'
 
-`--depth=N'
      hide accounts/postings deeper than N
+'-E --empty'
 
-`-E --empty'
      show items with zero amount, normally hidden
+'-B --cost'
 
-`-B --cost'
      convert amounts to their cost at transaction time (using the
      transaction price, if any)
+'-V --value'
 
-`--pivot TAGNAME'
+     convert amounts to their market value on the report end date (using
+     the most recent applicable market price, if any)
+'--pivot TAGNAME'
+
      organize reports by some tag's value instead of by account
+'--anon'
 
-`--anon'
      show anonymized accounts and payees
-
 
 
 Tag Table:
-Node: Top90
-Node: OPTIONS3144
-Ref: #options3231
+Node: Top74
+Node: OPTIONS3156
+Ref: #options3243
 
 End Tag Table

--- a/hledger-web/doc/hledger-web.1.txt
+++ b/hledger-web/doc/hledger-web.1.txt
@@ -57,22 +57,22 @@ DESCRIPTION
        With --file-url you can set a different base url for static  files,  eg
        for better caching or cookie-less serving on high performance websites.
 
-       Note there is no built-in  access  control  (aside  from  listening  on
-       127.0.0.1  by default).  So you will need to hide hledger-web behind an
-       authenticating proxy (such as apache or nginx) if you want to  restrict
+       Note  there  is  no  built-in  access  control (aside from listening on
+       127.0.0.1 by default).  So you will need to hide hledger-web behind  an
+       authenticating  proxy (such as apache or nginx) if you want to restrict
        who can see and add entries to your journal.
 
        Command-line options and arguments may be used to set an initial filter
-       on the data.  This is not shown in the web UI, but it will  be  applied
+       on  the  data.  This is not shown in the web UI, but it will be applied
        in addition to any search query entered there.
 
        With journal and timeclock files (but not CSV files, currently) the web
-       app detects changes made by other means and will show the new  data  on
-       the  next request.  If a change makes the file unparseable, hledger-web
+       app  detects  changes made by other means and will show the new data on
+       the next request.  If a change makes the file unparseable,  hledger-web
        will show an error until the file has been fixed.
 
 OPTIONS
-       Note: if invoking hledger-web as a hledger subcommand, write --  before
+       Note:  if invoking hledger-web as a hledger subcommand, write -- before
        options as shown above.
 
        --serve
@@ -85,21 +85,21 @@ OPTIONS
               listen on this TCP port (default: 5000)
 
        --base-url=URL
-              set  the  base  url  (default:  http://IPADDR:PORT).   You would
+              set the  base  url  (default:  http://IPADDR:PORT).   You  would
               change this when sharing over the network, or integrating within
               a larger website.
 
        --file-url=URL
               set the static files url (default: BASEURL/static).  hledger-web
-              normally serves static files itself, but if you wanted to  serve
-              them  from  another server for efficiency, you would set the url
+              normally  serves static files itself, but if you wanted to serve
+              them from another server for efficiency, you would set  the  url
               with this.
 
        hledger general options:
 
        -h     show general usage (or after COMMAND, the command's usage)
 
-       --help show the current program's manual as plain  text  (or  after  an
+       --help show  the  current  program's  manual as plain text (or after an
               add-on COMMAND, the add-on's manual)
 
        --man  show the current program's manual with man
@@ -116,7 +116,7 @@ OPTIONS
               use a different input file.  For stdin, use -
 
        --rules-file=RULESFILE
-              Conversion   rules  file  to  use  when  reading  CSV  (default:
+              Conversion  rules  file  to  use  when  reading  CSV   (default:
               FILE.rules)
 
        --alias=OLD=NEW
@@ -149,7 +149,7 @@ OPTIONS
               multiperiod/multicolumn report by year
 
        -p --period=PERIODEXP
-              set start date, end date, and/or reporting interval all at  once
+              set  start date, end date, and/or reporting interval all at once
               (overrides the flags above)
 
        --date2
@@ -174,8 +174,12 @@ OPTIONS
               show items with zero amount, normally hidden
 
        -B --cost
-              convert  amounts  to  their  cost at transaction time (using the
+              convert amounts to their cost at  transaction  time  (using  the
               transaction price, if any)
+
+       -V --value
+              convert  amounts  to  their  market value on the report end date
+              (using the most recent applicable market price, if any)
 
        --pivot TAGNAME
               organize reports by some tag's value instead of by account

--- a/hledger/Hledger/Cli/Balance.hs
+++ b/hledger/Hledger/Cli/Balance.hs
@@ -275,7 +275,6 @@ balancemode = (defCommandMode $ ["balance"] ++ aliases) { -- also accept but don
         "show historical ending balance in each period (includes postings before report start date)\n "
      ,flagNone ["tree"] (\opts -> setboolopt "tree" opts) "show accounts as a tree; amounts include subaccounts (default in simple reports)"
      ,flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list; amounts exclude subaccounts except when account is depth-clipped (default in multicolumn reports)\n "
-     ,flagNone ["value","V"] (setboolopt "value") "convert amounts to their market value on the report end date (using the most recent applicable market price, if any)"
      ,flagNone ["average","A"] (\opts -> setboolopt "average" opts) "show a row average column (in multicolumn reports)"
      ,flagNone ["row-total","T"] (\opts -> setboolopt "row-total" opts) "show a row total column (in multicolumn reports)"
      ,flagNone ["no-total","N"] (\opts -> setboolopt "no-total" opts) "omit the final total row"
@@ -314,23 +313,19 @@ balance opts@CliOpts{reportopts_=ropts} j = do
                                | otherwise   = ropts{accountlistmode_=ALTree}
                     in singleBalanceReport ropts' (queryFromOpts d ropts) j
                 | otherwise = balanceReport ropts (queryFromOpts d ropts) j
-              convert | value_ ropts = maybe id (balanceReportValue j) mvaluedate
-                      | otherwise = id
               render = case format of
                 "csv" -> \ropts r -> (++ "\n") $ printCSV $ balanceReportAsCsv ropts r
                 _     -> balanceReportAsText
-          writeOutput opts $ render ropts $ convert report
+          writeOutput opts $ render ropts report
         _ -> do
           let report = multiBalanceReport ropts (queryFromOpts d ropts) j
-              convert | value_ ropts = maybe id (multiBalanceReportValue j) mvaluedate
-                      | otherwise = id
               render = case format of
                 "csv" -> \ropts r -> (++ "\n") $ printCSV $ multiBalanceReportAsCsv ropts r
                 _     -> case baltype of
                   PeriodChange     -> periodChangeReportAsText
                   CumulativeChange -> cumulativeChangeReportAsText
                   HistoricalBalance -> historicalBalanceReportAsText
-          writeOutput opts $ render ropts $ convert report
+          writeOutput opts $ render ropts report
 
 -- single-column balance reports
 

--- a/hledger/Hledger/Cli/BalanceView.hs
+++ b/hledger/Hledger/Cli/BalanceView.hs
@@ -30,7 +30,6 @@ balanceviewmode bv@BV{..} = (defCommandMode $ bvmode : bvaliases) {
      groupUnnamed = [
       flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
      ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
-     ,flagNone ["value","V"] (setboolopt "value") "convert amounts to their market value on the report end date (using the most recent applicable market price, if any)"
      ,flagNone ["no-total","N"] (\opts -> setboolopt "no-total" opts) "omit the final total row"
      ,flagNone ["no-elide"] (\opts -> setboolopt "no-elide" opts) "don't squash boring parent accounts (in tree mode)"
      ,flagReq  ["format"] (\s opts -> Right $ setopt "format" s opts) "FORMATSTR" "use this custom line format (in simple reports)"
@@ -51,9 +50,7 @@ balanceviewQueryReport
 balanceviewQueryReport ropts currDay reportEnd j t q = ([view], Sum amt)
     where
       q' = And [queryFromOpts currDay (withoutBeginDate ropts), q j]
-      convert | value_ ropts = maybe id (balanceReportValue j) reportEnd
-              | otherwise    = id
-      rep@(_ , amt) = convert $ balanceReport ropts q' j
+      rep@(_ , amt) = balanceReport ropts q' j
       view = intercalate "\n" [t <> ":", balanceReportAsText ropts rep]
 
 balanceviewReport :: BalanceView -> CliOpts -> Journal -> IO ()

--- a/hledger/Hledger/Cli/BalanceView.hs
+++ b/hledger/Hledger/Cli/BalanceView.hs
@@ -62,7 +62,7 @@ balanceviewReport BV{..} CliOpts{reportopts_=ropts} j = do
            bvqueries
   mapM_ putStrLn (bvname : "" : views)
 
-  unless (no_total_ ropts) .  putStrLn . unlines $
+  unless (no_total_ ropts) . mapM_ putStrLn $
     [ "Total:"
     , "--------------------"
     , padleft 20 $ showMixedAmountWithoutPrice (getSum amt)

--- a/hledger/Hledger/Cli/BalanceView.hs
+++ b/hledger/Hledger/Cli/BalanceView.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+
+module Hledger.Cli.BalanceView (
+  BalanceView(..)
+ ,balanceviewReport
+) where
+
+import Data.Time.Calendar
+import Data.List
+import Data.Monoid (Sum(..), (<>))
+import qualified Data.Text as T
+
+import Hledger
+import Hledger.Cli.Balance
+import Hledger.Cli.CliOptions
+
+data BalanceView = BV { bvname    :: String
+                      , bvqueries :: [(String, Journal -> Query)]
+                      }
+
+balanceviewQueryReport
+    :: ReportOpts
+    -> Day
+    -> Journal
+    -> String
+    -> (Journal -> Query)
+    -> ([String], Sum MixedAmount)
+balanceviewQueryReport ropts d j t q = ([view], Sum amt)
+    where
+      q' = And [queryFromOpts d (withoutBeginDate ropts), q j]
+      rep@(_ , amt) = balanceReport ropts q' j
+      view = intercalate "\n" [t <> ":", balanceReportAsText ropts rep]
+
+balanceviewReport :: BalanceView -> CliOpts -> Journal -> IO ()
+balanceviewReport BV{..} CliOpts{reportopts_=ropts} j = do
+  d <- getCurrentDay
+  let (views, amt) = foldMap (uncurry (balanceviewQueryReport ropts d j)) bvqueries
+  mapM_ putStrLn (bvname : "" : views)
+  putStrLn . unlines $
+    [ "Total:"
+    , "--------------------"
+    , padleft 20 $ showMixedAmountWithoutPrice (getSum amt)
+    ]
+
+withoutBeginDate :: ReportOpts -> ReportOpts
+withoutBeginDate ropts@ReportOpts{..} = ropts{period_=p}
+  where
+    p = dateSpanAsPeriod $ DateSpan Nothing (periodEnd period_)
+

--- a/hledger/Hledger/Cli/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Balancesheet.hs
@@ -18,13 +18,15 @@ import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.BalanceView
 
-bsBV = BV "balancesheet"
-          ["bs"]
-          "show a balance sheet"
-          "Balance Sheet"
-          [ ("Assets", journalAssetAccountQuery)
-          , ("Liabilities", journalLiabilityAccountQuery)
-          ]
+bsBV = BalanceView {
+         bvmode    = "balancesheet",
+         bvaliases = ["bs"],
+         bvhelp    = "show a balance sheet",
+         bvtitle   = "Balance Sheet",
+         bvqueries = [ ("Assets"     , journalAssetAccountQuery),
+                       ("Liabilities", journalLiabilityAccountQuery)
+                     ]
+      }
 
 balancesheetmode :: Mode RawOpts
 balancesheetmode = balanceviewmode bsBV

--- a/hledger/Hledger/Cli/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Balancesheet.hs
@@ -11,38 +11,26 @@ module Hledger.Cli.Balancesheet (
  ,tests_Hledger_Cli_Balancesheet
 ) where
 
-import qualified Data.Text.Lazy.IO as LT
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
-import Text.Shakespeare.Text
 
 import Hledger
 import Hledger.Cli.CliOptions
-import Hledger.Cli.Balance
 import Hledger.Cli.BalanceView
 
+bsBV = BV "balancesheet"
+          ["bs"]
+          "show a balance sheet"
+          "Balance Sheet"
+          [ ("Assets", journalAssetAccountQuery)
+          , ("Liabilities", journalLiabilityAccountQuery)
+          ]
 
 balancesheetmode :: Mode RawOpts
-balancesheetmode = (defCommandMode $ ["balancesheet"]++aliases) {
-  modeHelp = "show a balance sheet" `withAliases` aliases
- ,modeGroupFlags = Group {
-     groupUnnamed = [
-      flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
-     ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
-     ]
-    ,groupHidden = []
-    ,groupNamed = [generalflagsgroup1]
-    }
- }
-  where aliases = ["bs"]
+balancesheetmode = balanceviewmode bsBV
 
 balancesheet :: CliOpts -> Journal -> IO ()
-balancesheet = balanceviewReport bv
-  where
-    bv = BV "Balance Sheet"
-            [ ("Assets", journalAssetAccountQuery)
-            , ("Liabilities", journalLiabilityAccountQuery)
-            ]
+balancesheet = balanceviewReport bsBV
 
 tests_Hledger_Cli_Balancesheet :: Test
 tests_Hledger_Cli_Balancesheet = TestList

--- a/hledger/Hledger/Cli/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Balancesheet.hs
@@ -19,6 +19,7 @@ import Text.Shakespeare.Text
 import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Balance
+import Hledger.Cli.BalanceView
 
 
 balancesheetmode :: Mode RawOpts
@@ -35,30 +36,13 @@ balancesheetmode = (defCommandMode $ ["balancesheet"]++aliases) {
  }
   where aliases = ["bs"]
 
--- | Print a simple balance sheet.
 balancesheet :: CliOpts -> Journal -> IO ()
-balancesheet CliOpts{reportopts_=ropts} j = do
-  -- let lines = case lineFormatFromOpts ropts of Left err, Right ...
-  d <- getCurrentDay
-  let q = queryFromOpts d (withoutBeginDate ropts)
-      assetreport@(_,assets)          = balanceReport ropts (And [q, journalAssetAccountQuery j]) j
-      liabilityreport@(_,liabilities) = balanceReport ropts (And [q, journalLiabilityAccountQuery j]) j
-      total = assets + liabilities
-  LT.putStr $ [lt|Balance Sheet
-
-Assets:
-#{balanceReportAsText ropts assetreport}
-Liabilities:
-#{balanceReportAsText ropts liabilityreport}
-Total:
---------------------
-#{padleft 20 $ showMixedAmountWithoutPrice total}
-|]
-
-withoutBeginDate :: ReportOpts -> ReportOpts
-withoutBeginDate ropts@ReportOpts{..} = ropts{period_=p}
+balancesheet = balanceviewReport bv
   where
-    p = dateSpanAsPeriod $ DateSpan Nothing (periodEnd period_)
+    bv = BV "Balance Sheet"
+            [ ("Assets", journalAssetAccountQuery)
+            , ("Liabilities", journalLiabilityAccountQuery)
+            ]
 
 tests_Hledger_Cli_Balancesheet :: Test
 tests_Hledger_Cli_Balancesheet = TestList

--- a/hledger/Hledger/Cli/Cashflow.hs
+++ b/hledger/Hledger/Cli/Cashflow.hs
@@ -21,12 +21,13 @@ import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.BalanceView
 
-cfBV = BV "cashflow"
-          ["cf"]
-          "show a cashflow statement statement"
-          "Cashflow Statement"
-          [ ("Cash flows", journalCashAccountQuery)
-          ]
+cfBV = BalanceView {
+         bvmode    = "cashflow",
+         bvaliases = ["cf"],
+         bvhelp    = "show a cashflow statement",
+         bvtitle   = "Cashflow Statement",
+         bvqueries = [("Cash flows", journalCashAccountQuery)]
+      }
 
 cashflowmode :: Mode RawOpts
 cashflowmode = balanceviewmode cfBV

--- a/hledger/Hledger/Cli/Cashflow.hs
+++ b/hledger/Hledger/Cli/Cashflow.hs
@@ -14,48 +14,25 @@ module Hledger.Cli.Cashflow (
  ,tests_Hledger_Cli_Cashflow
 ) where
 
-import qualified Data.Text.Lazy.IO as LT
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
-import Text.Shakespeare.Text
 
 import Hledger
 import Hledger.Cli.CliOptions
-import Hledger.Cli.Balance
+import Hledger.Cli.BalanceView
 
+cfBV = BV "cashflow"
+          ["cf"]
+          "show a cashflow statement statement"
+          "Cashflow Statement"
+          [ ("Cash flows", journalCashAccountQuery)
+          ]
 
 cashflowmode :: Mode RawOpts
-cashflowmode = (defCommandMode ["cashflow","cf"]) {
-  modeHelp = "show a cashflow statement" `withAliases` ["cf"]
- ,modeGroupFlags = Group {
-     groupUnnamed = [
-      flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
-     ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
-     ]
-    ,groupHidden = []
-    ,groupNamed = [generalflagsgroup1]
-    }
- }
+cashflowmode = balanceviewmode cfBV
 
--- | Print a simple cashflow statement.
 cashflow :: CliOpts -> Journal -> IO ()
-cashflow CliOpts{reportopts_=ropts} j = do
-  -- let lines = case lineFormatFromOpts ropts of Left err, Right ...
-  d <- getCurrentDay
-  let q = queryFromOpts d ropts
-      cashreport@(_,total) = balanceReport ropts (And [q, journalCashAccountQuery j]) j
-      -- operatingreport@(_,operating) = balanceReport ropts (And [q, journalOperatingAccountMatcher j]) j
-      -- investingreport@(_,investing) = balanceReport ropts (And [q, journalInvestingAccountMatcher j]) j
-      -- financingreport@(_,financing) = balanceReport ropts (And [q, journalFinancingAccountMatcher j]) j
-      -- total = operating + investing + financing
-  LT.putStr $ [lt|Cashflow Statement
-
-Cash flows:
-#{balanceReportAsText ropts cashreport}
-Total:
---------------------
-#{padleft 20 $ showMixedAmountWithoutPrice total}
-|]
+cashflow = balanceviewReport cfBV
 
 tests_Hledger_Cli_Cashflow :: Test
 tests_Hledger_Cli_Cashflow = TestList

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -144,6 +144,7 @@ reportflags = [
  ,flagReq  ["depth"]         (\s opts -> Right $ setopt "depth" s opts) "N" "hide accounts/postings deeper than N"
  ,flagNone ["empty","E"]     (setboolopt "empty") "show items with zero amount, normally hidden"
  ,flagNone ["cost","B"]      (setboolopt "cost") "convert amounts to their cost at transaction time (using the transaction price, if any)"
+ ,flagNone ["value","V"]     (setboolopt "value") "convert amounts to their market value on the report end date (using the most recent applicable market price, if any)"
  ,flagNone ["anon"]              (setboolopt "anon") "output ledger with anonymized accounts and payees."
  ]
 

--- a/hledger/Hledger/Cli/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Incomestatement.hs
@@ -18,13 +18,15 @@ import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.BalanceView
 
-isBV = BV "incomestatement"
-          ["is"]
-          "show an income statement"
-          "Income Statement"
-          [ ("Revenues", journalIncomeAccountQuery)
-          , ("Expenses", journalExpenseAccountQuery)
-          ]
+isBV = BalanceView {
+         bvmode    = "incomestatement",
+         bvaliases = ["is"],
+         bvhelp    = "show an income statement",
+         bvtitle   = "Income Statement",
+         bvqueries = [ ("Revenues", journalIncomeAccountQuery),
+                       ("Expenses", journalExpenseAccountQuery)
+                     ]
+      }
 
 incomestatementmode :: Mode RawOpts
 incomestatementmode = balanceviewmode isBV

--- a/hledger/Hledger/Cli/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Incomestatement.hs
@@ -11,48 +11,26 @@ module Hledger.Cli.Incomestatement (
  ,tests_Hledger_Cli_Incomestatement
 ) where
 
-import qualified Data.Text.Lazy.IO as LT
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
-import Text.Shakespeare.Text
 
 import Hledger
 import Hledger.Cli.CliOptions
-import Hledger.Cli.Balance
+import Hledger.Cli.BalanceView
 
+isBV = BV "incomestatement"
+          ["is"]
+          "show an income statement"
+          "Income Statement"
+          [ ("Revenues", journalIncomeAccountQuery)
+          , ("Expenses", journalExpenseAccountQuery)
+          ]
 
 incomestatementmode :: Mode RawOpts
-incomestatementmode = (defCommandMode $ ["incomestatement"]++aliases) {
-  modeHelp = "show an income statement" `withAliases` aliases
- ,modeGroupFlags = Group {
-     groupUnnamed = [
-      flagNone ["flat"] (\opts -> setboolopt "flat" opts) "show accounts as a list"
-     ,flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
-     ]
-    ,groupHidden = []
-    ,groupNamed = [generalflagsgroup1]
-    }
- }
-  where aliases = ["is"]
+incomestatementmode = balanceviewmode isBV
 
--- | Print a simple income statement.
 incomestatement :: CliOpts -> Journal -> IO ()
-incomestatement CliOpts{reportopts_=ropts} j = do
-  d <- getCurrentDay
-  let q = queryFromOpts d ropts
-      incomereport@(_,income)    = balanceReport ropts (And [q, journalIncomeAccountQuery j]) j
-      expensereport@(_,expenses) = balanceReport ropts (And [q, journalExpenseAccountQuery j]) j
-      total = income + expenses
-  LT.putStr $ [lt|Income Statement
-
-Revenues:
-#{balanceReportAsText ropts incomereport}
-Expenses:
-#{balanceReportAsText ropts expensereport}
-Total:
---------------------
-#{padleft 20 $ showMixedAmountWithoutPrice total}
-|]
+incomestatement = balanceviewReport isBV
 
 tests_Hledger_Cli_Incomestatement :: Test
 tests_Hledger_Cli_Incomestatement = TestList

--- a/hledger/doc/balance.m4.md
+++ b/hledger/doc/balance.m4.md
@@ -16,10 +16,6 @@ Show accounts and their balances. Alias: bal.
 `--flat`
 : show accounts as a list; amounts exclude subaccounts except when account is depth-clipped (default in multicolumn reports)
 
-`-V --value`
-: convert amounts to their market value on the report end date
-(using the most recent applicable [market price](journal.html#market-prices), if any)
-
 `-A --average`
 : show a row average column (in multicolumn mode)
 

--- a/hledger/doc/commands.m4.md
+++ b/hledger/doc/commands.m4.md
@@ -172,8 +172,17 @@ Show a balance sheet. Alias: bs.
 `--flat`
 : show full account names, as a list (default)
 
+`-N --no-total`
+: don't show the final total row
+
 `--drop=N`
 : in flat mode: omit N leading account name parts
+
+`--no-elide`
+: don't squash boring parent accounts (in tree mode)
+
+`--format=LINEFORMAT`
+: in single-column balance reports: use this custom line format
 
 This command displays a simple
 [balance sheet](http://en.wikipedia.org/wiki/Balance_sheet). It currently
@@ -207,8 +216,17 @@ Show a cashflow statement. Alias: cf.
 `--flat`
 : show full account names, as a list (default)
 
+`-N --no-total`
+: don't show the final total row
+
 `--drop=N`
 : in flat mode: omit N leading account name parts
+
+`--no-elide`
+: don't squash boring parent accounts (in tree mode)
+
+`--format=LINEFORMAT`
+: in single-column balance reports: use this custom line format
 
 This command displays a simple
 [cashflow statement](http://en.wikipedia.org/wiki/Cash_flow_statement)
@@ -272,8 +290,17 @@ Show an income statement. Alias: is.
 `--flat`
 : show full account names, as a list (default)
 
+`-N --no-total`
+: don't show the final total row
+
 `--drop=N`
 : in flat mode: omit N leading account name parts
+
+`--no-elide`
+: don't squash boring parent accounts (in tree mode)
+
+`--format=LINEFORMAT`
+: in single-column balance reports: use this custom line format
 
 This command displays a simple
 [income statement](http://en.wikipedia.org/wiki/Income_statement).  It

--- a/hledger/doc/hledger.1
+++ b/hledger/doc/hledger.1
@@ -357,6 +357,12 @@ price, if any)
 .RS
 .RE
 .TP
+.B \f[C]\-V\ \-\-value\f[]
+convert amounts to their market value on the report end date (using the
+most recent applicable market price, if any)
+.RS
+.RE
+.TP
 .B \f[C]\-\-pivot\ TAGNAME\f[]
 organize reports by some tag\[aq]s value instead of by account
 .RS
@@ -1243,12 +1249,6 @@ is depth\-clipped (default in multicolumn reports)
 .RS
 .RE
 .TP
-.B \f[C]\-V\ \-\-value\f[]
-convert amounts to their market value on the report end date (using the
-most recent applicable market price, if any)
-.RS
-.RE
-.TP
 .B \f[C]\-A\ \-\-average\f[]
 show a row average column (in multicolumn mode)
 .RS
@@ -1667,8 +1667,23 @@ show full account names, as a list (default)
 .RS
 .RE
 .TP
+.B \f[C]\-N\ \-\-no\-total\f[]
+don\[aq]t show the final total row
+.RS
+.RE
+.TP
 .B \f[C]\-\-drop=N\f[]
 in flat mode: omit N leading account name parts
+.RS
+.RE
+.TP
+.B \f[C]\-\-no\-elide\f[]
+don\[aq]t squash boring parent accounts (in tree mode)
+.RS
+.RE
+.TP
+.B \f[C]\-\-format=LINEFORMAT\f[]
+in single\-column balance reports: use this custom line format
 .RS
 .RE
 .PP
@@ -1708,8 +1723,23 @@ show full account names, as a list (default)
 .RS
 .RE
 .TP
+.B \f[C]\-N\ \-\-no\-total\f[]
+don\[aq]t show the final total row
+.RS
+.RE
+.TP
 .B \f[C]\-\-drop=N\f[]
 in flat mode: omit N leading account name parts
+.RS
+.RE
+.TP
+.B \f[C]\-\-no\-elide\f[]
+don\[aq]t squash boring parent accounts (in tree mode)
+.RS
+.RE
+.TP
+.B \f[C]\-\-format=LINEFORMAT\f[]
+in single\-column balance reports: use this custom line format
 .RS
 .RE
 .PP
@@ -1784,8 +1814,23 @@ show full account names, as a list (default)
 .RS
 .RE
 .TP
+.B \f[C]\-N\ \-\-no\-total\f[]
+don\[aq]t show the final total row
+.RS
+.RE
+.TP
 .B \f[C]\-\-drop=N\f[]
 in flat mode: omit N leading account name parts
+.RS
+.RE
+.TP
+.B \f[C]\-\-no\-elide\f[]
+don\[aq]t squash boring parent accounts (in tree mode)
+.RS
+.RE
+.TP
+.B \f[C]\-\-format=LINEFORMAT\f[]
+in single\-column balance reports: use this custom line format
 .RS
 .RE
 .PP

--- a/hledger/doc/hledger.1.info
+++ b/hledger/doc/hledger.1.info
@@ -1,31 +1,29 @@
-This is hledger/doc/hledger.1.info, produced by makeinfo version 4.8
-from stdin.
+This is hledger.1.info, produced by makeinfo version 5.2 from stdin.
 
 
-File: hledger.1.info,  Node: Top,  Up: (dir)
+File: hledger.1.info,  Node: Top,  Next: EXAMPLES,  Up: (dir)
 
 hledger(1) hledger dev
 **********************
 
 This is hledger's command-line interface (there are also curses and web
-interfaces). Its basic function is to read a plain text file describing
+interfaces).  Its basic function is to read a plain text file describing
 financial transactions (in accounting terms, a general journal) and
 print useful reports on standard output, or export them as CSV. hledger
 can also read some other file formats such as CSV files, translating
-them to journal format. Additionally, hledger lists other hledger-*
+them to journal format.  Additionally, hledger lists other hledger-*
 executables found in the user's $PATH and can invoke them as
 subcommands.
 
    hledger reads data from one or more files in hledger journal,
-timeclock, timedot, or CSV format specified with `-f', or
-`$LEDGER_FILE', or `$HOME/.hledger.journal' (on windows, perhaps
-`C:/Users/USER/.hledger.journal'). If using `$LEDGER_FILE', note this
-must be a real environment variable, not a shell variable. You can
-specify standard input with `-f-'.
+timeclock, timedot, or CSV format specified with '-f', or
+'$LEDGER_FILE', or '$HOME/.hledger.journal' (on windows, perhaps
+'C:/Users/USER/.hledger.journal').  If using '$LEDGER_FILE', note this
+must be a real environment variable, not a shell variable.  You can
+specify standard input with '-f-'.
 
    Transactions are dated movements of money between two (or more) named
 accounts, and are recorded with journal entries like this:
-
 
 2015/10/16 bought food
  expenses:food          $10
@@ -34,15 +32,14 @@ accounts, and are recorded with journal entries like this:
    For more about this format, see hledger_journal(5).
 
    Most users use a text editor to edit the journal, usually with an
-editor mode such as ledger-mode for added convenience. hledger's
+editor mode such as ledger-mode for added convenience.  hledger's
 interactive add command is another way to record new transactions.
 hledger never changes existing transactions.
 
    To get started, you can either save some entries like the above in
-`~/.hledger.journal', or run `hledger add' and follow the prompts. Then
-try some commands like `hledger print' or `hledger balance'. See
+'~/.hledger.journal', or run 'hledger add' and follow the prompts.  Then
+try some commands like 'hledger print' or 'hledger balance'.  See
 COMMANDS and EXAMPLES below.
-
 * Menu:
 
 * EXAMPLES::
@@ -60,7 +57,6 @@ File: hledger.1.info,  Node: EXAMPLES,  Next: OPTIONS,  Prev: Top,  Up: Top
 
 Two simple transactions in hledger journal format:
 
-
 2015/9/30 gift received
   assets:cash   $20
   income:gifts
@@ -71,7 +67,6 @@ Two simple transactions in hledger journal format:
 
    Some basic reports:
 
-
 $ hledger print
 2015/09/30 gift received
     assets:cash            $20
@@ -81,7 +76,6 @@ $ hledger print
     expenses:food           $10
     assets:cash            $-10
 
-
 $ hledger accounts --tree
 assets
   cash
@@ -90,7 +84,6 @@ expenses
 income
   gifts
 
-
 $ hledger balance
                  $10  assets:cash
                  $10  expenses:food
@@ -98,13 +91,11 @@ $ hledger balance
 --------------------
                    0
 
-
 $ hledger register cash
 2015/09/30 gift received   assets:cash               $20           $20
 2015/10/16 farmers market  assets:cash              $-10           $10
 
    More commands:
-
 
 $ hledger                                 # show available commands
 $ hledger add                             # add more transactions to the journal file
@@ -123,63 +114,59 @@ File: hledger.1.info,  Node: OPTIONS,  Next: QUERIES,  Prev: EXAMPLES,  Up: Top
 2 OPTIONS
 *********
 
-To see general usage and the command list: `hledger -h' or just
-`hledger'. To see usage for a specific command: `hledger COMMAND -h'.
+To see general usage and the command list: 'hledger -h' or just
+'hledger'.  To see usage for a specific command: 'hledger COMMAND -h'.
 
    hledger has several kinds of options:
 
    * General options are always available and can appear anywhere on the
-     command line. `hledger -h' shows these. Eg: `hledger --version'.
+     command line.  'hledger -h' shows these.  Eg: 'hledger --version'.
 
-   * Common reporting options are available with most commands. These
+   * Common reporting options are available with most commands.  These
      and all other non-general options must be written after COMMAND.
-     `hledger COMMAND -h' shows these. Eg: `hledger register --cleared'.
+     'hledger COMMAND -h' shows these.  Eg: 'hledger register
+     --cleared'.
 
    * Command-specific options are also provided by some commands.
-     `hledger COMMAND -h' shows these too. Eg: `hledger register
+     'hledger COMMAND -h' shows these too.  Eg: 'hledger register
      --average'.
 
    * Some hledger commands come from separate add-on executables, which
-     have their own options. `hledger COMMAND -h' shows these, as
-     usual. Such options, if not also supported by hledger, should be
-     written following a double hyphen argument (`--') so that
-     hledger's option parser does not complain. Eg: `hledger ui --
-     --register=checking'. Or, you can just run the add-on directly:
-     `hledger-ui --register=checking'.
+     have their own options.  'hledger COMMAND -h' shows these, as
+     usual.  Such options, if not also supported by hledger, should be
+     written following a double hyphen argument ('--') so that hledger's
+     option parser does not complain.  Eg: 'hledger ui --
+     --register=checking'.  Or, you can just run the add-on directly:
+     'hledger-ui --register=checking'.
 
-
-   Command arguments may also follow the command name. In most cases
-these specify a query which filters the data. Command options and
+   Command arguments may also follow the command name.  In most cases
+these specify a query which filters the data.  Command options and
 arguments can be intermixed.
 
    Option and argument values containing problematic characters should
 be escaped with double quotes, backslashes, or (best) single quotes.
 This means spaces, but also characters which are significant to your
-command shell, such as less-than/greater-than. Eg: `hledger register -p
+command shell, such as less-than/greater-than.  Eg: 'hledger register -p
 'last year' "accounts receivable (receivable|payable)" amt:\>100'.
 
    Characters which are significant to the shell and also in regular
 expressions, like parentheses, the pipe symbol and the dollar sign, must
-sometimes be double-escaped. Eg, to match the dollar symbol: `hledger
-balance cur:'\$'' or `hledger balance cur:\\$'.
+sometimes be double-escaped.  Eg, to match the dollar symbol: 'hledger
+balance cur:'\$'' or 'hledger balance cur:\\$'.
 
-   There's more.. options and arguments being passed by hledger to an
-add-on executable get de-escaped once in the process. In this case you
-might need triple-escaping. Eg: `hledger ui cur:'\\$'' or `hledger ui
+   There's more..  options and arguments being passed by hledger to an
+add-on executable get de-escaped once in the process.  In this case you
+might need triple-escaping.  Eg: 'hledger ui cur:'\\$'' or 'hledger ui
 cur:\\\\$'.
 
    If in doubt, keep things simple:
 
    * write options after the command
-
    * enclose problematic args in single quotes
-
    * if needed, also add a backslash to escape regexp metacharacters
-
    * run add-on executables directly
 
-   If you're really curious, add `--debug=2' for troubleshooting.
-
+   If you're really curious, add '--debug=2' for troubleshooting.
 * Menu:
 
 * General options::
@@ -201,35 +188,36 @@ File: hledger.1.info,  Node: General options,  Next: Reporting options,  Up: OPT
 
 Always available, can be written before or after COMMAND.
 
-`-h'
-     show general usage (or after COMMAND, the command's usage)
+'-h'
 
-`--help'
+     show general usage (or after COMMAND, the command's usage)
+'--help'
+
      show the current program's manual as plain text (or after an add-on
      COMMAND, the add-on's manual)
+'--man'
 
-`--man'
      show the current program's manual with man
+'--info'
 
-`--info'
      show the current program's manual with info
+'--version'
 
-`--version'
      show version
+'--debug[=N]'
 
-`--debug[=N]'
      show debug output (levels 1-9, default: 1)
+'-f FILE --file=FILE'
 
-`-f FILE --file=FILE'
-     use a different input file. For stdin, use -
+     use a different input file.  For stdin, use -
+'--rules-file=RULESFILE'
 
-`--rules-file=RULESFILE'
      Conversion rules file to use when reading CSV (default: FILE.rules)
+'--alias=OLD=NEW'
 
-`--alias=OLD=NEW'
      display accounts named OLD as NEW
+'-I --ignore-assertions'
 
-`-I --ignore-assertions'
      ignore any failing balance assertions in the journal
 
 
@@ -240,64 +228,69 @@ File: hledger.1.info,  Node: Reporting options,  Next: Input files,  Prev: Gener
 
 Common reporting options, must be written after COMMAND.
 
-`-b --begin=DATE'
+'-b --begin=DATE'
+
      include postings/txns on or after this date
+'-e --end=DATE'
 
-`-e --end=DATE'
      include postings/txns before this date
+'-D --daily'
 
-`-D --daily'
      multiperiod/multicolumn report by day
+'-W --weekly'
 
-`-W --weekly'
      multiperiod/multicolumn report by week
+'-M --monthly'
 
-`-M --monthly'
      multiperiod/multicolumn report by month
+'-Q --quarterly'
 
-`-Q --quarterly'
      multiperiod/multicolumn report by quarter
+'-Y --yearly'
 
-`-Y --yearly'
      multiperiod/multicolumn report by year
+'-p --period=PERIODEXP'
 
-`-p --period=PERIODEXP'
      set start date, end date, and/or reporting interval all at once
      (overrides the flags above)
+'--date2'
 
-`--date2'
      show, and match with -b/-e/-p/date:, secondary dates instead
+'-C --cleared'
 
-`-C --cleared'
      include only cleared postings/txns
+'--pending'
 
-`--pending'
      include only pending postings/txns
+'-U --uncleared'
 
-`-U --uncleared'
      include only uncleared (and pending) postings/txns
+'-R --real'
 
-`-R --real'
      include only non-virtual postings
+'--depth=N'
 
-`--depth=N'
      hide accounts/postings deeper than N
+'-E --empty'
 
-`-E --empty'
      show items with zero amount, normally hidden
+'-B --cost'
 
-`-B --cost'
      convert amounts to their cost at transaction time (using the
      transaction price, if any)
+'-V --value'
 
-`--pivot TAGNAME'
+     convert amounts to their market value on the report end date (using
+     the most recent applicable market price, if any)
+'--pivot TAGNAME'
+
      organize reports by some tag's value instead of by account
+'--anon'
 
-`--anon'
      show anonymized accounts and payees
 
    If a reporting option occurs more than once on the command line, the
-last one takes precedence. Eg -p jan -p feb is equivalent to -p feb.
+last one takes precedence.  Eg -p jan -p feb is equivalent to -p feb.
 
 
 File: hledger.1.info,  Node: Input files,  Next: Smart dates,  Prev: Reporting options,  Up: OPTIONS
@@ -306,58 +299,53 @@ File: hledger.1.info,  Node: Input files,  Next: Smart dates,  Prev: Reporting o
 ===============
 
 hledger reads transactions from a data file (and the add command writes
-to it). By default this file is `$HOME/.hledger.journal' (or on
-Windows, something like `C:/Users/USER/.hledger.journal'). You can
-override this with the `$LEDGER_FILE' environment variable:
-
+to it).  By default this file is '$HOME/.hledger.journal' (or on
+Windows, something like 'C:/Users/USER/.hledger.journal').  You can
+override this with the '$LEDGER_FILE' environment variable:
 
 $ setenv LEDGER_FILE ~/finance/2016.journal
 $ hledger stats
 
-   or with the `-f/--file' option:
-
+   or with the '-f/--file' option:
 
 $ hledger -f /some/file stats
 
-   The file name `-' (hyphen) means standard input:
-
+   The file name '-' (hyphen) means standard input:
 
 $ cat some.journal | hledger -f-
 
-   Usually the data file is in hledger's journal format, but it can
-also be one of several other formats, listed below. hledger detects the
+   Usually the data file is in hledger's journal format, but it can also
+be one of several other formats, listed below.  hledger detects the
 format automatically based on the file extension, or if that is not
 recognised, by trying each built-in "reader" in turn:
 
 Reader:     Reads:                             Used for file extensions:
---------------------------------------------------------------------------- 
-`journal'   hledger's journal format, also     `.journal' `.j' `.hledger'
-            some Ledger journals               `.ledger'
-`timeclock' timeclock files (precise time      `.timeclock'
-            logging)                           
-`timedot'   timedot files (approximate time    `.timedot'
-            logging)                           
-`csv'       comma-separated values (data       `.csv'
-            interchange)                       
+---------------------------------------------------------------------------
+'journal'   hledger's journal format, also     '.journal' '.j'
+            some Ledger journals               '.hledger' '.ledger'
+'timeclock' timeclock files (precise time      '.timeclock'
+            logging)
+'timedot'   timedot files (approximate time    '.timedot'
+            logging)
+'csv'       comma-separated values (data       '.csv'
+            interchange)
 
    If needed (eg to ensure correct error messages when a file has the
 "wrong" extension), you can force a specific reader/format by prepending
-it to the file path with a colon. Examples:
-
+it to the file path with a colon.  Examples:
 
 $ hledger -f csv:/some/csv-file.dat stats
 $ echo 'i 2009/13/1 08:00:00' | hledger print -ftimeclock:-
 
-   You can also specify multiple `-f' options, to read multiple files
-as one big journal. There are some limitations with this:
+   You can also specify multiple '-f' options, to read multiple files as
+one big journal.  There are some limitations with this:
 
    * directives in one file will not affect the other files
-
    * balance assertions will not see any account balances from previous
      files
 
    If you need those, either use the include directive, or concatenate
-the files, eg: `cat a.journal b.journal | hledger -f- CMD'.
+the files, eg: 'cat a.journal b.journal | hledger -f- CMD'.
 
 
 File: hledger.1.info,  Node: Smart dates,  Next: Report start & end date,  Prev: Input files,  Up: OPTIONS
@@ -366,21 +354,21 @@ File: hledger.1.info,  Node: Smart dates,  Next: Report start & end date,  Prev:
 ===============
 
 hledger's user interfaces accept a flexible "smart date" syntax (unlike
-dates in the journal file). Smart dates allow some english words, can be
-relative to today's date, and can have less-significant date parts
+dates in the journal file).  Smart dates allow some english words, can
+be relative to today's date, and can have less-significant date parts
 omitted (defaulting to 1).
 
    Examples:
 
-`2009/1/1', `2009/01/01', `2009-1-1', `2009.1.1'   simple dates, several separators allowed
-`2009/1', `2009'                                   same as above - a missing day or month defaults to 1
-`1/1', `january', `jan', `this year'               relative dates, meaning january 1 of the current year
-`next year'                                        january 1 of next year
-`this month'                                       the 1st of the current month
-`this week'                                        the most recent monday
-`last week'                                        the monday of the week before this one
-`lastweek'                                         spaces are optional
-`today', `yesterday', `tomorrow'                   
+'2009/1/1', '2009/01/01', '2009-1-1', '2009.1.1'   simple dates, several separators allowed
+'2009/1', '2009'                                   same as above - a missing day or month defaults to 1
+'1/1', 'january', 'jan', 'this year'               relative dates, meaning january 1 of the current year
+'next year'                                        january 1 of next year
+'this month'                                       the 1st of the current month
+'this week'                                        the most recent monday
+'last week'                                        the monday of the week before this one
+'lastweek'                                         spaces are optional
+'today', 'yesterday', 'tomorrow'
 
 
 File: hledger.1.info,  Node: Report start & end date,  Next: Report intervals,  Prev: Smart dates,  Up: OPTIONS
@@ -389,27 +377,27 @@ File: hledger.1.info,  Node: Report start & end date,  Next: Report intervals,  
 ===========================
 
 Most hledger reports show the full span of time represented by the
-journal data, by default. So, the effective report start and end dates
+journal data, by default.  So, the effective report start and end dates
 will be the earliest and latest transaction or posting dates found in
 the journal.
 
    Often you will want to see a shorter time span, such as the current
-month. You can specify a start and/or end date using `-b/--begin',
-`-e/--end', `-p/--period' or a `date:' query (described below). All of
-these accept the smart date syntax. One important thing to be aware of
-when specifying end dates: as in Ledger, end dates are exclusive, so
-you need to write the date _after_ the last day you want to include.
+month.  You can specify a start and/or end date using '-b/--begin',
+'-e/--end', '-p/--period' or a 'date:' query (described below).  All of
+these accept the smart date syntax.  One important thing to be aware of
+when specifying end dates: as in Ledger, end dates are exclusive, so you
+need to write the date _after_ the last day you want to include.
 
    Examples:
 
-`-b 2016/3/17'      begin on St. Patrick's day 2016
-`-e 12/1'           end at the start of december 1st of the current year (11/30 will be the last date included)
-`-b thismonth'      all transactions on or after the 1st of the current month
-`-p thismonth'      all transactions in the current month
-`date:2016/3/17-'   the above written as queries instead
-`date:-12/1'        
-`date:thismonth-'   
-`date:thismonth'    
+'-b 2016/3/17'      begin on St.  Patrick's day 2016
+'-e 12/1'           end at the start of december 1st of the current year (11/30 will be the last date included)
+'-b thismonth'      all transactions on or after the 1st of the current month
+'-p thismonth'      all transactions in the current month
+'date:2016/3/17-'   the above written as queries instead
+'date:-12/1'
+'date:thismonth-'
+'date:thismonth'
 
 
 File: hledger.1.info,  Node: Report intervals,  Next: Period expressions,  Prev: Report start & end date,  Up: OPTIONS
@@ -419,9 +407,9 @@ File: hledger.1.info,  Node: Report intervals,  Next: Period expressions,  Prev:
 
 A report interval can be specified so that commands like register,
 balance and activity will divide their reports into multiple subperiods.
-The basic intervals can be selected with one of `-D/--daily',
-`-W/--weekly', `-M/--monthly', `-Q/--quarterly', or `-Y/--yearly'. More
-complex intervals may be specified with a period expression. Report
+The basic intervals can be selected with one of '-D/--daily',
+'-W/--weekly', '-M/--monthly', '-Q/--quarterly', or '-Y/--yearly'.  More
+complex intervals may be specified with a period expression.  Report
 intervals can not be specified with a query, currently.
 
 
@@ -430,74 +418,74 @@ File: hledger.1.info,  Node: Period expressions,  Next: Depth limiting,  Prev: R
 2.7 Period expressions
 ======================
 
-The `-p/--period' option accepts period expressions, a shorthand way of
+The '-p/--period' option accepts period expressions, a shorthand way of
 expressing a start date, end date, and/or report interval all at once.
 
    Here's a basic period expression specifying the first quarter of
 2009.  Note, hledger always treats start dates as inclusive and end
 dates as exclusive:
 
-   `-p "from 2009/1/1 to 2009/4/1"'
+   '-p "from 2009/1/1 to 2009/4/1"'
 
    Keywords like "from" and "to" are optional, and so are the spaces, as
-long as you don't run two dates together. "to" can also be written as
-"-". These are equivalent to the above:
+long as you don't run two dates together.  "to" can also be written as
+"-".  These are equivalent to the above:
 
-`-p "2009/1/1 2009/4/1"'
-`-p2009/1/1to2009/4/1'
-`-p2009/1/1-2009/4/1'
+'-p "2009/1/1 2009/4/1"'
+'-p2009/1/1to2009/4/1'
+'-p2009/1/1-2009/4/1'
 
    Dates are smart dates, so if the current year is 2009, the above can
 also be written as:
 
-`-p "1/1 4/1"'
-`-p "january-apr"'
-`-p "this year to 4/1"'
+'-p "1/1 4/1"'
+'-p "january-apr"'
+'-p "this year to 4/1"'
 
    If you specify only one date, the missing start or end date will be
 the earliest or latest transaction in your journal:
 
-`-p "from 2009/1/1"'   everything after january 1, 2009
-`-p "from 2009/1"'     the same
-`-p "from 2009"'       the same
-`-p "to 2009"'         everything before january 1, 2009
+'-p "from 2009/1/1"'   everything after january 1, 2009
+'-p "from 2009/1"'     the same
+'-p "from 2009"'       the same
+'-p "to 2009"'         everything before january 1, 2009
 
    A single date with no "from" or "to" defines both the start and end
 date like so:
 
-`-p "2009"'       the year 2009; equivalent to "2009/1/1 to 2010/1/1"
-`-p "2009/1"'     the month of jan; equivalent to "2009/1/1 to 2009/2/1"
-`-p "2009/1/1"'   just that day; equivalent to "2009/1/1 to 2009/1/2"
+'-p "2009"'       the year 2009; equivalent to "2009/1/1 to 2010/1/1"
+'-p "2009/1"'     the month of jan; equivalent to "2009/1/1 to 2009/2/1"
+'-p "2009/1/1"'   just that day; equivalent to "2009/1/1 to 2009/1/2"
 
-   The argument of `-p' can also begin with, or be, a report interval
-expression. The basic report intervals are `daily', `weekly',
-`monthly', `quarterly', or `yearly', which have the same effect as the
-`-D',`-W',`-M',`-Q', or `-Y' flags. Between report interval and
-start/end dates (if any), the word `in' is optional. Examples:
+   The argument of '-p' can also begin with, or be, a report interval
+expression.  The basic report intervals are 'daily', 'weekly',
+'monthly', 'quarterly', or 'yearly', which have the same effect as the
+'-D','-W','-M','-Q', or '-Y' flags.  Between report interval and
+start/end dates (if any), the word 'in' is optional.  Examples:
 
-`-p "weekly from 2009/1/1 to 2009/4/1"'
-`-p "monthly in 2008"'
-`-p "quarterly"'
+'-p "weekly from 2009/1/1 to 2009/4/1"'
+'-p "monthly in 2008"'
+'-p "quarterly"'
 
    The following more complex report intervals are also supported:
-`biweekly', `bimonthly', `every N days|weeks|months|quarters|years',
-`every Nth day [of month]', `every Nth day of week'.
+'biweekly', 'bimonthly', 'every N days|weeks|months|quarters|years',
+'every Nth day [of month]', 'every Nth day of week'.
 
    Examples:
 
-`-p "bimonthly from 2008"'
-`-p "every 2 weeks"'
-`-p "every 5 days from 1/3"'
+'-p "bimonthly from 2008"'
+'-p "every 2 weeks"'
+'-p "every 5 days from 1/3"'
 
    Show historical balances at end of 15th each month (N is exclusive
 end date):
 
-   `hledger balance -H -p "every 16th day"'
+   'hledger balance -H -p "every 16th day"'
 
    Group postings from start of wednesday to end of next tuesday (N is
 start date and exclusive end date):
 
-   `hledger register checking -p "every 3rd day of week"'
+   'hledger register checking -p "every 3rd day of week"'
 
 
 File: hledger.1.info,  Node: Depth limiting,  Next: Pivoting,  Prev: Period expressions,  Up: OPTIONS
@@ -505,9 +493,9 @@ File: hledger.1.info,  Node: Depth limiting,  Next: Pivoting,  Prev: Period expr
 2.8 Depth limiting
 ==================
 
-With the `--depth N' option, commands like account, balance and
-register will show only the uppermost accounts in the account tree, down
-to level N. Use this when you want a summary with less detail.
+With the '--depth N' option, commands like account, balance and register
+will show only the uppermost accounts in the account tree, down to level
+N. Use this when you want a summary with less detail.
 
 
 File: hledger.1.info,  Node: Pivoting,  Next: Regular expressions,  Prev: Depth limiting,  Up: OPTIONS
@@ -516,18 +504,17 @@ File: hledger.1.info,  Node: Pivoting,  Next: Regular expressions,  Prev: Depth 
 ============
 
 Normally hledger sums amounts, and organizes them in a hierarchy, based
-on account name. The `--pivot TAGNAME' option causes it to sum and
+on account name.  The '--pivot TAGNAME' option causes it to sum and
 organize hierarchy based on some other field instead.
 
-   TAGNAME is the full, case-insensitive name of a tag you have
-defined, or one of the built-in implicit tags (like `code' or `payee').
-As with account names, when tag values have
-`multiple:colon-separated:parts' hledger will build hierarchy,
-displayed in tree-mode reports, summarisable with a depth limit, and so
-on.
+   TAGNAME is the full, case-insensitive name of a tag you have defined,
+or one of the built-in implicit tags (like 'code' or 'payee').  As with
+account names, when tag values have 'multiple:colon-separated:parts'
+hledger will build hierarchy, displayed in tree-mode reports,
+summarisable with a depth limit, and so on.
 
-   `--pivot' affects all reports, and is one of those options you can
-write before the command name if you wish. You can think of hledger
+   '--pivot' affects all reports, and is one of those options you can
+write before the command name if you wish.  You can think of hledger
 transforming the journal before any other processing, replacing every
 posting's account name with the value of the specified tag on that
 posting, inheriting it from the transaction or using a blank value if
@@ -535,13 +522,11 @@ it's not present.
 
    An example:
 
-
 2016/02/16 Member Fee Payment
     assets:bank account                    2 EUR
     income:member fees                    -2 EUR  ; member: John Doe
 
    Normal balance report showing account names:
-
 
 $ hledger balance
                2 EUR  assets:bank account
@@ -550,7 +535,6 @@ $ hledger balance
                    0
 
    Pivoted balance report, using member: tag values instead:
-
 
 $ hledger balance --pivot member
                2 EUR
@@ -561,7 +545,6 @@ $ hledger balance --pivot member
    One way to show only amounts with a member: value (using a query,
 described below):
 
-
 $ hledger balance --pivot member tag:member=.
               -2 EUR  John Doe
 --------------------
@@ -569,7 +552,6 @@ $ hledger balance --pivot member tag:member=.
 
    Another way (the acct: query matches against the pivoted "account
 name"):
-
 
 $ hledger balance --pivot member acct:.
               -2 EUR  John Doe
@@ -585,46 +567,38 @@ File: hledger.1.info,  Node: Regular expressions,  Prev: Pivoting,  Up: OPTIONS
 hledger uses regular expressions in a number of places:
 
    * query terms, on the command line and in the hledger-web search
-     form: `REGEX', `desc:REGEX', `cur:REGEX', `tag:...=REGEX'
+     form: 'REGEX', 'desc:REGEX', 'cur:REGEX', 'tag:...=REGEX'
+   * CSV rules conditional blocks: 'if REGEX ...'
+   * account alias directives and options: 'alias /REGEX/ =
+     REPLACEMENT', '--alias /REGEX/=REPLACEMENT'
 
-   * CSV rules conditional blocks: `if REGEX ...'
-
-   * account alias directives and options: `alias /REGEX/ =
-     REPLACEMENT', `--alias /REGEX/=REPLACEMENT'
-
-   hledger's regular expressions come from the regex-tdfa library. In
+   hledger's regular expressions come from the regex-tdfa library.  In
 general they:
 
    * are case insensitive
-
    * are infix matching (do not need to match the entire thing being
      matched)
-
    * are POSIX extended regular expressions
-
    * also support GNU word boundaries (\<, \>, \b, \B)
-
    * and parenthesised capturing groups and numeric backreferences in
      replacement strings
-
    * do not support mode modifiers like (?s)
 
    Some things to note:
 
-   * In the `alias' directive and `--alias' option, regular expressions
-     must be enclosed in forward slashes (`/REGEX/').  Elsewhere in
+   * In the 'alias' directive and '--alias' option, regular expressions
+     must be enclosed in forward slashes ('/REGEX/').  Elsewhere in
      hledger, these are not required.
 
-   * To match a regular expression metacharacter like `$' as a literal
-     character, prepend a backslash. Eg to search for amounts with the
-     dollar sign in hledger-web, write `cur:\$'.
+   * To match a regular expression metacharacter like '$' as a literal
+     character, prepend a backslash.  Eg to search for amounts with the
+     dollar sign in hledger-web, write 'cur:\$'.
 
-   * On the command line, some metacharacters like `$' have a special
+   * On the command line, some metacharacters like '$' have a special
      meaning to the shell and so must be escaped a second time, with
-     single or double quotes or another backslash. Eg, to match amounts
-     with the dollar sign from the command line, write `cur:'\$'' or
-     `cur:\\$'.
-
+     single or double quotes or another backslash.  Eg, to match amounts
+     with the dollar sign from the command line, write 'cur:'\$'' or
+     'cur:\\$'.
 
 
 File: hledger.1.info,  Node: QUERIES,  Next: COMMANDS,  Prev: OPTIONS,  Up: Top
@@ -633,104 +607,100 @@ File: hledger.1.info,  Node: QUERIES,  Next: COMMANDS,  Prev: OPTIONS,  Up: Top
 *********
 
 One of hledger's strengths is being able to quickly report on precise
-subsets of your data. Most commands accept an optional query expression,
-written as arguments after the command name, to filter the data by date,
-account name or other criteria. The syntax is similar to a web search:
-one or more space-separated search terms, quotes to enclose whitespace,
-optional prefixes to match specific fields. Multiple search terms are
-combined as follows:
+subsets of your data.  Most commands accept an optional query
+expression, written as arguments after the command name, to filter the
+data by date, account name or other criteria.  The syntax is similar to
+a web search: one or more space-separated search terms, quotes to
+enclose whitespace, optional prefixes to match specific fields.
+Multiple search terms are combined as follows:
 
    All commands except print: show transactions/postings/accounts which
 match (or negatively match)
 
    * any of the description terms AND
-
    * any of the account terms AND
-
    * all the other terms.
 
    The print command: show transactions which
 
    * match any of the description terms AND
-
    * have any postings matching any of the positive account terms AND
-
    * have no postings matching any of the negative account terms AND
-
    * match all the other terms.
 
    The following kinds of search terms can be used:
 
-*`REGEX'*
+*'REGEX'*
+
      match account names by this regular expression
+*'acct:REGEX'*
 
-*`acct:REGEX'*
      same as above
+*'amt:N, amt:<N, amt:<=N, amt:>N, amt:>=N'*
 
-*`amt:N, amt:<N, amt:<=N, amt:>N, amt:>=N'*
      match postings with a single-commodity amount that is equal to,
      less than, or greater than N. (Multi-commodity amounts are not
-     tested, and will always match.) The comparison has two modes: if N
+     tested, and will always match.)  The comparison has two modes: if N
      is preceded by a + or - sign (or is 0), the two signed numbers are
-     compared. Otherwise, the absolute magnitudes are compared,
+     compared.  Otherwise, the absolute magnitudes are compared,
      ignoring sign.
+*'code:REGEX'*
 
-*`code:REGEX'*
      match by transaction code (eg check number)
+*'cur:REGEX'*
 
-*`cur:REGEX'*
      match postings or transactions including any amounts whose
      currency/commodity symbol is fully matched by REGEX. (For a partial
-     match, use `.*REGEX.*'). Note, to match characters which are
-     regex-significant, like the dollar sign (`$'), you need to prepend
-     `\'. And when using the command line you need to add one more level
-     of quoting to hide it from the shell, so eg do: `hledger print
-     cur:'\$'' or `hledger print cur:\\$'.
+     match, use '.*REGEX.*').  Note, to match characters which are
+     regex-significant, like the dollar sign ('$'), you need to prepend
+     '\'.  And when using the command line you need to add one more
+     level of quoting to hide it from the shell, so eg do: 'hledger
+     print cur:'\$'' or 'hledger print cur:\\$'.
+*'desc:REGEX'*
 
-*`desc:REGEX'*
      match transaction descriptions
+*'date:PERIODEXPR'*
 
-*`date:PERIODEXPR'*
-     match dates within the specified period. PERIODEXPR is a period
-     expression (with no report interval). Examples: `date:2016',
-     `date:thismonth', `date:2000/2/1-2/15', `date:lastweek-'.  If the
-     `--date2' command line flag is present, this matches secondary
+     match dates within the specified period.  PERIODEXPR is a period
+     expression (with no report interval).  Examples: 'date:2016',
+     'date:thismonth', 'date:2000/2/1-2/15', 'date:lastweek-'.  If the
+     '--date2' command line flag is present, this matches secondary
      dates instead.
+*'date2:PERIODEXPR'*
 
-*`date2:PERIODEXPR'*
      match secondary dates within the specified period.
+*'depth:N'*
 
-*`depth:N'*
      match (or display, depending on command) accounts at or above this
      depth
+*'real:, real:0'*
 
-*`real:, real:0'*
      match real or virtual postings respectively
+*'status:*, status:!, status:'*
 
-*`status:*, status:!, status:'*
      match cleared, pending, or uncleared/pending transactions
      respectively
+*'tag:REGEX[=REGEX]'*
 
-*`tag:REGEX[=REGEX]'*
-     match by tag name, and optionally also by tag value. Note a tag:
-     query is considered to match a transaction if it matches any of
-     the postings.  Also remember that postings inherit the tags of
-     their parent transaction.
+     match by tag name, and optionally also by tag value.  Note a tag:
+     query is considered to match a transaction if it matches any of the
+     postings.  Also remember that postings inherit the tags of their
+     parent transaction.
+*'not:'*
 
-*`not:'*
      before any of the above negates the match.
+*'inacct:ACCTNAME'*
 
-*`inacct:ACCTNAME'*
      a special term used automatically when you click an account name in
      hledger-web, specifying the account register we are currently in
-     (selects the transactions of that account and how to show them,
-     can be filtered further with `acct' etc). Not supported elsewhere
-     in hledger.
+     (selects the transactions of that account and how to show them, can
+     be filtered further with 'acct' etc).  Not supported elsewhere in
+     hledger.
 
    Some of these can also be expressed as command-line options (eg
-`depth:2' is equivalent to `--depth 2'). Generally you can mix options
+'depth:2' is equivalent to '--depth 2').  Generally you can mix options
 and query arguments, and the resulting query will be their intersection
-(perhaps excluding the `-p/--period' option).
+(perhaps excluding the '-p/--period' option).
 
 
 File: hledger.1.info,  Node: COMMANDS,  Next: ADD-ON COMMANDS,  Prev: QUERIES,  Up: Top
@@ -738,18 +708,17 @@ File: hledger.1.info,  Node: COMMANDS,  Next: ADD-ON COMMANDS,  Prev: QUERIES,  
 4 COMMANDS
 **********
 
-hledger provides a number of subcommands; `hledger' with no arguments
+hledger provides a number of subcommands; 'hledger' with no arguments
 shows a list.
 
-   If you install additional `hledger-*' packages, or if you put
-programs or scripts named `hledger-NAME' in your PATH, these will also
+   If you install additional 'hledger-*' packages, or if you put
+programs or scripts named 'hledger-NAME' in your PATH, these will also
 be listed as subcommands.
 
-   Run a subcommand by writing its name as first argument (eg `hledger
-incomestatement'). You can also write any unambiguous prefix of a
-command name (`hledger inc'), or one of the standard short aliases
-displayed in the command list (`hledger is').
-
+   Run a subcommand by writing its name as first argument (eg 'hledger
+incomestatement').  You can also write any unambiguous prefix of a
+command name ('hledger inc'), or one of the standard short aliases
+displayed in the command list ('hledger is').
 * Menu:
 
 * accounts::
@@ -775,27 +744,27 @@ File: hledger.1.info,  Node: accounts,  Next: activity,  Up: COMMANDS
 
 Show account names.
 
-`--tree'
+'--tree'
+
      show short account names, as a tree
+'--flat'
 
-`--flat'
      show full account names, as a list (default)
+'--drop=N'
 
-`--drop=N'
      in flat mode: omit N leading account name parts
 
    This command lists all account names that are in use (ie, all the
-accounts which have at least one transaction posting to them). With
+accounts which have at least one transaction posting to them).  With
 query arguments, only matched account names are shown.
 
-   It shows a flat list by default. With `--tree', it uses indentation
+   It shows a flat list by default.  With '--tree', it uses indentation
 to show the account hierarchy.
 
-   In flat mode you can add `--drop N' to omit the first few account
+   In flat mode you can add '--drop N' to omit the first few account
 name components.
 
    Examples:
-
 
 $ hledger accounts --tree
 assets
@@ -812,7 +781,6 @@ income
 liabilities
   debts
 
-
 $ hledger accounts --drop 1
 bank:checking
 bank:saving
@@ -822,7 +790,6 @@ supplies
 gifts
 salary
 debts
-
 
 $ hledger accounts
 assets:bank:checking
@@ -844,8 +811,7 @@ Show an ascii barchart of posting counts per interval.
 
    The activity command displays an ascii histogram showing transaction
 counts by day, week, month or other reporting interval (by day is the
-default). With query arguments, it counts only matched transactions.
-
+default).  With query arguments, it counts only matched transactions.
 
 $ hledger activity --quarterly
 2008-01-01 **
@@ -861,50 +827,42 @@ File: hledger.1.info,  Node: add,  Next: balance,  Prev: activity,  Up: COMMANDS
 
 Prompt for transactions and add them to the journal.
 
-`--no-new-accounts'
+'--no-new-accounts'
+
      don't allow creating new accounts; helps prevent typos when
      entering account names
 
    Many hledger users edit their journals directly with a text editor,
 or generate them from CSV. For more interactive data entry, there is the
-`add' command, which prompts interactively on the console for new
+'add' command, which prompts interactively on the console for new
 transactions, and appends them to the journal file (if there are
-multiple `-f FILE' options, the first file is used.) Existing
-transactions are not changed. This is the only hledger command that
+multiple '-f FILE' options, the first file is used.)  Existing
+transactions are not changed.  This is the only hledger command that
 writes to the journal file.
 
-   To use it, just run `hledger add' and follow the prompts. You can
-add as many transactions as you like; when you are finished, enter `.'
+   To use it, just run 'hledger add' and follow the prompts.  You can
+add as many transactions as you like; when you are finished, enter '.'
 or press control-d or control-c to exit.
 
    Features:
 
    * add tries to provide useful defaults, using the most similar recent
      transaction (by description) as a template.
-
    * You can also set the initial defaults with command line arguments.
-
    * Readline-style edit keys can be used during data entry.
-
    * The tab key will auto-complete whenever possible - accounts,
-     descriptions, dates (`yesterday', `today', `tomorrow').  If the
+     descriptions, dates ('yesterday', 'today', 'tomorrow').  If the
      input area is empty, it will insert the default value.
-
-   * If the journal defines a default commodity, it will be added to
-     any bare numbers entered.
-
+   * If the journal defines a default commodity, it will be added to any
+     bare numbers entered.
    * A parenthesised transaction code may be entered following a date.
-
    * Comments and tags may be entered following a description or amount.
-
-   * If you make a mistake, enter `<' at any prompt to restart the
+   * If you make a mistake, enter '<' at any prompt to restart the
      transaction.
-
    * Input prompts are displayed in a different colour when the terminal
      supports it.
 
    Example (see the tutorial for a detailed explanation):
-
 
 $ hledger add
 Adding transactions to journal file /src/hledger/examples/sample.journal
@@ -937,59 +895,55 @@ File: hledger.1.info,  Node: balance,  Next: balancesheet,  Prev: add,  Up: COMM
 4.4 balance
 ===========
 
-Show accounts and their balances. Alias: bal.
+Show accounts and their balances.  Alias: bal.
 
-`--change'
+'--change'
+
      show balance change in each period (default)
+'--cumulative'
 
-`--cumulative'
      show balance change accumulated across periods (in multicolumn
      reports)
+'-H --historical'
 
-`-H --historical'
      show historical ending balance in each period (includes postings
      before report start date)
+'--tree'
 
-`--tree'
      show accounts as a tree; amounts include subaccounts (default in
      simple reports)
+'--flat'
 
-`--flat'
      show accounts as a list; amounts exclude subaccounts except when
      account is depth-clipped (default in multicolumn reports)
+'-A --average'
 
-`-V --value'
-     convert amounts to their market value on the report end date
-     (using the most recent applicable market price, if any)
-
-`-A --average'
      show a row average column (in multicolumn mode)
+'-T --row-total'
 
-`-T --row-total'
      show a row total column (in multicolumn mode)
+'-N --no-total'
 
-`-N --no-total'
      don't show the final total row
+'--drop=N'
 
-`--drop=N'
      omit N leading account name parts (in flat mode)
+'--no-elide'
 
-`--no-elide'
      don't squash boring parent accounts (in tree mode)
+'--format=LINEFORMAT'
 
-`--format=LINEFORMAT'
      in single-column balance reports: use this custom line format
+'-O FMT --output-format=FMT'
 
-`-O FMT --output-format=FMT'
-     select the output format. Supported formats: txt, csv.
+     select the output format.  Supported formats: txt, csv.
+'-o FILE --output-file=FILE'
 
-`-o FILE --output-file=FILE'
      write output to FILE. A file extension matching one of the above
      formats selects that format.
 
-   The balance command displays accounts and balances. It is hledger's
+   The balance command displays accounts and balances.  It is hledger's
 most featureful and most useful command.
-
 
 $ hledger balance
                  $-1  assets
@@ -1006,25 +960,24 @@ $ hledger balance
                    0
 
    More precisely, the balance command shows the _change_ to each
-account's balance caused by all (matched) postings. In the common case
+account's balance caused by all (matched) postings.  In the common case
 where you do not filter by date and your journal sets the correct
 opening balances, this is the same as the account's ending balance.
 
    By default, accounts are displayed hierarchically, with subaccounts
-indented below their parent. "Boring" accounts, which contain a single
+indented below their parent.  "Boring" accounts, which contain a single
 interesting subaccount and no balance of their own, are elided into the
-following line for more compact output. (Use `--no-elide' to prevent
+following line for more compact output.  (Use '--no-elide' to prevent
 this.)
 
    Each account's balance is the "inclusive" balance - it includes the
 balances of any subaccounts.
 
    Accounts which have zero balance (and no non-zero subaccounts) are
-omitted. Use `-E/--empty' to show them.
+omitted.  Use '-E/--empty' to show them.
 
-   A final total is displayed by default; use `-N/--no-total' to
+   A final total is displayed by default; use '-N/--no-total' to
 suppress it:
-
 
 $ hledger balance -p 2008/6 expenses --no-total
                   $2  expenses
@@ -1048,11 +1001,10 @@ File: hledger.1.info,  Node: Flat mode,  Next: Depth limited balance reports,  U
 ---------------
 
 To see a flat list of full account names instead of the default
-hierarchical display, use `--flat'. In this mode, accounts (unless
+hierarchical display, use '--flat'.  In this mode, accounts (unless
 depth-clipped) show their "exclusive" balance, excluding any subaccount
-balances. In this mode, you can also use `--drop N' to omit the first
+balances.  In this mode, you can also use '--drop N' to omit the first
 few account name components.
-
 
 $ hledger balance -p 2008/6 expenses -N --flat --drop 1
                   $1  food
@@ -1064,11 +1016,10 @@ File: hledger.1.info,  Node: Depth limited balance reports,  Next: Multicolumn b
 4.4.2 Depth limited balance reports
 -----------------------------------
 
-With `--depth N', balance shows accounts only to the specified depth.
-This is very useful to show a complex charts of accounts in less
-detail. In flat mode, balances from accounts below the depth limit will
-be shown as part of a parent account at the depth limit.
-
+With '--depth N', balance shows accounts only to the specified depth.
+This is very useful to show a complex charts of accounts in less detail.
+In flat mode, balances from accounts below the depth limit will be shown
+as part of a parent account at the depth limit.
 
 $ hledger balance -N --depth 1
                  $-1  assets
@@ -1083,13 +1034,12 @@ File: hledger.1.info,  Node: Multicolumn balance reports,  Next: Market value,  
 ---------------------------------
 
 With a reporting interval, multiple balance columns will be shown, one
-for each report period. There are three types of multi-column balance
+for each report period.  There are three types of multi-column balance
 report, showing different information:
 
   1. By default: each column shows the sum of postings in that period,
-     ie the account's change of balance in that period. This is useful
+     ie the account's change of balance in that period.  This is useful
      eg for a monthly income statement:
-
 
      $ hledger balance --quarterly income expenses -E
      Balance changes in 2008:
@@ -1103,10 +1053,9 @@ report, showing different information:
      -------------------++---------------------------------
                         ||     $-1      $1       0       0
 
-  2. With `--cumulative': each column shows the ending balance for that
-     period, accumulating the changes across periods, starting from 0
-     at the report start date:
-
+  2. With '--cumulative': each column shows the ending balance for that
+     period, accumulating the changes across periods, starting from 0 at
+     the report start date:
 
      $ hledger balance --quarterly income expenses -E --cumulative
      Ending balances (cumulative) in 2008:
@@ -1120,12 +1069,11 @@ report, showing different information:
      -------------------++-------------------------------------------------
                         ||         $-1           0           0           0
 
-  3. With `--historical/-H': each column shows the actual historical
+  3. With '--historical/-H': each column shows the actual historical
      ending balance for that period, accumulating the changes across
-     periods, starting from the actual balance at the report start
-     date. This is useful eg for a multi-period balance sheet, and when
-     you are showing only the data after a certain start date:
-
+     periods, starting from the actual balance at the report start date.
+     This is useful eg for a multi-period balance sheet, and when you
+     are showing only the data after a certain start date:
 
      $ hledger balance ^assets ^liabilities --quarterly --historical --begin 2008/4/1
      Ending balances (historical) in 2008/04/01-2008/12/31:
@@ -1139,31 +1087,29 @@ report, showing different information:
      ----------------------++-------------------------------------
                            ||           0           0           0
 
-
    Multi-column balance reports display accounts in flat mode by
-default; to see the hierarchy, use `--tree'.
+default; to see the hierarchy, use '--tree'.
 
-   With a reporting interval (like `--quarterly' above), the report
+   With a reporting interval (like '--quarterly' above), the report
 start/end dates will be adjusted if necessary so that they encompass the
-displayed report periods. This is so that the first and last periods
+displayed report periods.  This is so that the first and last periods
 will be "full" and comparable to the others.
 
-   The `-E/--empty' flag does two things in multicolumn balance
-reports: first, the report will show all columns within the specified
-report period (without -E, leading and trailing columns with all zeroes
-are not shown). Second, all accounts which existed at the report start
-date will be considered, not just the ones with activity during the
-report period (use -E to include low-activity accounts which would
-otherwise would be omitted).
+   The '-E/--empty' flag does two things in multicolumn balance reports:
+first, the report will show all columns within the specified report
+period (without -E, leading and trailing columns with all zeroes are not
+shown).  Second, all accounts which existed at the report start date
+will be considered, not just the ones with activity during the report
+period (use -E to include low-activity accounts which would otherwise
+would be omitted).
 
-   The `-T/--row-total' flag adds an additional column showing the
-total for each row.
+   The '-T/--row-total' flag adds an additional column showing the total
+for each row.
 
-   The `-A/--average' flag adds a column showing the average value in
+   The '-A/--average' flag adds a column showing the average value in
 each row.
 
    Here's an example of all three:
-
 
 $ hledger balance -Q income expenses --tree -ETA
 Balance changes in 2008:
@@ -1187,17 +1133,16 @@ File: hledger.1.info,  Node: Market value,  Next: Custom balance output,  Prev: 
 4.4.4 Market value
 ------------------
 
-The `-V/--value' flag converts the reported amounts to their market
+The '-V/--value' flag converts the reported amounts to their market
 value on the report end date, using the most recent applicable market
-prices, when known. Specifically, when there is a market price (P
+prices, when known.  Specifically, when there is a market price (P
 directive) for the amount's commodity, dated on or before the report end
 date (see hledger -> Report start & end date), the amount will be
-converted to the price's commodity. If multiple applicable prices are
+converted to the price's commodity.  If multiple applicable prices are
 defined, the latest-dated one is used (and if dates are equal, the one
 last parsed).
 
    For example:
-
 
 # one euro is worth this many dollars from nov 1
 P 2016/11/01 € $1.10
@@ -1212,19 +1157,16 @@ P 2016/12/21 € $1.03
 
    How many euros do I have ?
 
-
 $ hledger -f t.j bal euros
                 €100  assets:euros
 
-   What are they worth on nov 3 ? (no report end date specified,
+   What are they worth on nov 3 ?  (no report end date specified,
 defaults to the last date in the journal)
-
 
 $ hledger -f t.j bal euros -V
              $110.00  assets:euros
 
    What are they worth on dec 21 ?
-
 
 $ hledger -f t.j bal euros -V -e 2016/12/21
              $103.00  assets:euros
@@ -1241,8 +1183,7 @@ File: hledger.1.info,  Node: Custom balance output,  Next: Output destination,  
 ---------------------------
 
 In simple (non-multi-column) balance reports, you can customise the
-output with `--format FMT':
-
+output with '--format FMT':
 
 $ hledger balance --format "%20(account) %12(total)"
               assets          $-1
@@ -1259,50 +1200,40 @@ $ hledger balance --format "%20(account) %12(total)"
                                 0
 
    The FMT format string (plus a newline) specifies the formatting
-applied to each account/balance pair. It may contain any suitable text,
+applied to each account/balance pair.  It may contain any suitable text,
 with data fields interpolated like so:
 
-   `%[MIN][.MAX](FIELDNAME)'
+   '%[MIN][.MAX](FIELDNAME)'
 
    * MIN pads with spaces to at least this width (optional)
-
    * MAX truncates at this width (optional)
-
    * FIELDNAME must be enclosed in parentheses, and can be one of:
 
-        * `depth_spacer' - a number of spaces equal to the account's
+        * 'depth_spacer' - a number of spaces equal to the account's
           depth, or if MIN is specified, MIN * depth spaces.
-
-        * `account' - the account's name
-
-        * `total' - the account's balance/posted total, right justified
-
+        * 'account' - the account's name
+        * 'total' - the account's balance/posted total, right justified
 
    Also, FMT can begin with an optional prefix to control how
 multi-commodity amounts are rendered:
 
-   * `%_' - render on multiple lines, bottom-aligned (the default)
+   * '%_' - render on multiple lines, bottom-aligned (the default)
+   * '%^' - render on multiple lines, top-aligned
+   * '%,' - render on one line, comma-separated
 
-   * `%^' - render on multiple lines, top-aligned
-
-   * `%,' - render on one line, comma-separated
-
-   There are some quirks. Eg in one-line mode, `%(depth_spacer)' has no
-effect, instead `%(account)' has indentation built in.  Experimentation
+   There are some quirks.  Eg in one-line mode, '%(depth_spacer)' has no
+effect, instead '%(account)' has indentation built in.  Experimentation
 may be needed to get pleasing results.
 
    Some example formats:
 
-   * `%(total)' - the account's total
-
-   * `%-20.20(account)' - the account's name, left justified, padded to
+   * '%(total)' - the account's total
+   * '%-20.20(account)' - the account's name, left justified, padded to
      20 characters and clipped at 20 characters
-
-   * `%,%-50(account)  %25(total)' - account name padded to 50
+   * '%,%-50(account) %25(total)' - account name padded to 50
      characters, total padded to 20 characters, with multiple
      commodities rendered on one line
-
-   * `%20(total)  %2(depth_spacer)%-(account)' - the default format for
+   * '%20(total) %2(depth_spacer)%-(account)' - the default format for
      the single-column balance report
 
 
@@ -1312,9 +1243,8 @@ File: hledger.1.info,  Node: Output destination,  Next: CSV output,  Prev: Custo
 ------------------------
 
 The balance, print, register and stats commands can write their output
-to a destination other than the console. This is controlled by the
-`-o/--output-file' option.
-
+to a destination other than the console.  This is controlled by the
+'-o/--output-file' option.
 
 $ hledger balance -o -     # write to stdout (the default)
 $ hledger balance -o FILE  # write to FILE
@@ -1327,10 +1257,9 @@ File: hledger.1.info,  Node: CSV output,  Prev: Output destination,  Up: balance
 
 The balance, print and register commands can write their output as CSV.
 This is useful for exporting data to other applications, eg to make
-charts in a spreadsheet. This is controlled by the `-O/--output-format'
-option, or by specifying a `.csv' file extension with
-`-o/--output-file'.
-
+charts in a spreadsheet.  This is controlled by the '-O/--output-format'
+option, or by specifying a '.csv' file extension with
+'-o/--output-file'.
 
 $ hledger balance -O csv       # write CSV to stdout
 $ hledger balance -o FILE.csv  # write CSV to FILE.csv
@@ -1341,18 +1270,27 @@ File: hledger.1.info,  Node: balancesheet,  Next: cashflow,  Prev: balance,  Up:
 4.5 balancesheet
 ================
 
-Show a balance sheet. Alias: bs.
+Show a balance sheet.  Alias: bs.
 
-`--flat'
+'--flat'
+
      show full account names, as a list (default)
+'-N --no-total'
 
-`--drop=N'
+     don't show the final total row
+'--drop=N'
+
      in flat mode: omit N leading account name parts
+'--no-elide'
 
-   This command displays a simple balance sheet. It currently assumes
-that you have top-level accounts named `asset' and `liability' (plural
+     don't squash boring parent accounts (in tree mode)
+'--format=LINEFORMAT'
+
+     in single-column balance reports: use this custom line format
+
+   This command displays a simple balance sheet.  It currently assumes
+that you have top-level accounts named 'asset' and 'liability' (plural
 forms also allowed.)
-
 
 $ hledger balancesheet
 Balance Sheet
@@ -1379,20 +1317,28 @@ File: hledger.1.info,  Node: cashflow,  Next: help,  Prev: balancesheet,  Up: CO
 4.6 cashflow
 ============
 
-Show a cashflow statement. Alias: cf.
+Show a cashflow statement.  Alias: cf.
 
-`--flat'
+'--flat'
+
      show full account names, as a list (default)
+'-N --no-total'
 
-`--drop=N'
+     don't show the final total row
+'--drop=N'
+
      in flat mode: omit N leading account name parts
+'--no-elide'
 
-   This command displays a simple cashflow statement It shows the
-change in all "cash" (ie, liquid assets) accounts for the period. It
-currently assumes that cash accounts are under a top-level account named
-`asset' and do not contain `receivable' or `A/R' (plural forms also
-allowed.)
+     don't squash boring parent accounts (in tree mode)
+'--format=LINEFORMAT'
 
+     in single-column balance reports: use this custom line format
+
+   This command displays a simple cashflow statement It shows the change
+in all "cash" (ie, liquid assets) accounts for the period.  It currently
+assumes that cash accounts are under a top-level account named 'asset'
+and do not contain 'receivable' or 'A/R' (plural forms also allowed.)
 
 $ hledger cashflow
 Cashflow Statement
@@ -1416,18 +1362,16 @@ File: hledger.1.info,  Node: help,  Next: incomestatement,  Prev: cashflow,  Up:
 
 Show any of the hledger manuals.
 
-   The `help' command displays any of the main hledger man pages.
-(Unlike `hledger --help', which displays only the hledger man page.)
+   The 'help' command displays any of the main hledger man pages.
+(Unlike 'hledger --help', which displays only the hledger man page.)
 Run it with no arguments to list available topics (their names are
-shortened for easier typing), and run `hledger help TOPIC' to select
-one. The output is similar to a man page, but fixed width. It may be
-long, so you may wish to pipe it into a pager. See also info and man.
-
+shortened for easier typing), and run 'hledger help TOPIC' to select
+one.  The output is similar to a man page, but fixed width.  It may be
+long, so you may wish to pipe it into a pager.  See also info and man.
 
 $ hledger help
 Choose a topic, eg: hledger help cli
 cli, ui, web, api, journal, csv, timeclock, timedot
-
 
 $ hledger help cli | less
 
@@ -1449,18 +1393,27 @@ File: hledger.1.info,  Node: incomestatement,  Next: info,  Prev: help,  Up: COM
 4.8 incomestatement
 ===================
 
-Show an income statement. Alias: is.
+Show an income statement.  Alias: is.
 
-`--flat'
+'--flat'
+
      show full account names, as a list (default)
+'-N --no-total'
 
-`--drop=N'
+     don't show the final total row
+'--drop=N'
+
      in flat mode: omit N leading account name parts
+'--no-elide'
 
-   This command displays a simple income statement. It currently assumes
-that you have top-level accounts named `income' (or `revenue') and
-`expense' (plural forms also allowed.)
+     don't squash boring parent accounts (in tree mode)
+'--format=LINEFORMAT'
 
+     in single-column balance reports: use this custom line format
+
+   This command displays a simple income statement.  It currently
+assumes that you have top-level accounts named 'income' (or 'revenue')
+and 'expense' (plural forms also allowed.)
 
 $ hledger incomestatement
 Income Statement
@@ -1491,10 +1444,10 @@ File: hledger.1.info,  Node: info,  Next: man,  Prev: incomestatement,  Up: COMM
 
 Show any of the hledger manuals using info.
 
-   The `info' command displays any of the hledger reference manuals
-using the info hypertextual documentation viewer. This can be a very
-efficient way to browse large manuals. It requires the "info" program to
-be available in your PATH.
+   The 'info' command displays any of the hledger reference manuals
+using the info hypertextual documentation viewer.  This can be a very
+efficient way to browse large manuals.  It requires the "info" program
+to be available in your PATH.
 
    As with help, run it with no arguments to list available topics
 (manuals).
@@ -1507,10 +1460,10 @@ File: hledger.1.info,  Node: man,  Next: print,  Prev: info,  Up: COMMANDS
 
 Show any of the hledger manuals using man.
 
-   The `man' command displays any of the hledger reference manuals
-using man, the standard documentation viewer on unix systems. This will
-fit the text to your terminal width, and probably invoke a pager
-automatically. It requires the "man" program to be available in your
+   The 'man' command displays any of the hledger reference manuals using
+man, the standard documentation viewer on unix systems.  This will fit
+the text to your terminal width, and probably invoke a pager
+automatically.  It requires the "man" program to be available in your
 PATH.
 
    As with help, run it with no arguments to list available topics
@@ -1524,20 +1477,20 @@ File: hledger.1.info,  Node: print,  Next: register,  Prev: man,  Up: COMMANDS
 
 Show transactions from the journal.
 
-`--explicit'
-     show all amounts explicitly
+'--explicit'
 
-`-m STR --match=STR'
+     show all amounts explicitly
+'-m STR --match=STR'
+
      show the transaction whose description is most similar to STR, and
      is most recent
+'-O FMT --output-format=FMT'
 
-`-O FMT --output-format=FMT'
-     select the output format. Supported formats: txt, csv.
+     select the output format.  Supported formats: txt, csv.
+'-o FILE --output-file=FILE'
 
-`-o FILE --output-file=FILE'
      write output to FILE. A file extension matching one of the above
      formats selects that format.
-
 
 $ hledger print
 2008/01/01 income
@@ -1570,11 +1523,11 @@ directives or inter-transaction comments.
 
    Normally, transactions' implicit/explicit amount style is preserved:
 when an amount is omitted in the journal, it will be omitted in the
-output. You can use the `--explicit' flag to make all amounts explicit,
+output.  You can use the '--explicit' flag to make all amounts explicit,
 which can be useful for troubleshooting or for making your journal more
-readable and robust against data entry errors. Note, in this mode
-postings with a multi-commodity amount (possible with an implicit
-amount in a multi-commodity transaction) will be split into multiple
+readable and robust against data entry errors.  Note, in this mode
+postings with a multi-commodity amount (possible with an implicit amount
+in a multi-commodity transaction) will be split into multiple
 single-commodity postings, for valid journal output.
 
    With -B/-cost, amounts with transaction prices are converted to cost
@@ -1582,7 +1535,6 @@ single-commodity postings, for valid journal output.
 
    The print command also supports output destination and CSV output.
 Here's an example of print's CSV output:
-
 
 $ hledger print -Ocsv
 "txnidx","date","date2","status","code","description","comment","account","amount","commodity","credit","debit","posting-status","posting-comment"
@@ -1600,17 +1552,14 @@ $ hledger print -Ocsv
 
    * There is one CSV record per posting, with the parent transaction's
      fields repeated.
-
    * The "txnidx" (transaction index) field shows which postings belong
-     to the same transaction. (This number might change if transactions
+     to the same transaction.  (This number might change if transactions
      are reordered within the file, files are parsed/included in a
      different order, etc.)
-
    * The amount is separated into "commodity" (the symbol) and "amount"
      (numeric quantity) fields.
-
    * The numeric amount is repeated in either the "credit" or "debit"
-     column, for convenience. (Those names are not accurate in the
+     column, for convenience.  (Those names are not accurate in the
      accounting sense; it just puts negative amounts under credit and
      zero or greater amounts under debit.)
 
@@ -1620,37 +1569,37 @@ File: hledger.1.info,  Node: register,  Next: stats,  Prev: print,  Up: COMMANDS
 4.12 register
 =============
 
-Show postings and their running total. Alias: reg.
+Show postings and their running total.  Alias: reg.
 
-`--cumulative'
+'--cumulative'
+
      show running total from report start date (default)
+'-H --historical'
 
-`-H --historical'
      show historical running total/balance (includes postings before
      report start date)
+'-A --average'
 
-`-A --average'
      show running average of posting amounts instead of total (implies
      -empty)
+'-r --related'
 
-`-r --related'
      show postings' siblings instead
+'-w N --width=N'
 
-`-w N --width=N'
      set output width (default: terminal width or COLUMNS. -wN,M sets
      description width as well)
+'-O FMT --output-format=FMT'
 
-`-O FMT --output-format=FMT'
-     select the output format. Supported formats: txt, csv.
+     select the output format.  Supported formats: txt, csv.
+'-o FILE --output-file=FILE'
 
-`-o FILE --output-file=FILE'
      write output to FILE. A file extension matching one of the above
      formats selects that format.
 
    The register command displays postings, one per line, and their
-running total. This is typically used with a query selecting a
+running total.  This is typically used with a query selecting a
 particular account, to see that account's activity:
-
 
 $ hledger register checking
 2008/01/01 income               assets:bank:checking            $1            $1
@@ -1658,39 +1607,36 @@ $ hledger register checking
 2008/06/02 save                 assets:bank:checking           $-1            $1
 2008/12/31 pay off              assets:bank:checking           $-1             0
 
-   The `--historical'/`-H' flag adds the balance from any undisplayed
-prior postings to the running total. This is useful when you want to
+   The '--historical'/'-H' flag adds the balance from any undisplayed
+prior postings to the running total.  This is useful when you want to
 see only recent activity, with a historically accurate running balance:
-
 
 $ hledger register checking -b 2008/6 --historical
 2008/06/01 gift                 assets:bank:checking            $1            $2
 2008/06/02 save                 assets:bank:checking           $-1            $1
 2008/12/31 pay off              assets:bank:checking           $-1             0
 
-   The `--depth' option limits the amount of sub-account detail
+   The '--depth' option limits the amount of sub-account detail
 displayed.
 
-   The `--average'/`-A' flag shows the running average posting amount
+   The '--average'/'-A' flag shows the running average posting amount
 instead of the running total (so, the final number displayed is the
-average for the whole report period). This flag implies `--empty' (see
-below). It is affected by `--historical'. It works best when showing
+average for the whole report period).  This flag implies '--empty' (see
+below).  It is affected by '--historical'.  It works best when showing
 just one account and one commodity.
 
-   The `--related'/`-r' flag shows the _other_ postings in the
+   The '--related'/'-r' flag shows the _other_ postings in the
 transactions of the postings which would normally be shown.
 
    With a reporting interval, register shows summary postings, one per
 interval, aggregating the postings to each account:
-
 
 $ hledger register --monthly income
 2008/01                 income:salary                          $-1           $-1
 2008/06                 income:gifts                           $-1           $-2
 
    Periods with no activity, and summary postings with a zero amount,
-are not shown by default; use the `--empty'/`-E' flag to see them:
-
+are not shown by default; use the '--empty'/'-E' flag to see them:
 
 $ hledger register --monthly income -E
 2008/01                 income:salary                          $-1           $-1
@@ -1706,9 +1652,8 @@ $ hledger register --monthly income -E
 2008/11                                                          0           $-2
 2008/12                                                          0           $-2
 
-   Often, you'll want to see just one line per interval. The `--depth'
+   Often, you'll want to see just one line per interval.  The '--depth'
 option helps with this, causing subaccounts to be aggregated:
-
 
 $ hledger register --monthly assets --depth 1h
 2008/01                 assets                                  $1            $1
@@ -1717,9 +1662,8 @@ $ hledger register --monthly assets --depth 1h
 
    Note when using report intervals, if you specify start/end dates
 these will be adjusted outward if necessary to contain a whole number of
-intervals. This ensures that the first and last intervals are full
+intervals.  This ensures that the first and last intervals are full
 length and comparable to the others in the report.
-
 * Menu:
 
 * Custom register output::
@@ -1730,22 +1674,20 @@ File: hledger.1.info,  Node: Custom register output,  Up: register
 4.12.1 Custom register output
 -----------------------------
 
-register uses the full terminal width by default, except on windows. You
-can override this by setting the `COLUMNS' environment variable (not a
-bash shell variable) or by using the `--width'/`-w' option.
+register uses the full terminal width by default, except on windows.
+You can override this by setting the 'COLUMNS' environment variable (not
+a bash shell variable) or by using the '--width'/'-w' option.
 
    The description and account columns normally share the space equally
-(about half of (width - 40) each). You can adjust this by adding a
+(about half of (width - 40) each).  You can adjust this by adding a
 description width as part of -width's argument, comma-separated:
-`--width W,D' . Here's a diagram:
-
+'--width W,D' .  Here's a diagram:
 
 <--------------------------------- width (W) ---------------------------------->
 date (10)  description (D)       account (W-41-D)     amount (12)   balance (12)
 DDDDDDDDDD dddddddddddddddddddd  aaaaaaaaaaaaaaaaaaa  AAAAAAAAAAAA  AAAAAAAAAAAA
 
    and some examples:
-
 
 $ hledger reg                     # use terminal width (or 80 on windows)
 $ hledger reg -w 100              # use width 100
@@ -1754,8 +1696,8 @@ $ export COLUMNS=100; hledger reg # set till session end (or window resize)
 $ hledger reg -w 100,40           # set overall width 100, description width 40
 $ hledger reg -w $COLUMNS,40      # use terminal width, and set description width
 
-   The register command also supports the `-o/--output-file' and
-`-O/--output-format' options for controlling output destination and CSV
+   The register command also supports the '-o/--output-file' and
+'-O/--output-format' options for controlling output destination and CSV
 output.
 
 
@@ -1766,10 +1708,10 @@ File: hledger.1.info,  Node: stats,  Next: test,  Prev: register,  Up: COMMANDS
 
 Show some journal statistics.
 
-`-o FILE --output-file=FILE'
+'-o FILE --output-file=FILE'
+
      write output to FILE. A file extension matching one of the above
      formats selects that format.
-
 
 $ hledger stats
 Main journal file        : /src/hledger/examples/sample.journal
@@ -1783,11 +1725,11 @@ Payees/descriptions      : 5
 Accounts                 : 8 (depth 3)
 Commodities              : 1 ($)
 
-   The stats command displays summary information for the whole
-journal, or a matched part of it. With a reporting interval, it shows a
-report for each report period.
+   The stats command displays summary information for the whole journal,
+or a matched part of it.  With a reporting interval, it shows a report
+for each report period.
 
-   The stats command also supports `-o/--output-file' for controlling
+   The stats command also supports '-o/--output-file' for controlling
 output destination.
 
 
@@ -1798,13 +1740,12 @@ File: hledger.1.info,  Node: test,  Prev: stats,  Up: COMMANDS
 
 Run built-in unit tests.
 
-
 $ hledger test
 Cases: 74  Tried: 74  Errors: 0  Failures: 0
 
    This command runs hledger's built-in unit tests and displays a quick
-report. With a regular expression argument, it selects only tests with
-matching names. It's mainly used in development, but it's also nice to
+report.  With a regular expression argument, it selects only tests with
+matching names.  It's mainly used in development, but it's also nice to
 be able to check your hledger executable for smoke at any time.
 
 
@@ -1814,33 +1755,31 @@ File: hledger.1.info,  Node: ADD-ON COMMANDS,  Next: TROUBLESHOOTING,  Prev: COM
 *****************
 
 hledger also searches for external add-on commands, and will include
-these in the commands list. These are programs or scripts in your PATH
-whose name starts with `hledger-' and ends with a recognised file
-extension (currently: no extension, `bat',`com',`exe',
-`hs',`lhs',`pl',`py',`rb',`rkt',`sh').
+these in the commands list.  These are programs or scripts in your PATH
+whose name starts with 'hledger-' and ends with a recognised file
+extension (currently: no extension, 'bat','com','exe',
+'hs','lhs','pl','py','rb','rkt','sh').
 
    Add-ons can be invoked like any hledger command, but there are a few
-things to be aware of. Eg if the `hledger-web' add-on is installed,
+things to be aware of.  Eg if the 'hledger-web' add-on is installed,
 
-   * `hledger -h web' shows hledger's help, while `hledger web -h'
-     shows hledger-web's help.
+   * 'hledger -h web' shows hledger's help, while 'hledger web -h' shows
+     hledger-web's help.
 
-   * Flags specific to the add-on must have a preceding `--' to hide
-     them from hledger. So `hledger web --serve --port 9000' will be
-     rejected; you must use `hledger web -- --serve --port 9000'.
+   * Flags specific to the add-on must have a preceding '--' to hide
+     them from hledger.  So 'hledger web --serve --port 9000' will be
+     rejected; you must use 'hledger web -- --serve --port 9000'.
 
-   * You can always run add-ons directly if preferred: `hledger-web
+   * You can always run add-ons directly if preferred: 'hledger-web
      --serve --port 9000'.
 
-
    Add-ons are a relatively easy way to add local features or experiment
-with new ideas. They can be written in any language, but haskell scripts
-have a big advantage: they can use the same hledger (and haskell)
-library functions that built-in commands do, for command-line options,
-journal parsing, reporting, etc.
+with new ideas.  They can be written in any language, but haskell
+scripts have a big advantage: they can use the same hledger (and
+haskell) library functions that built-in commands do, for command-line
+options, journal parsing, reporting, etc.
 
    Here are some hledger add-ons available:
-
 * Menu:
 
 * Official add-ons::
@@ -1854,7 +1793,6 @@ File: hledger.1.info,  Node: Official add-ons,  Next: Third party add-ons,  Up: 
 ====================
 
 These are maintained and released along with hledger.
-
 * Menu:
 
 * api::
@@ -1893,7 +1831,6 @@ File: hledger.1.info,  Node: Third party add-ons,  Next: Experimental add-ons,  
 
 These are maintained separately, and usually updated shortly after a
 hledger release.
-
 * Menu:
 
 * diff::
@@ -1944,10 +1881,9 @@ File: hledger.1.info,  Node: Experimental add-ons,  Prev: Third party add-ons,  
 ========================
 
 These are available in source form in the hledger repo's bin/ directory;
-installing them is pretty easy. They may be less mature and documented
-than built-in commands. Reading and tweaking these is a good way to
+installing them is pretty easy.  They may be less mature and documented
+than built-in commands.  Reading and tweaking these is a good way to
 start making your own!
-
 * Menu:
 
 * autosync::
@@ -1969,7 +1905,7 @@ File: hledger.1.info,  Node: autosync,  Next: budget,  Up: Experimental add-ons
 --------------
 
 hledger-autosync is a symbolic link for easily running ledger-autosync,
-if installed. ledger-autosync does deduplicating conversion of OFX data
+if installed.  ledger-autosync does deduplicating conversion of OFX data
 and some CSV formats, and can also download the data if your bank offers
 OFX Direct Connect.
 
@@ -2080,26 +2016,25 @@ tracker):
 
    *Successfully installed, but "No command 'hledger' found"*
 stack and cabal install binaries into a special directory, which should
-be added to your PATH environment variable. Eg on unix-like systems,
+be added to your PATH environment variable.  Eg on unix-like systems,
 that is ~/.local/bin and ~/.cabal/bin respectively.
 
    *I set a custom LEDGER_FILE, but hledger is still using the default
 file*
-`LEDGER_FILE' should be a real environment variable, not just a shell
-variable. The command `env | grep LEDGER_FILE' should show it. You may
-need to use `export'. Here's an explanation.
+'LEDGER_FILE' should be a real environment variable, not just a shell
+variable.  The command 'env | grep LEDGER_FILE' should show it.  You may
+need to use 'export'.  Here's an explanation.
 
    *"Illegal byte sequence" or "Invalid or incomplete multibyte or wide
 character" errors*
 In order to handle non-ascii letters and symbols (like £), hledger
-needs an appropriate locale. This is usually configured system-wide;
-you can also configure it temporarily. The locale may need to be one
+needs an appropriate locale.  This is usually configured system-wide;
+you can also configure it temporarily.  The locale may need to be one
 that supports UTF-8, if you built hledger with GHC < 7.2 (or possibly
 always, I'm not sure yet).
 
    Here's an example of setting the locale temporarily, on ubuntu
 gnu/linux:
-
 
 $ file my.journal
 my.journal: UTF-8 Unicode text                 # <- the file is UTF8-encoded
@@ -2111,13 +2046,11 @@ $ LANG=en_US.utf8 hledger -f my.journal print   # <- use it for this command
 
    Here's one way to set it permanently, there are probably better ways:
 
-
 $ echo "export LANG=en_US.UTF-8" >>~/.bash_profile
 $ bash --login
 
-   If we preferred to use eg `fr_FR.utf8', we might have to install
-that first:
-
+   If we preferred to use eg 'fr_FR.utf8', we might have to install that
+first:
 
 $ apt-get install language-pack-fr
 $ locale -a
@@ -2132,7 +2065,7 @@ POSIX
 $ LANG=fr_FR.utf8 hledger -f my.journal print
 
    Note some platforms allow variant locale spellings, but not all
-(ubuntu accepts `fr_FR.UTF8', mac osx requires exactly `fr_FR.UTF-8').
+(ubuntu accepts 'fr_FR.UTF8', mac osx requires exactly 'fr_FR.UTF-8').
 
 
 File: hledger.1.info,  Node: Known limitations,  Prev: Run-time problems,  Up: TROUBLESHOOTING
@@ -2143,13 +2076,13 @@ File: hledger.1.info,  Node: Known limitations,  Prev: Run-time problems,  Up: T
 *Command line interface*
 
    Add-on command options, unless they are also understood by the main
-hledger executable, must be written after `--', like this: `hledger web
+hledger executable, must be written after '--', like this: 'hledger web
 -- --server'
 
    *Differences from Ledger*
 
-   Not all of Ledger's journal file syntax is supported. See file format
-differences.
+   Not all of Ledger's journal file syntax is supported.  See file
+format differences.
 
    hledger is slower than Ledger, and uses more memory, on large data
 files.
@@ -2162,131 +2095,130 @@ supported.
    In a windows Cygwin/MSYS/Mintty window, the tab key is not supported
 in hledger add.
 
-
 
 Tag Table:
-Node: Top82
-Node: EXAMPLES1873
-Ref: #examples1975
-Node: OPTIONS3627
-Ref: #options3731
-Node: General options6372
-Ref: #general-options6501
-Node: Reporting options7272
-Ref: #reporting-options7425
-Node: Input files8858
-Ref: #input-files8995
-Node: Smart dates11036
-Ref: #smart-dates11179
-Node: Report start & end date12176
-Ref: #report-start-end-date12348
-Node: Report intervals13424
-Ref: #report-intervals13589
-Node: Period expressions13988
-Ref: #period-expressions14148
-Node: Depth limiting16483
-Ref: #depth-limiting16627
-Node: Pivoting16828
-Ref: #pivoting16961
-Node: Regular expressions18792
-Ref: #regular-expressions18926
-Node: QUERIES20409
-Ref: #queries20513
-Node: COMMANDS24152
-Ref: #commands24266
-Node: accounts24939
-Ref: #accounts25039
-Node: activity26021
-Ref: #activity26133
-Node: add26492
-Ref: #add26593
-Node: balance29256
-Ref: #balance29369
-Node: Flat mode32382
-Ref: #flat-mode32509
-Node: Depth limited balance reports32928
-Ref: #depth-limited-balance-reports33131
-Node: Multicolumn balance reports33552
-Ref: #multicolumn-balance-reports33754
-Node: Market value38403
-Ref: #market-value38567
-Node: Custom balance output39868
-Ref: #custom-balance-output40041
-Node: Output destination42145
-Ref: #output-destination42310
-Node: CSV output42580
-Ref: #csv-output42699
-Node: balancesheet43096
-Ref: #balancesheet43224
-Node: cashflow43876
-Ref: #cashflow43993
-Node: help44683
-Ref: #help44795
-Node: incomestatement45632
-Ref: #incomestatement45762
-Node: info46489
-Ref: #info46596
-Node: man46958
-Ref: #man47055
-Node: print47458
-Ref: #print47563
-Node: register51312
-Ref: #register51425
-Node: Custom register output55917
-Ref: #custom-register-output56048
-Node: stats57345
-Ref: #stats57451
-Node: test58331
-Ref: #test58418
-Node: ADD-ON COMMANDS58785
-Ref: #add-on-commands58921
-Node: Official add-ons60206
-Ref: #official-add-ons60348
-Node: api60436
-Ref: #api60527
-Node: ui60579
-Ref: #ui60680
-Node: web60738
-Ref: #web60829
-Node: Third party add-ons60875
-Ref: #third-party-add-ons61052
-Node: diff61188
-Ref: #diff61287
-Node: iadd61386
-Ref: #iadd61502
-Node: interest61585
-Ref: #interest61708
-Node: irr61803
-Ref: #irr61903
-Node: Experimental add-ons61981
-Ref: #experimental-add-ons62135
-Node: autosync62521
-Ref: #autosync62635
-Node: budget62873
-Ref: #budget62997
-Node: chart63063
-Ref: #chart63182
-Node: check63253
-Ref: #check63377
-Node: check-dates63444
-Ref: #check-dates63580
-Node: dupes63653
-Ref: #dupes63778
-Node: equity63849
-Ref: #equity63971
-Node: prices64090
-Ref: #prices64219
-Node: print-unique64274
-Ref: #print-unique64423
-Node: register-match64516
-Ref: #register-match64672
-Node: rewrite64770
-Ref: #rewrite64891
-Node: TROUBLESHOOTING64969
-Ref: #troubleshooting65088
-Node: Run-time problems65142
-Ref: #run-time-problems65285
-Node: Known limitations67229
-Ref: #known-limitations67372
+Node: Top70
+Node: EXAMPLES1883
+Ref: #examples1985
+Node: OPTIONS3631
+Ref: #options3735
+Node: General options6393
+Ref: #general-options6522
+Node: Reporting options7295
+Ref: #reporting-options7448
+Node: Input files9024
+Ref: #input-files9161
+Node: Smart dates11124
+Ref: #smart-dates11267
+Node: Report start & end date12246
+Ref: #report-start-end-date12418
+Node: Report intervals13484
+Ref: #report-intervals13649
+Node: Period expressions14050
+Ref: #period-expressions14210
+Node: Depth limiting16550
+Ref: #depth-limiting16694
+Node: Pivoting16895
+Ref: #pivoting17028
+Node: Regular expressions18857
+Ref: #regular-expressions18991
+Node: QUERIES20469
+Ref: #queries20573
+Node: COMMANDS24219
+Ref: #commands24333
+Node: accounts25006
+Ref: #accounts25106
+Node: activity26088
+Ref: #activity26200
+Node: add26559
+Ref: #add26660
+Node: balance29318
+Ref: #balance29431
+Node: Flat mode32309
+Ref: #flat-mode32436
+Node: Depth limited balance reports32856
+Ref: #depth-limited-balance-reports33059
+Node: Multicolumn balance reports33479
+Ref: #multicolumn-balance-reports33681
+Node: Market value38329
+Ref: #market-value38493
+Node: Custom balance output39793
+Ref: #custom-balance-output39966
+Node: Output destination42059
+Ref: #output-destination42224
+Node: CSV output42494
+Ref: #csv-output42613
+Node: balancesheet43010
+Ref: #balancesheet43138
+Node: cashflow44005
+Ref: #cashflow44122
+Node: help45027
+Ref: #help45139
+Node: incomestatement45977
+Ref: #incomestatement46107
+Node: info47049
+Ref: #info47156
+Node: man47520
+Ref: #man47617
+Node: print48022
+Ref: #print48127
+Node: register51877
+Ref: #register51990
+Node: Custom register output56486
+Ref: #custom-register-output56617
+Node: stats57914
+Ref: #stats58020
+Node: test58901
+Ref: #test58988
+Node: ADD-ON COMMANDS59356
+Ref: #add-on-commands59492
+Node: Official add-ons60779
+Ref: #official-add-ons60921
+Node: api61008
+Ref: #api61099
+Node: ui61151
+Ref: #ui61252
+Node: web61310
+Ref: #web61401
+Node: Third party add-ons61447
+Ref: #third-party-add-ons61624
+Node: diff61759
+Ref: #diff61858
+Node: iadd61957
+Ref: #iadd62073
+Node: interest62156
+Ref: #interest62279
+Node: irr62374
+Ref: #irr62474
+Node: Experimental add-ons62552
+Ref: #experimental-add-ons62706
+Node: autosync63093
+Ref: #autosync63207
+Node: budget63446
+Ref: #budget63570
+Node: chart63636
+Ref: #chart63755
+Node: check63826
+Ref: #check63950
+Node: check-dates64017
+Ref: #check-dates64153
+Node: dupes64226
+Ref: #dupes64351
+Node: equity64422
+Ref: #equity64544
+Node: prices64663
+Ref: #prices64792
+Node: print-unique64847
+Ref: #print-unique64996
+Node: register-match65089
+Ref: #register-match65245
+Node: rewrite65343
+Ref: #rewrite65464
+Node: TROUBLESHOOTING65542
+Ref: #troubleshooting65661
+Node: Run-time problems65715
+Ref: #run-time-problems65858
+Node: Known limitations67805
+Ref: #known-limitations67948
 
 End Tag Table

--- a/hledger/doc/hledger.1.txt
+++ b/hledger/doc/hledger.1.txt
@@ -121,33 +121,33 @@ OPTIONS
          hledger COMMAND -h shows these.  Eg: hledger register --cleared.
 
        o Command-specific  options  are  also  provided  by   some   commands.
-         hledger COMMAND -h  shows these too.  Eg: hledger register --average.
+         hledger COMMAND -h shows these too.  Eg: hledger register --average.
 
-       o Some hledger commands come from separate  add-on  executables,  which
-         have  their  own  options.  hledger COMMAND -h shows these, as usual.
-         Such options, if not also supported by  hledger,  should  be  written
-         following  a  double  hyphen  argument  (--) so that hledger's option
-         parser does  not  complain.   Eg:  hledger ui -- --register=checking.
+       o Some  hledger  commands  come from separate add-on executables, which
+         have their own options.  hledger COMMAND -h shows  these,  as  usual.
+         Such  options,  if  not  also supported by hledger, should be written
+         following a double hyphen argument  (--)  so  that  hledger's  option
+         parser  does  not  complain.   Eg: hledger ui -- --register=checking.
          Or,  you  can  just  run  the  add-on  directly:  hledger-ui --regis-
          ter=checking.
 
-       Command arguments may also follow the  command  name.   In  most  cases
-       these  specify  a  query  which  filters the data.  Command options and
+       Command  arguments  may  also  follow  the command name.  In most cases
+       these specify a query which filters  the  data.   Command  options  and
        arguments can be intermixed.
 
-       Option and argument values containing problematic characters should  be
+       Option  and argument values containing problematic characters should be
        escaped with double quotes, backslashes, or (best) single quotes.  This
        means spaces, but also characters which are significant to your command
-       shell,    such    as    less-than/greater-than.    Eg:   hledger regis-
+       shell,   such   as    less-than/greater-than.     Eg:    hledger regis-
        ter -p 'last year' "accounts receivable (receiv-
        able|payable)" amt:\>100.
 
-       Characters  which  are  significant  to  the  shell and also in regular
-       expressions, like parentheses, the pipe symbol  and  the  dollar  sign,
-       must  sometimes  be  double-escaped.   Eg,  to match the dollar symbol:
+       Characters which are significant to  the  shell  and  also  in  regular
+       expressions,  like  parentheses,  the  pipe symbol and the dollar sign,
+       must sometimes be double-escaped.  Eg,  to  match  the  dollar  symbol:
        hledger balance cur:'\$' or hledger balance cur:\\$.
 
-       There's more..  options and arguments being passed  by  hledger  to  an
+       There's  more..   options  and  arguments being passed by hledger to an
        add-on executable get de-escaped once in the process.  In this case you
        might    need    triple-escaping.     Eg:    hledger ui cur:'\\$'    or
        hledger ui cur:\\\\$.
@@ -169,7 +169,7 @@ OPTIONS
 
        -h     show general usage (or after COMMAND, the command's usage)
 
-       --help show  the  current  program's  manual as plain text (or after an
+       --help show the current program's manual as plain  text  (or  after  an
               add-on COMMAND, the add-on's manual)
 
        --man  show the current program's manual with man
@@ -186,7 +186,7 @@ OPTIONS
               use a different input file.  For stdin, use -
 
        --rules-file=RULESFILE
-              Conversion  rules  file  to  use  when  reading  CSV   (default:
+              Conversion   rules  file  to  use  when  reading  CSV  (default:
               FILE.rules)
 
        --alias=OLD=NEW
@@ -220,7 +220,7 @@ OPTIONS
               multiperiod/multicolumn report by year
 
        -p --period=PERIODEXP
-              set  start date, end date, and/or reporting interval all at once
+              set start date, end date, and/or reporting interval all at  once
               (overrides the flags above)
 
        --date2
@@ -245,8 +245,12 @@ OPTIONS
               show items with zero amount, normally hidden
 
        -B --cost
-              convert amounts to their cost at  transaction  time  (using  the
+              convert  amounts  to  their  cost at transaction time (using the
               transaction price, if any)
+
+       -V --value
+              convert amounts to their market value on  the  report  end  date
+              (using the most recent applicable market price, if any)
 
        --pivot TAGNAME
               organize reports by some tag's value instead of by account
@@ -277,7 +281,6 @@ OPTIONS
        be one of several other formats, listed  below.   hledger  detects  the
        format  automatically  based  on  the file extension, or if that is not
        recognised, by trying each built-in "reader" in turn:
-
 
        Reader:       Reads:                              Used for file extensions:
        -----------------------------------------------------------------------------
@@ -316,13 +319,12 @@ OPTIONS
 
        Examples:
 
-
        2009/1/1,      2009/01/01,   simple dates, several sep-
        2009-1-1, 2009.1.1           arators allowed
        2009/1, 2009                 same  as above - a missing
                                     day or month defaults to 1
-       1/1,     january,     jan,   relative  dates,   meaning
-       this year                    january  1  of the current
+       1/1,     january,     jan,   relative   dates,  meaning
+       this year                    january 1 of  the  current
                                     year
        next year                    january 1 of next year
        this month                   the  1st  of  the  current
@@ -331,6 +333,7 @@ OPTIONS
        last week                    the  monday  of  the  week
                                     before this one
        lastweek                     spaces are optional
+
        today, yesterday, tomorrow
 
    Report start & end date
@@ -347,7 +350,6 @@ OPTIONS
        need to write the date after the last day you want to include.
 
        Examples:
-
 
        -b 2016/3/17      begin  on  St.   Patrick's
                          day 2016
@@ -376,26 +378,24 @@ OPTIONS
 
    Period expressions
        The -p/--period option accepts period expressions, a shorthand  way  of
-       expressing  a start date, end date, and/or report interval all at once.
+       expressing a start date, end date, and/or report interval all at once.
 
-       Here's a basic period expression specifying the first quarter of  2009.
-       Note,  hledger  always treats start dates as inclusive and end dates as
+       Here's  a basic period expression specifying the first quarter of 2009.
+       Note, hledger always treats start dates as inclusive and end  dates  as
        exclusive:
 
        -p "from 2009/1/1 to 2009/4/1"
 
-       Keywords like "from" and "to" are optional, and so are the  spaces,  as
-       long  as you don't run two dates together.  "to" can also be written as
+       Keywords  like  "from" and "to" are optional, and so are the spaces, as
+       long as you don't run two dates together.  "to" can also be written  as
        "-".  These are equivalent to the above:
-
 
        -p "2009/1/1 2009/4/1"
        -p2009/1/1to2009/4/1
        -p2009/1/1-2009/4/1
 
-       Dates are smart dates, so if the current year is 2009,  the  above  can
+       Dates  are  smart  dates, so if the current year is 2009, the above can
        also be written as:
-
 
        -p "1/1 4/1"
        -p "january-apr"
@@ -404,62 +404,57 @@ OPTIONS
        If you specify only one date, the missing start or end date will be the
        earliest or latest transaction in your journal:
 
-
-
        -p "from 2009/1/1"   everything  after  january
                             1, 2009
        -p "from 2009/1"     the same
        -p "from 2009"       the same
-       -p "to 2009"         everything  before january
+       -p "to 2009"         everything before  january
                             1, 2009
 
-       A single date with no "from" or "to" defines both  the  start  and  end
+       A  single  date  with  no "from" or "to" defines both the start and end
        date like so:
 
-
-       -p "2009"       the  year 2009; equivalent
+       -p "2009"       the year 2009;  equivalent
                        to "2009/1/1 to 2010/1/1"
-       -p "2009/1"     the month of jan;  equiva-
+       -p "2009/1"     the  month of jan; equiva-
                        lent   to   "2009/1/1   to
                        2009/2/1"
-       -p "2009/1/1"   just that day;  equivalent
+       -p "2009/1/1"   just  that day; equivalent
                        to "2009/1/1 to 2009/1/2"
 
-       The  argument  of  -p  can  also  begin  with, or be, a report interval
-       expression.  The basic report intervals  are  daily,  weekly,  monthly,
+       The argument of -p can also  begin  with,  or  be,  a  report  interval
+       expression.   The  basic  report  intervals are daily, weekly, monthly,
        quarterly, or yearly, which have the same effect as the -D,-W,-M,-Q, or
-       -Y flags.  Between report interval and start/end dates  (if  any),  the
+       -Y  flags.   Between  report interval and start/end dates (if any), the
        word in is optional.  Examples:
-
 
        -p "weekly from 2009/1/1 to 2009/4/1"
        -p "monthly in 2008"
        -p "quarterly"
 
        The  following  more  complex  report  intervals  are  also  supported:
-       biweekly,     bimonthly,      every N days|weeks|months|quarters|years,
+       biweekly,      bimonthly,     every N days|weeks|months|quarters|years,
        every Nth day [of month], every Nth day of week.
 
        Examples:
-
 
        -p "bimonthly from 2008"
        -p "every 2 weeks"
        -p "every 5 days from 1/3"
 
-       Show  historical balances at end of 15th each month (N is exclusive end
+       Show historical balances at end of 15th each month (N is exclusive  end
        date):
 
        hledger balance -H -p "every 16th day"
 
-       Group postings from start of wednesday to end of  next  tuesday  (N  is
+       Group  postings  from  start  of wednesday to end of next tuesday (N is
        start date and exclusive end date):
 
        hledger register checking -p "every 3rd day of week"
 
    Depth limiting
-       With  the --depth N option, commands like account, balance and register
-       will show only the uppermost accounts in  the  account  tree,  down  to
+       With the --depth N option, commands like account, balance and  register
+       will  show  only  the  uppermost  accounts in the account tree, down to
        level N.  Use this when you want a summary with less detail.
 
    Pivoting
@@ -467,17 +462,17 @@ OPTIONS
        on account name.  The --pivot TAGNAME option causes it to sum and orga-
        nize hierarchy based on some other field instead.
 
-       TAGNAME  is  the full, case-insensitive name of a tag you have defined,
-       or one of the built-in implicit tags (like code  or  payee).   As  with
-       account  names,  when  tag  values  have multiple:colon-separated:parts
+       TAGNAME is the full, case-insensitive name of a tag you  have  defined,
+       or  one  of  the  built-in implicit tags (like code or payee).  As with
+       account names,  when  tag  values  have  multiple:colon-separated:parts
        hledger will build hierarchy, displayed in tree-mode reports, summaris-
        able with a depth limit, and so on.
 
-       --pivot  affects all reports, and is one of those options you can write
-       before the command name if you wish.  You can think of  hledger  trans-
-       forming  the journal before any other processing, replacing every post-
+       --pivot affects all reports, and is one of those options you can  write
+       before  the  command name if you wish.  You can think of hledger trans-
+       forming the journal before any other processing, replacing every  post-
        ing's account name with the value of the specified tag on that posting,
-       inheriting  it  from the transaction or using a blank value if it's not
+       inheriting it from the transaction or using a blank value if  it's  not
        present.
 
        An example:
@@ -502,7 +497,7 @@ OPTIONS
               --------------------
                                  0
 
-       One way to show only amounts with  a  member:  value  (using  a  query,
+       One  way  to  show  only  amounts  with a member: value (using a query,
        described below):
 
               $ hledger balance --pivot member tag:member=.
@@ -510,7 +505,7 @@ OPTIONS
               --------------------
                             -2 EUR
 
-       Another  way  (the  acct:  query  matches  against the pivoted "account
+       Another way (the acct:  query  matches  against  the  pivoted  "account
        name"):
 
               $ hledger balance --pivot member acct:.
@@ -521,56 +516,56 @@ OPTIONS
    Regular expressions
        hledger uses regular expressions in a number of places:
 
-       o query terms, on the command line and in the hledger-web search  form:
+       o query  terms, on the command line and in the hledger-web search form:
          REGEX, desc:REGEX, cur:REGEX, tag:...=REGEX
 
        o CSV rules conditional blocks: if REGEX ...
 
-       o account  alias  directives  and options: alias /REGEX/ = REPLACEMENT,
+       o account alias directives  and  options:  alias /REGEX/ = REPLACEMENT,
          --alias /REGEX/=REPLACEMENT
 
-       hledger's regular expressions come from  the  regex-tdfa  library.   In
+       hledger's  regular  expressions  come  from the regex-tdfa library.  In
        general they:
 
        o are case insensitive
 
-       o are  infix  matching  (do  not  need  to match the entire thing being
+       o are infix matching (do not need  to  match  the  entire  thing  being
          matched)
 
        o are POSIX extended regular expressions
 
        o also support GNU word boundaries (\<, \>, \b, \B)
 
-       o and parenthesised capturing  groups  and  numeric  backreferences  in
+       o and  parenthesised  capturing  groups  and  numeric backreferences in
          replacement strings
 
        o do not support mode modifiers like (?s)
 
        Some things to note:
 
-       o In  the  alias directive and --alias option, regular expressions must
-         be enclosed in forward  slashes  (/REGEX/).   Elsewhere  in  hledger,
+       o In the alias directive and --alias option, regular  expressions  must
+         be  enclosed  in  forward  slashes  (/REGEX/).  Elsewhere in hledger,
          these are not required.
 
        o To match a regular expression metacharacter like $ as a literal char-
          acter, prepend a backslash.  Eg to search for amounts with the dollar
          sign in hledger-web, write cur:\$.
 
-       o On  the command line, some metacharacters like $ have a special mean-
+       o On the command line, some metacharacters like $ have a special  mean-
          ing to the shell and so must be escaped a second time, with single or
-         double  quotes  or  another backslash.  Eg, to match amounts with the
+         double quotes or another backslash.  Eg, to match  amounts  with  the
          dollar sign from the command line, write cur:'\$' or cur:\\$.
 
 QUERIES
-       One of hledger's strengths is being able to quickly report  on  precise
-       subsets  of  your data.  Most commands accept an optional query expres-
-       sion, written as arguments after the command name, to filter  the  data
-       by  date,  account  name or other criteria.  The syntax is similar to a
+       One  of  hledger's strengths is being able to quickly report on precise
+       subsets of your data.  Most commands accept an optional  query  expres-
+       sion,  written  as arguments after the command name, to filter the data
+       by date, account name or other criteria.  The syntax is  similar  to  a
        web search: one or more space-separated search terms, quotes to enclose
-       whitespace,  optional  prefixes  to  match  specific  fields.  Multiple
+       whitespace, optional  prefixes  to  match  specific  fields.   Multiple
        search terms are combined as follows:
 
-       All commands except print:  show  transactions/postings/accounts  which
+       All  commands  except  print: show transactions/postings/accounts which
        match (or negatively match)
 
        o any of the description terms AND
@@ -597,22 +592,22 @@ QUERIES
               same as above
 
        amt:N, amt:<N, amt:<=N, amt:>N, amt:>=N
-              match  postings with a single-commodity amount that is equal to,
-              less than, or greater than N.  (Multi-commodity amounts are  not
+              match postings with a single-commodity amount that is equal  to,
+              less  than, or greater than N.  (Multi-commodity amounts are not
               tested, and will always match.) The comparison has two modes: if
               N is preceded by a + or - sign (or is 0), the two signed numbers
-              are  compared.  Otherwise, the absolute magnitudes are compared,
+              are compared.  Otherwise, the absolute magnitudes are  compared,
               ignoring sign.
 
        code:REGEX
               match by transaction code (eg check number)
 
        cur:REGEX
-              match postings or transactions including any amounts whose  cur-
-              rency/commodity  symbol  is fully matched by REGEX.  (For a par-
+              match  postings or transactions including any amounts whose cur-
+              rency/commodity symbol is fully matched by REGEX.  (For  a  par-
               tial match, use .*REGEX.*).  Note, to match characters which are
               regex-significant, like the dollar sign ($), you need to prepend
-              \.  And when using the command line you need  to  add  one  more
+              \.   And  when  using  the command line you need to add one more
               level  of  quoting  to  hide  it  from  the  shell,  so  eg  do:
               hledger print cur:'\$' or hledger print cur:\\$.
 
@@ -621,29 +616,29 @@ QUERIES
 
        date:PERIODEXPR
               match dates within the specified period.  PERIODEXPR is a period
-              expression  (with  no  report  interval).   Examples: date:2016,
-              date:thismonth,  date:2000/2/1-2/15,  date:lastweek-.   If   the
-              --date2  command  line  flag  is present, this matches secondary
+              expression (with  no  report  interval).   Examples:  date:2016,
+              date:thismonth,   date:2000/2/1-2/15,  date:lastweek-.   If  the
+              --date2 command line flag is  present,  this  matches  secondary
               dates instead.
 
        date2:PERIODEXPR
               match secondary dates within the specified period.
 
        depth:N
-              match (or display, depending on command) accounts  at  or  above
+              match  (or  display,  depending on command) accounts at or above
               this depth
 
        real:, real:0
               match real or virtual postings respectively
 
        status:*, status:!, status:
-              match   cleared,   pending,  or  uncleared/pending  transactions
+              match  cleared,  pending,  or   uncleared/pending   transactions
               respectively
 
        tag:REGEX[=REGEX]
-              match by tag name, and optionally also by  tag  value.   Note  a
-              tag:  query  is  considered to match a transaction if it matches
-              any of the postings.  Also remember that  postings  inherit  the
+              match  by  tag  name,  and optionally also by tag value.  Note a
+              tag: query is considered to match a transaction  if  it  matches
+              any  of  the  postings.  Also remember that postings inherit the
               tags of their parent transaction.
 
        not:   before any of the above negates the match.
@@ -651,24 +646,24 @@ QUERIES
        inacct:ACCTNAME
               a special term used automatically when you click an account name
               in hledger-web, specifying the account register we are currently
-              in  (selects  the  transactions  of that account and how to show
-              them, can be filtered further with  acct  etc).   Not  supported
+              in (selects the transactions of that account  and  how  to  show
+              them,  can  be  filtered  further with acct etc).  Not supported
               elsewhere in hledger.
 
        Some of these can also be expressed as command-line options (eg depth:2
-       is equivalent to --depth 2).  Generally you can mix options  and  query
-       arguments,  and the resulting query will be their intersection (perhaps
+       is  equivalent  to --depth 2).  Generally you can mix options and query
+       arguments, and the resulting query will be their intersection  (perhaps
        excluding the -p/--period option).
 
 COMMANDS
-       hledger provides a number of subcommands;  hledger  with  no  arguments
+       hledger  provides  a  number  of subcommands; hledger with no arguments
        shows a list.
 
        If you install additional hledger-* packages, or if you put programs or
-       scripts named hledger-NAME in your PATH, these will also be  listed  as
+       scripts  named  hledger-NAME in your PATH, these will also be listed as
        subcommands.
 
-       Run   a   subcommand   by  writing  its  name  as  first  argument  (eg
+       Run  a  subcommand  by  writing  its  name  as   first   argument   (eg
        hledger incomestatement).  You can also write any unambiguous prefix of
        a command name (hledger inc), or one of the standard short aliases dis-
        played in the command list (hledger is).
@@ -683,14 +678,14 @@ COMMANDS
        --drop=N
               in flat mode: omit N leading account name parts
 
-       This command lists all account names that  are  in  use  (ie,  all  the
-       accounts  which  have  at least one transaction posting to them).  With
+       This  command  lists  all  account  names  that are in use (ie, all the
+       accounts which have at least one transaction posting  to  them).   With
        query arguments, only matched account names are shown.
 
-       It shows a flat list by default.  With --tree, it uses  indentation  to
+       It  shows  a flat list by default.  With --tree, it uses indentation to
        show the account hierarchy.
 
-       In  flat  mode  you can add --drop N to omit the first few account name
+       In flat mode you can add --drop N to omit the first  few  account  name
        components.
 
        Examples:
@@ -733,8 +728,8 @@ COMMANDS
    activity
        Show an ascii barchart of posting counts per interval.
 
-       The activity command displays an ascii  histogram  showing  transaction
-       counts  by  day, week, month or other reporting interval (by day is the
+       The  activity  command  displays an ascii histogram showing transaction
+       counts by day, week, month or other reporting interval (by day  is  the
        default).  With query arguments, it counts only matched transactions.
 
               $ hledger activity --quarterly
@@ -747,24 +742,24 @@ COMMANDS
        Prompt for transactions and add them to the journal.
 
        --no-new-accounts
-              don't allow creating new  accounts;  helps  prevent  typos  when
+              don't  allow  creating  new  accounts;  helps prevent typos when
               entering account names
 
-       Many  hledger users edit their journals directly with a text editor, or
-       generate them from CSV.  For more interactive data entry, there is  the
-       add  command, which prompts interactively on the console for new trans-
-       actions, and appends them to the journal file (if  there  are  multiple
+       Many hledger users edit their journals directly with a text editor,  or
+       generate  them from CSV.  For more interactive data entry, there is the
+       add command, which prompts interactively on the console for new  trans-
+       actions,  and  appends  them to the journal file (if there are multiple
        -f FILE options, the first file is used.) Existing transactions are not
-       changed.  This is the only hledger command that writes to  the  journal
+       changed.   This  is the only hledger command that writes to the journal
        file.
 
        To use it, just run hledger add and follow the prompts.  You can add as
-       many transactions as you like; when you are finished, enter . or  press
+       many  transactions as you like; when you are finished, enter . or press
        control-d or control-c to exit.
 
        Features:
 
-       o add  tries  to provide useful defaults, using the most similar recent
+       o add tries to provide useful defaults, using the most  similar  recent
          transaction (by description) as a template.
 
        o You can also set the initial defaults with command line arguments.
@@ -772,20 +767,20 @@ COMMANDS
        o Readline-style edit keys can be used during data entry.
 
        o The tab key will auto-complete whenever possible - accounts, descrip-
-         tions,  dates  (yesterday,  today,  tomorrow).   If the input area is
+         tions, dates (yesterday, today, tomorrow).   If  the  input  area  is
          empty, it will insert the default value.
 
-       o If the journal defines a default commodity, it will be added  to  any
+       o If  the  journal defines a default commodity, it will be added to any
          bare numbers entered.
 
        o A parenthesised transaction code may be entered following a date.
 
        o Comments and tags may be entered following a description or amount.
 
-       o If  you make a mistake, enter < at any prompt to restart the transac-
+       o If you make a mistake, enter < at any prompt to restart the  transac-
          tion.
 
-       o Input prompts are displayed in a different colour when  the  terminal
+       o Input  prompts  are displayed in a different colour when the terminal
          supports it.
 
        Example (see the tutorial for a detailed explanation):
@@ -822,7 +817,7 @@ COMMANDS
               show balance change in each period (default)
 
        --cumulative
-              show  balance  change accumulated across periods (in multicolumn
+              show balance change accumulated across periods  (in  multicolumn
               reports)
 
        -H --historical
@@ -834,10 +829,6 @@ COMMANDS
 
        --flat show accounts as a list; amounts exclude subaccounts except when
               account is depth-clipped (default in multicolumn reports)
-
-       -V --value
-              convert  amounts  to  their  market value on the report end date
-              (using the most recent applicable market price, if any)
 
        -A --average
               show a row average column (in multicolumn mode)
@@ -1062,13 +1053,13 @@ COMMANDS
               $ hledger -f t.j bal euros -V -e 2016/12/21
                            $103.00  assets:euros
 
-       Currently,  hledger's -V only uses market prices recorded with P direc-
+       Currently, hledger's -V only uses market prices recorded with P  direc-
        tives, not transaction prices (unlike Ledger).
 
        Using -B and -V together is allowed.
 
    Custom balance output
-       In simple (non-multi-column) balance reports,  you  can  customise  the
+       In  simple  (non-multi-column)  balance  reports, you can customise the
        output with --format FMT:
 
               $ hledger balance --format "%20(account) %12(total)"
@@ -1086,7 +1077,7 @@ COMMANDS
                                               0
 
        The FMT format string (plus a newline) specifies the formatting applied
-       to each account/balance pair.  It may contain any suitable  text,  with
+       to  each  account/balance pair.  It may contain any suitable text, with
        data fields interpolated like so:
 
        %[MIN][.MAX](FIELDNAME)
@@ -1097,14 +1088,14 @@ COMMANDS
 
        o FIELDNAME must be enclosed in parentheses, and can be one of:
 
-         o depth_spacer  - a number of spaces equal to the account's depth, or
+         o depth_spacer - a number of spaces equal to the account's depth,  or
            if MIN is specified, MIN * depth spaces.
 
          o account - the account's name
 
          o total - the account's balance/posted total, right justified
 
-       Also, FMT can begin with an optional prefix to control  how  multi-com-
+       Also,  FMT  can begin with an optional prefix to control how multi-com-
        modity amounts are rendered:
 
        o %_ - render on multiple lines, bottom-aligned (the default)
@@ -1113,7 +1104,7 @@ COMMANDS
 
        o %, - render on one line, comma-separated
 
-       There  are  some  quirks.   Eg in one-line mode, %(depth_spacer) has no
+       There are some quirks.  Eg in one-line  mode,  %(depth_spacer)  has  no
        effect, instead %(account) has indentation built in.
         Experimentation may be needed to get pleasing results.
 
@@ -1121,19 +1112,19 @@ COMMANDS
 
        o %(total) - the account's total
 
-       o %-20.20(account) - the account's name, left justified, padded  to  20
+       o %-20.20(account)  -  the account's name, left justified, padded to 20
          characters and clipped at 20 characters
 
-       o %,%-50(account)  %25(total)  -  account name padded to 50 characters,
-         total padded to 20 characters, with multiple commodities rendered  on
+       o %,%-50(account)  %25(total) - account name padded to  50  characters,
+         total  padded to 20 characters, with multiple commodities rendered on
          one line
 
-       o %20(total)  %2(depth_spacer)%-(account)  - the default format for the
+       o %20(total)  %2(depth_spacer)%-(account) - the default format for  the
          single-column balance report
 
    Output destination
-       The balance, print, register and stats commands can write their  output
-       to  a  destination  other  than the console.  This is controlled by the
+       The  balance, print, register and stats commands can write their output
+       to a destination other than the console.  This  is  controlled  by  the
        -o/--output-file option.
 
               $ hledger balance -o -     # write to stdout (the default)
@@ -1141,8 +1132,8 @@ COMMANDS
 
    CSV output
        The balance, print and register commands can write their output as CSV.
-       This  is  useful  for  exporting data to other applications, eg to make
-       charts in a spreadsheet.  This is controlled by the  -O/--output-format
+       This is useful for exporting data to other  applications,  eg  to  make
+       charts  in a spreadsheet.  This is controlled by the -O/--output-format
        option, or by specifying a .csv file extension with -o/--output-file.
 
               $ hledger balance -O csv       # write CSV to stdout
@@ -1153,11 +1144,20 @@ COMMANDS
 
        --flat show full account names, as a list (default)
 
+       -N --no-total
+              don't show the final total row
+
        --drop=N
               in flat mode: omit N leading account name parts
 
-       This  command  displays  a  simple balance sheet.  It currently assumes
-       that you have top-level accounts  named  asset  and  liability  (plural
+       --no-elide
+              don't squash boring parent accounts (in tree mode)
+
+       --format=LINEFORMAT
+              in single-column balance reports: use this custom line format
+
+       This command displays a simple balance  sheet.   It  currently  assumes
+       that  you  have  top-level  accounts  named asset and liability (plural
        forms also allowed.)
 
               $ hledger balancesheet
@@ -1184,12 +1184,21 @@ COMMANDS
 
        --flat show full account names, as a list (default)
 
+       -N --no-total
+              don't show the final total row
+
        --drop=N
               in flat mode: omit N leading account name parts
 
-       This  command  displays a simple cashflow statement It shows the change
-       in all "cash" (ie, liquid assets) accounts for  the  period.   It  cur-
-       rently  assumes  that cash accounts are under a top-level account named
+       --no-elide
+              don't squash boring parent accounts (in tree mode)
+
+       --format=LINEFORMAT
+              in single-column balance reports: use this custom line format
+
+       This command displays a simple cashflow statement It shows  the  change
+       in  all  "cash"  (ie,  liquid assets) accounts for the period.  It cur-
+       rently assumes that cash accounts are under a top-level  account  named
        asset and do not contain receivable or A/R (plural forms also allowed.)
 
               $ hledger cashflow
@@ -1239,8 +1248,17 @@ COMMANDS
 
        --flat show full account names, as a list (default)
 
+       -N --no-total
+              don't show the final total row
+
        --drop=N
               in flat mode: omit N leading account name parts
+
+       --no-elide
+              don't squash boring parent accounts (in tree mode)
+
+       --format=LINEFORMAT
+              in single-column balance reports: use this custom line format
 
        This command displays a simple income statement.  It currently  assumes
        that  you have top-level accounts named income (or revenue) and expense
@@ -1625,14 +1643,14 @@ ADD-ON COMMANDS
        hledger-dupes.hs checks for account names sharing the same leaf name.
 
    equity
-       hledger-equity.hs prints  balance-resetting  transactions,  useful  for
+       hledger-equity.hs  prints  balance-resetting  transactions,  useful for
        bringing account balances across file boundaries.
 
    prices
        hledger-prices.hs prints all prices from the journal.
 
    print-unique
-       hledger-print-unique.hs  prints  transactions  which  do  not  reuse an
+       hledger-print-unique.hs prints  transactions  which  do  not  reuse  an
        already-seen description.
 
    register-match
@@ -1645,13 +1663,13 @@ ADD-ON COMMANDS
 
 TROUBLESHOOTING
    Run-time problems
-       Here are some issues you might encounter  when  you  run  hledger  (and
-       remember  you can also seek help from the IRC channel, mail list or bug
+       Here  are  some  issues  you  might encounter when you run hledger (and
+       remember you can also seek help from the IRC channel, mail list or  bug
        tracker):
 
        Successfully installed, but "No command 'hledger' found"
        stack and cabal install binaries into a special directory, which should
-       be  added  to your PATH environment variable.  Eg on unix-like systems,
+       be added to your PATH environment variable.  Eg on  unix-like  systems,
        that is ~/.local/bin and ~/.cabal/bin respectively.
 
        I set a custom LEDGER_FILE, but hledger is still using the default file

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -144,6 +144,7 @@ library
       Hledger.Cli.Accounts
       Hledger.Cli.Balance
       Hledger.Cli.Balancesheet
+      Hledger.Cli.BalanceView
       Hledger.Cli.Cashflow
       Hledger.Cli.Help
       Hledger.Cli.Histogram

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -93,6 +93,7 @@ library:
   - Hledger.Cli.Accounts
   - Hledger.Cli.Balance
   - Hledger.Cli.Balancesheet
+  - Hledger.Cli.BalanceView
   - Hledger.Cli.Cashflow
   - Hledger.Cli.Help
   - Hledger.Cli.Histogram


### PR DESCRIPTION
**in progress**

As mentioned in https://github.com/simonmichael/hledger/pull/361, but never followed up.

I've successfully refactored/abstracted out `balancesheet`, `incomestatement`, and `cashflow`  under a unified wrapper.  From there I'm looking to bring things to some sort of feature parity with `balance` to the extent of what is relevant -- looks like it's just missing `-V`, `-N`, `--no-elide`, and `--format`, anyways.

Briefly thought about even including `balance` as a part of the abstraction, but not sure how to meaningfully handle the "table" views for `balancesheet` and `incomestatement`.  Maybe just print out two tables, one after the other?