### PR TITLE
Fix date of 1.2 release in CHANGES files

### DIFF
--- a/hledger-api/CHANGES
+++ b/hledger-api/CHANGES
@@ -2,14 +2,14 @@ User-visible changes in hledger-api.
 See also the hledger and the project change logs.
 
 
-# 1.2 (2016/3/31)
+# 1.2 (2017/3/31)
 
 see project changes at http://hledger.org/release-notes
 
 # 1.1 (2016/12/31)
 
 -   serves on 127.0.0.1 by default, --host option added (#432)
-    
+
     Consistent with hledger-web: serves only local requests by default,
     use --host=IPADDR to change this.
 

--- a/hledger-lib/CHANGES
+++ b/hledger-lib/CHANGES
@@ -2,7 +2,7 @@ API-ish changes in the hledger-lib package.
 See also the hledger and project change logs (for user-visible changes).
 
 
-# 1.2 (2016/3/31)
+# 1.2 (2017/3/31)
 
 ## journal format
 

--- a/hledger-ui/CHANGES
+++ b/hledger-ui/CHANGES
@@ -2,7 +2,7 @@ User-visible changes in hledger-ui.
 See also the hledger and project change logs.
 
 
-# 1.2 (2016/3/31)
+# 1.2 (2017/3/31)
 
 Fix a pattern match failure when pressing E on the transaction screen (fixes #508)
 

--- a/hledger-web/CHANGES
+++ b/hledger-web/CHANGES
@@ -2,7 +2,7 @@ User-visible changes in hledger-web.
 See also the hledger and the project change logs.
 
 
-# 1.2 (2016/3/31)
+# 1.2 (2017/3/31)
 
 Accounts with ? in name had empty registers (fixes #498) (Bryan Richter)
 

--- a/hledger/CHANGES
+++ b/hledger/CHANGES
@@ -2,7 +2,7 @@ User-visible changes in the hledger and hledger-lib packages.
 See also the project change log.
 
 
-# 1.2 (2016/3/31)
+# 1.2 (2017/3/31)
 
 ## CLI
 


### PR DESCRIPTION
I feel a little silly making a small PR for this, but the date did throw me off when I was wondering if version 1.2 was recent or not.

Thanks for making `hledger` by the way! I use it all the time.