### PR TITLE
doc: remove raw markup macro

### DIFF
--- a/hledger-web/hledger-web.m4.md
+++ b/hledger-web/hledger-web.m4.md
@@ -61,20 +61,20 @@ With `--serve`, it just runs the web app without exiting, and logs
 requests to the console.
 
 By default the server listens on IP address 127.0.0.1, accessible only to local requests.
-You can use `--host` to change this, eg `--host 0.0.0.0` to listen on all configured addresses. 
+You can use `--host` to change this, eg `--host 0.0.0.0` to listen on all configured addresses.
 
 Similarly, use `--port` to set a TCP port other than 5000, eg if you are
 running multiple hledger-web instances.
 
 You can use `--base-url` to change the protocol, hostname, port and path that appear in hyperlinks,
-useful eg for integrating hledger-web within a larger website. 
+useful eg for integrating hledger-web within a larger website.
 The default is `http://HOST:PORT/` using the server's configured host address and TCP port
 (or `http://HOST` if PORT is 80).
 
 With `--file-url` you can set a different base url for static files,
-eg for better caching or cookie-less serving on high performance websites. 
+eg for better caching or cookie-less serving on high performance websites.
 
-Note there is no built-in access control (aside from listening on 127.0.0.1 by default). 
+Note there is no built-in access control (aside from listening on 127.0.0.1 by default).
 So you will need to hide hledger-web behind an authenticating proxy (such as apache or nginx)
 if you want to restrict who can see and add entries to your journal.
 

--- a/site/doc/1.5/hledger-ui.md
+++ b/site/doc/1.5/hledger-ui.md
@@ -24,7 +24,7 @@ ledger(1).
 .highslide img {max-width:200px; border:0;}
 .highslide-caption {color:white; background-color:black;}
 </style>
-::: {style="float:right; max-width:200px; text-align:right;"}
+<div style="float:right; max-width:200px; text-align:right;">
 <a href="images/hledger-ui/hledger-ui-sample-acc2.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-ui/hledger-ui-sample-acc2.png" title="Accounts screen with query and depth limit" /></a>
 <a href="images/hledger-ui/hledger-ui-sample-acc.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-ui/hledger-ui-sample-acc.png" title="Accounts screen" /></a>
 <a href="images/hledger-ui/hledger-ui-sample-acc-greenterm.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-ui/hledger-ui-sample-acc-greenterm.png" title="Accounts screen with greenterm theme" /></a>
@@ -34,7 +34,7 @@ ledger(1).
 <a href="images/hledger-ui/hledger-ui-bcexample-acc.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-ui/hledger-ui-bcexample-acc.png" title="beancount example accounts" /></a>
 <a href="images/hledger-ui/hledger-ui-bcexample-acc-etrade-cash.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-ui/hledger-ui-bcexample-acc-etrade-cash.png" title="beancount example's etrade cash subaccount" /></a>
 <a href="images/hledger-ui/hledger-ui-bcexample-acc-etrade.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-ui/hledger-ui-bcexample-acc-etrade.png" title="beancount example's etrade investments, all commoditiess" /></a>
-:::
+</div>
 
 hledger-ui is hledger's curses-style interface, providing an efficient
 full-window text UI for viewing accounts and transactions, and some

--- a/site/doc/1.5/hledger-web.md
+++ b/site/doc/1.5/hledger-web.md
@@ -24,13 +24,12 @@ ledger(1).
 .highslide img {max-width:200px; border:thin grey solid; margin:0 0 1em 1em; }
 .highslide-caption {color:white; background-color:black;}
 </style>
-::: {style="float:right; max-width:200px; text-align:right;"}
+<div style="float:right; max-width:200px; text-align:right;">
 <a href="images/hledger-web/normal/register.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-web/normal/register.png" title="Account register view with accounts sidebar" /></a>
 <a href="images/hledger-web/normal/journal.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-web/normal/journal.png" title="Journal view" /></a>
 <a href="images/hledger-web/normal/help.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-web/normal/help.png" title="Help dialog" /></a>
 <a href="images/hledger-web/normal/add.png" class="highslide" onclick="return hs.expand(this)"><img src="images/hledger-web/normal/add.png" title="Add form" /></a>
-:::
-
+</div>
 hledger-web is hledger's web interface. It starts a simple web
 application for browsing and adding transactions, and optionally opens
 it in a web browser window if possible. It provides a more user-friendly


### PR DESCRIPTION
Alrighty, this should actually fix #692.  I actually verified it locally this time by running `make site-preview` :smile: 
Saw it here as well: http://hledger.org/hledger-ui.html
saw the `:::` macro in hledger-web, hledger-ui so removed. Not sure if
that had special behavior in somewhere in the build chain. Is this some kind of hakyll syntax?