### PR TITLE
Add fast flag to doctests.

### DIFF
--- a/hledger-lib/tests/doctests.hs
+++ b/hledger-lib/tests/doctests.hs
@@ -8,4 +8,4 @@ main = do
   fs1 <- glob "Hledger/**/*.hs"
   fs2 <- glob "Text/**/*.hs"
   --fs3 <- glob "other/ledger-parse/**/*.hs"
-  doctest $ filter (not . isInfixOf "/.") $ ["Hledger.hs"] ++ fs1 ++ fs2
+  doctest $ filter (not . isInfixOf "/.") $ ["--fast", "Hledger.hs"] ++ fs1 ++ fs2


### PR DESCRIPTION
Added the `--fast` flag to the doctest call. Benchmarks from my macbook pro below.

Execution time with `--fast`:
```
❯ bash -c "time make doctest"
hledger-lib-1.9.99: test (suite: doctests)

Examples: 179  Tried: 179  Errors: 0  Failures: 0

hledger-lib-1.9.99: Test suite doctests passed
doctest PASSED

real    0m13.432s
user    0m11.193s
sys     0m1.582s
```

Execution time without `--fast`:
```
❯ bash -c "time make doctest"
hledger-lib-1.9.99: test (suite: doctests)

Examples: 179  Tried: 179  Errors: 0  Failures: 0

hledger-lib-1.9.99: Test suite doctests passed
doctest PASSED

real    0m23.741s
user    0m15.847s
sys     0m4.872s
```



Fixes #802