### PR TITLE
Fix hledger-lib build with ghc 8.0.x and base-compat 0.10.x.

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PackageImports #-}
 {-|
 
 Date parsing and utilities for hledger.
@@ -73,9 +74,9 @@ module Hledger.Data.Dates (
 where
 
 import Prelude ()
-import Prelude.Compat
+import "base-compat" Prelude.Compat
 import Control.Monad
-import Data.List.Compat
+import "base-compat" Data.List.Compat
 import Data.Default
 import Data.Maybe
 import Data.Text (Text)

--- a/hledger-lib/Hledger/Data/StringFormat.hs
+++ b/hledger-lib/Hledger/Data/StringFormat.hs
@@ -2,7 +2,7 @@
 -- hledger's report item fields. The formats are used by
 -- report-specific renderers like renderBalanceReportItem.
 
-{-# LANGUAGE FlexibleContexts, TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts, TypeFamilies, PackageImports #-}
 
 module Hledger.Data.StringFormat (
           parseStringFormat
@@ -14,7 +14,7 @@ module Hledger.Data.StringFormat (
         ) where
 
 import Prelude ()
-import Prelude.Compat
+import "base-compat" Prelude.Compat
 import Numeric
 import Data.Char (isPrint)
 import Data.Maybe

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -106,9 +106,6 @@ import Data.Functor.Identity
 import Data.List.Compat
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import qualified Data.Map as M
 import qualified Data.Semigroup as Sem
 import Data.Text (Text)

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -15,6 +15,7 @@ Some of these might belong in Hledger.Read.JournalReader or Hledger.Read.
 --- * module
 {-# LANGUAGE CPP, BangPatterns, DeriveDataTypeable, RecordWildCards, NamedFieldPuns, NoMonoLocalBinds, ScopedTypeVariables, FlexibleContexts, TupleSections, OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PackageImports #-}
 
 module Hledger.Read.Common (
   Reader (..),
@@ -94,8 +95,8 @@ module Hledger.Read.Common (
 where
 --- * imports
 import Prelude ()
-import Prelude.Compat hiding (readFile)
-import Control.Monad.Compat
+import "base-compat" Prelude.Compat hiding (readFile)
+import "base-compat" Control.Monad.Compat
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError) --, catchError)
 import Control.Monad.State.Strict
 import Data.Char
@@ -103,7 +104,7 @@ import Data.Data
 import Data.Decimal (DecimalRaw (Decimal), Decimal)
 import Data.Default
 import Data.Functor.Identity
-import Data.List.Compat
+import "base-compat" Data.List.Compat
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe
 import qualified Data.Map as M

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -11,6 +11,7 @@ A reader for CSV data, using an extra rules file to help interpret the data.
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PackageImports #-}
 
 module Hledger.Read.CsvReader (
   -- * Reader
@@ -28,14 +29,14 @@ module Hledger.Read.CsvReader (
 )
 where
 import Prelude ()
-import Prelude.Compat hiding (getContents)
+import "base-compat" Prelude.Compat hiding (getContents)
 import Control.Exception hiding (try)
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State.Strict (StateT, get, modify', evalStateT)
 -- import Test.HUnit
 import Data.Char (toLower, isDigit, isSpace)
-import Data.List.Compat
+import "base-compat" Data.List.Compat
 import Data.List.NonEmpty (fromList)
 import Data.Maybe
 import Data.Ord

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -29,7 +29,7 @@ import cycles.
 
 --- * module
 
-{-# LANGUAGE CPP, RecordWildCards, NamedFieldPuns, NoMonoLocalBinds, ScopedTypeVariables, FlexibleContexts, TupleSections, OverloadedStrings #-}
+{-# LANGUAGE CPP, RecordWildCards, NamedFieldPuns, NoMonoLocalBinds, ScopedTypeVariables, FlexibleContexts, TupleSections, OverloadedStrings, PackageImports #-}
 
 module Hledger.Read.JournalReader (
 --- * exports
@@ -72,7 +72,7 @@ module Hledger.Read.JournalReader (
 where
 --- * imports
 import Prelude ()
-import Prelude.Compat hiding (readFile)
+import "base-compat" Prelude.Compat hiding (readFile)
 import qualified Control.Exception as C
 import Control.Monad
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError)

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -78,9 +78,6 @@ import Control.Monad
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError)
 import Control.Monad.State.Strict
 import qualified Data.Map.Strict as M
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import Data.Text (Text)
 import Data.String
 import Data.List

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -40,7 +40,7 @@ i, o or O.  The meanings of the codes are:
 
 -}
 
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, PackageImports #-}
 
 module Hledger.Read.TimeclockReader (
   -- * Reader
@@ -52,7 +52,7 @@ module Hledger.Read.TimeclockReader (
 )
 where
 import           Prelude ()
-import           Prelude.Compat
+import "base-compat" Prelude.Compat
 import           Control.Monad
 import           Control.Monad.Except (ExceptT)
 import           Control.Monad.State.Strict

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -23,7 +23,7 @@ inc.client1   .... .... ..
 
 -}
 
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, PackageImports #-}
 
 module Hledger.Read.TimedotReader (
   -- * Reader
@@ -35,7 +35,7 @@ module Hledger.Read.TimedotReader (
 )
 where
 import Prelude ()
-import Prelude.Compat
+import "base-compat" Prelude.Compat
 import Control.Monad
 import Control.Monad.Except (ExceptT)
 import Control.Monad.State.Strict

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 408bc36237e01b4976cc96ca0444f05937bd517efb0ef378e0d1d4aac76b9e56
+-- hash: f08b7ddfe8e3ee85bfdc0af7c7320be85b073578c872a98b23b9c6e5bbbe5650
 
 name:           hledger-lib
 version:        1.9.99
@@ -105,7 +105,7 @@ library
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-markup >=0.5.1
     , bytestring
     , cmdargs >=0.10
@@ -200,7 +200,7 @@ test-suite doctests
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-markup >=0.5.1
     , bytestring
     , cmdargs >=0.10
@@ -295,7 +295,7 @@ test-suite easytests
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-markup >=0.5.1
     , bytestring
     , cmdargs >=0.10
@@ -391,7 +391,7 @@ test-suite hunittests
     , ansi-terminal >=0.6.2.3
     , array
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-markup >=0.5.1
     , bytestring
     , cmdargs >=0.10

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -40,7 +40,7 @@ extra-source-files:
 
 dependencies:
 - base >=4.8 && <4.12
-- base-compat >=0.8.1
+- base-compat == 0.10.*
 - ansi-terminal >=0.6.2.3
 - array
 - blaze-markup >=0.5.1

--- a/hledger-ui/hledger-ui.cabal
+++ b/hledger-ui/hledger-ui.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0c78f681a99e0d6cc3ae1ff87b9397afc508292a6c412d00c85b5cdb5607b933
+-- hash: ecf98aad3ab1dc507594bf7da100bfa858c432a4e216023543e699f760a271d1
 
 name:           hledger-ui
 version:        1.9.99
@@ -69,7 +69,7 @@ executable hledger-ui
     , ansi-terminal >=0.6.2.3
     , async
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , cmdargs >=0.8
     , containers
     , data-default

--- a/hledger-ui/package.yaml
+++ b/hledger-ui/package.yaml
@@ -45,7 +45,7 @@ dependencies:
  - ansi-terminal >=0.6.2.3
  - async
  - base >=4.8 && <4.12
- - base-compat >=0.8.1
+ - base-compat == 0.10.*
  - cmdargs >=0.8
  - containers
  - data-default

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c000d351c61aeef057878385c2fbb01b696d20af9137ac2210902ba8de60bfaa
+-- hash: 7307cbaf625ff1863fcf59a405c2f148585b0cc13d02486494e726c5e609eb07
 
 name:           hledger-web
 version:        1.9.99
@@ -144,7 +144,7 @@ library
   build-depends:
       HUnit
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-html
     , blaze-markup
     , bytestring
@@ -195,7 +195,7 @@ executable hledger-web
   build-depends:
       HUnit
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-html
     , blaze-markup
     , bytestring
@@ -254,7 +254,7 @@ test-suite test
   build-depends:
       HUnit
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , blaze-html
     , blaze-markup
     , bytestring

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -65,7 +65,7 @@ dependencies:
 - hledger-lib >=1.9.99 && <2.0
 - hledger >=1.9.99 && <2.0
 - base >=4.8 && <4.12
-- base-compat >=0.8.1
+- base-compat == 0.10.*
 - blaze-html
 - blaze-markup
 - bytestring

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0f0ae8e75569c28e8c5987ba06696f6dbbbfc9334de43851eb1d1420ffc89d5a
+-- hash: c0eb869dc10f744521ca915b20715da6a280e9deb5089d74814f63c8b55c5cd9
 
 name:           hledger
 version:        1.9.99
@@ -116,7 +116,7 @@ library
     , HUnit
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , bytestring
     , cmdargs >=0.10
     , containers
@@ -168,7 +168,7 @@ executable hledger
     , HUnit
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , bytestring
     , cmdargs >=0.10
     , containers
@@ -222,7 +222,7 @@ test-suite test
     , HUnit
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , bytestring
     , cmdargs >=0.10
     , containers
@@ -275,7 +275,7 @@ benchmark bench
     , HUnit
     , ansi-terminal >=0.6.2.3
     , base >=4.8 && <4.12
-    , base-compat >=0.8.1
+    , base-compat ==0.10.*
     , bytestring
     , cmdargs >=0.10
     , containers

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -81,7 +81,7 @@ dependencies:
 - hledger-lib >=1.9.99 && <2.0
 - ansi-terminal >=0.6.2.3
 - base >=4.8 && <4.12
-- base-compat >=0.8.1
+- base-compat == 0.10.*
 - bytestring
 - cmdargs >=0.10
 - containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack build plan using GHC 8.4.2 and recent stackage nightly
 
-resolver: nightly-2018-04-25
+resolver: nightly-2018-06-02
 
 packages:
 - hledger-lib
@@ -18,11 +18,11 @@ extra-deps:
 - json-0.9.2
 - wai-handler-launch-3.0.2.4
 # hledger-api
-- servant-server-0.13
-- servant-swagger-1.1.5
-- swagger2-2.2.1
+# servant-server-0.13
+# servant-swagger-1.1.5
+# swagger2-2.2.1
 - http-media-0.7.1.2
-- servant-0.13
+# servant-0.13
 
 nix:
   pure: false


### PR DESCRIPTION
We don't need to import Data.Monoid because Prelude.Compat exports "<>"
already. In fact, importing that module causes build failures:

    Hledger/Read/Common.hs:725:62: error:
        Ambiguous occurrence ‘<>’
        It could refer to either ‘Sem.<>’,
                                 imported from ‘Prelude.Compat’ at Hledger/Read/Common.hs:97:1-39
                                 (and originally defined in ‘Data.Semigroup’)
                              or ‘Data.Monoid.<>’,
                                 imported from ‘Data.Monoid’ at Hledger/Read/Common.hs:110:1-18

Fixes https://github.com/simonmichael/hledger/issues/794.