### PR TITLE
Add Arch Linux to download page

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -31,6 +31,7 @@ latest release, or provide only some of the hledger tools.
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | Windows:             | see B below <!-- Download and run the [latest development builds](contributing.html) (-> Appveyor CI) -->
 | Mac:                 | **`brew install hledger`**
+| Arch Linux:          | **`pacaur -S hledger`**
 | Debian,&nbsp;Ubuntu: | **`sudo apt install hledger hledger-ui hledger-web`** (note [#541](https://github.com/simonmichael/hledger/issues/541))
 | Fedora,&nbsp;RHEL:   | **`sudo dnf install hledger`**
 | Gentoo:              | **`sudo layman -a haskell && sudo emerge hledger hledger-ui hledger-web`**


### PR DESCRIPTION
I just adopted and updated the [Arch User Repository (AUR) package](https://aur.archlinux.org/packages/hledger/) so here we go :smile_cat: 