### PR TITLE
ensure stack's nix config works on nixos

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,6 @@
 resolver: lts-10.3
 
 nix:
-  enable: false
   pure: false
   packages: [perl gmp ncurses zlib]
 


### PR DESCRIPTION
Fix #712 
I tested this on Arch Linux + a nix install and it does use nix for the stack installation when have mentioned config in my `~/.stack/config.yaml`.
@cdepillabout would you mind testing this on NixOS?
Thanks for the improvement too!