### PR TITLE
Fix #729

### DIFF
--- a/dev.hs
+++ b/dev.hs
@@ -51,7 +51,7 @@ timeReadJournal msg s = timeit msg $ either error id <$> readJournal Nothing Not
 main = do
   -- putStrLn $ regexReplaceCI "^aa" "xx" "aa:bb:cc:dd:ee"
 
-  (_t0,_j) <- timeit ("read "++journal) $ either error id <$> readJournalFile Nothing Nothing True journal
+  (_t0,_j) <- timeit ("read "++journal) $ either error id <$> readJournalFileWithOpts def journal
   return ()
   -- printf "Total: %0.2fs\n" (sum [t0,t1,t2,t3,t4])
 
@@ -156,7 +156,7 @@ main = do
 -- benchWithTimeit = do
 --   getCurrentDirectory >>= printf "Benchmarking hledger in %s with timeit\n"
 --   let opts = defcliopts{output_file_=Just outputfile}
---   (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFile Nothing Nothing True inputfile
+--   (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFileWithOpts def inputfile
 --   (t1,_) <- timeit ("print") $ print' opts j
 --   (t2,_) <- timeit ("register") $ register opts j
 --   (t3,_) <- timeit ("balance") $ balance  opts j

--- a/hledger-api/hledger-api.cabal
+++ b/hledger-api/hledger-api.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c1aecc57a80b7a88ba2774d93d5b1eedc43d04d6dbae964ce94307b643868534
+-- hash: f3ae96bc4a552af6049713498efd77ef61e5ade3bac393e45e47b484335029bd
 
 name:           hledger-api
 version:        1.9.99
@@ -51,6 +51,7 @@ executable hledger-api
     , base >=4.8 && <4.12
     , bytestring
     , containers
+    , data-default >=0.5
     , docopt
     , either
     , hledger >=1.9.99 && <2.0

--- a/hledger-api/hledger-api.hs
+++ b/hledger-api/hledger-api.hs
@@ -91,7 +91,7 @@ main = do
   let
     defd = "."
     d = getArgWithDefault args defd (longOption "static-dir")
-  readJournalFile Nothing def f >>= either error' (serveApi h p d f)
+  readJournalFileWithOpts def f >>= either error' (serveApi h p d f)
 
 serveApi :: String -> Int -> FilePath -> FilePath -> Journal -> IO ()
 serveApi h p d f j = do

--- a/hledger-api/hledger-api.hs
+++ b/hledger-api/hledger-api.hs
@@ -17,6 +17,7 @@ import           Control.Monad
 import           Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import           Data.Decimal
+import           Data.Default
 import qualified Data.Map as M
 import           Data.Proxy
 import           Data.String (fromString)
@@ -90,7 +91,7 @@ main = do
   let
     defd = "."
     d = getArgWithDefault args defd (longOption "static-dir")
-  readJournalFile Nothing Nothing True f >>= either error' (serveApi h p d f)
+  readJournalFile Nothing def f >>= either error' (serveApi h p d f)
 
 serveApi :: String -> Int -> FilePath -> FilePath -> Journal -> IO ()
 serveApi h p d f j = do

--- a/hledger-api/package.yaml
+++ b/hledger-api/package.yaml
@@ -38,6 +38,7 @@ dependencies:
 - aeson
 - bytestring
 - containers
+- data-default >=0.5
 - Decimal
 - docopt
 - either

--- a/hledger-lib/Hledger/Data/AutoTransaction.hs
+++ b/hledger-lib/Hledger/Data/AutoTransaction.hs
@@ -71,8 +71,9 @@ runModifierTransaction :: Query -> ModifierTransaction -> (Transaction -> Transa
 runModifierTransaction q mt = modifier where
     q' = simplifyQuery $ And [q, mtvaluequery mt (error "query cannot depend on current time")]
     mods = map runModifierPosting $ mtpostings mt
-    generatePostings ps = [m p | p <- ps, q' `matchesPosting` p, m <- mods]
-    modifier t@(tpostings -> ps) = t { tpostings = ps ++ generatePostings ps }
+    generatePostings ps = [p' | p <- ps
+                              , p' <- if q' `matchesPosting` p then p:[ m p | m <- mods] else [p]]
+    modifier t@(tpostings -> ps) = t { tpostings = generatePostings ps }
 
 -- | Extract 'Query' equivalent of 'mtvalueexpr' from 'ModifierTransaction'
 --

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -22,7 +22,6 @@ where
 
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
-import Control.Monad.Except (ExceptT)
 import Data.Data
 import Data.Decimal
 import Data.Default
@@ -328,28 +327,6 @@ type ParsedJournal = Journal
 -- | The id of a data format understood by hledger, eg @journal@ or @csv@.
 -- The --output-format option selects one of these for output.
 type StorageFormat = String
-
--- | A hledger journal reader is a triple of storage format name, a
--- detector of that format, and a parser from that format to Journal.
-data Reader = Reader {
-
-     -- The canonical name of the format handled by this reader
-     rFormat   :: StorageFormat
-
-     -- The file extensions recognised as containing this format
-    ,rExtensions :: [String]
-
-     -- A text parser for this format, accepting an optional rules file,
-     -- assertion-checking flag, and file path for error messages,
-     -- producing an exception-raising IO action that returns a journal
-     -- or error message.
-    ,rParser   :: Maybe FilePath -> Bool -> FilePath -> Text -> ExceptT String IO Journal
-
-     -- Experimental readers are never tried automatically.
-    ,rExperimental :: Bool
-    }
-
-instance Show Reader where show r = rFormat r ++ " reader"
 
 -- | An account, with name, balances and links to parent/subaccounts
 -- which let you walk up or down the account tree.

--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -15,6 +15,7 @@ module Hledger.Read (
   defaultJournal,
   defaultJournalPath,
   readJournalFilesWithOpts,
+  readJournalFileWithOpts,
   readJournalFiles,
   readJournalFile,
   requireJournalFileExists,
@@ -91,7 +92,7 @@ type PrefixedFilePath = FilePath
 
 -- | Read the default journal file specified by the environment, or raise an error.
 defaultJournal :: IO Journal
-defaultJournal = defaultJournalPath >>= readJournalFile Nothing def >>= either error' return
+defaultJournal = defaultJournalPath >>= readJournalFileWithOpts def >>= either error' return
 
 -- | Get the default journal file path specified by the environment.
 -- Like ledger, we look first for the LEDGER_FILE environment

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -60,7 +60,7 @@ import Text.Printf (printf)
 import Hledger.Data
 import Hledger.Utils.UTF8IOCompat (getContents)
 import Hledger.Utils
-import Hledger.Read.Common (amountp, statusp, genericSourcePos)
+import Hledger.Read.Common (Reader(..),InputOpts(..),amountp, statusp, genericSourcePos)
 
 
 reader :: Reader
@@ -73,8 +73,9 @@ reader = Reader
 
 -- | Parse and post-process a "Journal" from CSV data, or give an error.
 -- XXX currently ignores the string and reads from the file path
-parse :: Maybe FilePath -> Bool -> FilePath -> Text -> ExceptT String IO Journal
-parse rulesfile _ f t = do
+parse :: InputOpts -> FilePath -> Text -> ExceptT String IO Journal
+parse iopts f t = do
+  let rulesfile = mrules_file_ iopts
   r <- liftIO $ readJournalFromCsv rulesfile f t
   case r of Left e -> throwError e
             Right j -> return $ journalNumberAndTieTransactions j

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -119,8 +119,8 @@ reader = Reader
 
 -- | Parse and post-process a "Journal" from hledger's journal file
 -- format, or give an error.
-parse :: Maybe FilePath -> Bool -> FilePath -> Text -> ExceptT String IO Journal
-parse _ = parseAndFinaliseJournal journalp
+parse :: InputOpts -> FilePath -> Text -> ExceptT String IO Journal
+parse = parseAndFinaliseJournal journalp
 
 --- * parsers
 --- ** journal

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -79,8 +79,8 @@ reader = Reader
 -- | Parse and post-process a "Journal" from timeclock.el's timeclock
 -- format, saving the provided file path and the current time, or give an
 -- error.
-parse :: Maybe FilePath -> Bool -> FilePath -> Text -> ExceptT String IO Journal
-parse _ = parseAndFinaliseJournal timeclockfilep
+parse :: InputOpts -> FilePath -> Text -> ExceptT String IO Journal
+parse = parseAndFinaliseJournal timeclockfilep
 
 timeclockfilep :: ErroringJournalParser IO ParsedJournal
 timeclockfilep = do many timeclockitemp

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -65,8 +65,8 @@ reader = Reader
   }
 
 -- | Parse and post-process a "Journal" from the timedot format, or give an error.
-parse :: Maybe FilePath -> Bool -> FilePath -> Text -> ExceptT String IO Journal
-parse _ = parseAndFinaliseJournal timedotfilep
+parse :: InputOpts -> FilePath -> Text -> ExceptT String IO Journal
+parse = parseAndFinaliseJournal timedotfilep
 
 timedotfilep :: JournalParser m ParsedJournal
 timedotfilep = do many timedotfileitemp

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -115,14 +115,12 @@ data ReportOpts = ReportOpts {
       --   normally positive for a more conventional display.   
     ,color_          :: Bool
     ,forecast_       :: Bool
-    ,auto_           :: Bool
  } deriving (Show, Data, Typeable)
 
 instance Default ReportOpts where def = defreportopts
 
 defreportopts :: ReportOpts
 defreportopts = ReportOpts
-    def
     def
     def
     def
@@ -181,7 +179,6 @@ rawOptsToReportOpts rawopts = checkReportOpts <$> do
     ,pretty_tables_ = boolopt "pretty-tables" rawopts'
     ,color_       = color
     ,forecast_    = boolopt "forecast" rawopts'
-    ,auto_        = boolopt "auto" rawopts'
     }
 
 -- | Do extra validation of raw option values, raising an error if there's a problem.

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -932,9 +932,11 @@ This example adds a corresponding (unbalanced) budget posting to every transacti
 $ hledger print --auto
 2017/12/14
     expenses:gifts             $20
-    assets
     (budget:gifts)            $-20
+    assets
 ```
+
+Automated postings would not be distinguishable from equivalent postings written by hand. In particular, they would affect [amount inference|#postings] and [balance assertion|#balance-assertions] checks in the usual way.
 
 # EDITOR SUPPORT
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -81,7 +81,6 @@ withJournalDoUICommand uopts@UIOpts{cliopts_=copts} cmd = do
          . journalApplyAliases (aliasesFromOpts copts)
        <=< journalApplyValue (reportopts_ copts)
        <=< journalAddForecast copts
-         . generateAutomaticPostings (reportopts_ copts)
   either error' fn ej
 
 runBrickUi :: UIOpts -> Journal -> IO ()

--- a/hledger-web/Application.hs
+++ b/hledger-web/Application.hs
@@ -39,7 +39,7 @@ import Handler.SidebarR
 
 import Hledger.Web.WebOptions (WebOpts(..), defwebopts)
 import Hledger.Data (Journal, nulljournal)
-import Hledger.Read (readJournalFile)
+import Hledger.Read (readJournalFileWithOpts)
 import Hledger.Utils (error')
 import Hledger.Cli.CliOptions (defcliopts, journalFilePathFromOpts)
 
@@ -80,7 +80,7 @@ makeFoundation conf opts = do
 getApplicationDev :: IO (Int, Application)
 getApplicationDev = do
   f <- head `fmap` journalFilePathFromOpts defcliopts -- XXX head should be safe for now
-  j <- either error' id `fmap` readJournalFile Nothing def f
+  j <- either error' id `fmap` readJournalFileWithOpts def f
   defaultDevelApp loader (makeApplication defwebopts j)
   where
     loader = Yesod.Default.Config.loadConfig (configSettings Development)

--- a/hledger-web/Application.hs
+++ b/hledger-web/Application.hs
@@ -6,6 +6,7 @@ module Application
     , makeFoundation
     ) where
 
+import Data.Default
 import Data.IORef
 import Import
 import Yesod.Default.Config
@@ -79,7 +80,7 @@ makeFoundation conf opts = do
 getApplicationDev :: IO (Int, Application)
 getApplicationDev = do
   f <- head `fmap` journalFilePathFromOpts defcliopts -- XXX head should be safe for now
-  j <- either error' id `fmap` readJournalFile Nothing Nothing True f
+  j <- either error' id `fmap` readJournalFile Nothing def f
   defaultDevelApp loader (makeApplication defwebopts j)
   where
     loader = Yesod.Default.Config.loadConfig (configSettings Development)

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -66,7 +66,7 @@ withJournalDo' opts@WebOpts {cliopts_ = cliopts} cmd = do
          . journalApplyAliases (aliasesFromOpts cliopts)
        <=< journalApplyValue (reportopts_ cliopts)
        <=< journalAddForecast cliopts
-  readJournalFile Nothing def f >>= either error' fn
+  readJournalFileWithOpts def f >>= either error' fn
 
 -- | The web command.
 web :: WebOpts -> Journal -> IO ()

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -23,6 +23,7 @@ import Network.Wai.Handler.Launch (runHostPortUrl)
 import Control.Applicative ((<$>))
 #endif
 import Control.Monad
+import Data.Default
 import Data.Text (pack)
 import System.Exit (exitSuccess)
 import System.IO (hFlush, stdout)
@@ -65,8 +66,7 @@ withJournalDo' opts@WebOpts {cliopts_ = cliopts} cmd = do
          . journalApplyAliases (aliasesFromOpts cliopts)
        <=< journalApplyValue (reportopts_ cliopts)
        <=< journalAddForecast cliopts
-         . generateAutomaticPostings (reportopts_ cliopts)
-  readJournalFile Nothing Nothing True f >>= either error' fn
+  readJournalFile Nothing def f >>= either error' fn
 
 -- | The web command.
 web :: WebOpts -> Journal -> IO ()

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -37,6 +37,7 @@ module Hledger.Cli.Commands (
 where
 
 import Control.Monad
+import Data.Default
 import Data.List
 import Data.List.Split (splitOn)
 #if !(MIN_VERSION_base(4,11,0))
@@ -269,8 +270,8 @@ tests_Hledger_Cli_Commands = TestList [
   
   ,"apply account directive" ~: 
     let ignoresourcepos j = j{jtxns=map (\t -> t{tsourcepos=nullsourcepos}) (jtxns j)} in
-    let sameParse str1 str2 = do j1 <- readJournal Nothing Nothing True Nothing str1 >>= either error' (return . ignoresourcepos)
-                                 j2 <- readJournal Nothing Nothing True Nothing str2 >>= either error' (return . ignoresourcepos)
+    let sameParse str1 str2 = do j1 <- readJournal Nothing def Nothing str1 >>= either error' (return . ignoresourcepos)
+                                 j2 <- readJournal Nothing def Nothing str2 >>= either error' (return . ignoresourcepos)
                                  j1 `is` j2{jlastreadtime=jlastreadtime j1, jfiles=jfiles j1} --, jparsestate=jparsestate j1}
     in sameParse
                          ("2008/12/07 One\n  alpha  $-1\n  beta  $1\n" <>
@@ -287,13 +288,13 @@ tests_Hledger_Cli_Commands = TestList [
                          )
 
   ,"apply account directive should preserve \"virtual\" posting type" ~: do
-    j <- readJournal Nothing Nothing True Nothing "apply account test\n2008/12/07 One\n  (from)  $-1\n  (to)  $1\n" >>= either error' return
+    j <- readJournal Nothing def Nothing "apply account test\n2008/12/07 One\n  (from)  $-1\n  (to)  $1\n" >>= either error' return
     let p = head $ tpostings $ head $ jtxns j
     assertBool "" $ paccount p == "test:from"
     assertBool "" $ ptype p == VirtualPosting
   
   ,"account aliases" ~: do
-    j <- readJournal Nothing Nothing True Nothing "!alias expenses = equity:draw:personal\n1/1\n (expenses:food)  1\n" >>= either error' return
+    j <- readJournal Nothing def Nothing "!alias expenses = equity:draw:personal\n1/1\n (expenses:food)  1\n" >>= either error' return
     let p = head $ tpostings $ head $ jtxns j
     assertBool "" $ paccount p == "equity:draw:personal:food"
 
@@ -315,7 +316,7 @@ tests_Hledger_Cli_Commands = TestList [
   --     `is` "aa:aa:aaaaaaaaaaaaaa")
 
   ,"default year" ~: do
-    j <- readJournal Nothing Nothing True Nothing defaultyear_journal_txt >>= either error' return
+    j <- readJournal Nothing def Nothing defaultyear_journal_txt >>= either error' return
     tdate (head $ jtxns j) `is` fromGregorian 2009 1 1
     return ()
 

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -19,7 +19,7 @@ You can use the command line:
 or ghci:
 
 > $ ghci hledger
-> > j <- readJournalFile Nothing Nothing True "examples/sample.journal"
+> > j <- readJournalFileWithOpts def "examples/sample.journal"
 > > register [] ["income","expenses"] j
 > 2008/01/01 income               income:salary                   $-1          $-1
 > 2008/06/01 gift                 income:gifts                    $-1          $-2

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -57,8 +57,6 @@ import Hledger.Data
 import Hledger.Read
 import Hledger.Reports
 import Hledger.Utils
-import Hledger.Query (Query(Any))
-
 
 -- | Parse the user's specified journal file, maybe apply some transformations
 -- (aliases, pivot) and run a hledger command on it, or throw an error.
@@ -75,7 +73,6 @@ withJournalDo opts cmd = do
           . journalApplyAliases (aliasesFromOpts opts)
         <=< journalApplyValue (reportopts_ opts)
         <=< journalAddForecast opts
-          . generateAutomaticPostings (reportopts_ opts)
   either error' f ej
 
 -- | Apply the pivot transformation on a journal, if option is present.
@@ -146,15 +143,6 @@ journalAddForecast opts j = do
       let assrt = not . ignore_assertions_ $ inputopts_ opts
       in
        either error' id $ journalBalanceTransactions assrt j
-
--- | Generate Automatic postings and add them to the current journal.
-generateAutomaticPostings :: ReportOpts -> Journal -> Journal
-generateAutomaticPostings ropts j = 
-  if auto_ ropts then j { jtxns = map modifier $ jtxns j } else j
-  where
-    modifier = foldr (flip (.) . runModifierTransaction') id mtxns
-    runModifierTransaction' = fmap txnTieKnot . runModifierTransaction Any
-    mtxns = jmodifiertxns j
 
 -- | Write some output to stdout or to a file selected by --output-file.
 -- If the file exists it will be overwritten.

--- a/hledger/bench/bench.hs
+++ b/hledger/bench/bench.hs
@@ -4,6 +4,7 @@
 
 import Criterion.Main     (defaultMainWith, defaultConfig, bench, nfIO)
 -- import QuickBench        (defaultMain)
+import Data.Default
 import System.Directory   (getCurrentDirectory)
 import System.Environment (getArgs, withArgs)
 import System.TimeIt      (timeItT)
@@ -33,7 +34,7 @@ main = do
 benchWithTimeit = do
   getCurrentDirectory >>= printf "Benchmarking hledger in %s with timeit\n"
   let opts = defcliopts{output_file_=Just outputfile}
-  (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFile Nothing Nothing True inputfile
+  (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFileWithOpts def inputfile
   (t1,_) <- timeit ("print") $ print' opts j
   (t2,_) <- timeit ("register") $ register opts j
   (t3,_) <- timeit ("balance") $ balance  opts j
@@ -49,9 +50,9 @@ timeit name action = do
 benchWithCriterion = do
   getCurrentDirectory >>= printf "Benchmarking hledger in %s with criterion\n"
   let opts = defcliopts{output_file_=Just "/dev/null"}
-  j <- either error id <$> readJournalFile Nothing Nothing True inputfile
+  j <- either error id <$> readJournalFileWithOpts def inputfile
   Criterion.Main.defaultMainWith defaultConfig $ [
-    bench ("read "++inputfile) $ nfIO $ (either error const <$> readJournalFile Nothing Nothing True inputfile),
+    bench ("read "++inputfile) $ nfIO $ (either error const <$> readJournalFileWithOpts def inputfile),
     bench ("print")            $ nfIO $ print'   opts j,
     bench ("register")         $ nfIO $ register opts j,
     bench ("balance")          $ nfIO $ balance  opts j,

--- a/tests/budget/auto.test
+++ b/tests/budget/auto.test
@@ -15,10 +15,10 @@ hledger print -f- --auto
 >>>
 2016/01/01 paycheck
     income:remuneration           $-100
-    income:donations               $-15
-    assets:bank
     (liabilities:tax)              $-33    ; income tax
+    income:donations               $-15
     (liabilities:tax)               $-5    ; income tax
+    assets:bank
 
 2016/01/01 withdraw
     assets:cash             $20
@@ -42,12 +42,27 @@ hledger register -f- --auto
   (liabilities:tax)  *.33  ; income tax
 >>>
 2016/01/01 paycheck             income:remuneration          $-100         $-100
-                                income:donations              $-15         $-115
-                                assets:bank                   $115             0
-                                (liabilities:tax)             $-33          $-33
-                                (liabilities:tax)              $-5          $-38
+                                (liabilities:tax)             $-33         $-133
+                                income:donations              $-15         $-148
+                                (liabilities:tax)              $-5         $-153
+                                assets:bank                   $115          $-38
 2016/01/01 withdraw             assets:cash                    $20          $-18
                                 assets:bank                   $-20          $-38
+>>>2
+>>>=0
+
+hledger register -f- --auto
+<<<
+= trigger
+  (target)   10
+
+2018/1/1
+  (trigger)   1
+  (target)    1    = 11  ; this assertion would not fail, auto posting will be taken into account
+>>>
+2018/01/01                      (trigger)                        1             1
+                                (target)                        10            11
+                                (target)                         1            12
 >>>2
 >>>=0
 

--- a/tests/misc/rewrite.test
+++ b/tests/misc/rewrite.test
@@ -14,10 +14,10 @@ hledger rewrite -f- ^income --add-posting '(liabilities:tax)  *.33  ; income tax
 >>>
 2016/01/01 paycheck
     income:remuneration           $-100
-    income:donations               $-15
-    assets:bank
     (liabilities:tax)              $-33    ; income tax
+    income:donations               $-15
     (liabilities:tax)               $-5    ; income tax
+    assets:bank
 
 2016/01/01 withdraw
     assets:cash             $20
@@ -194,25 +194,25 @@ hledger rewrite -f- date:2017/1  --add-posting 'Here comes Santa  $0'
 
 2017/01/01
     expenses:food             $20.00
+    (budget:food)            $-20.00
+    Here comes Santa               0
     expenses:leisure          $15.00
+    (budget:misc)            $-15.00
+    Here comes Santa               0
     expenses:grocery          $30.00
+    (budget:food)            $-30.00
+    Here comes Santa               0
     assets:cash
     Here comes Santa               0
-    Here comes Santa               0
-    Here comes Santa               0
-    Here comes Santa               0
-    (budget:food)            $-20.00
-    (budget:food)            $-30.00
-    (budget:misc)            $-15.00
 
 2017/01/02
     assets:cash              $200.00
+    Here comes Santa               0
     assets:bank
-    Here comes Santa               0
-    Here comes Santa               0
     assets:bank               $-1.60
     expenses:fee               $1.60    ; cash withdraw fee
     (budget:misc)             $-1.60
+    Here comes Santa               0
 
 2017/02/01
     assets:cash         $100.00


### PR DESCRIPTION
This PR moves auto posting generation to a point before journalFinalise (which will infer missing amounts and check balance assertions). This makes auto posting identical in behavior to similar postings written manually in the appropriate transactions (and should fix #729).

Rather than add yet another bool argument to all the parsers that will drive auto posting generation, I opted to provide them with full InputOpts instead. I moved Reader type definition to Hledger.Read.Common to make it work and avoid circular module dependencies.

I also changed auto posing generator slightly to inject generated postings immediately after the one that triggered them. This yields more natural ordering and, I think, will help with mixing auto postings and balance assertions
