### PR TITLE
allow glob patterns in 'include' directive

### DIFF
--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -208,8 +208,9 @@ includedirectivep = do
         fileglob <- case tryCompileWith compDefault{errorRecovery=False} filename of
             Right x -> pure x
             Left e -> parseErrorAt parserpos $ "Invalid glob pattern: " ++ e
-        -- Get all matching files in the current working directory
-        filepaths <- liftIO $ globDir1 fileglob curdir
+        -- Get all matching files in the current working directory, sorting in
+        -- lexicographic order to simulate the output of 'ls'.
+        filepaths <- liftIO $ sort <$> globDir1 fileglob curdir
         if (not . null) filepaths
             then pure filepaths
             else parseErrorAt parserpos$  "No existing files match pattern: " ++ filename

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -94,7 +94,7 @@ import Text.Megaparsec.Char
 import Text.Megaparsec.Custom
 import Text.Printf
 import System.FilePath
-import System.FilePath.Glob hiding (match)
+import "Glob" System.FilePath.Glob hiding (match)
 
 import Hledger.Data
 import Hledger.Read.Common

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -191,17 +191,18 @@ includedirectivep = do
   lift (skipSome spacenonewline)
   filename <- T.unpack <$> takeWhileP Nothing (/= '\n') -- don't consume newline yet
 
-  -- save parent state
-  parentParserState <- getParserState
-  parentj <- get
-
-  let childj = newJournalWithParseStateFrom parentj
   parentpos <- getPosition
 
   -- read child input
   let curdir = takeDirectory (sourceName parentpos)
   filepath <- lift $ expandPath curdir filename `orRethrowIOError` (show parentpos ++ " locating " ++ filename)
   childInput <- lift $ readFilePortably filepath `orRethrowIOError` (show parentpos ++ " reading " ++ filepath)
+
+  -- save parent state
+  parentParserState <- getParserState
+  parentj <- get
+
+  let childj = newJournalWithParseStateFrom parentj
 
   -- set child state
   setInput childInput

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -193,9 +193,11 @@ includedirectivep = do
 
   parentpos <- getPosition
 
+  curdir <- lift $ expandPath (takeDirectory $ sourceName parentpos) ""
+                   `orRethrowIOError` (show parentpos ++ " locating " ++ filename)
+   -- </> correctly handles case when 'filename' is absolute
+  let filepath = curdir </> filename
   -- read child input
-  let curdir = takeDirectory (sourceName parentpos)
-  filepath <- lift $ expandPath curdir filename `orRethrowIOError` (show parentpos ++ " locating " ++ filename)
   childInput <- lift $ readFilePortably filepath `orRethrowIOError` (show parentpos ++ " reading " ++ filepath)
 
   -- save parent state

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0d06b98a1e8163de682c1b719a86583bda63677b613a54eaf62778dea185dcb4
+-- hash: 43aa3146bd1ffaeb1d8fa11aef445ffdb30976bcb6bc6285e93199a770cb982c
 
 name:           hledger-lib
 version:        1.10.99
@@ -102,6 +102,7 @@ library
   ghc-options: -Wall -fno-warn-unused-do-bind -fno-warn-name-shadowing -fno-warn-missing-signatures -fno-warn-type-defaults -fno-warn-orphans
   build-depends:
       Decimal
+    , Glob >=0.9
     , HUnit
     , ansi-terminal >=0.6.2.3
     , array
@@ -294,6 +295,7 @@ test-suite easytests
   ghc-options: -Wall -fno-warn-unused-do-bind -fno-warn-name-shadowing -fno-warn-missing-signatures -fno-warn-type-defaults -fno-warn-orphans
   build-depends:
       Decimal
+    , Glob >=0.9
     , HUnit
     , ansi-terminal >=0.6.2.3
     , array
@@ -391,6 +393,7 @@ test-suite hunittests
   ghc-options: -Wall -fno-warn-unused-do-bind -fno-warn-name-shadowing -fno-warn-missing-signatures -fno-warn-type-defaults -fno-warn-orphans
   build-depends:
       Decimal
+    , Glob >=0.9
     , HUnit
     , ansi-terminal >=0.6.2.3
     , array

--- a/hledger-lib/hledger_journal.5
+++ b/hledger-lib/hledger_journal.5
@@ -1011,7 +1011,8 @@ include\ path/to/file.journal
 .PP
 If the path does not begin with a slash, it is relative to the current
 file.
-Glob patterns (\f[C]*\f[]) are not currently supported.
+The include file path may contain common glob patterns (e.g.
+\f[C]*\f[]).
 .PP
 The \f[C]include\f[] directive can only be used in journal files.
 It can include journal, timeclock or timedot files, but not CSV files.

--- a/hledger-lib/hledger_journal.info
+++ b/hledger-lib/hledger_journal.info
@@ -878,7 +878,8 @@ directive, like this:
 include path/to/file.journal
 
    If the path does not begin with a slash, it is relative to the
