### PR TITLE
Rewriting and refactoring parsers (WIP)

### DIFF
--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -475,7 +475,7 @@ transactionp = do
   -- ptrace "transactionp"
   pos <- getPosition
   date <- datep <?> "transaction"
-  edate <- optional (secondarydatep date) <?> "secondary date"
+  edate <- optional (lift $ secondarydatep date) <?> "secondary date"
   lookAhead (lift spacenonewline <|> newline) <?> "whitespace or newline"
   status <- lift statusp <?> "cleared status"
   code <- lift codep <?> "transaction code"

--- a/tests/journal/dates.test
+++ b/tests/journal/dates.test
@@ -5,7 +5,7 @@ hledger -f- print
 2010/31/12 x
    a  1
    b
->>>2 /bad date/
+>>>2 /invalid date/
 >>>= 1
 # 2. too-large day
 hledger -f- print
@@ -13,7 +13,7 @@ hledger -f- print
 2010/12/32 x
    a  1
    b
->>>2 /bad date/
+>>>2 /invalid date/
 >>>= 1
 # 3. 29th feb on leap year should be ok
 hledger -f- print
@@ -33,7 +33,7 @@ hledger -f- print
 2001/2/29 x
    a  1
    b
->>>2 /bad date/
+>>>2 /invalid date/
 >>>= 1
 # 5. dates must be followed by whitespace or newline
 hledger -f- print

--- a/tests/journal/posting-dates.test
+++ b/tests/journal/posting-dates.test
@@ -50,5 +50,5 @@ end comment
 2000/1/2
    b  0   ; [1/1=1/2/3/4] bad second date, should error
 
->>>2 /9:25/
+>>>2 /9:23/
 >>>=1


### PR DESCRIPTION
I have been working on rewriting and refactoring the parsers in `/hledger-lib/Hledger/Read/Common.hs`. I have tried to make it easier to follow the logic of the parsers by adding more structure, but this also makes the code more verbose. So, I'm not entirely sure that these rewrites represent an improvement, and I would appreciate feedback.

This PR:
- Rewrites the date parser `datep`. This changes the method of parsing, and hence the way in which the parser fails and also the error messages. I have modified some of the date parsing tests to accomodate these changes.
- Rewrites the raw number parser `rawnumberp` and `fromRawNumber`. I have added two new types, `DigitGrp` and `RawNumber`, to give more structure to this parser. `DigitGrp` replaces `String` as a more efficient representation of digit groups. `RawNumber` attempts to capture as much information as possible about a raw number parsed without external hints (i.e. by `rawnumberp` and without an `AmountStyle`). This change also modifies the API by modifying the types of `rawnumberp` and `fromRawNumber`.
- Makes superficial changes to clean up some other parsers

These changes also represent a small improvement in performance.

Before:

```
> hledger -f ../examples/10000x1000x10.journal register +RTS -s > /dev/null
   5,556,836,424 bytes allocated in the heap
     249,067,432 bytes copied during GC
      27,899,544 bytes maximum residency (10 sample(s))
         848,256 bytes maximum slop
              74 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5379 colls,     0 par    0.262s   0.262s     0.0000s    0.0013s
  Gen  1        10 colls,     0 par    0.167s   0.200s     0.0200s    0.0550s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    3.416s  (  3.462s elapsed)
  GC      time    0.428s  (  0.463s elapsed)
  EXIT    time    0.000s  (  0.005s elapsed)
  Total   time    3.845s  (  3.931s elapsed)

  Alloc rate    1,626,898,582 bytes per MUT second

  Productivity  88.8% of total user, 88.2% of total elapsed
```
After:
```
> hledger -f examples/10000x1000x10.journal register +RTS -s > /dev/null
   5,288,582,328 bytes allocated in the heap
     249,780,424 bytes copied during GC
      27,894,008 bytes maximum residency (10 sample(s))
         854,768 bytes maximum slop
              75 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5121 colls,     0 par    0.242s   0.246s     0.0000s    0.0012s
  Gen  1        10 colls,     0 par    0.163s   0.196s     0.0196s    0.0553s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.001s elapsed)
  MUT     time    3.186s  (  3.243s elapsed)
  GC      time    0.405s  (  0.442s elapsed)
  EXIT    time    0.000s  (  0.004s elapsed)
  Total   time    3.591s  (  3.691s elapsed)

  Alloc rate    1,659,882,235 bytes per MUT second

  Productivity  88.7% of total user, 88.0% of total elapsed
```