### PR TITLE
prices: improve precision and add inverted costs

### DIFF
--- a/tests/bin/prices.test
+++ b/tests/bin/prices.test
@@ -39,9 +39,30 @@ P 2016/2/1 EUR $1.05
     expenses             20 EUR @@ $21.45
     assets:bank
 >>>
+P 2016-01-01 EUR $1.06
 P 2016-01-02 EUR $1.07
 P 2016-01-03 EUR $1.0725
+P 2016-02-01 EUR $1.05
+>>>2
+>>>=0
+
+# inverted costs from postings can be calculated
+../../bin/hledger-prices -f- --inverted-costs
+<<<
+P 2016/1/1 EUR $1.06
+P 2016/2/1 EUR $1.05
+
+2016/1/1 paycheck
+    income:remuneration     $-100
+    income:donations         $-15
+    assets:bank
+
+2016/1/3 spend
+    expenses             $21.45 @@ 20.00 EUR
+    assets:bank
+>>>
 P 2016-01-01 EUR $1.06
+P 2016-01-03 EUR $1.0725
 P 2016-02-01 EUR $1.05
 >>>2
 >>>=0

--- a/tests/bin/prices.test
+++ b/tests/bin/prices.test
@@ -34,8 +34,13 @@ P 2016/2/1 EUR $1.05
 2016/1/2 spend
     expenses             20 EUR @ $1.07
     assets:bank
+
+2016/1/3 spend
+    expenses             20 EUR @@ $21.45
+    assets:bank
 >>>
 P 2016-01-02 EUR $1.07
+P 2016-01-03 EUR $1.0725
 P 2016-01-01 EUR $1.06
 P 2016-02-01 EUR $1.05
 >>>2


### PR DESCRIPTION
- Precision is extended for inferred prices from division.
- Support for reverse price inference to support use cases when people bring money into transaction from account with non-main currency.
- Sort prices by dates.