### PR TITLE
lib: fix issue where spaces were allowed as decimal points

### DIFF
--- a/tests/journal/amounts-and-commodities.test
+++ b/tests/journal/amounts-and-commodities.test
@@ -117,23 +117,23 @@ $ hledger -f- bal -V -N
 
 # 9. Here the amount is parsed as 1. I think (hope) no country uses space 
 # for decimal point, so we should parse this as 1000.
-#<     
-#2018-01-01
-# (a)   USD1 000
-#
-#$ hledger -f- reg amt:1
+<
+2018-01-01
+ (a)   USD1 000
+
+$ hledger -f- reg amt:1
 
 # 10. This commodity directive should complain about a missing decimal point,
 # which we now require.
-#<
-#commodity 1 000  USD
-#
-#2018-01-01
-#  (a)   USD1 000
-#
-#$ hledger -f- bal
-#>2 /decimal point/
-#>=1
+<
+commodity 1 000  USD
+
+2018-01-01
+  (a)   USD1 000
+
+$ hledger -f- bal
+>2 /decimal point/
+>=1
 
 # 11. After a space-grouped amount, a posting comment should parse.
 <


### PR DESCRIPTION
This PR fixes #749 by implementing the changes discussed therein. That is, we ensure that a whitespace character is never used as a decimal point.

This PR also enables the tests that were prepared for issue #749.