### PR TITLE
lib: fix budget display to always display percent consumed and handle costs

### DIFF
--- a/tests/budget/budget.test
+++ b/tests/budget/budget.test
@@ -37,7 +37,7 @@ Balance changes in 2016/12/01-2016/12/03:
  <unbudgeted>:expenses ||                  0                   0                  $40 
  assets:cash           || $-10 [40% of $-25]  $-14 [56% of $-25]  $-51 [204% of $-25] 
  expenses:food         ||  $10 [100% of $10]     $9 [90% of $10]    $11 [110% of $10] 
- expenses:leisure      ||            0 [$15]     $5 [33% of $15]              0 [$15] 
+ expenses:leisure      ||      0 [0% of $15]     $5 [33% of $15]        0 [0% of $15] 
 -----------------------++-------------------------------------------------------------
                        ||                  0                   0                    0 
 
@@ -83,10 +83,60 @@ Balance changes in 2016/12/01-2016/12/03:
  assets:cash      || $-10 [40% of $-25]  $-14 [56% of $-25]  $-51 [204% of $-25] 
  expenses:cab     ||                  0                   0                  $15 
  expenses:food    ||  $10 [100% of $10]     $9 [90% of $10]    $11 [110% of $10] 
- expenses:leisure ||            0 [$15]     $5 [33% of $15]              0 [$15] 
+ expenses:leisure ||      0 [0% of $15]     $5 [33% of $15]        0 [0% of $15] 
  expenses:movies  ||                  0                   0                  $25 
 ------------------++-------------------------------------------------------------
                   ||                  0                   0                    0 
+
+>>>2
+>>>=0
+
+# Test that budget works with mix of commodities
+hledger bal -D -b 2016-12-01 -e 2016-12-04 -f - --budget
+<<<
+2016/12/01
+    expenses:food  £10 @@ $15
+    assets:cash
+
+2016/12/02
+    expenses:food  10 CAD @ $1
+    assets:cash
+
+2016/12/02
+    expenses:food  10 CAD @ $1.1
+    assets:cash
+
+2016/12/03
+    expenses:food  $11
+    assets:cash
+
+2016/12/02
+    expenses:leisure  $5
+    assets:cash
+
+2016/12/03
+    expenses:movies  $25
+    assets:cash
+
+2016/12/03
+    expenses:cab  $15
+    assets:cash
+
+~ daily from 2016/1/1
+    expenses:food     $10
+    expenses:leisure  $15
+    assets:cash
+>>>
+Balance changes in 2016/12/01-2016/12/03:
+
+                       ||         2016/12/01             2016/12/02           2016/12/03 
+=======================++================================================================
+ <unbudgeted>:expenses ||                  0                      0                  $40 
+ assets:cash           || $-15 [60% of $-25]  $-26.0 [104% of $-25]  $-51 [204% of $-25] 
+ expenses:food         ||  £10 [150% of $10]   20 CAD [210% of $10]    $11 [110% of $10] 
+ expenses:leisure      ||      0 [0% of $15]        $5 [33% of $15]        0 [0% of $15] 
+-----------------------++----------------------------------------------------------------
+                       ||          $-15, £10         $-21.0, 20 CAD                    0 
 
 >>>2
 >>>=0


### PR DESCRIPTION

For multi-column balance report, if there are no transactions in the
given period for budgeted account, display [0% of <budget>] for
consistency.

If balance is a mix of commodities, convert to cost basis for the
purposes of computing percent of balance spent.