### PR TITLE
add JSON output format

### DIFF
--- a/hledger-api/hledger-api.hs
+++ b/hledger-api/hledger-api.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main where
@@ -160,44 +159,6 @@ hledgerApiApp staticdir j = Servant.serve api server
             thisacctq = Acct $ accountNameToAccountRegex a -- includes subs
           return $ accountTransactionsReport ropts j q thisacctq
 
-instance ToJSON Status where toJSON = genericToJSON defaultOptions -- avoiding https://github.com/bos/aeson/issues/290
-instance ToJSON GenericSourcePos where toJSON = genericToJSON defaultOptions
-instance ToJSON Decimal where
-  toJSON = toJSON . show
-instance ToJSON Amount where toJSON = genericToJSON defaultOptions
-instance ToJSON AmountStyle where toJSON = genericToJSON defaultOptions
-instance ToJSON Side where toJSON = genericToJSON defaultOptions
-instance ToJSON DigitGroupStyle where toJSON = genericToJSON defaultOptions
-instance ToJSON MixedAmount where toJSON = genericToJSON defaultOptions
-instance ToJSON Price where toJSON = genericToJSON defaultOptions
-instance ToJSON MarketPrice where toJSON = genericToJSON defaultOptions
-instance ToJSON PostingType where toJSON = genericToJSON defaultOptions
-instance ToJSON Posting where
-  toJSON Posting{..} =
-    object
-    ["pdate"             .= toJSON pdate
-    ,"pdate2"            .= toJSON pdate2
-    ,"pstatus"           .= toJSON pstatus
-    ,"paccount"          .= toJSON paccount
-    ,"pamount"           .= toJSON pamount
-    ,"pcomment"          .= toJSON pcomment
-    ,"ptype"             .= toJSON ptype
-    ,"ptags"             .= toJSON ptags
-    ,"pbalanceassertion" .= toJSON pbalanceassertion
-    ,"ptransactionidx"   .= toJSON (maybe "" (show.tindex) ptransaction)
-    ]
-instance ToJSON Transaction where toJSON = genericToJSON defaultOptions
-instance ToJSON Account where
-  toJSON a =
-    object
-    ["aname"        .= toJSON (aname a)
-    ,"aebalance"    .= toJSON (aebalance a)
-    ,"aibalance"    .= toJSON (aibalance a)
-    ,"anumpostings" .= toJSON (anumpostings a)
-    ,"aboring"      .= toJSON (aboring a)
-    ,"aparentname"  .= toJSON (maybe "" aname $ aparent a)
-    ,"asubs"        .= toJSON (map toJSON $ asubs a)
-    ]
 instance ToSchema Status
 instance ToSchema GenericSourcePos
 instance ToSchema Decimal

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0359b7d353e59a15012d14a39fea7d133562b202c70969984a8fd918f27417e8
+-- hash: 1332f7c0746a3de64e5fa5dde1d9f1786d215634f026dcd1aac53afa284190fc
 
 name:           hledger-lib
 version:        1.5.99
@@ -56,6 +56,7 @@ library
   build-depends:
       Decimal
     , HUnit
+    , aeson
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <5
@@ -146,6 +147,7 @@ test-suite doctests
       Decimal
     , Glob >=0.7
     , HUnit
+    , aeson
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <5
@@ -235,6 +237,7 @@ test-suite hunittests
   build-depends:
       Decimal
     , HUnit
+    , aeson
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <5

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -71,6 +71,7 @@ dependencies:
 - utf8-string >=0.3.5
 - HUnit
 - extra
