### PR TITLE
Pandoc 2 fixes

### DIFF
--- a/site/hakyll-std/TableOfContents.hs
+++ b/site/hakyll-std/TableOfContents.hs
@@ -54,7 +54,7 @@ markupHeader :: Tree Block -> H.Html
 markupHeader (Node (Header _ (ident, _, keyvals) inline) headers)
   | headers == [] = H.li $ link
   | otherwise     = H.li $ link <> (H.ol $ markupHeaders headers)
-  where render x  = write5HtmlString def (Pandoc nullMeta [(Plain x)])
+  where render x  = writeHtml5String def (Pandoc nullMeta [(Plain x)])
         section   = fromMaybe (render inline) (lookup "toc" keyvals)
         link      = H.a ! A.href (H.toValue $ "#" ++ ident) $ preEscapedToHtml $ unpack section
 markupHeader _ = error "what"

--- a/site/hakyll-std/hakyll-std.hs
+++ b/site/hakyll-std/hakyll-std.hs
@@ -2,7 +2,6 @@
 {- stack exec --verbosity info
    --stack-yaml=../../stack-ghc8.2.yaml
    --package hakyll
-   --package pandoc
    -- ghc
 -} 
 -- pandoc must be >= 2                                                                                                                                                                           

--- a/site/hakyll-std/hakyll-std.hs
+++ b/site/hakyll-std/hakyll-std.hs
@@ -113,11 +113,11 @@ pandocReaderOptions = def
 
 -- http://hackage.haskell.org/package/pandoc-1.13/docs/src/Text-Pandoc-Options.html#WriterOptions
 pandocWriterOptions = def
-  {writerHighlight=True
+---  {writerHighlight=True
   -- this would change the value of pandoc's $highlight-css$ var
   -- for now, let the user provide these styles
   -- ,writerHighlightStyle=tango
-  }
+  --- }
 
 pandocTransform = tableOfContents "right"
 


### PR DESCRIPTION
This fixes a few issues with the files in `site/hakyll-std` regarding the updates that happenned to Pandoc.

Basically, pandoc decided to monadify-everything, which means we need to build the document using `runPure`.

Additionally, `unpack` needs to be called inside the `fromMaybe` so that both arguments are of type `String`.

I think ideally this file would be phased out.

These fixes need to get in before https://github.com/simonmichael/hledger/issues/670 can make progress.