### PR TITLE
JPY separators

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -700,7 +700,7 @@ fromRawNumber raw mExp = case raw of
     in  Right (quantity, precision, mDecPt, Nothing)
 
   WithSeparators digitSep digitGrps mDecimals -> case mExp of
-    Nothing -> 
+    Nothing ->
       let mDecPt = fmap fst mDecimals
           decimalGrp = maybe mempty snd mDecimals
           digitGroupStyle = DigitGroups digitSep (groupSizes digitGrps)

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -822,7 +822,10 @@ isDecimalPointChar :: Char -> Bool
 isDecimalPointChar c = c == '.' || c == ','
 
 isDigitSeparatorChar :: Char -> Bool
-isDigitSeparatorChar c = isDecimalPointChar c || c == ' '
+isDigitSeparatorChar c =
+  isDecimalPointChar c || c == ' ' ||
+  -- Japanese support
+  c == '兆' || c == '億' || c == '万'
 
 
 data DigitGrp = DigitGrp {

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -317,7 +317,7 @@ formatdirectivep expectedsym = do
   Amount{acommodity,astyle} <- amountp
   _ <- lift followingcommentp
   if acommodity==expectedsym
-    then 
+    then
       if asdecimalpoint astyle == Nothing
       then parserErrorAt pos pleaseincludedecimalpoint
       else return $ dbg2 "style from format subdirective" astyle


### PR DESCRIPTION
OK so I've taken a first stab at doing #796.

However, there's something I don't get about unit tests: in my second commit I added a clearly-wrong test (with a willingly changed digit), and yet `stack --nix test` doesn't fail (though I had to locally reset the `stack.yml` snapshot to `[…]-15` instead of `-25` in order to remove the need for ghc8.4.2, but I guess this shouldn't matter much).

From my reading of https://github.com/simonmichael/hledger/wiki/Developer-workflows it should however have been tested and failed (at least the place where I've added the test looks very much like a unit test), so I'm not sure what I'm doing wrong in the adding-a-test or the testing procedure?

Disclaimer: I'm not used to haskell development, and even though I did a few toy projects with it, I still don't really grok how the toolchain actually works.