### PR TITLE
specify nix integration options in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ resolver: nightly-2017-12-05
 
 nix:
   enable: false
+  pure: false
   packages: [perl gmp ncurses zlib]
 
 # extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,10 @@
 
 resolver: nightly-2017-12-05
 
+nix:
+  enable: false
+  packages: [perl gmp ncurses zlib]
+
 # extra-deps:
 
 packages:


### PR DESCRIPTION
Resolves #668, possibly #669.
I was able to successfully build master using this `stack.yaml` and running the following:
```
$ stack --nix --no-nix-pure install
```
The `nix-no-pure` preserves `LANG` and other user environment variables so the documentation files will build successfully. It may be a better nix practice to use a `shell.nix` as outlined [here](https://docs.haskellstack.org/en/stable/nix_integration/) to set the `LANG` explicitly. An example file is [here](https://github.com/aelve/guide/blob/master/shell.nix)