### PR TITLE
feat(hledger-ui): added neovim as a supported editor

### DIFF
--- a/hledger-ui/Hledger/UI/Editor.hs
+++ b/hledger-ui/Hledger/UI/Editor.hs
@@ -83,7 +83,7 @@ identifyEditor :: String -> EditorType
 identifyEditor cmd
   | "emacsclient" `isPrefixOf` exe = EmacsClient
   | "emacs" `isPrefixOf` exe       = Emacs
-  | exe `elem` ["vi","vim","ex","view","gvim","gview","evim","eview","rvim","rview","rgvim","rgview"]
+  | exe `elem` ["vi","nvim","vim","ex","view","gvim","gview","evim","eview","rvim","rview","rgvim","rgview"]
                                    = Vi
   | otherwise                      = Other
   where


### PR DESCRIPTION
When neovim is set as EDITOR hleger will jump to the correct line number of the transaction; before hledger will open journal at top of the file