### PR TITLE
hledger-check: compatibility with stack8.0.yaml

### DIFF
--- a/bin/hledger-check.hs
+++ b/bin/hledger-check.hs
@@ -82,6 +82,7 @@ import Control.Arrow (first)
 import Control.Monad (mplus, mzero, unless, void)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State.Strict (runStateT)
+import Data.String (fromString)
 import Data.Function (on)
 import Data.Functor.Identity (Identity(..))
 import Data.List (foldl', groupBy, intercalate, nub, sortOn)
@@ -471,5 +472,5 @@ sameish f = (==) `on` f . toGregorian . H.postingDate
 
 -- | Helper for 'Compare' and 'Connect' parsers.
 gostringsp :: Monad m => [(String, a)] -> H.TextParser m a
-gostringsp ((s,a):rest) = P.try (P.string (pack s) *> pure a) `mplus` gostringsp rest
+gostringsp ((s,a):rest) = P.try (P.string (fromString s) *> pure a) `mplus` gostringsp rest
 gostringsp [] = mzero


### PR DESCRIPTION
Fix build error for `hledger-check` external addon that have no compatibility with older versions of `megaparsec`.

When built with `stack8.0.yaml` included in `hledger`:

```
[1 of 1] Compiling Main             ( hledger-check.hs, hledger-check.o )

hledger-check.hs:474:44: error:
    • Couldn't match type ‘Data.Text.Internal.Text’ with ‘[Char]’
      Expected type: String
        Actual type: Data.Text.Internal.Text
    • In the first argument of ‘P.string’, namely ‘(pack s)’
      In the first argument of ‘(*>)’, namely ‘P.string (pack s)’
      In the first argument of ‘P.try’, namely
        ‘(P.string (pack s) *> pure a)’
```