### PR TITLE
Treat commandline aliases same way as file aliases

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -16,7 +16,6 @@ module Hledger.Data.Journal (
   addModifierTransaction,
   addPeriodicTransaction,
   addTransaction,
-  journalApplyAliases,
   journalBalanceTransactions,
   journalApplyCommodityStyles,
   commodityStylesFromAmounts,
@@ -484,19 +483,6 @@ filterJournalTransactionsByAccount apats j@Journal{jtxns=ts} = j{jtxns=filter tm
       (negatives,positives) = partition isnegativepat apats
 
 -}
-
--- | Apply additional account aliases (eg from the command-line) to all postings in a journal.
-journalApplyAliases :: [AccountAlias] -> Journal -> Journal
-journalApplyAliases aliases j@Journal{jtxns=ts} =
-  -- (if null aliases
-  --  then id
-  --  else (dbgtrace $
-  --        "applying additional command-line aliases:\n"
-  --        ++ chomp (unlines $ map (" "++) $ lines $ ppShow aliases))) $
-  j{jtxns=map dotransaction ts}
-    where
-      dotransaction t@Transaction{tpostings=ps} = t{tpostings=map doposting ps}
-      doposting p@Posting{paccount=a} = p{paccount= accountNameApplyAliases aliases a}
 
 -- | Do post-parse processing on a parsed journal to make it ready for
 -- use.  Reverse parsed data to normal order, canonicalise amount

--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -25,7 +25,6 @@ module Hledger.Read (
   readJournal',
 
   -- * Re-exported
-  JournalReader.accountaliasp,
   JournalReader.postingp,
   module Hledger.Read.Common,
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -78,7 +78,6 @@ withJournalDoUICommand uopts@UIOpts{cliopts_=copts} cmd = do
   let fn = cmd uopts
          . pivotByOpts copts
          . anonymiseByOpts copts
-         . journalApplyAliases (aliasesFromOpts copts)
        <=< journalApplyValue (reportopts_ copts)
        <=< journalAddForecast copts
   either error' fn ej

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -63,7 +63,6 @@ withJournalDo' opts@WebOpts {cliopts_ = cliopts} cmd = do
   let fn = cmd opts
          . pivotByOpts cliopts
          . anonymiseByOpts cliopts
-         . journalApplyAliases (aliasesFromOpts cliopts)
        <=< journalApplyValue (reportopts_ cliopts)
        <=< journalAddForecast cliopts
   readJournalFile def f >>= either error' fn

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -44,7 +44,6 @@ module Hledger.Cli.CliOptions (
   -- possibly these should move into argsToCliOpts
   -- * CLI option accessors
   -- | These do the extra processing required for some options.
-  aliasesFromOpts,
   journalFilePathFromOpts,
   rulesFilePathFromOpts,
   outputFileFromOpts,
@@ -483,11 +482,6 @@ getHledgerCliOpts mode' = do
         putStrLn $ "search query: " ++ show (queryFromOpts d $ reportopts_ opts)
 
 -- CliOpts accessors
-
--- | Get the account name aliases from options, if any.
-aliasesFromOpts :: CliOpts -> [AccountAlias]
-aliasesFromOpts = map (\a -> fromparse $ runParser accountaliasp ("--alias "++quoteIfNeeded a) $ T.pack a)
-                  . aliases_ . inputopts_
 
 -- | Get the (tilde-expanded, absolute) journal file path from
 -- 1. options, 2. an environment variable, or 3. the default.

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -70,7 +70,6 @@ withJournalDo opts cmd = do
   let f   = cmd opts
           . pivotByOpts opts
           . anonymiseByOpts opts
-          . journalApplyAliases (aliasesFromOpts opts)
         <=< journalApplyValue (reportopts_ opts)
         <=< journalAddForecast opts
   either error' f ej
@@ -161,7 +160,7 @@ writeOutput opts s = do
 journalReload :: CliOpts -> IO (Either String Journal)
 journalReload opts = do
   journalpaths <- journalFilePathFromOpts opts
-  ((pivotByOpts opts . journalApplyAliases (aliasesFromOpts opts)) <$>) <$>
+  (pivotByOpts opts <$>) <$>
     readJournalFiles (inputopts_ opts) journalpaths
 
 -- | Re-read the option-specified journal file(s), but only if any of

--- a/tests/misc/account-aliases.test
+++ b/tests/misc/account-aliases.test
@@ -122,6 +122,36 @@ alias E=F
 >>>2
 >>>=0
 
+# alias options 
+hledger -f- balance --alias=cc=credit-card --alias=b=bank
+<<<
+01/01 Opening balances
+	(bank)         100
+	(credit-card)  -10
+
+01/02
+	expenses  5
+	cc
+
+01/03
+	expenses  5
+	b
+
+01/04 Credit card charge
+	cc  = 0
+    b
+
+01/05
+	expenses  5
+	b         = 75
+>>>
+                  75  bank
+                  15  expenses
+--------------------
+                  90
+>>>2
+>>>=0
+
 # query will search both origin and substitution in alias
 hledger -f- reg '^a$' '^b$'
 <<<


### PR DESCRIPTION
Commandline aliases are injected into parser state at the beginning of parsing, making them behave exactly the same way as if they were written at the top of the file. Aliases would now affect transactions
prior to amount inference and balance checks, which should fix #730