### PR TITLE
Fix backtracking in periodexpr parser

### DIFF
--- a/hledger-lib/Hledger/Data/AutoTransaction.hs
+++ b/hledger-lib/Hledger/Data/AutoTransaction.hs
@@ -219,6 +219,12 @@ renderPostingCommentDates p = p { pcomment = comment' }
 -- 2018/11/29
 --     hi           $1.00
 -- <BLANKLINE>
+-- >>> gen "2017/1"
+-- 2017/01/01
+--     hi           $1.00
+-- <BLANKLINE>
+-- >>> gen ""
+-- ... Failed to parse ...
 -- >>> gen "weekly from 2017"
 -- *** Exception: Unable to generate transactions according to "weekly from 2017" as 2017-01-01 is not a first day of the week
 -- >>> gen "monthly from 2017/5/4"

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -43,6 +43,8 @@ data WhichDate = PrimaryDate | SecondaryDate deriving (Eq,Show)
 
 data DateSpan = DateSpan (Maybe Day) (Maybe Day) deriving (Eq,Ord,Data,Generic,Typeable)
 
+instance Default DateSpan where def = DateSpan Nothing Nothing
+
 instance NFData DateSpan
 
 -- synonyms for various date-related scalars

--- a/hledger-lib/Hledger/Utils/Parse.hs
+++ b/hledger-lib/Hledger/Utils/Parse.hs
@@ -38,6 +38,9 @@ choice' = choice . map try
 choiceInState :: [StateT s (ParsecT MPErr Text m) a] -> StateT s (ParsecT MPErr Text m) a
 choiceInState = choice . map try
 
+surroundedBy :: Applicative m => m openclose -> m a -> m a
+surroundedBy p = between p p
+
 parsewith :: Parsec e Text a -> Text -> Either (ParseError Char e) a
 parsewith p = runParser p ""
 


### PR DESCRIPTION
- Simplify ~and make more strict~ doctests for periodexpr.
- ~Test that expose backtracking issue. Borrowed from simonmichael/hledger#654 .~
- Besides consuming leading space consume ending space for periodexpr also.
- Drop implicit option (def, def) behaviour of periodexpr. I.e. disallow hledger reg -p '' and auto-transaction with heading just '~'.
- Slightly re-factor periodexpr.
- _Ensure that reportinginterval doesn't consume trailing space. Useful if  we'll start disallowing periods like "every1stjan2009-"._