### PR TITLE
doc: Remove non-ASCII from man- and infopages

### DIFF
--- a/hledger-lib/hledger_journal.5
+++ b/hledger-lib/hledger_journal.5
@@ -649,8 +649,8 @@ Write the price per unit, as \f[C]\@\ UNITPRICE\f[] after the amount:
 .nf
 \f[C]
 2009/1/1
-\ \ assets:euros\ \ \ \ \ €100\ \@\ $1.35\ \ ;\ one\ hundred\ euros\ purchased\ at\ $1.35\ each
-\ \ assets:dollars\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ ;\ balancing\ amount\ is\ \-$135.00
+\ \ assets:euros\ \ \ \ \ 100\ EUR\ \@\ $1.35\ \ ;\ one\ hundred\ euros\ purchased\ at\ $1.35\ each
+\ \ assets:dollars\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ ;\ balancing\ amount\ is\ \-$135.00
 \f[]
 .fi
 .RE
@@ -661,7 +661,7 @@ Write the total price, as \f[C]\@\@\ TOTALPRICE\f[] after the amount:
 .nf
 \f[C]
 2009/1/1
-\ \ assets:euros\ \ \ \ \ €100\ \@\@\ $135\ \ ;\ one\ hundred\ euros\ purchased\ at\ $135\ for\ the\ lot
+\ \ assets:euros\ \ \ \ \ 100\ EUR\ \@\@\ $135\ \ ;\ one\ hundred\ euros\ purchased\ at\ $135\ for\ the\ lot
 \ \ assets:dollars
 \f[]
 .fi
@@ -674,7 +674,7 @@ hledger infer the price that balances the transaction:
 .nf
 \f[C]
 2009/1/1
-\ \ assets:euros\ \ \ \ \ €100\ \ \ \ \ \ \ \ \ \ ;\ one\ hundred\ euros\ purchased
+\ \ assets:euros\ \ \ \ 100\ EUR\ \ \ \ \ \ \ \ ;\ one\ hundred\ euros\ purchased
 \ \ assets:dollars\ \ $\-135\ \ \ \ \ \ \ \ \ \ ;\ for\ $135
 \f[]
 .fi
@@ -691,8 +691,8 @@ Eg here is how \-B affects the balance report for the example above:
 .nf
 \f[C]
 $\ hledger\ bal\ \-N\ \-\-flat
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ $\-135\ \ assets:dollars
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ €100\ \ assets:euros
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ $\-135\ \ \ \ assets:dollars
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ 100\ EUR\ \ assets:euros
 $\ hledger\ bal\ \-N\ \-\-flat\ \-B
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ $\-135\ \ assets:dollars
 \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ $135\ \ assets:euros\ \ \ \ #\ <\-\ the\ euros\[aq]\ cost
@@ -709,15 +709,15 @@ equivalent, \-B shows something different:
 \f[C]
 2009/1/1
 \ \ assets:dollars\ \ $\-135\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ ;\ 135\ dollars\ sold
-\ \ assets:euros\ \ \ \ \ €100\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ ;\ for\ 100\ euros
+\ \ assets:euros\ \ \ \ 100\ EUR\ \ \ \ \ \ \ \ \ \ \ \ \ ;\ for\ 100\ euros
 \f[]
 .fi
 .IP
 .nf
 \f[C]
 $\ hledger\ bal\ \-N\ \-\-flat\ \-B
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ €\-100\ \ assets:dollars\ \ #\ <\-\ the\ dollars\[aq]\ selling\ price
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ €100\ \ assets:euros
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \-100\ EUR\ \ assets:dollars\ \ #\ <\-\ the\ dollars\[aq]\ selling\ price
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ 100\ EUR\ \ assets:euros
 \f[]
 .fi
 .SS Comments
@@ -1010,8 +1010,8 @@ dollars during 2009, and $1.40 from 2010 onward:
 .IP
 .nf
 \f[C]
-P\ 2009/1/1\ €\ $1.35
-P\ 2010/1/1\ €\ $1.40
+P\ 2009/1/1\ EUR\ $1.35
+P\ 2010/1/1\ EUR\ $1.40
 \f[]
 .fi
 .PP

