### PR TITLE
Fixing bs/is/cf --flat regressions

### DIFF
--- a/hledger/Hledger/Cli/BalanceView.hs
+++ b/hledger/Hledger/Cli/BalanceView.hs
@@ -176,8 +176,11 @@ balanceviewReport BalanceView{..} CliOpts{command_=cmd, reportopts_=ropts, rawop
         -- Balance.hs for more information.
     treeIfNotPeriod
       | flat_ ropts = id
-      | otherwise   = case balancetype of
-          PeriodChange -> id
-          _            -> \o -> o { accountlistmode_ = ALTree }
+      | otherwise   = case (balancetype, interval_ ropts) of
+          (HistoricalBalance, NoInterval) -> \o ->
+              o { accountlistmode_ = ALTree }
+          (CumulativeChange , NoInterval) -> \o ->
+              o { accountlistmode_ = ALTree }
+          _                               -> id
     merging (Table hLeft hTop dat) (Table hLeft' _ dat') =
         Table (T.Group DoubleLine [hLeft, hLeft']) hTop (dat ++ dat')

--- a/hledger/Hledger/Cli/BalanceView.hs
+++ b/hledger/Hledger/Cli/BalanceView.hs
@@ -168,6 +168,16 @@ balanceviewReport BalanceView{..} CliOpts{command_=cmd, reportopts_=ropts, rawop
         PeriodChange      -> "(Balance Changes)"
         CumulativeChange  -> "(Cumulative Ending Balances)"
         HistoricalBalance -> "(Historical Ending Balances)"
-    ropts' = ropts { balancetype_ = balancetype }
+    ropts' = treeIfNotPeriod $ ropts { balancetype_ = balancetype }
+        -- For --historical/--cumulative, we must use multiBalanceReport.
+        -- (This forces --no-elide.)
+        -- These settings format the output in a way that we can convert to
+        -- a normal balance report using singleBalanceReport.  See
+        -- Balance.hs for more information.
+    treeIfNotPeriod
+      | flat_ ropts = id
+      | otherwise   = case balancetype of
+          PeriodChange -> id
+          _            -> \o -> o { accountlistmode_ = ALTree }
     merging (Table hLeft hTop dat) (Table hLeft' _ dat') =
         Table (T.Group DoubleLine [hLeft, hLeft']) hTop (dat ++ dat')


### PR DESCRIPTION
Should properly address #552, and also #565.  Looks like the issue was that I was trying to duplicate the code in `Balance.hs`, but did not duplicate the logic completely (left out an extra conditional).  Would be nice if all the code duplication doesn't have to be here...i'll try to see if there's a way to consolidate the two in the future.