### PR TITLE
cli: Fix compilation without LANG/LC_ALL set

### DIFF
--- a/hledger/Hledger/Cli/DocFiles.hs
+++ b/hledger/Hledger/Cli/DocFiles.hs
@@ -22,6 +22,8 @@ module Hledger.Cli.DocFiles (
 
 import Prelude ()
 import "base-compat-batteries" Prelude.Compat
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BC
 import Data.FileEmbed
 import Data.String
 import System.IO
@@ -32,82 +34,82 @@ import Hledger.Utils (first3, second3, third3)
 
 type Topic = String
 
-docFiles :: IsString a => [(Topic, (a, a, a))]
+docFiles :: [(Topic, (ByteString, ByteString, ByteString))]
 docFiles = [
    ("hledger",
-    ($(makeRelativeToProject "embeddedfiles/hledger.1" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger.1" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger.info" >>= embedFile)
     ))
   ,("hledger-ui",
-    ($(makeRelativeToProject "embeddedfiles/hledger-ui.1" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger-ui.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger-ui.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger-ui.1" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger-ui.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger-ui.info" >>= embedFile)
     ))
   ,("hledger-web",
-    ($(makeRelativeToProject "embeddedfiles/hledger-web.1" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger-web.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger-web.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger-web.1" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger-web.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger-web.info" >>= embedFile)
     ))
   ,("hledger-api",
-    ($(makeRelativeToProject "embeddedfiles/hledger-api.1" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger-api.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger-api.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger-api.1" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger-api.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger-api.info" >>= embedFile)
     ))
   ,("journal",
-    ($(makeRelativeToProject "embeddedfiles/hledger_journal.5" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_journal.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_journal.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger_journal.5" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_journal.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_journal.info" >>= embedFile)
     ))
   ,("csv",
-    ($(makeRelativeToProject "embeddedfiles/hledger_csv.5" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_csv.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_csv.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger_csv.5" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_csv.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_csv.info" >>= embedFile)
     ))
   ,("timeclock",
-    ($(makeRelativeToProject "embeddedfiles/hledger_timeclock.5" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_timeclock.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_timeclock.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger_timeclock.5" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_timeclock.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_timeclock.info" >>= embedFile)
     ))
   ,("timedot",
-    ($(makeRelativeToProject "embeddedfiles/hledger_timedot.5" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_timedot.txt" >>= embedStringFile)
-    ,$(makeRelativeToProject "embeddedfiles/hledger_timedot.info" >>= embedStringFile)
+    ($(makeRelativeToProject "embeddedfiles/hledger_timedot.5" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_timedot.txt" >>= embedFile)
+    ,$(makeRelativeToProject "embeddedfiles/hledger_timedot.info" >>= embedFile)
     ))
   ]
 
 docTopics :: [Topic]
 docTopics = map fst docFiles
 
-lookupDocTxt :: IsString a => Topic -> a
+lookupDocTxt :: Topic -> ByteString
 lookupDocTxt name =
   maybe (fromString $ "No text manual found for topic: "++name) second3 $ lookup name docFiles
 
-lookupDocNroff :: IsString a => Topic -> a
+lookupDocNroff :: Topic -> ByteString
 lookupDocNroff name =
   maybe (fromString $ "No man page found for topic: "++name) first3 $ lookup name docFiles
 
-lookupDocInfo :: IsString a => Topic -> a
+lookupDocInfo :: Topic -> ByteString
 lookupDocInfo name =
   maybe (fromString $ "No info manual found for topic: "++name) third3 $ lookup name docFiles
 
 printHelpForTopic :: Topic -> IO ()
 printHelpForTopic t =
-  putStrLn $ lookupDocTxt t
+  BC.putStr (lookupDocTxt t)
 
 runPagerForTopic :: FilePath -> Topic -> IO ()
 runPagerForTopic exe t = do
   (Just inp, _, _, ph) <- createProcess (proc exe []){
     std_in=CreatePipe
     }
-  hPutStrLn inp (lookupDocTxt t)
+  BC.hPutStrLn inp (lookupDocTxt t)
   _ <- waitForProcess ph
   return ()
 
 runManForTopic :: Topic -> IO ()
 runManForTopic t =
   withSystemTempFile ("hledger-"++t++".nroff") $ \f h -> do
-    hPutStrLn h $ lookupDocNroff t
+    BC.hPutStrLn h $ lookupDocNroff t
     hClose h
      -- the temp file path will presumably have a slash in it, so man should read it
     callCommand $ "man " ++ f
@@ -115,7 +117,7 @@ runManForTopic t =
 runInfoForTopic :: Topic -> IO ()
 runInfoForTopic t =
   withSystemTempFile ("hledger-"++t++".info") $ \f h -> do
-    hPutStrLn h $ lookupDocInfo t
+    BC.hPutStrLn h $ lookupDocInfo t
     hClose h
     callCommand $ "info " ++ f
 


### PR DESCRIPTION
Embedded files are now assumed to be UTF-8 independently of the system locale. This also replaces the file-embed dependency with `Hledger.Cli.TH`, where `embedStringFile` has been changed to assume UTF-8 (`utf8_bom`).

Compilation without a locale (e.g. in `nix-shell --pure` or `docker run -it fedora:28 bash` as @talex5 mentioned) now works without a problem.

~~I've also changed the `nix:` sections of `stack.yaml`s to use pure nix shells, and added the required dependencies of happy/alex - `stack build --nix` works for all build configs. (I'm on NixOS, so I can't actually develop without `--nix`, and compiling in a pure shell is also a nice bonus.)~~

Fixes #420, #813. ~~This is also a better solution to the closed #669.~~