--- a/hledger-lib/hledger_journal.info
+++ b/hledger-lib/hledger_journal.info
@@ -620,20 +620,20 @@ certain date.
   1. Write the price per unit, as '@ UNITPRICE' after the amount:
 
      2009/1/1
-       assets:euros     €100 @ $1.35  ; one hundred euros purchased at $1.35 each
-       assets:dollars                 ; balancing amount is -$135.00
+       assets:euros     100 EUR @ $1.35  ; one hundred euros purchased at $1.35 each
+       assets:dollars                    ; balancing amount is -$135.00
 
   2. Write the total price, as '@@ TOTALPRICE' after the amount:
 
      2009/1/1
-       assets:euros     €100 @@ $135  ; one hundred euros purchased at $135 for the lot
+       assets:euros     100 EUR @@ $135  ; one hundred euros purchased at $135 for the lot
        assets:dollars
 
   3. Specify amounts for all postings, using exactly two commodities,
      and let hledger infer the price that balances the transaction:
 
      2009/1/1
-       assets:euros     €100          ; one hundred euros purchased
+       assets:euros    100 EUR        ; one hundred euros purchased
        assets:dollars  $-135          ; for $135
 
    (Ledger users: Ledger uses a different syntax for fixed prices,
@@ -645,8 +645,8 @@ Ledger).  Eg here is how -B affects the balance report for the example
 above:
 
 $ hledger bal -N --flat
-               $-135  assets:dollars
-                €100  assets:euros
+               $-135    assets:dollars
+               100 EUR  assets:euros
 $ hledger bal -N --flat -B
                $-135  assets:dollars
                 $135  assets:euros    # <- the euros' cost
@@ -658,11 +658,11 @@ transaction is equivalent, -B shows something different:
 
 2009/1/1
   assets:dollars  $-135               ; 135 dollars sold
-  assets:euros     €100               ; for 100 euros
+  assets:euros    100 EUR             ; for 100 euros
 
 $ hledger bal -N --flat -B
-               €-100  assets:dollars  # <- the dollars' selling price
-                €100  assets:euros
+               -100 EUR  assets:dollars  # <- the dollars' selling price
+                100 EUR  assets:euros
 
 
 File: hledger_journal.info,  Node: Comments,  Next: Tags,  Prev: Transaction prices,  Up: FILE FORMAT
@@ -937,8 +937,8 @@ P DATE COMMODITYA COMMODITYBAMOUNT
    These two market price directives say that one euro was worth 1.35 US
 dollars during 2009, and $1.40 from 2010 onward:
 
-P 2009/1/1 € $1.35
-P 2010/1/1 € $1.40
+P 2009/1/1 EUR $1.35
+P 2010/1/1 EUR $1.40
 
    The '-V/--value' flag can be used to convert reported amounts to
 another commodity using these prices.
@@ -1319,49 +1319,49 @@ Node: Balance Assignments21356
 Ref: #balance-assignments21537
 Node: Transaction prices22657
 Ref: #transaction-prices22826