+- aeson
 # for ledger-parse:
 #- parsers >=0.5
 #- system-filepath

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -161,7 +161,7 @@ reportflags = [
 
 -- | Common output-related flags: --output-file, --output-format...
 outputflags = [outputFormatFlag, outputFileFlag]
-outputFormatFlag = flagReq  ["output-format","O"] (\s opts -> Right $ setopt "output-format" s opts) "FMT" "select the output format. Supported formats:\ntxt, csv, html."
+outputFormatFlag = flagReq  ["output-format","O"] (\s opts -> Right $ setopt "output-format" s opts) "FMT" "select the output format. Supported formats:\ntxt, csv, html and json."
 outputFileFlag   = flagReq  ["output-file","o"]   (\s opts -> Right $ setopt "output-file" s opts) "FILE" "write output to FILE. A file extension matching one of the above formats selects that format."
 
 argsFlag :: FlagHelp -> Arg RawOpts
@@ -525,6 +525,7 @@ outputFormats =
   [defaultOutputFormat] ++
   ["csv"
   ,"html"
+  ,"json"
   ]
 
 -- | Get the output format from the --output-format option,

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -263,8 +263,6 @@ import Test.HUnit
 import Text.Printf (printf)
 import Text.Tabular as T
 import Text.Tabular.AsciiWide
-import Data.Aeson.Text
-import qualified Data.Text.Lazy as TL
 
 import Hledger
 import Hledger.Cli.CliOptions

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -263,6 +263,8 @@ import Test.HUnit
 import Text.Printf (printf)
 import Text.Tabular as T
 import Text.Tabular.AsciiWide
+import Data.Aeson.Text
+import qualified Data.Text.Lazy as TL
 
 import Hledger
 import Hledger.Cli.CliOptions
@@ -321,6 +323,7 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
               render = case format of
                 "csv"  -> \ropts r -> (++ "\n") $ printCSV $ balanceReportAsCsv ropts r
                 "html" -> \_ _ -> error' "Sorry, HTML output is not yet implemented for this kind of report."  -- TODO
+                "json" -> \_ _ -> error' "Sorry, JSON output is not yet implemented for this kind of report."  -- TODO
                 _      -> balanceReportAsText
           writeOutput opts $ render ropts report
           
@@ -332,6 +335,7 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
               render = case format of
                 "csv"  -> const $ error' "Sorry, CSV output is not yet implemented for this kind of report."  -- TODO
                 "html" -> const $ error' "Sorry, HTML output is not yet implemented for this kind of report."  -- TODO
+                "json" -> const $ error' "Sorry, JSON output is not yet implemented for this kind of report."  -- TODO
                 _     -> multiBalanceReportWithBudgetAsText ropts budgetReport
           writeOutput opts $ render report
           
@@ -340,6 +344,7 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
               render = case format of
                 "csv"  -> (++ "\n") . printCSV . multiBalanceReportAsCsv ropts
                 "html" ->  (++ "\n") . TL.unpack . L.renderText . multiBalanceReportAsHtml ropts
+                "json" -> const $ error' "Sorry, JSON output is not yet implemented for this kind of report."  -- TODO
                 _      -> multiBalanceReportAsText ropts
           writeOutput opts $ render report
 

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -20,6 +20,8 @@ import qualified Data.Text as T
 import System.Console.CmdArgs.Explicit
 import Test.HUnit
 import Text.CSV
+import Data.Aeson.Text
+import qualified Data.Text.Lazy as TL
 
 import Hledger
 import Hledger.Cli.CliOptions
@@ -61,6 +63,7 @@ printEntries opts@CliOpts{reportopts_=ropts} j = do
       (render, ropts') = case fmt of
         "csv"  -> ((++"\n") . printCSV . entriesReportAsCsv, ropts{accountlistmode_=ALFlat})
         "html" -> (const $ error' "Sorry, HTML output is not yet implemented for this kind of report.", ropts{accountlistmode_=ALFlat})  -- TODO
+        "json" -> (TL.unpack . encodeToLazyText, ropts{accountlistmode_=ALFlat})
         _      -> (entriesReportAsText opts,                 ropts)
   writeOutput opts $ render $ entriesReport ropts' q j
 

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -22,6 +22,8 @@ import qualified Data.Text as T
 import System.Console.CmdArgs.Explicit
 import Text.CSV
 import Test.HUnit
+import Data.Aeson.Text
+import qualified Data.Text.Lazy as TL
 
 import Hledger
 import Hledger.Cli.CliOptions
@@ -63,6 +65,7 @@ register opts@CliOpts{reportopts_=ropts} j = do
   let fmt = outputFormatFromOpts opts
       render | fmt=="csv"  = const ((++"\n") . printCSV . postingsReportAsCsv)
              | fmt=="html" = const $ error' "Sorry, HTML output is not yet implemented for this kind of report."  -- TODO
+             | fmt=="json" = const (TL.unpack . encodeToLazyText)
              | otherwise   = postingsReportAsText
   writeOutput opts $ render opts $ postingsReport ropts (queryFromOpts d ropts) j
 

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -207,6 +207,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportopts_=r
       case format of
         "csv"  -> printCSV (compoundBalanceReportAsCsv ropts cbr) ++ "\n"
         "html" -> (++ "\n") $ TL.unpack $ L.renderText $ compoundBalanceReportAsHtml ropts cbr
+        "json" -> "Sorry, JSON output is not yet implemented for this kind of report."  -- TODO
         _      -> compoundBalanceReportAsText ropts' cbr
 
 -- | Given a MultiBalanceReport and its normal balance sign,

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cb1407ac28a973e8fc74c9e78c06c2c29715873a64eb4586417cf02d12bfa60f
+-- hash: 614f3c1d6a4adab9b7858a3358175346c25ed3f374721cbdaf2a381af71de91a
 
 name:           hledger
 version:        1.5.99
@@ -82,6 +82,7 @@ library
       Decimal
     , Diff
     , HUnit
+    , aeson
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <5
     , base-compat >=0.8.1
@@ -164,6 +165,7 @@ executable hledger
   build-depends:
       Decimal
     , HUnit
+    , aeson
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <5
     , base-compat >=0.8.1
@@ -216,6 +218,7 @@ test-suite test
   build-depends:
       Decimal
     , HUnit
+    , aeson
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <5
     , base-compat >=0.8.1
@@ -265,7 +268,8 @@ benchmark bench
       bench
   ghc-options: -Wall -fno-warn-unused-do-bind -fno-warn-name-shadowing -fno-warn-missing-signatures -fno-warn-type-defaults -fno-warn-orphans
   build-depends:
-      ansi-terminal >=0.6.2.3
+      aeson
+    , ansi-terminal >=0.6.2.3
     , base >=4.8 && <5
     , base-compat >=0.8.1
     , criterion

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -88,6 +88,7 @@ dependencies:
 - time >=1.5
 - utility-ht >=0.0.13
 - hledger-lib >=1.5.99 && <1.6
+- aeson
 
 when:
 - condition: (!(os(windows))) && (flag(terminfo))


### PR DESCRIPTION
implementation done for

```
LEDGER_FILE=hledger.journal stack exec -- hledger print -O json
LEDGER_FILE=hledger.journal stack exec -- hledger register cash -O json
```

not done for
```
LEDGER_FILE=hledger.journal stack exec -- hledger balance --quarterly income expenses -E -O json
LEDGER_FILE=hledger.journal stack exec -- hledger balance -O json
```

didn't know how to trigger the other codepaths.
```
budgetJournal
multiBalanceReport
compoundBalanceCommand
```

hledger.journal is from the manual
```
2015/9/30 gift received
  assets:cash   $20
  income:gifts

2015/10/16 farmers market
  expenses:food    $10
  assets:cash

```

related to https://github.com/simonmichael/hledger/issues/689