### PR TITLE
Clone from github over https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ install: # command output is hidden as they complete
   # shelltestrunner, need unreleased installable version
   #- git clone http://github.com/simonmichael/shelltestrunner
   #- if [[ ! -d shelltestrunner ]]; then git clone http://github.com/simonmichael/shelltestrunner; fi
-  - git clone http://github.com/simonmichael/shelltestrunner
+  - git clone https://github.com/simonmichael/shelltestrunner
   - if [[ ! -x ~/.local/bin/shelltest ]]; then stack install --stack-yaml=shelltestrunner/stack.yaml; fi
   - shelltest --version
 


### PR DESCRIPTION
This should hopefully fix the following Travis CI build error:
```
fatal: unable to access 'http://github.com/simonmichael/shelltestrunner/': Failed to connect to github.com port 443: Connection timed out
```

(see https://travis-ci.org/simonmichael/hledger/jobs/323972730#L487 )