### PR TITLE
lib, app, web, ui: rename readJournalFile[s]WithOpts to readJournalFile

### DIFF
--- a/dev.hs
+++ b/dev.hs
@@ -13,6 +13,7 @@ import System.TimeIt      (timeItT)
 import Text.Printf
 
 import Hledger
+import Data.Default (def)
 -- import Hledger.Utils.Regex (toRegexCI)
 -- import Hledger.Utils.Debug
 -- import qualified Hledger.Read.JournalReader as JR
@@ -46,18 +47,18 @@ timeit name action = do
   return (t,a)
 
 timeReadJournal :: String -> String -> IO (Double, Journal)
-timeReadJournal msg s = timeit msg $ either error id <$> readJournal Nothing Nothing True Nothing s
+timeReadJournal msg s = timeit msg $ either error id <$> readJournal def Nothing s
 
 main = do
   -- putStrLn $ regexReplaceCI "^aa" "xx" "aa:bb:cc:dd:ee"
 
-  (_t0,_j) <- timeit ("read "++journal) $ either error id <$> readJournalFileWithOpts def journal
+  (_t0,_j) <- timeit ("read "++journal) $ either error id <$> readJournalFile def journal
   return ()
   -- printf "Total: %0.2fs\n" (sum [t0,t1,t2,t3,t4])
 
   -- -- read the input journal
   -- s <- readFile journal
-  -- j <- either error id <$> readJournal Nothing Nothing True Nothing s
+  -- j <- either error id <$> readJournal def Nothing s
   -- -- putStrLn $ show $ length $ jtxns j -- sanity check we parsed it all
   -- let accts = map paccount $ journalPostings j
 
@@ -82,10 +83,10 @@ main = do
 
   --   -- ,bench ("readJournal") $ whnfIO $
   --   --    either error id <$>
-  --   --    readJournal Nothing Nothing True Nothing s
+  --   --    readJournal def Nothing s
   --   -- ,bench ("readJournal with aliases") $ whnfIO $
   --   --    either error id <$>
