### PR TITLE
Exclude Fixed Assets from Cashflow Report

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -293,9 +293,9 @@ journalEquityAccountQuery _ = Acct "^equity(:|$)"
 -- | A query for Cash (-equivalent) accounts in this journal (ie,
 -- accounts which appear on the cashflow statement.)  This is currently
 -- hard-coded to be all the Asset accounts except for those containing the
--- case-insensitive regex @(receivable|A/R)@.
+-- case-insensitive regex @(receivable|A/R|fixed)@.
 journalCashAccountQuery  :: Journal -> Query
-journalCashAccountQuery j = And [journalAssetAccountQuery j, Not $ Acct "(receivable|A/R)"]
+journalCashAccountQuery j = And [journalAssetAccountQuery j, Not $ Acct "(receivable|A/R|fixed)"]
 
 -- Various kinds of filtering on journals. We do it differently depending
 -- on the command.

--- a/tests/cashflow/cashflow.test
+++ b/tests/cashflow/cashflow.test
@@ -243,3 +243,24 @@ Cashflow Statement
 
 >>>2
 >>>= 0
+
+# 12. exclude fixed assets from cashflow
+hledger -f - cashflow
+<<<
+2016/1/1
+  assets  1
+  b
+
+2016/1/1
+  assets:fixed assets:equipment  1
+  b
+>>>
+Cashflow Statement
+
+Cash flows:
+                   1  assets
+--------------------
+                   1
+
+>>>2
+>>>= 0


### PR DESCRIPTION
Add "fixed" to the regex used to exclude asset accounts from cashflow
reports.  Assumes accounts are set up something like:
```
assets:fixed assets:equipment
assets:fixed assets:vehicles
assets:fixed assets:buildings
```