### PR TITLE
web: Make "Add transaction" button tabbable (#430)

### DIFF
--- a/hledger-web/Handler/JournalR.hs
+++ b/hledger-web/Handler/JournalR.hs
@@ -37,7 +37,7 @@ getJournalR = do
        <div .row>
         <h2 #contenttitle>#{title}
         <!-- p>Journal entries record movements of commodities between accounts. -->
-        <a #addformlink role="button" style="cursor:pointer; margin-top:1em;" data-toggle="modal" data-target="#addmodal" title="Add a new transaction to the journal" >Add a transaction
+        <a #addformlink role="button" style="cursor:pointer; margin-top:1em;" data-toggle="modal" data-target="#addmodal" title="Add a new transaction to the journal" href="#">Add a transaction
        <div .table-responsive>
         ^{maincontent}
      |]


### PR DESCRIPTION
This fixes the rest of #430.

Adding a href to an anchor makes it into a button, adding it into the tab order and making it clickable. While having data-toggle="modal" adds JS onclick to the link, making it clickable, it is adding href="#" that makes it selectable via tab and clickable via space.