### PR TITLE
Update Arch Linux command

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -22,7 +22,7 @@ latest release, or provide only some of the hledger tools.
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | Windows:             | [Latest developer builds](https://ci.appveyor.com/project/simonmichael/hledger/build/artifacts) (no hledger-ui, [please help](https://github.com/jtdaugherty/vty/pull/1#issuecomment-297143444))
 | Mac:                 | **`brew install hledger`** (CLI only, [please help ](https://github.com/simonmichael/hledger/issues/321#issuecomment-179920520))
-| Arch Linux:          | **`pacaur -S hledger`**
+| Arch Linux:          | **`pacman -S hledger`**
 | Debian,&nbsp;Ubuntu: | **`sudo apt install hledger hledger-ui hledger-web`**
 | Fedora,&nbsp;RHEL:   | **`sudo dnf install hledger`**
 | Gentoo:              | **`sudo layman -a haskell && sudo emerge hledger hledger-ui hledger-web`**


### PR DESCRIPTION
`hledger` is is now part of Arch Linux [community] so it's now available directly from `pacman`