-Node: Comments25094
-Ref: #comments25228
-Node: Tags26398
-Ref: #tags26516
-Node: Directives27918
-Ref: #directives28061
-Node: Directive scope multiple files28517
-Ref: #directive-scope-multiple-files28705
-Node: Comment blocks29655
-Ref: #comment-blocks29839
-Node: Including other files30015
-Ref: #including-other-files30195
-Node: Default year30584
-Ref: #default-year30753
-Node: Declaring commodities31176
-Ref: #declaring-commodities31359
-Node: Default commodity32586
-Ref: #default-commodity32762
-Node: Market prices33398
-Ref: #market-prices33563
-Node: Declaring accounts34404
-Ref: #declaring-accounts34580
-Node: Rewriting accounts35927
-Ref: #rewriting-accounts36112
-Node: Basic aliases36716
-Ref: #basic-aliases36862
-Node: Regex aliases37552
-Ref: #regex-aliases37723
-Node: Multiple aliases38441
-Ref: #multiple-aliases38616
-Node: end aliases39114
-Ref: #end-aliases39261
-Node: Default parent account39362
-Ref: #default-parent-account39530
-Node: Periodic transactions40189
-Ref: #periodic-transactions40368
-Node: Generating forecasts with periodic transactions41609
-Ref: #generating-forecasts-with-periodic-transactions41890
-Node: Setting budget goals with periodic transactions42983
-Ref: #setting-budget-goals-with-periodic-transactions43264
-Node: Automated postings43723
-Ref: #automated-postings43877
-Node: EDITOR SUPPORT45017
-Ref: #editor-support45135
+Node: Comments25099
+Ref: #comments25233
+Node: Tags26403
+Ref: #tags26521
+Node: Directives27923
+Ref: #directives28066
+Node: Directive scope multiple files28522
+Ref: #directive-scope-multiple-files28710
+Node: Comment blocks29660
+Ref: #comment-blocks29844
+Node: Including other files30020
+Ref: #including-other-files30200
+Node: Default year30589
+Ref: #default-year30758
+Node: Declaring commodities31181
+Ref: #declaring-commodities31364
+Node: Default commodity32591
+Ref: #default-commodity32767
+Node: Market prices33403
+Ref: #market-prices33568
+Node: Declaring accounts34409
+Ref: #declaring-accounts34585
+Node: Rewriting accounts35932
+Ref: #rewriting-accounts36117
+Node: Basic aliases36721
+Ref: #basic-aliases36867
+Node: Regex aliases37557
+Ref: #regex-aliases37728
+Node: Multiple aliases38446
+Ref: #multiple-aliases38621
+Node: end aliases39119
+Ref: #end-aliases39266
+Node: Default parent account39367
+Ref: #default-parent-account39535
+Node: Periodic transactions40194
+Ref: #periodic-transactions40373
+Node: Generating forecasts with periodic transactions41614
+Ref: #generating-forecasts-with-periodic-transactions41895
+Node: Setting budget goals with periodic transactions42988
+Ref: #setting-budget-goals-with-periodic-transactions43269
+Node: Automated postings43728
+Ref: #automated-postings43882
+Node: EDITOR SUPPORT45022
+Ref: #editor-support45140
 
 End Tag Table

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -473,15 +473,15 @@ There are several ways to record a transaction price:
 
     ```journal
     2009/1/1
-      assets:euros     €100 @ $1.35  ; one hundred euros purchased at $1.35 each
-      assets:dollars                 ; balancing amount is -$135.00
+      assets:euros     100 EUR @ $1.35  ; one hundred euros purchased at $1.35 each
+      assets:dollars                    ; balancing amount is -$135.00
     ```
 
 2. Write the total price, as `@@ TOTALPRICE` after the amount:
 
     ```journal
     2009/1/1
-      assets:euros     €100 @@ $135  ; one hundred euros purchased at $135 for the lot
+      assets:euros     100 EUR @@ $135  ; one hundred euros purchased at $135 for the lot
       assets:dollars
     ```
 
@@ -490,7 +490,7 @@ There are several ways to record a transaction price:
 
     ```journal
     2009/1/1
-      assets:euros     €100          ; one hundred euros purchased
+      assets:euros    100 EUR        ; one hundred euros purchased
       assets:dollars  $-135          ; for $135
     ```
 
@@ -504,8 +504,8 @@ Eg here is how -B affects the balance report for the example above:
 
 ```shell
 $ hledger bal -N --flat
-               $-135  assets:dollars
-                €100  assets:euros
+               $-135    assets:dollars
+               100 EUR  assets:euros
 $ hledger bal -N --flat -B
                $-135  assets:dollars
                 $135  assets:euros    # <- the euros' cost
@@ -519,12 +519,12 @@ is equivalent, -B shows something different:
 ```journal
 2009/1/1
   assets:dollars  $-135               ; 135 dollars sold
-  assets:euros     €100               ; for 100 euros
+  assets:euros    100 EUR             ; for 100 euros
 ```
 ```shell
 $ hledger bal -N --flat -B
-               €-100  assets:dollars  # <- the dollars' selling price
-                €100  assets:euros
+               -100 EUR  assets:dollars  # <- the dollars' selling price
+                100 EUR  assets:euros
 ```
 
 ## Comments
@@ -754,8 +754,8 @@ P DATE COMMODITYA COMMODITYBAMOUNT
 These two market price directives say that one euro was worth 1.35 US dollars during 2009, 
 and $1.40 from 2010 onward:
 ```journal
