### PR TITLE
Allow to use space as a digit groups separator

### DIFF
--- a/hledger-lib/doc/hledger_journal.5.m4.md
+++ b/hledger-lib/doc/hledger_journal.5.m4.md
@@ -267,7 +267,8 @@ Amounts consist of a number and (usually) a currency symbol or commodity name. S
   `3 "green apples"`\
   `-$1,000,000.00`\
   `INR 9,99,99,999.00`\
-  `EUR -2.000.000,00`
+  `EUR -2.000.000,00`\
+  `1 999 999.9455`
 
 As you can see, the amount format is somewhat flexible:
 
@@ -275,7 +276,8 @@ As you can see, the amount format is somewhat flexible:
 - the commodity is a symbol, word, or phrase, on the left or right, with or without a separating space.
   If the commodity contains numbers, spaces or non-word punctuation it must be enclosed in double quotes.
 - negative amounts with a commodity on the left can have the minus sign before or after it
-- digit groups (thousands, or any other grouping) can be separated by commas (in which case period is used for decimal point) or periods (in which case comma is used for decimal point)
+- digit groups (thousands, or any other grouping) can be separated by space or comma or period and should be used as separator between all groups
+- decimal part can be separated by comma or period and should be different from digit groups separator
 
 You can use any of these variations when recording data. However, there is some ambiguous way of representing numbers like `$1.000` and `$1,000` both may mean either one thousand or one dollar. By default hledger will assume that this is sole delimiter is used only for decimals. On the other hand commodity format declared prior to that line will help to resolve that ambiguity differently:
 

--- a/tests/journal/numbers.test
+++ b/tests/journal/numbers.test
@@ -43,6 +43,32 @@ hledger bal -f -
 >>>
 >>>=1
 
+# Space between digits groups
+hledger bal -f - --no-total
+<<<
+2017/1/1
+	a   1 000.00 EUR
+	b  -1 000.00 EUR
+>>>
+        1 000.00 EUR  a
+       -1 000.00 EUR  b
+>>>2
+>>>=0
+
+# Space between digits groups in commodity directive
+hledger bal -f - --no-total
+<<<
+commodity 1 000.00 EUR
+
+2017/1/1
+	a   1,000.00 EUR
+	b  -1,000.00 EUR
+>>>
+        1 000.00 EUR  a
+       -1 000.00 EUR  b
+>>>2
+>>>=0
+
 # Default commodity
 hledger bal -f -
 <<<


### PR DESCRIPTION
Note that this pull request shares some common history with #635, but still can go independently.

Resolves #330