### PR TITLE
lib: Fix compile errors in tests

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -881,7 +881,6 @@ journalDateSpan secondary j
       pdates   = concatMap (catMaybes . map (if secondary then (Just . postingDate2) else pdate) . tpostings) ts
       ts       = jtxns j
 
--- #ifdef TESTS
 test_journalDateSpan = do
  "journalDateSpan" ~: do
   assertEqual "" (DateSpan (Just $ fromGregorian 2014 1 10) (Just $ fromGregorian 2014 10 11))
@@ -894,7 +893,6 @@ test_journalDateSpan = do
                                             ,tpostings = [posting{pdate2=Just (parsedate "2014/10/10")}]
                                             }
                             ]}
--- #endif
 
 -- | Apply the pivot transformation to all postings in a journal,
 -- replacing their account name by their value for the given field or tag.

--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -346,6 +346,7 @@ samplejournal = readJournal' $ T.unlines
 tests_Hledger_Read = TestList $
   tests_readJournal'
   ++ [
+   tests_Hledger_Read_Common,
    JournalReader.tests_Hledger_Read_JournalReader,
 --    LedgerReader.tests_Hledger_Read_LedgerReader,
    TimeclockReader.tests_Hledger_Read_TimeclockReader,

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -90,7 +90,10 @@ module Hledger.Read.Common (
 
   -- ** misc
   singlespacedtextp,
-  singlespacep
+  singlespacep,
+
+  -- * tests
+  tests_Hledger_Read_Common
 )
 where
 --- * imports
@@ -115,6 +118,7 @@ import qualified Data.Text as T
 import Data.Time.Calendar
 import Data.Time.LocalTime
 import System.Time (getClockTime)
+import Test.HUnit
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer (decimal)
@@ -475,19 +479,21 @@ spaceandamountormissingp =
     lift $ skipSome spacenonewline
     Mixed . (:[]) <$> amountp
 
-#ifdef TESTS
-assertParseEqual' :: (Show a, Eq a) => (Either ParseError a) -> a -> Assertion
-assertParseEqual' parse expected = either (assertFailure.show) (`is'` expected) parse
+assertParseEqual' ::
+     (Show a, Eq a)
+  => Identity (Either (ParseError Char CustomErr) a)
+  -> a
+  -> Assertion
+assertParseEqual' parse expected = either (assertFailure.show) (`is'` expected) (runIdentity parse)
 
 is' :: (Eq a, Show a) => a -> a -> Assertion
-a `is'` e = assertEqual e a
+a `is'` e = assertEqual "values are equal" e a
 
-test_spaceandamountormissingp = do
+test_spaceandamountormissingp = TestCase $ do
     assertParseEqual' (parseWithState mempty spaceandamountormissingp " $47.18") (Mixed [usd 47.18])
     assertParseEqual' (parseWithState mempty spaceandamountormissingp "$47.18") missingmixedamt
     assertParseEqual' (parseWithState mempty spaceandamountormissingp " ") missingmixedamt
     assertParseEqual' (parseWithState mempty spaceandamountormissingp "") missingmixedamt
-#endif
 
 -- | Parse a single-commodity amount, with optional symbol on the left or
 -- right, optional unit or total price, and optional (ignored)
@@ -502,8 +508,7 @@ amountwithoutpricep :: JournalParser m Amount
 amountwithoutpricep =
   try leftsymbolamountp <|> try rightsymbolamountp <|> nosymbolamountp
 
-#ifdef TESTS
-test_amountp = do
+test_amountp = TestCase $ do
     assertParseEqual' (parseWithState mempty amountp "$47.18") (usd 47.18)
     assertParseEqual' (parseWithState mempty amountp "$1.") (usd 1 `withPrecision` 0)
   -- ,"amount with unit price" ~: do
@@ -514,7 +519,6 @@ test_amountp = do
     assertParseEqual'
      (parseWithState mempty amountp "$10 @@ €5")
      (usd 10 `withPrecision` 0 @@ (eur 5 `withPrecision` 0))
-#endif
 
 -- | Parse an amount from a string, or get an error.
 amountp' :: String -> Amount
@@ -1177,3 +1181,5 @@ match' :: TextParser m a -> TextParser m (Text, a)
 match' p = do
   (!txt, p) <- match p
   pure (txt, p)
+
+tests_Hledger_Read_Common = TestList [test_spaceandamountormissingp, test_amountp]

--- a/hledger-lib/Hledger/Read/LedgerReader.hs.disabled
+++ b/hledger-lib/Hledger/Read/LedgerReader.hs.disabled
@@ -21,10 +21,6 @@ import Data.Text (Text, pack)
 import Data.Text.Encoding (encodeUtf8)
 -- import Safe
 import Test.HUnit
--- #ifdef TESTS
--- import Test.Framework
--- import Text.Megaparsec.Error
--- #endif
 import Text.Megaparsec (eof)
 -- import Text.Printf
 import System.Time


### PR DESCRIPTION
A continuation of #800.

Unfortunately, the tests don't pass - there are three test failures here, where I don't know what the intended result is:
```
: [Failed]
values are equal
expected: Amount {acommodity="$", aquantity=10.00, ..}
 but got: Amount {acommodity="$", aquantity=10, ..}
: [Failed]
Equal comment
expected: " tcomment1\n tcomment2\n ttag1: val1\n"
 but got: "tcomment1\ntcomment2\nttag1: val1\n"
: [Failed]
Posting is parsed well
expected: " a: a a \n b: b b \n"
 but got: "a: a a\nb: b b\n"
```

I also saw a ton of disabled and commented out tests - I suppose those should eventually be enabled and uncommented again?