### PR TITLE
Improving parse errors

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -523,6 +523,7 @@ test_spaceandamountormissingp = do
 amountp :: JournalParser m Amount
 amountp = label "amount" $ do
   amount <- amountwithoutpricep
+  lift $ skipMany spacenonewline
   price <- priceamountp
   pure $ amount { aprice = price }
 
@@ -657,7 +658,7 @@ simplecommoditysymbolp = takeWhile1P Nothing (not . isNonsimpleCommodityChar)
 
 priceamountp :: JournalParser m Price
 priceamountp = option NoPrice $ do
-  try $ lift (skipMany spacenonewline) *> char '@'
+  char '@'
   priceConstructor <- char '@' *> pure TotalPrice <|> pure UnitPrice
 
   lift (skipMany spacenonewline)

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -636,7 +636,8 @@ postingp mTransactionYear = do
     account <- modifiedaccountnamep
     return (status, account)
   let (ptype, account') = (accountNamePostingType account, textUnbracket account)
-  amount <- spaceandamountormissingp
+  lift (skipMany spacenonewline)
+  amount <- option missingmixedamt $ Mixed . (:[]) <$> amountp
   massertion <- partialbalanceassertionp
   _ <- fixedlotpricep
   lift (skipMany spacenonewline)


### PR DESCRIPTION
This PR aims to improve the parse errors for parsers in `hledger-lib/Hledger/Read/Common.hs`

I'm not yet sure how best to improve the parse errors, so these changes might be considered a work in progress. I've basically tried to minimize the backtracking of the parsers and to write out more descriptive labels and error messages.

---

This PR contains one breaking change: in an amount, the multiplier symbol `*` must now always preceed the negative sign `-`. Before the changes, the multiplier came after the sign in `leftsymbolamountp`, whereas the sign came before the multiplier in `rightsymbolamountp` and `nosymbolamountp`. This PR factors out the parsing of the multipliers and signs from these three parsers into a single parser under `amountwithoutpricep` (in order to reduce backtracking), where the multiplier must come before the sign.

If this breakage is unacceptable, one workaround would be to accept signs before _and_ after the multiplier.

I am unable to tell why the order of the multiplier and sign is different between the `left-` and `right-` parsers. FYI, I think the most recent change to the parsing of modifiers was in #557.

---

Parse error examples:

```
$ cat datetime.timeclock 
i 2016-01-31 12:00:99 a:aa
o 2016-01-31 16:00

$ ./hledger-master -f datetime.timeclock reg
hledger-master: datetime.timeclock:1:22:
  |
1 | i 2016-01-31 12:00:99 a:aa
  |                      ^
expecting digit

$ ./hledger-new -f datetime.timeclock reg      
hledger-new: datetime.timeclock:1:20:
  |
1 | i 2016-01-31 12:00:99 a:aa
  |                    ^^
invalid time (bad second)
```

```
$ cat amount.journal
2018/06/20
    acct1     1,000.00.0 $
    acct2

$ ./hledger-master -f amount.journal reg
hledger-master: amount.journal:2:15:
  |
2 |     acct1     1,000.00.0 $
  |               ^
unexpected '1'
expecting ';', end of input, or newline

$ ./hledger-new -f amount.journal reg
hledger-new: amount.journal:2:23:
  |
2 |     acct1     1,000.00.0 $
  |                       ^
invalid number (invalid use of separator)
```

```
$ cat price.journal                    
2018/06/20
    acct1     1,000.00 $ @
    acct2

$ ./hledger-master -f price.journal reg
hledger-master: price.journal:2:26:
  |
2 |     acct1     1,000.00 $ @
  |                          ^
unexpected '@'
expecting ';', end of input, or newline

$ ./hledger-new -f price.journal reg      
hledger-new: price.journal:2:27:
  |
2 |     acct1     1,000.00 $ @
  |                           ^
unexpected newline
expecting '@' or amount (as a price)
```

```
$ cat amount.journal2                    
2018/06/20
    acct1     1,000.00 $ ???
    acct2

$ ./hledger-master -f amount.journal2 reg
hledger-master: amount.journal2:2:26:
  |
2 |     acct1     1,000.00 $ ???
  |                          ^
unexpected '?'
expecting ';', end of input, or newline

$ ./hledger-new -f amount.journal2 reg      
hledger-new: amount.journal2:2:26:
  |
2 |     acct1     1,000.00 $ ???
  |                          ^
unexpected '?'
expecting ';', '=', '{', end of input, newline, or the rest of amount
```