### PR TITLE
lib: Fix filtering by payee and note (#598)

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -187,16 +187,18 @@ transactionPayee :: Transaction -> Text
 transactionPayee = fst . payeeAndNoteFromDescription . tdescription
 
 transactionNote :: Transaction -> Text
-transactionNote = fst . payeeAndNoteFromDescription . tdescription
+transactionNote = snd . payeeAndNoteFromDescription . tdescription
 
 -- | Parse a transaction's description into payee and note (aka narration) fields,
 -- assuming a convention of separating these with | (like Beancount).
 -- Ie, everything up to the first | is the payee, everything after it is the note.
 -- When there's no |, payee == note == description.
 payeeAndNoteFromDescription :: Text -> (Text,Text)
-payeeAndNoteFromDescription t = (textstrip p, textstrip $ T.tail n)
+payeeAndNoteFromDescription t
+  | T.null n = (t, t)
+  | otherwise = (textstrip p, textstrip $ T.drop 1 n)
   where
-    (p,n) = T.breakOn "|" t
+    (p, n) = T.span (/= '|') t
 
 -- | Tags for this posting including implicit and any inherited from its parent transaction.
 postingAllImplicitTags :: Posting -> [Tag]


### PR DESCRIPTION
Fixes #598.

Neither parseQuery nor matchPosting/matchTransaction were set up to accept payee:/note: filters. Also, transactionNote was non-functional (it returned payee) and payeeAndNoteFromDescription didn't actually fulfill its documentation, namely "When there's no |, payee == note == description."

Edit: It's also occurred to me that in the Query datatype, Desc and Code are obsolete. I'd suggest either replacing them with either `Tag "desc"`, or maybe with an `ImplicitTag` type.

Edit2: After looking at the code in more detail (and fixing broken tests, namely not:tag:.), it seems to me that the whole Query module could use some more datatypes instead of string matching - eg. aggregate implicit tags into a `data ImplicitTag` (with Desc and Code there as well) or using a parser instead of parseQueryTerm with a cascade of T.stripPrefix.