### PR TITLE
doc: fix readme markdown formatting on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For some, it is a simpler, less distracting, more future-proof alternative to Qu
 
 For more, see http://hledger.org.
 
-##Support
+## Support
 
 ### Backers
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/hledger#backer)]


### PR DESCRIPTION
An update to GitHub's markdown parser made it so a space is required between hash characters and the text of titles for them to be displayed correctly.