### PR TITLE
Make transaction modifiers work correctly with inferred amounts

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -22,6 +22,9 @@ module Hledger.Data.Journal (
   journalCommodityStyles,
   journalConvertAmountsToCost,
   journalFinalise,
+  journalReverse,
+  journalSetTime,
+  journalSetFilePath,
   journalPivot,
   -- * Filtering
   filterJournalTransactions,
@@ -518,6 +521,23 @@ filterJournalTransactionsByAccount apats j@Journal{jtxns=ts} = j{jtxns=filter tm
       (negatives,positives) = partition isnegativepat apats
 
 -}
+
+journalReverse :: Journal -> Journal
+journalReverse j =
+  j {jfiles            = reverse $ jfiles j
+    ,jdeclaredaccounts = reverse $ jdeclaredaccounts j
+    ,jtxns             = reverse $ jtxns j
+    ,jtxnmodifiers     = reverse $ jtxnmodifiers j
+    ,jperiodictxns     = reverse $ jperiodictxns j
+    ,jmarketprices     = reverse $ jmarketprices j
+    }
+
+journalSetTime :: ClockTime -> Journal -> Journal
+journalSetTime t j = j{ jlastreadtime = t }
+
+journalSetFilePath :: FilePath -> Text -> Journal -> Journal
+journalSetFilePath path txt j = j {jfiles = (path,txt) : jfiles j}
+
 
 -- | Do post-parse processing on a parsed journal to make it ready for
 -- use.  Reverse parsed data to normal order, standardise amount

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -264,7 +264,7 @@ parseAndFinaliseJournal parser iopts f txt = do
         -- the options for checking assertions.
         let runFin :: Bool -> Bool -> (ParsedJournal -> Either String Journal)
             runFin reorder ignore = journalFinalise t f txt reorder ignore
-            fj = if auto_ iopts
+            fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                  then applyTransactionModifiers <$>
                       runFin True False pj >>=
                       runFin False (not $ ignore_assertions_ iopts)
@@ -295,7 +295,7 @@ parseAndFinaliseJournal' parser iopts f txt = do
       -- options for checking assertions.
       let runFin :: Bool -> Bool -> (ParsedJournal -> Either String Journal)
           runFin reorder ignore = journalFinalise t f txt reorder ignore
-          fj = if auto_ iopts
+          fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                then applyTransactionModifiers <$>
                     runFin True False pj >>=
                     runFin False (not $ ignore_assertions_ iopts)

--- a/tests/budget/auto.test
+++ b/tests/budget/auto.test
@@ -91,3 +91,22 @@ hledger balance -f- --auto
                 $-38
 >>>2
 >>>=0
+
+hledger print -f- --auto
+<<<
+= ^expenses:groceries
+    [budget:groceries]                           *-1
+    [assets:bank:checking]                        *1
+
+2018/10/7 * MARKET
+    expenses:groceries:food
+    assets:bank:checking                         $-20
+>>>
+2018/10/07 * MARKET
+    expenses:groceries:food
+    [budget:groceries]                 $-20
+    [assets:bank:checking]              $20
+    assets:bank:checking               $-20
+
+>>>2
+>>>=0


### PR DESCRIPTION
This solves #893 by having `journalFinalise` run twice with automated transactions: the first run takes care of reordering and inferring amounts (but does not check assertions), the second does not reorder. It was necessary to make reordering a boolean flag in `journalFinalise`. Note that if `--auto` is not specified, the finalization is only run one time, as before.