### PR TITLE
Attempting to fix issue #655

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -16,7 +16,66 @@ Some of these might belong in Hledger.Read.JournalReader or Hledger.Read.
 {-# LANGUAGE CPP, BangPatterns, DeriveDataTypeable, RecordWildCards, NamedFieldPuns, NoMonoLocalBinds, ScopedTypeVariables, FlexibleContexts, TupleSections, OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Hledger.Read.Common
+module Hledger.Read.Common (
+  Reader (..),
+  InputOpts (..),
+  rawOptsToInputOpts,
+
+  -- * parsing utilities
+  runTextParser,
+  runJournalParser,
+  rjp,
+  runErroringJournalParser,
+  rejp,
+  genericSourcePos,
+  journalSourcePos,
+  generateAutomaticPostings,
+  parseAndFinaliseJournal,
+  setYear,
+  setDefaultCommodityAndStyle,
+  getDefaultCommodityAndStyle,
+  pushParentAccount,
+  popParentAccount,
+  getParentAccount,
+  addAccountAlias,
+  clearAccountAliases,
+  journalAddFile,
+  parserErrorAt,
+
+  -- * parsers
+  -- ** transaction bits
+  statusp,
+  codep,
+  descriptionp,
+
+  -- ** dates
+  datep,
+  datetimep,
+  secondarydatep,
+
+  -- ** account names
+  modifiedaccountnamep,
+  accountnamep,
+
+  -- ** amounts
+  spaceandamountormissingp,
+  amountp,
+  mamountp',
+  commoditysymbolp,
+  partialbalanceassertionp,
+  fixedlotpricep,
+  numberp,
+
+  -- ** comments
+  multilinecommentp,
+  emptyorcommentlinep,
+  followingcommentp,
+  followingcommentandtagsp,
+
+  -- ** tags
+  commentTags,
+  tagsp
+)
 where
 --- * imports
 import Prelude ()
@@ -107,7 +166,7 @@ rawOptsToInputOpts rawopts = InputOpts{
   ,auto_              = boolopt "auto" rawopts                        
   }
 
---- * parsing utils
+--- * parsing utilities
 
 -- | Run a string parser with no state in the identity monad.
 runTextParser, rtp :: TextParser Identity a -> Text -> Either (ParseError Char MPErr) a


### PR DESCRIPTION
Hi again! I'm attempting to address #655. As before, since I'm new to FOSS, please feel free to tell me if there is something that I could be doing better! This pull request makes more changes than my last, so I hope I haven't overstepped any boundaries.

As I understand the issue, the semicolon is included in the tag name because the comment passed to the tags parser `tagsp` by `followingcommentandtagsp` (all in `Common.hs`) is not stripped of its semicolon (or whitespace). Although the internal comment parsers based on `commentStartingWithp` do perform this stripping, they are not used because of the need to reparse the comment as-is when looking for tags in order to preserve error positions.

To address the issue, I have modified the internal comment parsers in `Common.hs` to additionally output the source position of the line of text they return. Now, `followingcommentandtagsp` uses the internal parsers to obtain the individual lines of multi-line comments, where each line is annotated with a source position. These lines are passed individually to the tags parser `tagsp` (and also to the posting dates parser). This allows `tagsp` to operate on stripped comment lines while preserving the error position reporting. Note that breaking multi-line comments into their individual lines for the purpose of parsing tags (and dates) is valid because tags (and dates) are not permitted to contain line breaks.

This change fixes the test case in #655:
```
$ cat a.j
2017/11/01 Gas Station
     Expenses:Travel    $18.03  ;qwe:
     Liabilities:CreditCard

$ make ghci
ghci> import Data.Default
ghci> Right j <- readJournalFiles def ["a.j"]
ghci> ptags $ head $ tpostings $ head $ jtxns j
[("qwe","")]
```

To implement this change, I first added an explicit export list because I wanted to know which functions I could change without affecting users of the module; however, I'm not sure if the module was intended not to have an explicit export list. I also did some refactoring of the comment parsers.

Also, my commit from yesterday is showing up in this pull request, and I'm not sure why that is or how ot fix it.