### PR TITLE
Refactor comment parsers

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -835,7 +835,7 @@ followingcommentlinesp :: TextParser m [(SourcePos, Text)]
 followingcommentlinesp = do
   skipMany spacenonewline
   samelineComment@(_, samelineCommentText)
-    <- try commentp <|> (,) <$> (getPosition <* newline) <*> pure ""
+    <- try commentp <|> (,) <$> (getPosition <* eolof) <*> pure ""
   newlineComments <- many $ try $ do
     skipSome spacenonewline -- leading whitespace is required
     commentp

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -100,7 +100,7 @@ timeclockfilep = do many timeclockitemp
       -- character, excepting transactions versus empty (blank or
       -- comment-only) lines, can use choice w/o try
       timeclockitemp = choice [ 
-                            void emptyorcommentlinep
+                            void (lift emptyorcommentlinep)
                           , timeclockentryp >>= \e -> modify' (\j -> j{jparsetimeclockentries = e : jparsetimeclockentries j})
                           ] <?> "timeclock entry, or default year or historical price directive"
 

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -77,7 +77,7 @@ timedotfilep = do many timedotfileitemp
       timedotfileitemp = do
         ptrace "timedotfileitemp"
         choice [
-          void emptyorcommentlinep
+          void $ lift emptyorcommentlinep
          ,timedotdayp >>= \ts -> modify' (addTransactions ts)
          ] <?> "timedot day entry, or default year or comment line or blank line"
 
@@ -95,7 +95,7 @@ timedotdayp :: JournalParser m [Transaction]
 timedotdayp = do
   ptrace " timedotdayp"
   d <- datep <* lift eolof
-  es <- catMaybes <$> many (const Nothing <$> try emptyorcommentlinep <|>
+  es <- catMaybes <$> many (const Nothing <$> try (lift emptyorcommentlinep) <|>
                             Just <$> (notFollowedBy datep >> timedotentryp))
   return $ map (\t -> t{tdate=d}) es -- <$> many timedotentryp
 
@@ -111,9 +111,9 @@ timedotentryp = do
   a <- modifiedaccountnamep
   lift (skipMany spacenonewline)
   hours <-
-    try (followingcommentp >> return 0)
+    try (lift followingcommentp >> return 0)
     <|> (timedotdurationp <*
-         (try followingcommentp <|> (newline >> return "")))
+         (try (lift followingcommentp) <|> (newline >> return "")))
   let t = nulltransaction{
         tsourcepos = pos,
         tstatus    = Cleared,


### PR DESCRIPTION
In this PR I refactor the comment parsers (in `Hledger/Read`).

I have done this to prepare for a discussion and potential implementation of changes to the allowed syntax for comments, tags, date-tags, and bracketed dates. The intention of this PR, however, is to preserve the current syntax and behaviour.

The primary refactoring in this PR, taking place in the first four commits, is the weakening of several parsers from `ErroringJournalParser` (`StateT Journal`, `ParsecT`, and `ExceptT`) or `JournalParser` (`StateT Journal`, `ParsecT`) to `SimpleTextParser` (`Parsec`). From brief checks (`+RTS s`), this change is associated with a slight decrease in performance (slightly longer runtime, slightly higher memory usage when parsing comments). This is surprising to me, as I was expecting these changes to at least preserve performance. (Perhaps it is something to with strictness? Or maybe I have done something silly.)

The fifth commit removes the redundant parsing alternatives following `followingcommentsp` (and `followingcommentandtagsp`), in `Read/JournalReader.hs`. These alternatives are redundant because they parse a case that is already attempted in `followingcommentsp`.

The sixth commit is just cleanup and polish. I hope my code style is acceptable for the project; if not, I am willing to go back and reformat it.

In this PR, I have built and tested with `stack --stack-yaml=ghc7.10.yaml`, so hopefully I will not break backwards compatibility again.