### PR TITLE
More work on the parser

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -603,7 +603,8 @@ nosymbolamountp = do
   <?> "no-symbol amount"
 
 commoditysymbolp :: TextParser m CommoditySymbol
-commoditysymbolp = (quotedcommoditysymbolp <|> simplecommoditysymbolp) <?> "commodity symbol"
+commoditysymbolp =
+  quotedcommoditysymbolp <|> simplecommoditysymbolp <?> "commodity symbol"
 
 quotedcommoditysymbolp :: TextParser m CommoditySymbol
 quotedcommoditysymbolp =
@@ -617,11 +618,7 @@ priceamountp :: Monad m => JournalParser m Price
 priceamountp = option NoPrice $ try $ do
   lift (skipMany spacenonewline)
   char '@'
-
-  m <- optional $ char '@'
-  let priceConstructor = case m of
-        Just _  -> TotalPrice
-        Nothing -> UnitPrice
+  priceConstructor <- char '@' *> pure TotalPrice <|> pure UnitPrice
 
   lift (skipMany spacenonewline)
   priceAmount <- amountwithoutpricep
@@ -688,12 +685,7 @@ numberp suggestedStyle = do
     <?> "numberp"
 
 exponentp :: TextParser m Int
-exponentp = do
-  char' 'e'
-  sign <- signp
-  d <- decimal
-  pure $ sign d
-  <?> "exponentp"
+exponentp = char' 'e' *> signp <*> decimal <?> "exponentp"
 
 -- | Interpret a raw number as a decimal number.
 --

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -386,14 +386,14 @@ datep' mYear = do
 
     case fromGregorianValid year month day of
       Nothing -> fail $ "well-formed but invalid date: " ++ dateStr
-      Just date -> pure date
+      Just date -> pure $! date
 
   partialDate :: Maybe Year -> Integer -> Char -> Int -> TextParser m Day
   partialDate mYear month sep day = case mYear of
     Just year ->
       case fromGregorianValid year (fromIntegral month) day of
         Nothing -> fail $ "well-formed but invalid date: " ++ dateStr
-        Just date -> pure date
+        Just date -> pure $! date
       where dateStr = show year ++ [sep] ++ show month ++ [sep] ++ show day
 
     Nothing -> fail $
@@ -446,7 +446,7 @@ modifiedaccountnamep = do
   parent <- getParentAccount
   aliases <- getAccountAliases
   a <- lift accountnamep
-  return $
+  return $!
     accountNameApplyAliases aliases $
      -- XXX accountNameApplyAliasesMemo ? doesn't seem to make a difference
     joinAccountNames parent
@@ -461,7 +461,7 @@ accountnamep :: TextParser m AccountName
 accountnamep = do
   firstPart <- part
   otherParts <- many $ try $ singleSpace *> part
-  pure $ T.unwords $ firstPart : otherParts
+  pure $! T.unwords $ firstPart : otherParts
   where
     part = takeWhile1P Nothing (not . isSpace)
     singleSpace = void spacenonewline *> notFollowedBy spacenonewline
@@ -822,8 +822,8 @@ isDigitSeparatorChar c = isDecimalPointChar c || c == ' '
 
 
 data DigitGrp = DigitGrp {
-  digitGroupLength :: Int,
-  digitGroupNumber :: Integer
+  digitGroupLength :: !Int,
+  digitGroupNumber :: !Integer
 } deriving (Eq)
 
 instance Show DigitGrp where

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -811,17 +811,17 @@ rawnumberp = label "rawnumberp" $ do
 
   leadingDecimalPt :: TextParser m RawNumber
   leadingDecimalPt =
-    LeadingDecimalPt <$> satisfy isDecimalPointChar <*> pdigitgroup
+    LeadingDecimalPt <$> satisfy isDecimalPointChar <*> digitgroupp
 
   leadingDigits :: TextParser m RawNumber
   leadingDigits = do
-    grp1 <- pdigitgroup
+    grp1 <- digitgroupp
     withSeparators grp1 <|> trailingDecimalPt grp1 <|> pure (NoSeparators grp1)
 
   withSeparators :: DigitGrp -> TextParser m RawNumber
   withSeparators grp1 = do
-    (sep, grp2) <- try $ (,) <$> satisfy isDigitSeparatorChar <*> pdigitgroup
-    grps <- many $ try $ char sep *> pdigitgroup
+    (sep, grp2) <- try $ (,) <$> satisfy isDigitSeparatorChar <*> digitgroupp
+    grps <- many $ try $ char sep *> digitgroupp
 
     let digitGroups = grp1 : grp2 : grps
     withDecimalPt sep digitGroups <|> pure (withoutDecimalPt grp1 sep grp2 grps)
@@ -829,7 +829,7 @@ rawnumberp = label "rawnumberp" $ do
   withDecimalPt :: Char -> [DigitGrp] -> TextParser m RawNumber
   withDecimalPt digitSep digitGroups = do
     decimalPt <- satisfy $ \c -> isDecimalPointChar c && c /= digitSep
