### PR TITLE
Disabling --cumulative for balancesheet, and also removed subtitle headings for 'default modes'

### DIFF
--- a/hledger/Hledger/Cli/BalanceView.hs
+++ b/hledger/Hledger/Cli/BalanceView.hs
@@ -33,8 +33,8 @@ data BalanceView = BalanceView {
       bvhelp     :: String,                        -- ^ command line help message
       bvtitle    :: String,                        -- ^ title of the view
       bvqueries  :: [(String, Journal -> Query)],  -- ^ named queries that make up the view
-      bvtype     :: BalanceType                    -- ^ the type of balance this view shows.
-                                                   --   This overrides user input.
+      bvdeftype  :: BalanceType,                   -- ^ the type of balance this view shows.
+      bvtypes    :: [BalanceType]                  -- ^ alternatively allowed types
 }
 
 balanceviewmode :: BalanceView -> Mode RawOpts
@@ -68,8 +68,8 @@ balanceviewmode BalanceView{..} = (defCommandMode $ bvmode : bvaliases) {
  }
  where
    defType :: BalanceType -> String
-   defType bt | bt == bvtype = " (default)"
-              | otherwise    = ""
+   defType bt | bt == bvdeftype = " (default)"
+              | otherwise       = ""
 
 balanceviewQueryReport
     :: ReportOpts
@@ -160,7 +160,7 @@ balanceviewReport BalanceView{..} CliOpts{reportopts_=ropts, rawopts_=raw} j = d
         "cumulative":_ -> Just CumulativeChange
         "change":_     -> Just PeriodChange
         _              -> Nothing
-    balancetype = fromMaybe bvtype overwriteBalanceType
+    balancetype = fromMaybe bvdeftype overwriteBalanceType
     -- we must clarify that the statements aren't actual income statements,
     -- etc. if the user overrides the balance type
     balanceclarification = flip fmap overwriteBalanceType $ \t ->

--- a/hledger/Hledger/Cli/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Balancesheet.hs
@@ -26,7 +26,8 @@ bsBV = BalanceView {
          bvqueries  = [ ("Assets"     , journalAssetAccountQuery),
                         ("Liabilities", journalLiabilityAccountQuery)
                       ],
-         bvtype     = HistoricalBalance
+         bvdeftype  = HistoricalBalance,
+         bvtypes    = [PeriodChange]
       }
 
 balancesheetmode :: Mode RawOpts

--- a/hledger/Hledger/Cli/Cashflow.hs
+++ b/hledger/Hledger/Cli/Cashflow.hs
@@ -27,7 +27,8 @@ cfBV = BalanceView {
          bvhelp     = "show a cashflow statement",
          bvtitle    = "Cashflow Statement",
          bvqueries  = [("Cash flows", journalCashAccountQuery)],
-         bvtype     = PeriodChange
+         bvdeftype  = PeriodChange,
+         bvtypes    = [CumulativeChange, HistoricalBalance]
       }
 
 cashflowmode :: Mode RawOpts

--- a/hledger/Hledger/Cli/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Incomestatement.hs
@@ -26,7 +26,8 @@ isBV = BalanceView {
          bvqueries  = [ ("Revenues", journalIncomeAccountQuery),
                         ("Expenses", journalExpenseAccountQuery)
                       ],
-         bvtype     = PeriodChange
+         bvdeftype  = PeriodChange,
+         bvtypes    = [CumulativeChange, HistoricalBalance]
       }
 
 incomestatementmode :: Mode RawOpts

--- a/hledger/doc/commands.m4.md
+++ b/hledger/doc/commands.m4.md
@@ -169,14 +169,11 @@ _include_({{balance.m4.md}})
 ## balancesheet
 Show a balance sheet. Alias: bs.
 
-`--change`
-: show balance change in each period, instead of historical ending balances
-
-`--cumulative`
-: show balance change accumulated across periods (in multicolumn reports), instead of historical ending balances
-
 `-H --historical`
 : show historical ending balance in each period (includes postings before report start date) (default)
+
+`--change`
+: show balance change in each period, instead of historical ending balances
 
 `--tree`
 : show accounts as a tree; amounts include subaccounts (default in simple reports)


### PR DESCRIPTION
`balancesheet --historical`, `incomestatement --change`, and `cashflow --change` no longer show the subheading qualifying their balance types.  In effect, `--historical` becomes a no-op for `balancesheet`, etc.

`balancesheet --cumulative` is an error because `--cumulative` is not a flag in the flag group.  It doesn't show up on `balancesheet -h`.