### PR TITLE
A fix for a bug with the -H option. It did not show anything when a period with no transactions was chosen rather than show the ending balances.

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -929,6 +929,10 @@ abspat pat = if isnegativepat pat then drop (length negateprefix) pat else pat
 --     expenses:supplies  $1
 --     assets:cash
 --
+-- 2008/10/01 take a loan
+--     assets:bank:checking $1
+--     liabilities:debts    $-1
+--
 -- 2008/12/31 * pay off
 --     liabilities:debts  $1
 --     assets:bank:checking
@@ -1000,6 +1004,22 @@ Right samplejournal = journalBalanceTransactions False $
              tpostings=["expenses:food" `post` usd 1
                        ,"expenses:supplies" `post` usd 1
                        ,"assets:cash" `post` missingamt
+                       ],
+             tpreceding_comment_lines=""
+           }
+          ,
+           txnTieKnot $ Transaction {
+             tindex=0,
+             tsourcepos=nullsourcepos,
+             tdate=parsedate "2008/10/01",
+             tdate2=Nothing,
+             tstatus=Unmarked,
+             tcode="",
+             tdescription="take a loan",
+             tcomment="",
+             ttags=[],
+             tpostings=["assets:bank:checking" `post` usd 1
+                       ,"liabilities:debts" `post` usd (-1)
                        ],
              tpreceding_comment_lines=""
            }

--- a/hledger-lib/Hledger/Data/Ledger.hs
+++ b/hledger-lib/Hledger/Data/Ledger.hs
@@ -93,8 +93,8 @@ ledgerCommodities = M.keys . jinferredcommodities . ljournal
 tests_ledgerFromJournal = [
  "ledgerFromJournal" ~: do
   assertEqual "" (0) (length $ ledgerPostings $ ledgerFromJournal Any nulljournal)
-  assertEqual "" (11) (length $ ledgerPostings $ ledgerFromJournal Any samplejournal)
-  assertEqual "" (6) (length $ ledgerPostings $ ledgerFromJournal (Depth 2) samplejournal)
+  assertEqual "" (13) (length $ ledgerPostings $ ledgerFromJournal Any samplejournal)
+  assertEqual "" (7) (length $ ledgerPostings $ ledgerFromJournal (Depth 2) samplejournal)
  ]
 
 tests_Hledger_Data_Ledger = TestList $

--- a/hledger-lib/Hledger/Reports.hs
+++ b/hledger-lib/Hledger/Reports.hs
@@ -39,5 +39,6 @@ tests_Hledger_Reports = TestList $
  tests_Hledger_Reports_ReportOptions,
  tests_Hledger_Reports_EntriesReport,
  tests_Hledger_Reports_PostingsReport,
- tests_Hledger_Reports_BalanceReport
+ tests_Hledger_Reports_BalanceReport,
+ tests_Hledger_Reports_MultiBalanceReport
  ]

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -281,6 +281,20 @@ tests_balanceReport =
      ],
      Mixed [usd0])
 
