### PR TITLE
lib: fix performance regression introduced in 30ae9914

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -830,12 +830,14 @@ followingcommentp = T.unlines . map snd <$> followingcommentlinesp
 followingcommentlinesp :: JournalParser m [(SourcePos, Text)]
 followingcommentlinesp = do
   lift $ skipMany spacenonewline
-  samelineComment <- try commentp
-                 <|> (,) <$> (getPosition <* newline) <*> pure ""
+  samelineComment@(_, samelineCommentText)
+    <- try commentp <|> (,) <$> (getPosition <* newline) <*> pure ""
   newlineComments <- many $ try $ do
     lift $ skipSome spacenonewline -- leading whitespace is required
     commentp
-  pure $ samelineComment : newlineComments
+  if T.null samelineCommentText && null newlineComments
+    then pure []
+    else pure $ samelineComment : newlineComments
 
 -- | Parse a possibly multi-line comment following a semicolon, and
 -- any tags and/or posting dates within it. Posting dates can be


### PR DESCRIPTION
In commit 30ae9914, I introduced a performance regression: the memory usage of `hledger -f examples/10000x10000x10.journal register +RTS -s > /dev/null` (compiled with `-O2`) increased from `92 MB` to `104 MB`. The change contained in this pull request reverses the regression when applied to both 30ae9914 and the current master branch.