-P 2009/1/1 € $1.35
-P 2010/1/1 € $1.40
+P 2009/1/1 EUR $1.35
+P 2010/1/1 EUR $1.40
 ```
 
 The [`-V/--value`](manual.html#market-value) flag can be used to convert reported amounts

--- a/hledger-lib/hledger_journal.txt
+++ b/hledger-lib/hledger_journal.txt
@@ -480,59 +480,59 @@ FILE FORMAT
        1. Write the price per unit, as @ UNITPRICE after the amount:
 
                   2009/1/1
-                    assets:euros     100 @ $1.35  ; one hundred euros purchased at $1.35 each
-                    assets:dollars                 ; balancing amount is -$135.00
+                    assets:euros     100 EUR @ $1.35  ; one hundred euros purchased at $1.35 each
+                    assets:dollars                    ; balancing amount is -$135.00
 
        2. Write the total price, as @@ TOTALPRICE after the amount:
 
                   2009/1/1
-                    assets:euros     100 @@ $135  ; one hundred euros purchased at $135 for the lot
+                    assets:euros     100 EUR @@ $135  ; one hundred euros purchased at $135 for the lot
                     assets:dollars
 
        3. Specify amounts for all postings, using exactly two commodities, and
           let hledger infer the price that balances the transaction:
 
                   2009/1/1
-                    assets:euros     100          ; one hundred euros purchased
+                    assets:euros    100 EUR        ; one hundred euros purchased
                     assets:dollars  $-135          ; for $135
 
        (Ledger users: Ledger uses a different syntax for fixed prices, {=UNIT-
        PRICE}, which hledger currently ignores).
 
-       Use the -B/--cost flag to convert amounts to their transaction  price's
+       Use  the -B/--cost flag to convert amounts to their transaction price's
        commodity, if any.  (mnemonic: "B" is from "cost Basis", as in Ledger).
        Eg here is how -B affects the balance report for the example above:
 
               $ hledger bal -N --flat
-                             $-135  assets:dollars
-                              100  assets:euros
+                             $-135    assets:dollars
+                             100 EUR  assets:euros
               $ hledger bal -N --flat -B
                              $-135  assets:dollars
                               $135  assets:euros    # <- the euros' cost
 
-       Note -B is sensitive to the order of postings when a transaction  price
-       is  inferred:  the  inferred price will be in the commodity of the last
+       Note  -B is sensitive to the order of postings when a transaction price
+       is inferred: the inferred price will be in the commodity  of  the  last
        amount.  So if example 3's postings are reversed, while the transaction
        is equivalent, -B shows something different:
 
               2009/1/1
                 assets:dollars  $-135               ; 135 dollars sold
-                assets:euros     100               ; for 100 euros
+                assets:euros    100 EUR             ; for 100 euros
 
               $ hledger bal -N --flat -B
-                             -100  assets:dollars  # <- the dollars' selling price
-                              100  assets:euros
+                             -100 EUR  assets:dollars  # <- the dollars' selling price
+                              100 EUR  assets:euros
 
    Comments
        Lines in the journal beginning with a semicolon (;) or hash (#) or star
-       (*) are comments, and will be ignored.  (Star comments  cause  org-mode
-       nodes  to  be  ignored, allowing emacs users to fold and navigate their
+       (*)  are  comments, and will be ignored.  (Star comments cause org-mode
+       nodes to be ignored, allowing emacs users to fold  and  navigate  their
        journals with org-mode or orgstruct-mode.)
 
-       You can attach comments to a transaction  by  writing  them  after  the
-       description  and/or  indented  on the following lines (before the post-
-       ings).  Similarly, you can attach comments to an individual posting  by
-       writing  them  after the amount and/or indented on the following lines.
+       You  can  attach  comments  to  a transaction by writing them after the
+       description and/or indented on the following lines  (before  the  post-
+       ings).   Similarly, you can attach comments to an individual posting by
+       writing them after the amount and/or indented on the  following  lines.
        Transaction and posting comments must begin with a semicolon (;).
 
        Some examples:
@@ -733,25 +733,25 @@ FILE FORMAT
 
        o COMMODITYA is the symbol of the commodity being priced
 
-       o COMMODITYBAMOUNT  is an amount (symbol and quantity) in a second com-
+       o COMMODITYBAMOUNT is an amount (symbol and quantity) in a second  com-
          modity, giving the price in commodity B of one unit of commodity A.
 
-       These two market price directives say that one euro was worth  1.35  US
+       These  two  market price directives say that one euro was worth 1.35 US
        dollars during 2009, and $1.40 from 2010 onward:
 
-              P 2009/1/1  $1.35
-              P 2010/1/1  $1.40
+              P 2009/1/1 EUR $1.35
+              P 2010/1/1 EUR $1.40
 
-       The  -V/--value flag can be used to convert reported amounts to another
+       The -V/--value flag can be used to convert reported amounts to  another
        commodity using these prices.
 
    Declaring accounts
-       The account directive predeclares account names.  The simplest form  is
+       The  account directive predeclares account names.  The simplest form is
        account ACCTNAME, eg:
 
               account assets:bank:checking
 
-       Currently  this  mainly  helps  with  account name autocompletion in eg
+       Currently this mainly helps with  account  name  autocompletion  in  eg
        hledger add, hledger-iadd, hledger-web, and ledger-mode.
        In future it will also help detect misspelled accounts.
 

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -978,15 +978,15 @@ For example:
 .nf
 \f[C]
 #\ one\ euro\ is\ worth\ this\ many\ dollars\ from\ nov\ 1
-P\ 2016/11/01\ €\ $1.10
+P\ 2016/11/01\ EUR\ $1.10
 
 #\ purchase\ some\ euros\ on\ nov\ 3
 2016/11/3
-\ \ \ \ assets:euros\ \ \ \ \ \ \ \ €100
+\ \ \ \ assets:euros\ \ \ \ \ \ \ \ 100\ EUR
 \ \ \ \ assets:checking
 
 #\ the\ euro\ is\ worth\ fewer\ dollars\ by\ dec\ 21
-P\ 2016/12/21\ €\ $1.03
+P\ 2016/12/21\ EUR\ $1.03
 \f[]
 .fi
 .PP
@@ -995,7 +995,7 @@ How many euros do I have ?
 .nf
 \f[C]
 $\ hledger\ \-f\ t.j\ bal\ \-N\ euros
-\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ €100\ \ assets:euros
+\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ 100\ EUR\ \ assets:euros
 \f[]
 .fi
 .PP
@@ -2964,8 +2964,8 @@ multibyte or wide character\[rq] errors\f[]
 .PD 0
 .P
 .PD
-In order to handle non\-ascii letters and symbols (like £), hledger
-needs an appropriate locale.
+In order to handle non\-ascii letters and symbols, hledger needs an
+appropriate locale.
 This is usually configured system\-wide; you can also configure it
 temporarily.
 The locale may need to be one that supports UTF\-8, if you built hledger

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -657,20 +657,20 @@ recent one, or in case of equal dates, the last-parsed one.
    For example:
 
 # one euro is worth this many dollars from nov 1
-P 2016/11/01 € $1.10
+P 2016/11/01 EUR $1.10
 
 # purchase some euros on nov 3
 2016/11/3
-    assets:euros        €100
+    assets:euros        100 EUR
     assets:checking
 
 # the euro is worth fewer dollars by dec 21
-P 2016/12/21 € $1.03
+P 2016/12/21 EUR $1.03
 
    How many euros do I have ?
 
 $ hledger -f t.j bal -N euros
-                €100  assets:euros
+                100 EUR  assets:euros
 
    What are they worth at end of nov 3 ?
 
@@ -2465,106 +2465,106 @@ Node: Cost21487
 Ref: #cost21595
 Node: Market value21713
 Ref: #market-value21848
-Node: Combining -B and -V23214
-Ref: #combining--b-and--v23377
-Node: Output destination23524
-Ref: #output-destination23686
-Node: Output format23969
-Ref: #output-format24121
-Node: Regular expressions24506
-Ref: #regular-expressions24643
-Node: QUERIES26004
-Ref: #queries26106
-Node: COMMANDS30068
-Ref: #commands30180
-Node: accounts31162
-Ref: #accounts31260
-Node: activity32506
-Ref: #activity32616
-Node: add32976
-Ref: #add33075
-Node: balance35736
-Ref: #balance35847
-Node: Classic balance report38930
-Ref: #classic-balance-report39103
-Node: Customising the classic balance report40472
-Ref: #customising-the-classic-balance-report40700
-Node: Colour support42774
-Ref: #colour-support42941
-Node: Flat mode43114
-Ref: #flat-mode43262
-Node: Depth limited balance reports43675
-Ref: #depth-limited-balance-reports43875
-Node: Multicolumn balance report44331
-Ref: #multicolumn-balance-report44529
-Node: Budget report49709
-Ref: #budget-report49852
-Ref: #output-format-152886
-Node: balancesheet52964
-Ref: #balancesheet53100
-Node: balancesheetequity55411
-Ref: #balancesheetequity55560
-Node: cashflow56097
-Ref: #cashflow56225
-Node: check-dates58348
-Ref: #check-dates58475
-Node: check-dupes58592
-Ref: #check-dupes58716
-Node: close58853
-Ref: #close58960
-Node: help59290
-Ref: #help59390
-Node: import60464
-Ref: #import60578
-Node: incomestatement61308
-Ref: #incomestatement61442
-Node: prices63846
-Ref: #prices63961
-Node: print64004
-Ref: #print64114
-Node: print-unique69008
-Ref: #print-unique69134
-Node: register69202
-Ref: #register69329
-Node: Custom register output73830
-Ref: #custom-register-output73959
-Node: register-match75189
-Ref: #register-match75323
-Node: rewrite75506
-Ref: #rewrite75623
-Node: stats75692
-Ref: #stats75795
-Node: tags76665
-Ref: #tags76763
-Node: test76999
-Ref: #test77083
-Node: ADD-ON COMMANDS77451
-Ref: #add-on-commands77561
-Node: Official add-ons78848
-Ref: #official-add-ons78988
-Node: api79075
-Ref: #api79164
-Node: ui79216
-Ref: #ui79315
-Node: web79373
-Ref: #web79462
-Node: Third party add-ons79508
-Ref: #third-party-add-ons79683
-Node: diff79818
-Ref: #diff79915
-Node: iadd80014
-Ref: #iadd80128
-Node: interest80211
-Ref: #interest80332
-Node: irr80427
-Ref: #irr80525
-Node: Experimental add-ons80603
-Ref: #experimental-add-ons80755
-Node: autosync81035
-Ref: #autosync81146
-Node: chart81385
-Ref: #chart81504
-Node: check81575
-Ref: #check81677
+Node: Combining -B and -V23216
+Ref: #combining--b-and--v23379
+Node: Output destination23526
+Ref: #output-destination23688
+Node: Output format23971
+Ref: #output-format24123
+Node: Regular expressions24508
+Ref: #regular-expressions24645
+Node: QUERIES26006
+Ref: #queries26108
+Node: COMMANDS30070
+Ref: #commands30182
+Node: accounts31164
+Ref: #accounts31262
+Node: activity32508
+Ref: #activity32618
+Node: add32978
+Ref: #add33077
+Node: balance35738
+Ref: #balance35849
+Node: Classic balance report38932
+Ref: #classic-balance-report39105
+Node: Customising the classic balance report40474
+Ref: #customising-the-classic-balance-report40702
+Node: Colour support42776
+Ref: #colour-support42943
+Node: Flat mode43116
+Ref: #flat-mode43264
+Node: Depth limited balance reports43677
+Ref: #depth-limited-balance-reports43877
+Node: Multicolumn balance report44333
+Ref: #multicolumn-balance-report44531
+Node: Budget report49711
+Ref: #budget-report49854
+Ref: #output-format-152888
+Node: balancesheet52966
+Ref: #balancesheet53102
+Node: balancesheetequity55413
+Ref: #balancesheetequity55562
+Node: cashflow56099
+Ref: #cashflow56227
+Node: check-dates58350
+Ref: #check-dates58477
+Node: check-dupes58594
+Ref: #check-dupes58718
+Node: close58855
+Ref: #close58962
+Node: help59292
+Ref: #help59392
+Node: import60466
+Ref: #import60580
+Node: incomestatement61310
+Ref: #incomestatement61444
+Node: prices63848
+Ref: #prices63963
+Node: print64006
+Ref: #print64116
+Node: print-unique69010
+Ref: #print-unique69136
+Node: register69204
+Ref: #register69331
+Node: Custom register output73832
+Ref: #custom-register-output73961
+Node: register-match75191
+Ref: #register-match75325
+Node: rewrite75508
+Ref: #rewrite75625
+Node: stats75694
+Ref: #stats75797
+Node: tags76667
+Ref: #tags76765
+Node: test77001
+Ref: #test77085
+Node: ADD-ON COMMANDS77453
+Ref: #add-on-commands77563
+Node: Official add-ons78850
+Ref: #official-add-ons78990
+Node: api79077
+Ref: #api79166
+Node: ui79218
+Ref: #ui79317
+Node: web79375
+Ref: #web79464
+Node: Third party add-ons79510
+Ref: #third-party-add-ons79685
+Node: diff79820
+Ref: #diff79917
+Node: iadd80016
+Ref: #iadd80130
+Node: interest80213
+Ref: #interest80334
+Node: irr80429
+Ref: #irr80527
+Node: Experimental add-ons80605
+Ref: #experimental-add-ons80757
+Node: autosync81037
+Ref: #autosync81148
+Node: chart81387
+Ref: #chart81506
+Node: check81577
+Ref: #check81679
 
 End Tag Table

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -623,20 +623,20 @@ OPTIONS
        For example:
 
               # one euro is worth this many dollars from nov 1
-              P 2016/11/01  $1.10
+              P 2016/11/01 EUR $1.10
 
               # purchase some euros on nov 3
               2016/11/3
-                  assets:euros        100
+                  assets:euros        100 EUR
                   assets:checking
 
               # the euro is worth fewer dollars by dec 21
-              P 2016/12/21  $1.03
+              P 2016/12/21 EUR $1.03
 
        How many euros do I have ?
 
               $ hledger -f t.j bal -N euros
-                              100  assets:euros
+                              100 EUR  assets:euros
 
        What are they worth at end of nov 3 ?
 
@@ -2145,8 +2145,8 @@ TROUBLESHOOTING
 
        "Illegal  byte  sequence"  or  "Invalid or incomplete multibyte or wide
        character" errors
-       In order to handle non-ascii letters and symbols (like ), hledger needs
-       an appropriate locale.  This is usually configured system-wide; you can
+       In order to handle non-ascii letters  and  symbols,  hledger  needs  an
+       appropriate  locale.   This  is usually configured system-wide; you can
        also configure it temporarily.  The locale may need to be one that sup-
        ports  UTF-8,  if you built hledger with GHC < 7.2 (or possibly always,
        I'm not sure yet).

--- a/hledger/hledger_options.m4.md
+++ b/hledger/hledger_options.m4.md
@@ -392,20 +392,20 @@ For example:
 
 ```journal
 # one euro is worth this many dollars from nov 1
