### PR TITLE
lib: Allow balance-only entries in csv reader

### DIFF
--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -228,6 +228,7 @@ postingAsLines elideamount onelineamounts ps p = concat [
     shownAmounts
       | elideamount    = [""]
       | onelineamounts = [fitString (Just amtwidth) Nothing False False $ showMixedAmountOneLine $ pamount p]
+      | null (amounts $ pamount p) = [""]
       | otherwise      = map (fitStringMulti (Just amtwidth) Nothing False False . showAmount ) . amounts $ pamount p
       where
         amtwidth = maximum $ 12 : map (strWidth . showMixedAmount . pamount) ps  -- min. 12 for backwards compatibility
@@ -254,7 +255,7 @@ showPostingLines p = postingAsLines False False ps p where
 tests_postingAsLines = [
    "postingAsLines" ~: do
     let p `gives` ls = assertEqual (show p) ls (postingAsLines False False [p] p)
-    posting `gives` []
+    posting `gives` [""]
     posting{
       pstatus=Cleared,
       paccount="a",


### PR DESCRIPTION
This PR enables the csv reader to import rows with no amount but with a balance entry.
I hope it is not too dirty :)

PS: This codebase is quite a pleasure to edit, thanks to all the maintainers