### PR TITLE
Anonymize original postings

### DIFF
--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -106,6 +106,7 @@ anonymise j
       pAnons p = p { paccount = T.intercalate (T.pack ":") . map anon . T.splitOn (T.pack ":") . paccount $ p
                    , pcomment = T.empty
                    , ptransaction = fmap tAnons . ptransaction $ p
+                   , porigin = pAnons <$> porigin p
                    }
       tAnons txn = txn { tpostings = map pAnons . tpostings $ txn
                        , tdescription = anon . tdescription $ txn


### PR DESCRIPTION
I took another look at #878 and figured out that the reason why the balancesheet doesn’t just show zeros is that the original postings are present for inferred postings and are not anonymized. That causes the query to match for all postings with inferred amounts. By also anonymizing the original posting we now get zeros as expected and we avoid accidentally leaking information (the problem probably isn’t limited to balancesheet queries).