### PR TITLE
Use pandoc From Stackage Snapshot

### DIFF
--- a/Shake.hs
+++ b/Shake.hs
@@ -68,8 +68,7 @@ usage = unlines
   ,"./Shake --help           # show options, eg --color"
   ]
 
-pandoc = "pandoc"                   -- pandoc from PATH (faster)
-         --  "stack exec -- pandoc" -- pandoc from project's stackage snapshot
+pandoc = "stack exec -- pandoc" -- pandoc from project's stackage snapshot
 hakyllstd = "site/hakyll-std/hakyll-std"
 makeinfo = "makeinfo"
 -- nroff = "nroff"


### PR DESCRIPTION
Use pandoc from stackage snapshot when building documentation to ensure
that pandoc and the pandoc filters are built against the same version of
pandoc-types; otherwise, the filters can fail with an obtuse error (see
https://github.com/jgm/pandoc/issues/3217).