+  ,"balanceReport with period on a populated period" ~: do
+    (defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2)}, samplejournal) `gives`
+     (
+      [
+       ("assets:bank:checking","assets:bank:checking",0, mamountp' "$1.00")
+      ,("income:salary","income:salary",0, mamountp' "$-1.00")
+      ],
+      Mixed [usd0])
+
+   ,"balanceReport with period on an unpopulated period" ~: do
+    (defreportopts{period_= PeriodBetween (fromGregorian 2008 1 2) (fromGregorian 2008 1 3)}, samplejournal) `gives`
+     ([],Mixed [nullamt])
+
+
 
 {-
     ,"accounts report with account pattern o" ~:

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -213,8 +213,10 @@ tests_balanceReport =
   ,"balanceReport with no args on sample journal" ~: do
    (defreportopts, samplejournal) `gives`
     ([
-      ("assets","assets",0, mamountp' "$-1.00")
-     ,("assets:bank:saving","bank:saving",1, mamountp' "$1.00")
+      ("assets","assets",0, mamountp' "$0.00")
+     ,("assets:bank","bank",1, mamountp' "$2.00")
+     ,("assets:bank:checking","checking",2, mamountp' "$1.00")
+     ,("assets:bank:saving","saving",2, mamountp' "$1.00")
      ,("assets:cash","cash",1, mamountp' "$-2.00")
      ,("expenses","expenses",0, mamountp' "$2.00")
      ,("expenses:food","food",1, mamountp' "$1.00")
@@ -222,27 +224,22 @@ tests_balanceReport =
      ,("income","income",0, mamountp' "$-2.00")
      ,("income:gifts","gifts",1, mamountp' "$-1.00")
      ,("income:salary","salary",1, mamountp' "$-1.00")
-     ,("liabilities:debts","liabilities:debts",0, mamountp' "$1.00")
      ],
      Mixed [usd0])
 
   ,"balanceReport with --depth=N" ~: do
    (defreportopts{depth_=Just 1}, samplejournal) `gives`
     ([
-      ("assets",      "assets",      0, mamountp' "$-1.00")
-     ,("expenses",    "expenses",    0, mamountp'  "$2.00")
+     ("expenses",    "expenses",    0, mamountp'  "$2.00")
      ,("income",      "income",      0, mamountp' "$-2.00")
-     ,("liabilities", "liabilities", 0, mamountp'  "$1.00")
      ],
      Mixed [usd0])
 
   ,"balanceReport with depth:N" ~: do
    (defreportopts{query_="depth:1"}, samplejournal) `gives`
     ([
-      ("assets",      "assets",      0, mamountp' "$-1.00")
-     ,("expenses",    "expenses",    0, mamountp'  "$2.00")
+     ("expenses",    "expenses",    0, mamountp'  "$2.00")
      ,("income",      "income",      0, mamountp' "$-2.00")
-     ,("liabilities", "liabilities", 0, mamountp'  "$1.00")
      ],
      Mixed [usd0])
 
@@ -268,16 +265,13 @@ tests_balanceReport =
   ,"balanceReport with not:desc:" ~: do
    (defreportopts{query_="not:desc:income"}, samplejournal) `gives`
     ([
-      ("assets","assets",0, mamountp' "$-2.00")
-     ,("assets:bank","bank",1, Mixed [usd0])
-     ,("assets:bank:checking","checking",2,mamountp' "$-1.00")
-     ,("assets:bank:saving","saving",2, mamountp' "$1.00")
+      ("assets","assets",0, mamountp' "$-1.00")
+     ,("assets:bank:saving","bank:saving",1, mamountp' "$1.00")
      ,("assets:cash","cash",1, mamountp' "$-2.00")
      ,("expenses","expenses",0, mamountp' "$2.00")
      ,("expenses:food","food",1, mamountp' "$1.00")
      ,("expenses:supplies","supplies",1, mamountp' "$1.00")
      ,("income:gifts","income:gifts",0, mamountp' "$-1.00")
-     ,("liabilities:debts","liabilities:debts",0, mamountp' "$1.00")
      ],
      Mixed [usd0])
 

--- a/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
@@ -60,7 +60,7 @@ newtype MultiBalanceReport =
                      ,MultiBalanceReportTotals
                      )
 type MultiBalanceReportRow    = (AccountName, AccountName, Int, [MixedAmount], MixedAmount, MixedAmount)
-type MultiBalanceReportTotals = ([MixedAmount], MixedAmount, MixedAmount)
+type MultiBalanceReportTotals = ([MixedAmount], MixedAmount, MixedAmount) -- (Totals list, sum of totals, average of totals)
 
 instance Show MultiBalanceReport where
     -- use ppShow to break long lists onto multiple lines

--- a/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
@@ -241,6 +241,20 @@ tests_multiBalanceReport =
       ,("income:salary","salary",2, [mamountp' "$-1.00"], mamountp' "$-1.00",Mixed [amount0 {aquantity=(-1)}])
       ],
       Mixed [usd0])
+
+   ,"multiBalanceReport tests the ability to have a valid history on an empty period (More complex)" ~: do
+    (defreportopts{period_= PeriodBetween (fromGregorian 2009 1 1) (fromGregorian 2009 1 2), balancetype_=HistoricalBalance}, samplejournal) `gives`
+     (
+      [
+      ("assets:bank:checking","checking",3, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amount0 {aquantity=1}])
+      ,("assets:bank:saving","saving",3, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amount0 {aquantity=1}])
+      ,("assets:cash","cash",2, [mamountp' "$-2.00"], mamountp' "$-2.00",Mixed [amount0 {aquantity=(-2)}])
+      ,("expenses:food","food",2, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amount0 {aquantity=(1)}])
+      ,("expenses:supplies","supplies",2, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amount0 {aquantity=(1)}])
+      ,("income:gifts","gifts",2, [mamountp' "$-1.00"], mamountp' "$-1.00",Mixed [amount0 {aquantity=(-1)}])
+      ,("income:salary","salary",2, [mamountp' "$-1.00"], mamountp' "$-1.00",Mixed [amount0 {aquantity=(-1)}])
+      ],
+      Mixed [usd0])
   ]
 
 tests_Hledger_Reports_MultiBalanceReport :: Test

--- a/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
@@ -156,7 +156,7 @@ multiBalanceReport opts q j = MultiBalanceReport (displayspans, items, totalsrow
           dbg1 "displayedAccts" $
           (if tree_ opts then expandAccountNames else id) $
           nub $ map (clipOrEllipsifyAccountName depth) $
-          if empty_ opts then nub $ sort $ startAccts ++ postedAccts else postedAccts
+          if empty_ opts || (balancetype_ opts) == HistoricalBalance then nub $ sort $ startAccts ++ postedAccts else postedAccts
 
       acctBalChangesPerSpan :: [[(ClippedAccountName, MixedAmount)]] =
           dbg1 "acctBalChangesPerSpan"

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -263,17 +263,17 @@ tests_postingsReport = [
    -- with the query specified explicitly
    let (query, journal) `gives` n = (length $ snd $ postingsReport defreportopts query journal) `is` n
    (Any, nulljournal) `gives` 0
-   (Any, samplejournal) `gives` 11
+   (Any, samplejournal) `gives` 13
    -- register --depth just clips account names
-   (Depth 2, samplejournal) `gives` 11
+   (Depth 2, samplejournal) `gives` 13
    (And [Depth 1, StatusQ Cleared, Acct "expenses"], samplejournal) `gives` 2
    (And [And [Depth 1, StatusQ Cleared], Acct "expenses"], samplejournal) `gives` 2
 
    -- with query and/or command-line options
-   assertEqual "" 11 (length $ snd $ postingsReport defreportopts Any samplejournal)
-   assertEqual ""  9 (length $ snd $ postingsReport defreportopts{interval_=Months 1} Any samplejournal)
-   assertEqual "" 19 (length $ snd $ postingsReport defreportopts{interval_=Months 1, empty_=True} Any samplejournal)
-   assertEqual ""  4 (length $ snd $ postingsReport defreportopts (Acct "assets:bank:checking") samplejournal)
+   assertEqual "" 13 (length $ snd $ postingsReport defreportopts Any samplejournal)
+   assertEqual "" 11 (length $ snd $ postingsReport defreportopts{interval_=Months 1} Any samplejournal)
+   assertEqual "" 20 (length $ snd $ postingsReport defreportopts{interval_=Months 1, empty_=True} Any samplejournal)
+   assertEqual ""  5 (length $ snd $ postingsReport defreportopts (Acct "assets:bank:checking") samplejournal)
 
    -- (defreportopts, And [Acct "a a", Acct "'b"], samplejournal2) `gives` 0
    -- [(Just (parsedate "2008-01-01","income"),assets:bank:checking             $1,$1)

--- a/hledger-lib/doc/hledger_journal.5.m4.md
+++ b/hledger-lib/doc/hledger_journal.5.m4.md
@@ -55,6 +55,10 @@ Here's an example:
     expenses:supplies     $1    ; <- this transaction debits two expense accounts
     assets:cash                 ; <- $-2 inferred
 
+2008/10/01 take a loan
+    assets:bank:checking  $1
+    liabilities:debts    $-1
+
 2008/12/31 * pay off            ; <- an optional * or ! after the date means "cleared" (or anything you want)
     liabilities:debts     $1
     assets:bank:checking


### PR DESCRIPTION
These set of patches add a testing context for the fix and the fix itself.
The testing context is to make sure the fix does in fact behave like it should. They were added for BalanceReport and MultiBalanceReport only.

this is an excerp of one of the patches description :

This patch fixes a bug that happened when using the -H option on
a period without any transaction. Previously, the behavior was no output
at all even though it should have shown the previous ending balances of
past transactions. (This is similar to previously using -H with -E, but
with the extra advantage of not showing empty accounts)