### PR TITLE
Fix typo in help docs

### DIFF
--- a/doc/mockups/help.txt
+++ b/doc/mockups/help.txt
@@ -516,7 +516,7 @@ Get help:
  help|man|info        show any of the hledger manuals in text/info/man format
                       see also -h, CMD -h, --help|--man|--info
 *** d
-Get help: (see also -h, CMD -h, --help|---man|--info)
+Get help: (see also -h, CMD -h, --help|--man|--info)
  help|man|info        show any of the hledger manuals in text/info/man format
 
 ** hledger (commands list)

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -264,7 +264,7 @@ Misc:
  rewrite              add automated postings to certain transactions
  test                 run some self tests
 OTHERCMDS
-Help: (see also -h, CMD -h, --help|---man|--info)
+Help: (see also -h, CMD -h, --help|--man|--info)
  help|man|info        show any of the hledger manuals in text/man/info format
 |]
 


### PR DESCRIPTION
Documentation listed `---man` as the command to bring up the man pages instead of the correct `--man`