### PR TITLE
WIP: Web: Prevent Adding Transactions with Invalid Date

### DIFF
--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -87,15 +87,12 @@ addForm j today = identifyForm "add" $ \extra -> do
       nulltransaction {tdate = date, tdescription = desc, tpostings = postings}
 
     dateFS = FieldSettings "date" Nothing Nothing (Just "date")
-      [("class", "form-control input-lg"), ("placeholder", "Date")]
+      [("class", "form-control input-lg")]
     descFS = FieldSettings "desc" Nothing Nothing (Just "description")
       [("class", "form-control input-lg typeahead"), ("placeholder", "Description"), ("size", "40")]
     acctFS = FieldSettings "amount" Nothing Nothing (Just "account") []
     amtFS = FieldSettings "amount" Nothing Nothing (Just "amount") []
-    dateField = checkMMap (pure . validateDate) (T.pack . show) textField
-    validateDate s =
-      first (const ("Invalid date format" :: Text)) $
-      fixSmartDateStrEither' today (T.strip s)
+    dateField = dayField
 
     listField = Field
       { fieldParse = const . pure . Right . Just . dropWhileEnd T.null


### PR DESCRIPTION
Fixes #433 

Works in Chrome, Firefox, Edge by preventing the user from entering invalid dates (will work until the year 9999 😄).

I also removed the serverside date validation code and let Yesod handle it instead.

If Safari should be supported, there's a somewhat lightweight polyfill available: https://www.npmjs.com/package/date-input-polyfill

<img width="917" alt="screen shot 2018-10-05 at 4 25 44 pm" src="https://user-images.githubusercontent.com/2773700/46564324-6bee0280-c8bb-11e8-8e0e-6156f98fdfac.png">

TODO:
- Add the Safari Polyfill.
- Remove the old date picker button.