### PR TITLE
lib: fix balance --budget in the presence of --value

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -400,9 +400,7 @@ canonicaliseAmount styles a@Amount{acommodity=c, astyle=s} = a{astyle=s'}
 amountValue :: Journal -> Day -> Amount -> Amount
 amountValue j d a =
   case commodityValue j d (acommodity a) of
-    Just v  -> v{aquantity=aquantity v * aquantity a
-                ,aprice=aprice a
-                }
+    Just v  -> v{aquantity=aquantity v * aquantity a}
     Nothing -> a
 
 -- This is here not in Commodity.hs to use the Amount Show instance above for debugging. 

--- a/tests/budget/budget.test
+++ b/tests/budget/budget.test
@@ -316,3 +316,31 @@ Budget performance in 2018/01/01:
 
 # TODO
 # 15. respect --sort-amount
+
+# 16. respect --value
+<
+P 2018/01/26 SHARE €10
+
+2018/05/17 Dividend
+    revenue:dividend       €-10
+    assets:pension          €10
+
+2018/05/17 Buy
+    assets:pension:shares   1 SHARE @ €10
+    assets:pension          €-10
+
+~ monthly from 2018/06 to 2018/07
+    assets:pension                    €1
+    assets:bank
+
+$ hledger -f - bal -M --budget --cumulative --forecast --value
+Budget performance in 2018/05/01-2018/06/30:
+
+                ||                      May                       Jun 
+================++====================================================
+ <unbudgeted>   ||    €-10                      €-10                  
+ assets:bank    ||       0                       €-1 [ 100% of   €-1] 
+ assets:pension ||     €10                       €11 [1100% of    €1] 
+----------------++----------------------------------------------------
+                ||       0                         0 [             0] 
+


### PR DESCRIPTION
This fixes #862 

I thnk that `amountValue` should not transplant original price of the amount into the amount value, as this will incorrectly inflate amount further down the line whenever `amountValue` of `costOfAmount` is applied on the result.

Fix is verified using sample from #862 