### PR TITLE
cli: command to list included files

### DIFF
--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -278,6 +278,7 @@ standardAddonsHelp = [
   ,("vty", "start the curses-style interface")
   ,("web", "start the web interface")
   ,("accounts", "list account names")
+  ,("files", "list included files")
   ,("balance-csv", "output a balance report as CSV")
   ,("close", "show a transaction entry zeroing all accounts")
   ,("print-unique", "print only transactions with unique descriptions")

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -64,6 +64,7 @@ import Hledger.Cli.Commands.Cashflow
 import Hledger.Cli.Commands.Checkdates
 import Hledger.Cli.Commands.Checkdupes
 import Hledger.Cli.Commands.Close
+import Hledger.Cli.Commands.Files
 import Hledger.Cli.Commands.Help
 import Hledger.Cli.Commands.Import
 import Hledger.Cli.Commands.Incomestatement
@@ -93,6 +94,7 @@ builtinCommands = [
   ,(closemode              , close)
   ,(helpmode               , help')
   ,(importmode             , importcmd)
+  ,(filesmode              , files)
   ,(incomestatementmode    , incomestatement)
   ,(pricesmode             , prices)
   ,(printmode              , print')

--- a/hledger/Hledger/Cli/Commands/Files.hs
+++ b/hledger/Hledger/Cli/Commands/Files.hs
@@ -1,0 +1,48 @@
+{-|
+
+The @files@ command lists included files.
+
+-}
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hledger.Cli.Commands.Files (
+  filesmode
+ ,files
+) where
+
+import Data.List
+-- import Data.Text (Text)
+import Safe
+import System.Console.CmdArgs.Explicit as C
+
+import Hledger
+import Prelude hiding (putStrLn)
+import Hledger.Utils.UTF8IOCompat (putStrLn)
+import Hledger.Cli.CliOptions
+
+
+-- | Command line options for this command.
+filesmode = (defCommandMode $ ["files"] ) {
+  modeHelp = "show names of included files" 
+ ,modeHelpSuffix = [
+     "This command lists names of all files included in the parsed journal(s)." 
+    ,"With REGEX argument will list only files matching regular expression (case sensitive)."
+   ]
+ ,modeGroupFlags = C.Group {
+     groupUnnamed = []
+    ,groupHidden = []
+    ,groupNamed = [generalflagsgroup2]
+    }
+ ,modeArgs=  ([], Just $ argsFlag "[REGEX]")
+ }
+
+-- | The files command.
+files :: CliOpts -> Journal -> IO ()
+files CliOpts{rawopts_=rawopts} j = do
+  let args = listofstringopt "args" rawopts
+      regex = headMay args
+      files = (maybe id (filter . regexMatches) regex) 
+              $ map fst 
+              $ jfiles j
+  mapM_ putStrLn files

--- a/hledger/hledger_commands.m4.md
+++ b/hledger/hledger_commands.m4.md
@@ -368,6 +368,10 @@ or for closing out income/expenses for a period.
 This was formerly called "equity", as in Ledger, and that alias is also accepted.
 See close --help for more.   
 
+## files
+List all files included in the journal. With a REGEX argument,
+only file names matching the regular expression (case sensitive) are shown.
+
 ## help
 Show any of the hledger manuals.
 

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -140,6 +140,7 @@ library:
   - Hledger.Cli.Commands.Checkdupes
   - Hledger.Cli.Commands.Close
   - Hledger.Cli.Commands.Help
+  - Hledger.Cli.Commands.Files
   - Hledger.Cli.Commands.Import
   - Hledger.Cli.Commands.Incomestatement
   - Hledger.Cli.Commands.Prices


### PR DESCRIPTION
This adds "hledger includes" that will list all included files.

This is useful for auditing and automation (I plan to build some Shake rules around rebuilding included files from CSV's)