### PR TITLE
hledger-lib: add missing Semigroup instance for Journal

### DIFF
--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -84,6 +84,8 @@ library
     , transformers >=0.2
     , uglymemo
     , utf8-string >=0.3.5
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups == 0.18.*
   exposed-modules:
       Hledger
       Hledger.Data


### PR DESCRIPTION
GHC 8.4.1 makes Semigroup a superclass of Monoid. See
https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid
for details.

I could not run the test suite with GHC 7.10.3 because of https://github.com/joelburget/easytest/issues/3, but the test suite did succeed with the other compilers.