### PR TITLE
lib: fix parsing of amounts with a whitespace digits separator 

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -763,8 +763,9 @@ rawnumberp = do
         leadingDigits <- some digitChar
         option (Nothing, [leadingDigits]) . try $ do
             firstSep <- oneOf sepChars <|> whitespaceChar
-            groups <- some digitChar `sepBy1` char firstSep
-            return (Just firstSep, leadingDigits : groups)
+            secondGroup <- some digitChar
+            otherGroups <- many $ try $ char firstSep *> some digitChar
+            return (Just firstSep, leadingDigits : secondGroup : otherGroups)
 
     let remSepChars = maybe sepChars (`delete` sepChars) firstSep
         modifier

--- a/tests/journal/amounts-and-commodities.test
+++ b/tests/journal/amounts-and-commodities.test
@@ -136,17 +136,17 @@ $ hledger -f- bal -V -N
 #>=1
 
 # 11. After a space-grouped amount, a posting comment should parse.
-#<
-#2018-01-01
-#  (a)   USD 1 000  ;comment
-#
-#$ hledger -f- print
-#> //    # any stdout, no stderr, 0 exit code
+<
+2018-01-01
+  (a)   USD 1 000  ;comment
+
+$ hledger -f- print
+> //    # any stdout, no stderr, 0 exit code
 
 # 12. After a space-grouped amount, trailing whitespace should parse.
-#<
-#2018-01-01
-#  (a)   USD 1 000 
-#
-#$ hledger -f- print
-#> //    # any stdout, no stderr, 0 exit code
+<
+2018-01-01
+  (a)   USD 1 000 
+
+$ hledger -f- print
+> //    # any stdout, no stderr, 0 exit code


### PR DESCRIPTION
This PR addresses a problem which was found in issue #749. This PR does not address that issue.

The problem was that we fail to parse the following journal
```
commodity 1 000  USD

2018-01-01
  (a)   USD1 000
```
failing with the following error
```
hledger: test.journal:1:12:
unexpected space
expecting digit
```
We fail to parse this next journal as well
```
2018-01-01
  (a)   USD1 000 ; comment
```
```
hledger: test2.journal:2:9:
unexpected 'U'
expecting '=', '{', end of input, or newline
```
It seems that the issue is caused by the use of a space as the digits separator and trailing whitespace after the amount. The current parser consumes the trailing whitespace as a separator and then expects at least another digit, which it does not find. This patch groups together the separator and the following digit group. With this patch, the above two journals parse successfully.