### PR TITLE
Use skipMany/skipSome for parsing spacenonewline

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -660,7 +660,7 @@ smartdate = do
 smartdateonly :: SimpleTextParser SmartDate
 smartdateonly = do
   d <- smartdate
-  many spacenonewline
+  skipMany spacenonewline
   eof
   return d
 
@@ -769,7 +769,7 @@ lastthisnextthing = do
        ,"this"
        ,"next"
       ]
-  many spacenonewline  -- make the space optional for easier scripting
+  skipMany spacenonewline  -- make the space optional for easier scripting
   p <- choice $ map mptext [
         "day"
        ,"week"
@@ -827,7 +827,7 @@ lastthisnextthing = do
 -- >>> p "every 2nd day of month 2009-"
 -- Right (DayOfMonth 2,DateSpan 2009/01/01-)
 periodexpr :: Day -> SimpleTextParser (Interval, DateSpan)
-periodexpr rdate = surroundedBy (many spacenonewline) . choice $ map try [
+periodexpr rdate = surroundedBy (skipMany spacenonewline) . choice $ map try [
                     intervalanddateperiodexpr rdate,
                     (,) NoInterval <$> periodexprdatespan rdate
                    ]
@@ -836,7 +836,7 @@ intervalanddateperiodexpr :: Day -> SimpleTextParser (Interval, DateSpan)
 intervalanddateperiodexpr rdate = do
   i <- reportinginterval
   s <- option def . try $ do
-      many spacenonewline
+      skipMany spacenonewline
       periodexprdatespan rdate
   return (i,s)
 
@@ -853,46 +853,46 @@ reportinginterval = choice' [
                        do string "bimonthly"
                           return $ Months 2,
                        do string "every"
-                          many spacenonewline
+                          skipMany spacenonewline
                           n <- nth
-                          many spacenonewline
+                          skipMany spacenonewline
                           string "day"
                           of_ "week"
                           return $ DayOfWeek n,
                        do string "every"
-                          many spacenonewline
+                          skipMany spacenonewline
                           n <- weekday
                           return $ DayOfWeek n,
                        do string "every"
-                          many spacenonewline
+                          skipMany spacenonewline
                           n <- nth
-                          many spacenonewline
+                          skipMany spacenonewline
                           string "day"
                           optOf_ "month"
                           return $ DayOfMonth n,
                        do string "every"
                           let mnth = choice' [month, mon] >>= \(_,m,_) -> return (read m)
-                          d_o_y <- makePermParser $ DayOfYear <$$> try (many spacenonewline *> mnth) <||> try (many spacenonewline *> nth)
+                          d_o_y <- makePermParser $ DayOfYear <$$> try (skipMany spacenonewline *> mnth) <||> try (skipMany spacenonewline *> nth)
                           optOf_ "year"
                           return d_o_y,
                        do string "every"
-                          many spacenonewline
+                          skipMany spacenonewline
                           ("",m,d) <- md
                           optOf_ "year"
                           return $ DayOfYear (read m) (read d),
                        do string "every"
-                          many spacenonewline
+                          skipMany spacenonewline
                           n <- nth
-                          many spacenonewline
+                          skipMany spacenonewline
                           wd <- weekday
                           optOf_ "month"
                           return $ WeekdayOfMonth n wd
                     ]
     where
       of_ period = do
-        many spacenonewline
+        skipMany spacenonewline
         string "of"
-        many spacenonewline
+        skipMany spacenonewline
         string period
         
       optOf_ period = optional $ try $ of_ period
@@ -908,13 +908,13 @@ reportinginterval = choice' [
           do mptext compact'
              return $ intcons 1,
           do mptext "every"
-             many spacenonewline
+             skipMany spacenonewline
              mptext singular'
              return $ intcons 1,
           do mptext "every"
-             many spacenonewline
+             skipMany spacenonewline
              n <- fmap read $ some digitChar
-             many spacenonewline
+             skipMany spacenonewline
              mptext plural'
              return $ intcons n
           ]
