### PR TITLE
Allow "re-parsing" with custom parse errors, some commodity cleanups

### DIFF
--- a/hledger-lib/Hledger/Data/Commodity.hs
+++ b/hledger-lib/Hledger/Data/Commodity.hs
@@ -27,12 +27,14 @@ import Hledger.Utils
 
 
 -- characters that may not be used in a non-quoted commodity symbol
-nonsimplecommoditychars = "0123456789-+.@*;\n \"{}=" :: [Char]
+nonsimplecommoditychars = "0123456789-+.,@*;\n \"{}=" :: [Char]
 
+-- should we specifiy `isDecimalPointChar c` rather than explicitly
+-- listing '.' and ','?
 isNonsimpleCommodityChar :: Char -> Bool
 isNonsimpleCommodityChar c = isDigit c || c `textElem` otherChars
  where
-   otherChars = "-+.@*;\n \"{}=" :: T.Text
+   otherChars = "-+.,@*;\n \"{}=" :: T.Text
    textElem = T.any . (==)
 
 quoteCommoditySymbolIfNeeded s | T.any (isNonsimpleCommodityChar) s = "\"" <> s <> "\""

--- a/hledger-lib/Hledger/Data/Commodity.hs
+++ b/hledger-lib/Hledger/Data/Commodity.hs
@@ -13,21 +13,12 @@ are thousands separated by comma, significant decimal places and so on.
 module Hledger.Data.Commodity
 where
 import Data.Char (isDigit)
-import Data.List
-import Data.Maybe (fromMaybe)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Monoid
 #endif
 import qualified Data.Text as T
 import Test.HUnit
--- import qualified Data.Map as M
 
-import Hledger.Data.Types
-import Hledger.Utils
-
-
--- characters that may not be used in a non-quoted commodity symbol
-nonsimplecommoditychars = "0123456789-+.,@*;\n \"{}=" :: [Char]
 
 -- should we specifiy `isDecimalPointChar c` rather than explicitly
 -- listing '.' and ','?
@@ -40,48 +31,5 @@ isNonsimpleCommodityChar c = isDigit c || c `textElem` otherChars
 quoteCommoditySymbolIfNeeded s | T.any (isNonsimpleCommodityChar) s = "\"" <> s <> "\""
                                | otherwise = s
 
-commodity = ""
-
--- handy constructors for tests
--- unknown = commodity
--- usd     = "$"
--- eur     = "€"
--- gbp     = "£"
--- hour    = "h"
-
--- Some sample commodity' names and symbols, for use in tests..
-commoditysymbols =
-  [("unknown","")
-  ,("usd","$")
-  ,("eur","€")
-  ,("gbp","£")
-  ,("hour","h")
-  ]
-
--- | Look up one of the sample commodities' symbol by name.
-comm :: String -> CommoditySymbol
-comm name = snd $ fromMaybe
-              (error' "commodity lookup failed")
-              (find (\n -> fst n == name) commoditysymbols)
-
--- | Find the conversion rate between two commodities. Currently returns 1.
-conversionRate :: CommoditySymbol -> CommoditySymbol -> Double
-conversionRate _ _ = 1
-
--- -- | Convert a list of commodities to a map from commodity symbols to
--- -- unique, display-preference-canonicalised commodities.
--- canonicaliseCommodities :: [CommoditySymbol] -> Map.Map String CommoditySymbol
--- canonicaliseCommodities cs =
---     Map.fromList [(s,firstc{precision=maxp}) | s <- symbols,
---                   let cs = commoditymap ! s,
---                   let firstc = head cs,
---                   let maxp = maximum $ map precision cs
---                  ]
---   where
---     commoditymap = Map.fromList [(s, commoditieswithsymbol s) | s <- symbols]
---     commoditieswithsymbol s = filter ((s==) . symbol) cs
---     symbols = nub $ map symbol cs
-
 tests_Hledger_Data_Commodity = TestList [
  ]
-

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -265,14 +265,14 @@ indentedlinep = lift (skipSome spacenonewline) >> (rstrip <$> lift restofline)
 -- >>> Right _ <- rjp commoditydirectivep "commodity $\n  format $1.00"
 -- >>> Right _ <- rjp commoditydirectivep "commodity $\n\n" -- a commodity with no format
 -- >>> Right _ <- rjp commoditydirectivep "commodity $1.00\n  format $1.00" -- both, what happens ?
-commoditydirectivep :: JournalParser m ()
+commoditydirectivep :: Monad m => JournalParser m ()
 commoditydirectivep = commoditydirectiveonelinep <|> commoditydirectivemultilinep
 
 -- | Parse a one-line commodity directive.
 --
 -- >>> Right _ <- rjp commoditydirectiveonelinep "commodity $1.00"
 -- >>> Right _ <- rjp commoditydirectiveonelinep "commodity $1.00 ; blah\n"
-commoditydirectiveonelinep :: JournalParser m ()
+commoditydirectiveonelinep :: Monad m => JournalParser m ()
 commoditydirectiveonelinep = do
   (pos, Amount{acommodity,astyle}) <- try $ do
     string "commodity"
@@ -293,7 +293,7 @@ pleaseincludedecimalpoint = "to avoid ambiguity, please include a decimal point 
 -- | Parse a multi-line commodity directive, containing 0 or more format subdirectives.
 --
 -- >>> Right _ <- rjp commoditydirectivemultilinep "commodity $ ; blah \n  format $1.00 ; blah"
-commoditydirectivemultilinep :: JournalParser m ()
+commoditydirectivemultilinep :: Monad m => JournalParser m ()
 commoditydirectivemultilinep = do
   string "commodity"
   lift (skipSome spacenonewline)
@@ -307,7 +307,7 @@ commoditydirectivemultilinep = do
 
 -- | Parse a format (sub)directive, throwing a parse error if its
 -- symbol does not match the one given.
-formatdirectivep :: CommoditySymbol -> JournalParser m AmountStyle
+formatdirectivep :: Monad m => CommoditySymbol -> JournalParser m AmountStyle
 formatdirectivep expectedsym = do
   string "format"
   lift (skipSome spacenonewline)
@@ -404,7 +404,7 @@ defaultyeardirectivep = do
   failIfInvalidYear y
   setYear y'
 
-defaultcommoditydirectivep :: JournalParser m ()
+defaultcommoditydirectivep :: Monad m => JournalParser m ()
 defaultcommoditydirectivep = do
   char 'D' <?> "default commodity"
   lift (skipSome spacenonewline)
@@ -415,7 +415,7 @@ defaultcommoditydirectivep = do
   then parseErrorAt pos pleaseincludedecimalpoint
   else setDefaultCommodityAndStyle (acommodity, astyle)
 
-marketpricedirectivep :: JournalParser m MarketPrice
+marketpricedirectivep :: Monad m => JournalParser m MarketPrice
 marketpricedirectivep = do
   char 'P' <?> "market price"
   lift (skipMany spacenonewline)
@@ -435,7 +435,7 @@ ignoredpricecommoditydirectivep = do
   lift restofline
   return ()
 
-commodityconversiondirectivep :: JournalParser m ()
+commodityconversiondirectivep :: Monad m => JournalParser m ()
 commodityconversiondirectivep = do
   char 'C' <?> "commodity conversion"
   lift (skipSome spacenonewline)
@@ -449,7 +449,7 @@ commodityconversiondirectivep = do
 
 --- ** transactions
 
-modifiertransactionp :: JournalParser m ModifierTransaction
+modifiertransactionp :: Monad m => JournalParser m ModifierTransaction
 modifiertransactionp = do
   char '=' <?> "modifier transaction"
   lift (skipMany spacenonewline)
@@ -502,7 +502,7 @@ periodictransactionp = do
     }
 
 -- | Parse a (possibly unbalanced) transaction.