-  --   --    readJournal Nothing Nothing True Nothing (
+  --   --    readJournal def Nothing (
   --   --      unlines [
   --   --         "alias /^fb:/=xx \n"
   --   --         ,"alias /^f1:/=xx \n"
@@ -156,7 +157,7 @@ main = do
 -- benchWithTimeit = do
 --   getCurrentDirectory >>= printf "Benchmarking hledger in %s with timeit\n"
 --   let opts = defcliopts{output_file_=Just outputfile}
---   (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFileWithOpts def inputfile
+--   (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFile def inputfile
 --   (t1,_) <- timeit ("print") $ print' opts j
 --   (t2,_) <- timeit ("register") $ register opts j
 --   (t3,_) <- timeit ("balance") $ balance  opts j

--- a/hledger-api/hledger-api.hs
+++ b/hledger-api/hledger-api.hs
@@ -91,7 +91,7 @@ main = do
   let
     defd = "."
     d = getArgWithDefault args defd (longOption "static-dir")
-  readJournalFileWithOpts def f >>= either error' (serveApi h p d f)
+  readJournalFile def f >>= either error' (serveApi h p d f)
 
 serveApi :: String -> Int -> FilePath -> FilePath -> Journal -> IO ()
 serveApi h p d f j = do

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -350,7 +350,7 @@ tests_balanceReport =
      ]
 
     ,"accounts report with cost basis" ~: do
-       j <- (readJournal Nothing Nothing Nothing $ unlines
+       j <- (readJournal def Nothing $ unlines
               [""
               ,"2008/1/1 test           "
               ,"  a:b          10h @ $50"

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -74,7 +74,7 @@ main = do
 withJournalDoUICommand :: UIOpts -> (UIOpts -> Journal -> IO ()) -> IO ()
 withJournalDoUICommand uopts@UIOpts{cliopts_=copts} cmd = do
   journalpath <- journalFilePathFromOpts copts
-  ej <- readJournalFilesWithOpts (inputopts_ copts) journalpath
+  ej <- readJournalFiles (inputopts_ copts) journalpath
   let fn = cmd uopts
          . pivotByOpts copts
          . anonymiseByOpts copts

--- a/hledger-web/Application.hs
+++ b/hledger-web/Application.hs
@@ -39,7 +39,7 @@ import Handler.SidebarR
 
 import Hledger.Web.WebOptions (WebOpts(..), defwebopts)
 import Hledger.Data (Journal, nulljournal)
-import Hledger.Read (readJournalFileWithOpts)
+import Hledger.Read (readJournalFile)
 import Hledger.Utils (error')
 import Hledger.Cli.CliOptions (defcliopts, journalFilePathFromOpts)
 
@@ -80,7 +80,7 @@ makeFoundation conf opts = do
 getApplicationDev :: IO (Int, Application)
 getApplicationDev = do
   f <- head `fmap` journalFilePathFromOpts defcliopts -- XXX head should be safe for now
-  j <- either error' id `fmap` readJournalFileWithOpts def f
+  j <- either error' id `fmap` readJournalFile def f
   defaultDevelApp loader (makeApplication defwebopts j)
   where
     loader = Yesod.Default.Config.loadConfig (configSettings Development)

--- a/hledger-web/Handler/EditForm.hs
+++ b/hledger-web/Handler/EditForm.hs
@@ -61,7 +61,7 @@
 --        setMessage "No change"
 --        redirect JournalR
 --      else do
---       jE <- liftIO $ readJournal Nothing Nothing True (Just journalpath) tnew
+--       jE <- liftIO $ readJournal def (Just journalpath) tnew
 --       either
 --        (\e -> do
 --           setMessage $ toHtml e

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -66,7 +66,7 @@ withJournalDo' opts@WebOpts {cliopts_ = cliopts} cmd = do
          . journalApplyAliases (aliasesFromOpts cliopts)
        <=< journalApplyValue (reportopts_ cliopts)
        <=< journalAddForecast cliopts
-  readJournalFileWithOpts def f >>= either error' fn
+  readJournalFile def f >>= either error' fn
 
 -- | The web command.
 web :: WebOpts -> Journal -> IO ()

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -270,8 +270,8 @@ tests_Hledger_Cli_Commands = TestList [
   
   ,"apply account directive" ~: 
     let ignoresourcepos j = j{jtxns=map (\t -> t{tsourcepos=nullsourcepos}) (jtxns j)} in
-    let sameParse str1 str2 = do j1 <- readJournal Nothing def Nothing str1 >>= either error' (return . ignoresourcepos)
-                                 j2 <- readJournal Nothing def Nothing str2 >>= either error' (return . ignoresourcepos)
+    let sameParse str1 str2 = do j1 <- readJournal def Nothing str1 >>= either error' (return . ignoresourcepos)
+                                 j2 <- readJournal def Nothing str2 >>= either error' (return . ignoresourcepos)
                                  j1 `is` j2{jlastreadtime=jlastreadtime j1, jfiles=jfiles j1} --, jparsestate=jparsestate j1}
     in sameParse
                          ("2008/12/07 One\n  alpha  $-1\n  beta  $1\n" <>
@@ -288,13 +288,13 @@ tests_Hledger_Cli_Commands = TestList [
                          )
 
   ,"apply account directive should preserve \"virtual\" posting type" ~: do
-    j <- readJournal Nothing def Nothing "apply account test\n2008/12/07 One\n  (from)  $-1\n  (to)  $1\n" >>= either error' return
+    j <- readJournal def Nothing "apply account test\n2008/12/07 One\n  (from)  $-1\n  (to)  $1\n" >>= either error' return
     let p = head $ tpostings $ head $ jtxns j
     assertBool "" $ paccount p == "test:from"
     assertBool "" $ ptype p == VirtualPosting
   
   ,"account aliases" ~: do
-    j <- readJournal Nothing def Nothing "!alias expenses = equity:draw:personal\n1/1\n (expenses:food)  1\n" >>= either error' return
+    j <- readJournal def Nothing "!alias expenses = equity:draw:personal\n1/1\n (expenses:food)  1\n" >>= either error' return
     let p = head $ tpostings $ head $ jtxns j
     assertBool "" $ paccount p == "equity:draw:personal:food"
 
@@ -316,7 +316,7 @@ tests_Hledger_Cli_Commands = TestList [
   --     `is` "aa:aa:aaaaaaaaaaaaaa")
 
   ,"default year" ~: do
-    j <- readJournal Nothing def Nothing defaultyear_journal_txt >>= either error' return
+    j <- readJournal def Nothing defaultyear_journal_txt >>= either error' return
     tdate (head $ jtxns j) `is` fromGregorian 2009 1 1
     return ()
 

--- a/hledger/Hledger/Cli/Commands/Import.hs
+++ b/hledger/Hledger/Cli/Commands/Import.hs
@@ -44,7 +44,7 @@ importcmd opts@CliOpts{rawopts_=rawopts,inputopts_=iopts} j = do
   case inputfiles of
     [] -> error' "please provide one or more input files as arguments"
     fs -> do
-      enewj <- readJournalFilesWithOpts iopts' fs
+      enewj <- readJournalFiles iopts' fs
       case enewj of
         Left e     -> error' e 
         Right newj ->

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -19,7 +19,7 @@ You can use the command line:
 or ghci:
 
 > $ ghci hledger
-> > j <- readJournalFileWithOpts def "examples/sample.journal"
+> > j <- readJournalFile def "examples/sample.journal"
 > > register [] ["income","expenses"] j
 > 2008/01/01 income               income:salary                   $-1          $-1
 > 2008/06/01 gift                 income:gifts                    $-1          $-2

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -66,7 +66,7 @@ withJournalDo opts cmd = do
   -- it's stdin, or it doesn't exist and we are adding. We read it strictly
   -- to let the add command work.
   journalpaths <- journalFilePathFromOpts opts
-  ej <- readJournalFilesWithOpts (inputopts_ opts) journalpaths
+  ej <- readJournalFiles (inputopts_ opts) journalpaths
   let f   = cmd opts
           . pivotByOpts opts
           . anonymiseByOpts opts
@@ -152,8 +152,8 @@ writeOutput opts s = do
   (if f == "-" then putStr else writeFile f) s
   
 -- -- | Get a journal from the given string and options, or throw an error.
--- readJournalWithOpts :: CliOpts -> String -> IO Journal
--- readJournalWithOpts opts s = readJournal Nothing Nothing Nothing s >>= either error' return
+-- readJournal :: CliOpts -> String -> IO Journal
+-- readJournal opts s = readJournal def Nothing s >>= either error' return
 
 -- | Re-read the journal file(s) specified by options and maybe apply some
 -- transformations (aliases, pivot), or return an error string.
@@ -162,7 +162,7 @@ journalReload :: CliOpts -> IO (Either String Journal)
 journalReload opts = do
   journalpaths <- journalFilePathFromOpts opts
   ((pivotByOpts opts . journalApplyAliases (aliasesFromOpts opts)) <$>) <$>
-    readJournalFilesWithOpts (inputopts_ opts) journalpaths
+    readJournalFiles (inputopts_ opts) journalpaths
 
 -- | Re-read the option-specified journal file(s), but only if any of
 -- them has changed since last read. (If the file is standard input,

--- a/hledger/bench/bench.hs
+++ b/hledger/bench/bench.hs
@@ -34,7 +34,7 @@ main = do
 benchWithTimeit = do
   getCurrentDirectory >>= printf "Benchmarking hledger in %s with timeit\n"
   let opts = defcliopts{output_file_=Just outputfile}
-  (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFileWithOpts def inputfile
+  (t0,j) <- timeit ("read "++inputfile) $ either error id <$> readJournalFile def inputfile
   (t1,_) <- timeit ("print") $ print' opts j
   (t2,_) <- timeit ("register") $ register opts j
   (t3,_) <- timeit ("balance") $ balance  opts j
@@ -50,9 +50,9 @@ timeit name action = do
 benchWithCriterion = do
   getCurrentDirectory >>= printf "Benchmarking hledger in %s with criterion\n"
   let opts = defcliopts{output_file_=Just "/dev/null"}
-  j <- either error id <$> readJournalFileWithOpts def inputfile
+  j <- either error id <$> readJournalFile def inputfile
   Criterion.Main.defaultMainWith defaultConfig $ [
-    bench ("read "++inputfile) $ nfIO $ (either error const <$> readJournalFileWithOpts def inputfile),
+    bench ("read "++inputfile) $ nfIO $ (either error const <$> readJournalFile def inputfile),
     bench ("print")            $ nfIO $ print'   opts j,
     bench ("register")         $ nfIO $ register opts j,
     bench ("balance")          $ nfIO $ balance  opts j,


### PR DESCRIPTION
Same for tryReader[s]WithOpts -> tryReader[s]

Remove InputOpts-less versions of tryReader and readJournal as they are unused.