### PR TITLE
Docs: Nix Stack build note.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist/
 dist-newstyle/
 /Shake
 /.shake.html
+.stack-work/
 
 # hledger stuff
 old

--- a/site/download.md
+++ b/site/download.md
@@ -109,6 +109,8 @@ The latest [master branch](https://github.com/simonmichael/hledger/commits/maste
 
 Cabal users can use the `cabal-install.sh` or `cabal.project` files instead.
 
+Nix users taking advantage of Stack integration may need to use Stack's `--no-nix-pure` flag to build hledger.
+
 
 <a name="d"></a>
 


### PR DESCRIPTION
Add the `--no-nix-pure` flag to forward environment variables.
Without this flag the build fails.