### PR TITLE
Balance assertion errors now show line of failed assertion posting.

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -535,7 +535,9 @@ checkBalanceAssertion p@Posting{ pbalanceassertion = Just ass} amt
             (case ptransaction p of
                Nothing -> ":" -- shouldn't happen
                Just t ->  printf " in %s:\nin transaction:\n%s"
-                          (showGenericSourcePos $ tsourcepos t) (chomp $ show t) :: String)
+                          (showGenericSourcePos postingPos) (chomp $ show t) :: String
+                            where postingLine = fromJust $ elemIndex p $ tpostings t -- assume postings are in order
+                                  postingPos = increaseSourceLine (1+postingLine) (tsourcepos t))
             (showPostingLine p)
             (showDate $ postingDate p)
             (T.unpack $ paccount p) -- XXX pack

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -42,6 +42,7 @@ module Hledger.Data.Transaction (
   sourceFilePath,
   sourceFirstLine,
   showGenericSourcePos,
+  increaseSourceLine,
   -- * misc.
   tests_Hledger_Data_Transaction
 )
@@ -80,6 +81,10 @@ sourceFirstLine :: GenericSourcePos -> Int
 sourceFirstLine = \case
     GenericSourcePos _ line _ -> line
     JournalSourcePos _ (line, _) -> line
+
+increaseSourceLine :: Int -> GenericSourcePos -> GenericSourcePos
+increaseSourceLine val (GenericSourcePos fp line col) = GenericSourcePos fp (line+val) col
+increaseSourceLine val (JournalSourcePos fp (first, _)) = GenericSourcePos fp (first+val) 0
 
 showGenericSourcePos :: GenericSourcePos -> String
 showGenericSourcePos = \case

--- a/tests/journal/balance-assertions.test
+++ b/tests/journal/balance-assertions.test
@@ -57,7 +57,7 @@ hledger -f - stats
   b   $-1  = $-3
 
 >>>
->>>2 /balance assertion error.*lines 9-12/
+>>>2 /balance assertion error.*line 11/
 >>>=1
 
 # 4. should also work without commodity symbols


### PR DESCRIPTION
Addresses #481.

This works, but I'm very new to Haskell and I'm not sure I'm breaking any rules or best practices. Please let me know if there's a better way to do anything, especially where I'm increasing the `GenericSourcePos`'s line number.

Also, this currently prints column 0. Should we try for a custom message instead?