### PR TITLE
ui, web: Enable --pivot and --anon in ui and web (#474)

### DIFF
--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -77,7 +77,11 @@ withJournalDoUICommand uopts@UIOpts{cliopts_=copts} cmd = do
   rulespath <- rulesFilePathFromOpts copts
   journalpath <- journalFilePathFromOpts copts
   ej <- readJournalFiles Nothing rulespath (not $ ignore_assertions_ copts) journalpath
-  either error' (cmd uopts . journalApplyAliases (aliasesFromOpts copts)) ej
+  let fn = cmd uopts .
+           pivotByOpts copts .
+           anonymiseByOpts copts .
+           journalApplyAliases (aliasesFromOpts copts)
+  either error' fn ej
 
 runBrickUi :: UIOpts -> Journal -> IO ()
 runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{reportopts_=ropts}} j = do

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -19,6 +19,8 @@ module Hledger.Cli.Utils
      writeFileWithBackup,
      writeFileWithBackupIfChanged,
      readFileStrictly,
+     pivotByOpts,
+     anonymiseByOpts,
      Test(TestList),
     )
 where


### PR DESCRIPTION
This is a very simple change, fixing #474.

I've exposed pivot and anon from Cli.Utils and used them in the custom withJournalDo that -ui and -web have. Other tools can already use --pivot and --anon (at least the tools in /bin), as they use the withJournalDo from Cli.Utils (either directly or using a wrapper, as hledger-budger does).

Though I'd suggest changing the signature of withJournalDo to `CliOpts -> (Journal -> IO ()) -> IO ()` and partially applying the whole UiOpts/WebOpts, so that there can be one unified withJournalDo.
(I haven't done that now, as that changes the API and requires more changes.)