### PR TITLE
Small fixes to journal handling (styles, error, commodity scope)

### DIFF
--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -203,7 +203,7 @@ includedirectivep = do
       either
         (throwError
           . ((show parentpos ++ " in included file " ++ show filename ++ ":\n") ++)
-          . show)
+          . parseErrorPretty)
         (return . journalAddFile (filepath, txt))
         ej1
   case ej of

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -217,6 +217,7 @@ newJournalWithParseStateFrom j = mempty{
   ,jparsedefaultcommodity = jparsedefaultcommodity j
   ,jparseparentaccounts   = jparseparentaccounts j
   ,jparsealiases          = jparsealiases j
+  ,jcommodities           = jcommodities j
   -- ,jparsetransactioncount = jparsetransactioncount j
   ,jparsetimeclockentries = jparsetimeclockentries j
   }


### PR DESCRIPTION
- Small additional fix for issue spot by @dashed in #487 to inherit effect of `commodity` directive on parsing included files.
- Fix style canonicalization when `--cost` option applied ( #509 ).
- Get pretty error report for included journals ( #660 ).