-P 2016/11/01 € $1.10
+P 2016/11/01 EUR $1.10
 
 # purchase some euros on nov 3
 2016/11/3
-    assets:euros        €100
+    assets:euros        100 EUR
     assets:checking
 
 # the euro is worth fewer dollars by dec 21
-P 2016/12/21 € $1.03
+P 2016/12/21 EUR $1.03
 ```
 How many euros do I have ?
 ```
 $ hledger -f t.j bal -N euros
-                €100  assets:euros
+                100 EUR  assets:euros
 ```
 What are they worth at end of nov 3 ?
 ```

--- a/hledger/hledger_troubleshooting.m4.md
+++ b/hledger/hledger_troubleshooting.m4.md
@@ -17,7 +17,7 @@ The command `env | grep LEDGER_FILE` should show it.
 You may need to use `export`. Here's an [explanation](http://stackoverflow.com/a/7411509).
 
 **"Illegal byte sequence" or "Invalid or incomplete multibyte or wide character" errors**  
-In order to handle non-ascii letters and symbols (like £), hledger needs
+In order to handle non-ascii letters and symbols, hledger needs
 an appropriate locale. This is usually configured system-wide; you can
 also configure it temporarily.  The locale may need to be one that
 supports UTF-8, if you built hledger with GHC < 7.2 (or possibly always,


### PR DESCRIPTION
Fixes #813. For some reason, my whitespace distribution is wildly different in *.txt files, so I've committed only the relevant parts of them.