-transactionp :: JournalParser m Transaction
+transactionp :: Monad m => JournalParser m Transaction
 transactionp = do
   -- ptrace "transactionp"
   startpos <- getPosition
@@ -616,7 +616,7 @@ test_transactionp = do
 
 -- Parse the following whitespace-beginning lines as postings, posting
 -- tags, and/or comments (inferring year, if needed, from the given date).
-postingsp :: Maybe Year -> JournalParser m [Posting]
+postingsp :: Monad m => Maybe Year -> JournalParser m [Posting]
 postingsp mTransactionYear = many (postingp mTransactionYear) <?> "postings"
 
 -- linebeginningwithspaces :: JournalParser m String
@@ -626,7 +626,7 @@ postingsp mTransactionYear = many (postingp mTransactionYear) <?> "postings"
 --   cs <- lift restofline
 --   return $ sp ++ (c:cs) ++ "\n"
 
-postingp :: Maybe Year -> JournalParser m Posting
+postingp :: Monad m => Maybe Year -> JournalParser m Posting
 postingp mTransactionYear = do
   -- pdbg 0 "postingp"
   (status, account) <- try $ do

--- a/hledger-lib/Text/Megaparsec/Custom.hs
+++ b/hledger-lib/Text/Megaparsec/Custom.hs
@@ -16,6 +16,8 @@ module Text.Megaparsec.Custom (
 
   -- * Re-parsing
   SourceExcerpt,
+  getExcerptText,
+
   excerpt_,
   reparseExcerpt,
 
@@ -112,7 +114,13 @@ withSource s e =
 -- data type is to preserve the content and source position of the excerpt
 -- so that parse errors raised during "re-parsing" may properly reference
 -- the original source.
+
 data SourceExcerpt = SourceExcerpt SourcePos Text
+
+-- | Get the raw text of a source excerpt.
+
+getExcerptText :: SourceExcerpt -> Text
+getExcerptText (SourceExcerpt _ txt) = txt
 
 -- | `sourceExcerpt p` applies the given parser `p` and extracts the
 -- portion of the source consumed by `p`, along with the source position

--- a/tests/journal/numbers.test
+++ b/tests/journal/numbers.test
@@ -221,3 +221,37 @@ hledger bal -f -
 	b  -,100.0 EUR
 >>>
 >>>=1
+
+# 20. the digit group separator '.' should not be mistaken for a commodity
+hledger bal -f -
+<<<
+2017/1/1
+	a   1..
+    b
+>>>
+>>>=1
+
+# 21. the decimal separator '.' should not be mistaken for a commodity
+hledger bal -f -
+<<<
+2017/1/1
+	a   .1 $
+    b
+>>>=0
+
+# 22. the digit group separator ',' should not be mistaken for a commodity
+hledger bal -f -
+<<<
+2017/1/1
+	a   1,,
+    b
+>>>
+>>>=1
+
+# 23. the decimal separator ',' should not be mistaken for a commodity
+hledger bal -f -
+<<<
+2017/1/1
+	a   ,1 $
+    b
+>>>=0


### PR DESCRIPTION
This PR allows the use of "re-parsing" with the custom parse errors, and applies this "re-parsing" to two parsers:
- the number parser, to delay the interpretation of numbers (in anticipation of changes potentially required issue #793), and
- the period transaction parser, to separate out the handling of the whitespace rules for period expressions (restoring the original behaviour in PR #807).

Additionally, this PR disallows a comma `,` from being interpreted as a commodity, adds tests for this case, and removes unused commodity code.