-    decimalDigitGroup <- option mempty pdigitgroup
+    decimalDigitGroup <- option mempty digitgroupp
 
     pure $ BothSeparators digitSep digitGroups decimalPt decimalDigitGroup
 
@@ -870,8 +870,8 @@ instance Monoid DigitGrp where
   mempty = DigitGrp 0 0
   mappend = (Sem.<>)
 
-pdigitgroup :: TextParser m DigitGrp
-pdigitgroup = label "digit group"
+digitgroupp :: TextParser m DigitGrp
+digitgroupp = label "digit group"
             $ makeGroup <$> takeWhile1P (Just "digit") isDigit
   where
     makeGroup = uncurry DigitGrp . foldl' step (0, 0) . T.unpack

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -461,14 +461,7 @@ accountnamep :: TextParser m AccountName
 accountnamep = do
   firstPart <- part
   otherParts <- many $ try $ singleSpace *> part
-  let account = T.unwords $ firstPart : otherParts
-
-  let roundTripAccount =
-        accountNameFromComponents $ accountNameComponents account
-  when (account /= roundTripAccount) $ fail $
-    "account name seems ill-formed: " ++ T.unpack account
-
-  pure account
+  pure $ T.unwords $ firstPart : otherParts
   where
     part = takeWhile1P Nothing (not . isSpace)
     singleSpace = void spacenonewline *> notFollowedBy spacenonewline

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -190,19 +190,15 @@ runTextParser, rtp :: TextParser Identity a -> Text -> Either (ParseError Char V
 runTextParser p t =  runParser p "" t
 rtp = runTextParser
 
--- XXX odd, why doesn't this take a JournalParser ?
 -- | Run a journal parser with a null journal-parsing state.
-runJournalParser, rjp :: Monad m => TextParser m a -> Text -> m (Either (ParseError Char Void) a)
-runJournalParser p t = runParserT p "" t
+runJournalParser, rjp :: Monad m => JournalParser m a -> Text -> m (Either (ParseError Char Void) a)
+runJournalParser p t = runParserT (evalStateT p mempty) "" t
 rjp = runJournalParser
 
 -- | Run an error-raising journal parser with a null journal-parsing state.
 runErroringJournalParser, rejp :: Monad m => ErroringJournalParser m a -> Text -> m (Either String a)
-runErroringJournalParser p t =
-  runExceptT $
-  runJournalParser (evalStateT p mempty)
-                   t >>=
-  either (throwError . parseErrorPretty) return
+runErroringJournalParser p t = runExceptT $
+  runJournalParser p t >>= either (throwError . parseErrorPretty) return
 rejp = runErroringJournalParser
 
 genericSourcePos :: SourcePos -> GenericSourcePos


### PR DESCRIPTION
I've done some more work to refactor and touch up the parser, continuing the work in the last pull request.

This pull request:
- Refactors the parsing of signs (for numbers) and extracts the handling of signs out of `fromRawNumber`. My rationale for this is that the sign can be applied independently of the logic in `fromRawNumber`.
- Refactors the raw number parser (again) in an attempt to reduce the verbosity introduced in the last pull request. I have split off the `AmbiguousNumber` constructor of `RawNumber` into its own type, and introduced a function `AmbiguousNumber -> RawNumber` explicitly capturing the disambiguation logic. I have also reduced the number of remaining constructors in `RawNumber` to just two, distinguishing whether a raw number has digit separators or not. My rationale for distinguishing digit separators is that we use this distinction later when we disallow the mixing of digit group separators and exponential notation.
- Merges the handling of exponential notation into `fromRawNumber`. My rationale for this is that the information necessary for applying expoentials to a number are more explicitly represented in the inputs to `fromRawNumber` than in its outputs. Furthermore, this allows the parser `exponentp` to simply return `Int`.
- Makes various other small cleanups
- Adds some strictness annotations to address some regressions caused by other commits in this pull request
- Changes the parsing of numbers to accept only spaces (as opposed to any unicode space character) for digit group separators (this was actually changed in the previous PR)

Other notes:
- I feel that the raw number parser and amount parser could be further factored, though perhaps it is best to wait until after we've decided how exactly to handle the parsing of amounts (i.e.the recent issues concerning digit separators, decimal points, commodity directives, etc.).
- By changing the types of `rawnumberp` and `fromRawNumber`, I have changed the API. Perhaps it makes sense to remove these functions from the export list? I find no use of these functions in other modules or downstream libraries when using `grep`.
- I wonder if our handling of precision in amounts is completely correct. In `hledger-lib/Hledger/Data/Amounts.hs`, we define `maxprecision = 999998`, while the precision in `type Quantity = Data.Decimal.Decimal` is represented by `Word8`, with a maximum of 255 decimal places.
- Also, what is referred to by the comments `-- XXX should restrict to a simple amount` in `hledger-lib/Hledger/Read/Common.hs`? Is there more cleanup to do, or is this comment outdated?