-current file.  Glob patterns ('*') are not currently supported.
+current file.  The include file path may contain common glob patterns
+(e.g.  '*').
 
    The 'include' directive can only be used in journal files.  It can
 include journal, timeclock or timedot files, but not CSV files.

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -698,7 +698,9 @@ include path/to/file.journal
 ```
 
 If the path does not begin with a slash, it is relative to the current file.
-Glob patterns (`*`) are not currently supported.
+The include file path may contain
+[common glob patterns](https://hackage.haskell.org/package/Glob-0.9.2/docs/System-FilePath-Glob.html#v:compile)
+(e.g. `*`).
 
 The `include` directive can only be used in journal files.
 It can include journal, timeclock or timedot files, but not CSV files.

--- a/hledger-lib/hledger_journal.txt
+++ b/hledger-lib/hledger_journal.txt
@@ -705,7 +705,8 @@ FILE FORMAT
               include path/to/file.journal
 
        If  the path does not begin with a slash, it is relative to the current
-       file.  Glob patterns (*) are not currently supported.
+       file.  The include file path may contain  common  glob  patterns  (e.g.
+       *).
 
        The include directive can only  be  used  in  journal  files.   It  can
        include journal, timeclock or timedot files, but not CSV files.

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -72,6 +72,7 @@ dependencies:
 - utf8-string >=0.3.5
 - HUnit
 - extra
+- Glob >= 0.9
 # for ledger-parse:
 #- parsers >=0.5
 #- system-filepath

--- a/tests/journal/include.test
+++ b/tests/journal/include.test
@@ -37,7 +37,7 @@ include b.timedot
 >>>=0
 
 # 3. include glob patterns
-printf '2018/01/01\n (A)  1\n' >xy.journal; printf '2018/02/01\n  (B)  1' >yy.journal; hledger -f - print; rm -rf x.journal y.journal
+printf '2018/01/01\n (A)  1\n' >xy.journal; printf '2018/02/01\n  (B)  1' >yy.journal; hledger -f - print; rm -f xy.journal yy.journal
 <<<
 include *y.journal
 >>>

--- a/tests/journal/include.test
+++ b/tests/journal/include.test
@@ -35,3 +35,16 @@ include b.timedot
     (b.bb)            1.00
 
 >>>=0
+
+# 3. include glob patterns
+printf '2018/01/01\n (A)  1\n' >xy.journal; printf '2018/02/01\n  (B)  1' >yy.journal; hledger -f - print; rm -rf x.journal y.journal
+<<<
+include *y.journal
+>>>
+2018/01/01
+    (A)               1
+
+2018/02/01
+    (B)               1
+
+>>>=0

--- a/tests/journal/include.test
+++ b/tests/journal/include.test
@@ -48,3 +48,15 @@ include *y.journal
     (B)               1
 
 >>>=0
+
+# 4. include invalid glob patterns
+hledger -f - print
+<<<
+include [.journal
+>>>=1
+
+# 5. include nonexsitant file
+hledger -f - print
+<<<
+include doesnotexist.journal
+>>>=1

--- a/tests/journal/include.test
+++ b/tests/journal/include.test
@@ -37,14 +37,14 @@ include b.timedot
 >>>=0
 
 # 3. include glob patterns
-printf '2018/01/01\n (A)  1\n' >xy.journal; printf '2018/02/01\n  (B)  1' >yy.journal; hledger -f - print; rm -f xy.journal yy.journal
+printf '2018/01/01\n (A)  1\n' >ab.journal; printf '2018/01/01\n  (B)  1' >bb.journal; hledger -f - print; rm -f ab.journal bb.journal
 <<<
-include *y.journal
+include *b.journal
 >>>
 2018/01/01
     (A)               1
 
-2018/02/01
+2018/01/01
     (B)               1
 
 >>>=0


### PR DESCRIPTION
Closes #843 and #303.

I am opening this as a "work in progress" to make sure I am on the right path, and get some feedback (especially on style)

#### Questions

+ ~~All the functional tests pass, however it seems that the doctests are failing. The root cause is that the `Glob` and `filemanip` packages both export modules called `System.FilePath.Glob`, and doctest does not know how to deal with this. I am a Haskell noob, so I am unsure how to proceed.~~

+ ~~Do we care that this change may potentially break existing journal files? Notably journal files that have filenames that are also valid glob patterns. IMO this does not seem relevant, but I wanted to bring it up.~~

+ Currently we are setting/resetting the parser state inside `parseChild`. Should this be factored out to the call site instead?

+ We are updating the journal after reading each child. Should we instead create all the child journals in a list, and then make a single call like `put $ (fold childrenj) <> parentj`? I was unsure how much I should assume about what `newJournalWithParseStateFrom` does...

+ ~~When parsing should fail I have used the general `fail` from `Control.Monad.Except`, however I see that elsewhere in `JournalReader.hs` there are explicit calls to `parseErrorAt`. I decided to use `fail` because I just want the current position reported anyway, so I can avoid threading the parser position around, or calling `getPosition`.~~