@@ -933,10 +933,10 @@ periodexprdatespan rdate = choice $ map try [
 
 doubledatespan :: Day -> SimpleTextParser DateSpan
 doubledatespan rdate = do
-  optional (string "from" >> many spacenonewline)
+  optional (string "from" >> skipMany spacenonewline)
   b <- smartdate
-  many spacenonewline
-  optional (choice [string "to", string "-"] >> many spacenonewline)
+  skipMany spacenonewline
+  optional (choice [string "to", string "-"] >> skipMany spacenonewline)
   e <- smartdate
   return $ DateSpan (Just $ fixSmartDate rdate b) (Just $ fixSmartDate rdate e)
 
@@ -944,7 +944,7 @@ fromdatespan :: Day -> SimpleTextParser DateSpan
 fromdatespan rdate = do
   b <- choice [
     do
-      string "from" >> many spacenonewline
+      string "from" >> skipMany spacenonewline
       smartdate
     ,
     do
@@ -956,13 +956,13 @@ fromdatespan rdate = do
 
 todatespan :: Day -> SimpleTextParser DateSpan
 todatespan rdate = do
-  choice [string "to", string "-"] >> many spacenonewline
+  choice [string "to", string "-"] >> skipMany spacenonewline
   e <- smartdate
   return $ DateSpan Nothing (Just $ fixSmartDate rdate e)
 
 justdatespan :: Day -> SimpleTextParser DateSpan
 justdatespan rdate = do
-  optional (string "in" >> many spacenonewline)
+  optional (string "in" >> skipMany spacenonewline)
   d <- smartdate
   return $ spanFromSmartDate rdate d
 

--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -188,7 +188,7 @@ words'' :: [T.Text] -> T.Text -> [T.Text]
 words'' prefixes = fromparse . parsewith maybeprefixedquotedphrases -- XXX
     where
       maybeprefixedquotedphrases :: SimpleTextParser [T.Text]
-      maybeprefixedquotedphrases = choice' [prefixedQuotedPattern, singleQuotedPattern, doubleQuotedPattern, pattern] `sepBy` some spacenonewline
+      maybeprefixedquotedphrases = choice' [prefixedQuotedPattern, singleQuotedPattern, doubleQuotedPattern, pattern] `sepBy` skipSome spacenonewline
       prefixedQuotedPattern :: SimpleTextParser T.Text
       prefixedQuotedPattern = do
         not' <- fromMaybe "" `fmap` (optional $ mptext "not:")

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -109,10 +109,10 @@ timeclockentryp :: JournalParser m TimeclockEntry
 timeclockentryp = do
   sourcepos <- genericSourcePos <$> lift getPosition
   code <- oneOf ("bhioO" :: [Char])
-  lift (some spacenonewline)
+  lift (skipSome spacenonewline)
   datetime <- datetimep
-  account <- fromMaybe "" <$> optional (lift (some spacenonewline) >> modifiedaccountnamep)
-  description <- T.pack . fromMaybe "" <$> lift (optional (some spacenonewline >> restofline))
+  account <- fromMaybe "" <$> optional (lift (skipSome spacenonewline) >> modifiedaccountnamep)
+  description <- T.pack . fromMaybe "" <$> lift (optional (skipSome spacenonewline >> restofline))
   return $ TimeclockEntry sourcepos (read [code]) datetime account description
 
 tests_Hledger_Read_TimeclockReader = TestList [

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -107,9 +107,9 @@ timedotentryp :: JournalParser m Transaction
 timedotentryp = do
   ptrace "  timedotentryp"
   pos <- genericSourcePos <$> getPosition
-  lift (many spacenonewline)
+  lift (skipMany spacenonewline)
   a <- modifiedaccountnamep
-  lift (many spacenonewline)
+  lift (skipMany spacenonewline)
   hours <-
     try (followingcommentp >> return 0)
     <|> (timedotdurationp <*
@@ -143,7 +143,7 @@ timedotnumericp :: JournalParser m Quantity
 timedotnumericp = do
   (q, _, _, _) <- lift $ numberp Nothing
   msymbol <- optional $ choice $ map (string . fst) timeUnits
-  lift (many spacenonewline)
+  lift (skipMany spacenonewline)
   let q' = 
         case msymbol of
           Nothing  -> q

--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -129,7 +129,7 @@ words' :: String -> [String]
 words' "" = []
 words' s  = map stripquotes $ fromparse $ parsewithString p s
     where
-      p = do ss <- (singleQuotedPattern <|> doubleQuotedPattern <|> pattern) `sepBy` some spacenonewline
+      p = do ss <- (singleQuotedPattern <|> doubleQuotedPattern <|> pattern) `sepBy` skipSome spacenonewline
              -- eof
              return ss
       pattern = many (noneOf whitespacechars)

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -197,7 +197,7 @@ dateAndCodeWizard EntryState{..} = do
             dateandcodep = do
                 d <- smartdate
                 c <- optional codep
-                many spacenonewline
+                skipMany spacenonewline
                 eof
                 return (d, T.pack $ fromMaybe "" c)
       -- defday = fixSmartDate today $ fromparse $ (parse smartdate "" . lowercase) defdate
@@ -294,7 +294,7 @@ amountAndCommentWizard EntryState{..} = do
       amountandcommentp :: JournalParser Identity (Amount, Text)
       amountandcommentp = do
         a <- amountp
-        lift (many spacenonewline)
+        lift (skipMany spacenonewline)
         c <- T.pack <$> fromMaybe "" `fmap` optional (char ';' >> many anyChar)
         -- eof
         return (a,c)


### PR DESCRIPTION
Using `many` and `some` only to then ignore the result will still allocate the list of characters. By using `skipMany/skipSome` we can avoid this and thereby slightly reduce memory allocations.

The gains are sadly not particularly large but running a balance report with `+RTS -s` shows a decrease in total bytes allocated as well as max residency (and also a minor improvement in runtime performance but that’s probably too small to be significant):

Old:
```
     650,905,632 bytes allocated in the heap
      74,621,888 bytes copied during GC
       9,646,752 bytes maximum residency (9 sample(s))
          64,864 bytes maximum slop
              29 MB total memory in use (0 MB lost due to fragmentation)
```
New:
```
     646,328,488 bytes allocated in the heap
      73,869,168 bytes copied during GC
       9,375,360 bytes maximum residency (9 sample(s))
          70,016 bytes maximum slop
              28 MB total memory in use (0 MB lost due to fragmentation)
```