### PR TITLE
lib: speed up bal/bs by removing needless numeric comparisons

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -75,6 +75,7 @@ import Data.Array.ST
 import Data.Functor.Identity (Identity(..))
 import qualified Data.HashTable.ST.Cuckoo as HT
 import Data.List
+import Data.List.Extra (groupSort)
 -- import Data.Map (findWithDefault)
 import Data.Maybe
 import Data.Monoid
@@ -752,8 +753,7 @@ journalInferCommodityStyles j =
 commodityStylesFromAmounts :: [Amount] -> M.Map CommoditySymbol AmountStyle
 commodityStylesFromAmounts amts = M.fromList commstyles
   where
-    samecomm = \a1 a2 -> acommodity a1 == acommodity a2
-    commamts = [(acommodity $ head as, as) | as <- groupBy samecomm $ sortBy (comparing acommodity) amts]
+    commamts = groupSort [(acommodity as, as) | as <- amts]
     commstyles = [(c, canonicalStyleFrom $ map astyle as) | (c,as) <- commamts]
 
 -- | Given an ordered list of amount styles, choose a canonical style.

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -83,6 +83,7 @@ library
     , uglymemo
     , utf8-string >=0.3.5 && <1.1
     , HUnit
+    , extra
   exposed-modules:
       Hledger
       Hledger.Data
@@ -171,6 +172,7 @@ test-suite doctests
     , uglymemo
     , utf8-string >=0.3.5 && <1.1
     , HUnit
+    , extra
     , doctest >=0.8
     , Glob >=0.7
   other-modules:
@@ -259,6 +261,7 @@ test-suite hunittests
     , uglymemo
     , utf8-string >=0.3.5 && <1.1
     , HUnit
+    , extra
     , hledger-lib
     , test-framework
     , test-framework-hunit

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -70,6 +70,7 @@ dependencies:
 - uglymemo
 - utf8-string >=0.3.5 && <1.1
 - HUnit
+- extra
 # for ledger-parse:
 #- parsers >= 0.5
 #- system-filepath


### PR DESCRIPTION
accountsFromPostings is currently doing excessive work when
adding up postings in each account. There is no need to sort postings
by amount since summing up does not depend on order. It is enough to
sort (for grouping purposes) by accountname only.