### PR TITLE
lib, app: better descriptions for forecast transactions

### DIFF
--- a/hledger-lib/Hledger/Data/AutoTransaction.hs
+++ b/hledger-lib/Hledger/Data/AutoTransaction.hs
@@ -145,89 +145,79 @@ renderPostingCommentDates p = p { pcomment = comment' }
 --
 -- >>> let gen str = mapM_ (putStr . show) $ runPeriodicTransaction (PeriodicTransaction str ["hi" `post` usd 1]) nulldatespan
 -- >>> gen "monthly from 2017/1 to 2017/4"
--- 2017/01/01
+-- 2017/01/01 Forecast transaction (monthly from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/02/01
+-- 2017/02/01 Forecast transaction (monthly from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/03/01
+-- 2017/03/01 Forecast transaction (monthly from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen "monthly from 2017/1 to 2017/5"
--- 2017/01/01
+-- 2017/01/01 Forecast transaction (monthly from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/02/01
+-- 2017/02/01 Forecast transaction (monthly from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/03/01
+-- 2017/03/01 Forecast transaction (monthly from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/04/01
+-- 2017/04/01 Forecast transaction (monthly from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen "every 2nd day of month from 2017/02 to 2017/04"
--- 2017/01/02
+-- 2017/01/02 Forecast transaction (every 2nd day of month from 2017/02 to 2017/04)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/02/02
+-- 2017/02/02 Forecast transaction (every 2nd day of month from 2017/02 to 2017/04)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/03/02
---     hi           $1.00
--- <BLANKLINE>
--- >>> gen "monthly from 2017/1 to 2017/4"
--- 2017/01/01
---     hi           $1.00
--- <BLANKLINE>
--- 2017/02/01
---     hi           $1.00
--- <BLANKLINE>
--- 2017/03/01
+-- 2017/03/02 Forecast transaction (every 2nd day of month from 2017/02 to 2017/04)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen "every 30th day of month from 2017/1 to 2017/5"
--- 2016/12/30
+-- 2016/12/30 Forecast transaction (every 30th day of month from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/01/30
+-- 2017/01/30 Forecast transaction (every 30th day of month from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/02/28
+-- 2017/02/28 Forecast transaction (every 30th day of month from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/03/30
+-- 2017/03/30 Forecast transaction (every 30th day of month from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/04/30
+-- 2017/04/30 Forecast transaction (every 30th day of month from 2017/1 to 2017/5)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen "every 2nd Thursday of month from 2017/1 to 2017/4"
--- 2016/12/08
+-- 2016/12/08 Forecast transaction (every 2nd Thursday of month from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/01/12
+-- 2017/01/12 Forecast transaction (every 2nd Thursday of month from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/02/09
+-- 2017/02/09 Forecast transaction (every 2nd Thursday of month from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/03/09
+-- 2017/03/09 Forecast transaction (every 2nd Thursday of month from 2017/1 to 2017/4)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen "every nov 29th from 2017 to 2019"
--- 2016/11/29
+-- 2016/11/29 Forecast transaction (every nov 29th from 2017 to 2019)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2017/11/29
+-- 2017/11/29 Forecast transaction (every nov 29th from 2017 to 2019)
 --     hi           $1.00
 -- <BLANKLINE>
--- 2018/11/29
+-- 2018/11/29 Forecast transaction (every nov 29th from 2017 to 2019)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen "2017/1"
--- 2017/01/01
+-- 2017/01/01 Forecast transaction (2017/1)
 --     hi           $1.00
 -- <BLANKLINE>
 -- >>> gen ""
@@ -249,7 +239,8 @@ runPeriodicTransaction pt =
     let fillspan = ptspan `spanIntersect` requestedspan
     in  [ t{tdate=d} | (DateSpan (Just d) _) <- ptinterval `splitSpan` fillspan ]
   where
-    t = nulltransaction { tpostings = ptpostings pt }
+    descr = T.pack $ "Forecast transaction (" ++ T.unpack periodexpr ++ ")"
+    t = nulltransaction { tpostings = ptpostings pt, tdescription = descr }
     periodexpr = ptperiodicexpr pt
     currentdateerr = error' $ "Current date cannot be referenced in " ++ show (T.unpack periodexpr)
     (ptinterval, ptspan) =

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -131,8 +131,7 @@ journalAddForecast opts j = do
   let startDate = fromMaybe today $ spanEnd (jdatespan j) 
       endDate = fromMaybe (addDays 180 today) $ periodEnd (period_ ropts)
       dates = DateSpan (Just startDate) (Just endDate)
-      withForecast = [makeForecast t | pt <- jperiodictxns j, t <- runPeriodicTransaction pt dates, spanContainsDate dates (tdate t) ] ++ (jtxns j)
-      makeForecast t = txnTieKnot $ t { tdescription = T.pack "Forecast transaction" }
+      withForecast = [ txnTieKnot t | pt <- jperiodictxns j, t <- runPeriodicTransaction pt dates, spanContainsDate dates (tdate t) ] ++ (jtxns j)
       ropts = reportopts_ opts
   if forecast_ ropts 
     then return $ journalBalanceTransactions' opts j { jtxns = withForecast }

--- a/tests/budget/forecast.test
+++ b/tests/budget/forecast.test
@@ -45,7 +45,7 @@ hledger print -b 2016-11 -e 2017-02 -f - --forecast
     expenses:housing            $600
     assets:cash
 
-2017/01/01 Forecast transaction
+2017/01/01 Forecast transaction (monthly from 2016/1)
     income                    $-1000
     expenses:food                $20
     expenses:leisure             $15


### PR DESCRIPTION
Include period in the description of generated forecast transaction. I think that this greatly improves the output of "print" and "register" with --forecast.