### PR TITLE
Add missing assrt param to documentation.

### DIFF
--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -19,7 +19,7 @@ You can use the command line:
 or ghci:
 
 > $ ghci hledger
-> > j <- readJournalFile Nothing Nothing "examples/sample.journal"
+> > j <- readJournalFile Nothing Nothing True "examples/sample.journal"
 > > register [] ["income","expenses"] j
 > 2008/01/01 income               income:salary                   $-1          $-1
 > 2008/06/01 gift                 income:gifts                    $-1          $-2


### PR DESCRIPTION
I was working through the documentation, and this wouldn't work as-is. I noticed that there is an additional argument `assrt` which is not used here. Passing `True` causes this example to work.