### PR TITLE
multi-commodity assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ TAGS
 /[0-9]*
 #
 *.j
+*.sw[op]
 
 # haskell stuff
 *.dyn_hi
@@ -43,11 +44,13 @@ TAGS
 *.hi
 *.p_o
 *.hp
+.cabal-sandbox/
 cabal-dev*
 cabal.project.local
 cabal.sandbox.config
 dist/
 dist-newstyle/
+.ghc.environment.*
 /Shake
 /.shake.html
 .stack-work/

--- a/hledger-api/hledger-api.hs
+++ b/hledger-api/hledger-api.hs
@@ -170,6 +170,7 @@ instance ToJSON AmountStyle where toJSON = genericToJSON defaultOptions
 instance ToJSON Side where toJSON = genericToJSON defaultOptions
 instance ToJSON DigitGroupStyle where toJSON = genericToJSON defaultOptions
 instance ToJSON MixedAmount where toJSON = genericToJSON defaultOptions
+instance ToJSON BalanceAssertion where toJSON = genericToJSON defaultOptions
 instance ToJSON Price where toJSON = genericToJSON defaultOptions
 instance ToJSON MarketPrice where toJSON = genericToJSON defaultOptions
 instance ToJSON PostingType where toJSON = genericToJSON defaultOptions
@@ -213,6 +214,7 @@ instance ToSchema AmountStyle
 instance ToSchema Side
 instance ToSchema DigitGroupStyle
 instance ToSchema MixedAmount
+instance ToSchema BalanceAssertion
 instance ToSchema Price
 #if MIN_VERSION_swagger2(2,1,5)
   where declareNamedSchema = genericDeclareNamedSchemaUnrestricted defaultSchemaOptions

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -105,6 +105,7 @@ nullsourcepos = JournalSourcePos "" (1,1)
 nullassertion, assertion :: BalanceAssertion
 nullassertion = BalanceAssertion
                   {baamount=nullamt
+                  ,baexact=False
                   ,baposition=nullsourcepos
                   }
 assertion = nullassertion

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -15,6 +15,9 @@ module Hledger.Data.Posting (
   nullposting,
   posting,
   post,
+  nullsourcepos,
+  nullassertion,
+  assertion,
   -- * operations
   originalPosting,
   postingStatus,
@@ -95,6 +98,16 @@ posting = nullposting
 
 post :: AccountName -> Amount -> Posting
 post acct amt = posting {paccount=acct, pamount=Mixed [amt]}
+
+nullsourcepos :: GenericSourcePos
+nullsourcepos = JournalSourcePos "" (1,1)
+
+nullassertion, assertion :: BalanceAssertion
+nullassertion = BalanceAssertion
+                  {baamount=nullamt
+                  ,baposition=nullsourcepos
+                  }
+assertion = nullassertion
 
 -- Get the original posting, if any.
 originalPosting :: Posting -> Posting

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -12,7 +12,6 @@ tags.
 
 module Hledger.Data.Transaction (
   -- * Transaction
-  nullsourcepos,
   nulltransaction,
   txnTieKnot,
   txnUntieKnot,
@@ -76,9 +75,6 @@ showGenericSourcePos :: GenericSourcePos -> String
 showGenericSourcePos = \case
     GenericSourcePos fp line column -> show fp ++ " (line " ++ show line ++ ", column " ++ show column ++ ")"
     JournalSourcePos fp (line, line') -> show fp ++ " (lines " ++ show line ++ "-" ++ show line' ++ ")"
-
-nullsourcepos :: GenericSourcePos
-nullsourcepos = JournalSourcePos "" (1,1)
 
 nulltransaction :: Transaction
 nulltransaction = Transaction {
@@ -170,7 +166,7 @@ postingAsLines elideamount onelineamounts ps p = concat [
     | postingblock <- postingblocks]
   where
     postingblocks = [map rstrip $ lines $ concatTopPadded [statusandaccount, "  ", amount, assertion, samelinecomment] | amount <- shownAmounts]
-    assertion = maybe "" ((" = " ++) . showAmountWithZeroCommodity . fst) $ pbalanceassertion p
+    assertion = maybe "" ((" = " ++) . showAmountWithZeroCommodity . baamount) $ pbalanceassertion p
     statusandaccount = indent $ fitString (Just $ minwidth) Nothing False True $ pstatusandacct p
         where
           -- pad to the maximum account name width, plus 2 to leave room for status flags, to keep amounts aligned  
@@ -543,10 +539,8 @@ tests_Transaction = tests "Transaction" [
           ,"    assets:checking"
           ,""
           ]
-    ]
 
-  ,tests "showTransaction" [
-     test "show a balanced transaction, no eliding" $
+    ,test "show a balanced transaction, no eliding" $
        (let t = Transaction 0 nullsourcepos (parsedate "2007/01/28") Nothing Unmarked "" "coopportunity" "" []
                 [posting{paccount="expenses:food:groceries", pamount=Mixed [usd 47.18], ptransaction=Just t}
                 ,posting{paccount="assets:checking", pamount=Mixed [usd (-47.18)], ptransaction=Just t}

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -236,8 +236,11 @@ instance Show Status where -- custom show.. bad idea.. don't do it..
   show Pending   = "!"
   show Cleared   = "*"
 
+-- | The amount to compare an account's balance to, to verify that the history
+-- leading to a given point is correct or to set the account to a known value.
 data BalanceAssertion = BalanceAssertion {
-      baamount   :: Amount,
+      baamount   :: Amount,             -- ^ the expected value of a particular commodity
+      baexact    :: Bool,               -- ^ whether the assertion is exclusive, and doesn't allow other commodities alongside 'baamount'
       baposition :: GenericSourcePos
     } deriving (Eq,Typeable,Data,Generic,Show)
 

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -236,21 +236,26 @@ instance Show Status where -- custom show.. bad idea.. don't do it..
   show Pending   = "!"
   show Cleared   = "*"
 
-type BalanceAssertion = Maybe (Amount, GenericSourcePos)
+data BalanceAssertion = BalanceAssertion {
+      baamount   :: Amount,
+      baposition :: GenericSourcePos
+    } deriving (Eq,Typeable,Data,Generic,Show)
+
+instance NFData BalanceAssertion
 
 data Posting = Posting {
-      pdate             :: Maybe Day,         -- ^ this posting's date, if different from the transaction's
-      pdate2            :: Maybe Day,         -- ^ this posting's secondary date, if different from the transaction's
+      pdate             :: Maybe Day,               -- ^ this posting's date, if different from the transaction's
+      pdate2            :: Maybe Day,               -- ^ this posting's secondary date, if different from the transaction's
       pstatus           :: Status,
       paccount          :: AccountName,
       pamount           :: MixedAmount,
-      pcomment          :: Text,              -- ^ this posting's comment lines, as a single non-indented multi-line string
+      pcomment          :: Text,                    -- ^ this posting's comment lines, as a single non-indented multi-line string
       ptype             :: PostingType,
-      ptags             :: [Tag],             -- ^ tag names and values, extracted from the comment
-      pbalanceassertion :: BalanceAssertion,  -- ^ optional: the expected balance in this commodity in the account after this posting
-      ptransaction      :: Maybe Transaction, -- ^ this posting's parent transaction (co-recursive types).
-                                              -- Tying this knot gets tedious, Maybe makes it easier/optional.
-      porigin           :: Maybe Posting      -- ^ original posting if this one is result of any transformations (one level only)
+      ptags             :: [Tag],                   -- ^ tag names and values, extracted from the comment
+      pbalanceassertion :: Maybe BalanceAssertion,  -- ^ optional: the expected balance in this commodity in the account after this posting
+      ptransaction      :: Maybe Transaction,       -- ^ this posting's parent transaction (co-recursive types).
+                                                    -- Tying this knot gets tedious, Maybe makes it easier/optional.
+      porigin           :: Maybe Posting            -- ^ original posting if this one is result of any transformations (one level only)
     } deriving (Typeable,Data,Generic)
 
 instance NFData Posting

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -721,10 +721,12 @@ balanceassertionp :: JournalParser m BalanceAssertion
 balanceassertionp = do
   sourcepos <- genericSourcePos <$> lift getSourcePos
   char '='
+  exact <- optional $ try $ char '='
   lift (skipMany spacenonewline)
   a <- amountp <?> "amount (for a balance assertion or assignment)" -- XXX should restrict to a simple amount
   return BalanceAssertion
     { baamount = a
+    , baexact = isJust exact
     , baposition = sourcepos
     }
 

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -74,7 +74,7 @@ module Hledger.Read.Common (
   mamountp',
   commoditysymbolp,
   priceamountp,
-  partialbalanceassertionp,
+  balanceassertionp,
   fixedlotpricep,
   numberp,
   fromRawNumber,
@@ -717,23 +717,16 @@ priceamountp = option NoPrice $ do
 
   pure $ priceConstructor priceAmount
 
-partialbalanceassertionp :: JournalParser m BalanceAssertion
-partialbalanceassertionp = optional $ do
+balanceassertionp :: JournalParser m BalanceAssertion
+balanceassertionp = do
   sourcepos <- genericSourcePos <$> lift getSourcePos
   char '='
   lift (skipMany spacenonewline)
   a <- amountp <?> "amount (for a balance assertion or assignment)" -- XXX should restrict to a simple amount
-  return (a, sourcepos)
-
--- balanceassertion :: Monad m => TextParser m (Maybe MixedAmount)
--- balanceassertion =
---     try (do
---           lift (skipMany spacenonewline)
---           string "=="
---           lift (skipMany spacenonewline)
---           a <- amountp -- XXX should restrict to a simple amount
---           return $ Just $ Mixed [a])
---          <|> return Nothing
+  return BalanceAssertion
+    { baamount = a
+    , baposition = sourcepos
+    }
 
 -- http://ledger-cli.org/3.0/doc/ledger3.html#Fixing-Lot-Prices
 fixedlotpricep :: JournalParser m (Maybe Amount)

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -719,11 +719,8 @@ priceamountp = option NoPrice $ do
 
 partialbalanceassertionp :: JournalParser m BalanceAssertion
 partialbalanceassertionp = optional $ do
-  sourcepos <- try $ do
-    lift (skipMany spacenonewline)
-    sourcepos <- genericSourcePos <$> lift getSourcePos
-    char '='
-    pure sourcepos
+  sourcepos <- genericSourcePos <$> lift getSourcePos
+  char '='
   lift (skipMany spacenonewline)
   a <- amountp <?> "amount (for a balance assertion or assignment)" -- XXX should restrict to a simple amount
   return (a, sourcepos)

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -752,7 +752,7 @@ transactionFromCsvRecord sourcepos rules record = t
         ,posting {paccount=account2, pamount=amount2, ptransaction=Just t}
         ]
       }
-    toAssertion (a, b) = BalanceAssertion{
+    toAssertion (a, b) = assertion{
       baamount   = a,
       baposition = b
       }

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -748,9 +748,13 @@ transactionFromCsvRecord sourcepos rules record = t
       tcomment                 = T.pack comment,
       tpreceding_comment_lines = T.pack precomment,
       tpostings                =
-        [posting {paccount=account1, pamount=amount1, ptransaction=Just t, pbalanceassertion=balance}
+        [posting {paccount=account1, pamount=amount1, ptransaction=Just t, pbalanceassertion=toAssertion <$> balance}
         ,posting {paccount=account2, pamount=amount2, ptransaction=Just t}
         ]
+      }
+    toAssertion (a, b) = BalanceAssertion{
+      baamount   = a,
+      baposition = b
       }
 
 getAmountStr :: CsvRules -> CsvRecord -> Maybe String

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -590,7 +590,7 @@ postingp mTransactionYear = do
   lift (skipMany spacenonewline)
   amount <- option missingmixedamt $ Mixed . (:[]) <$> amountp
   lift (skipMany spacenonewline)
-  massertion <- partialbalanceassertionp
+  massertion <- optional $ balanceassertionp
   _ <- fixedlotpricep
   lift (skipMany spacenonewline)
   (comment,tags,mdate,mdate2) <- lift $ postingcommentp mTransactionYear

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -589,6 +589,7 @@ postingp mTransactionYear = do
   let (ptype, account') = (accountNamePostingType account, textUnbracket account)
   lift (skipMany spacenonewline)
   amount <- option missingmixedamt $ Mixed . (:[]) <$> amountp
+  lift (skipMany spacenonewline)
   massertion <- partialbalanceassertionp
   _ <- fixedlotpricep
   lift (skipMany spacenonewline)

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -730,6 +730,8 @@ tests_JournalReader = tests "JournalReader" [
     ,test "quoted commodity symbol with digits" $ expectParse (postingp Nothing) "  a  1 \"DE123\"\n"
 
     ,test "balance assertion and fixed lot price" $ expectParse (postingp Nothing) "  a  1 \"DE123\" =$1 { =2.2 EUR} \n"
+
+    ,test "balance assertion over entire contents of account" $ expectParse (postingp Nothing) "  a  $1 == $1\n"
     ]
 
   ,tests "transactionmodifierp" [

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -85,7 +85,7 @@ close CliOpts{rawopts_=rawopts, reportopts_=ropts} j = do
       balancingamt = negate $ sum $ map (\(_,_,_,b) -> normaliseMixedAmountSquashPricesForDisplay b) acctbals
       ps = [posting{paccount=a
                    ,pamount=mixed [b]
-                   ,pbalanceassertion=Just (b,nullsourcepos)
+                   ,pbalanceassertion=Just assertion{ baamount=b }
                    }
            |(a,_,_,mb) <- acctbals
            ,b <- amounts $ normaliseMixedAmountSquashPricesForDisplay mb
@@ -93,7 +93,7 @@ close CliOpts{rawopts_=rawopts, reportopts_=ropts} j = do
            ++ [posting{paccount="equity:opening balances", pamount=balancingamt}]
       nps = [posting{paccount=a
                     ,pamount=mixed [negate b]
-                    ,pbalanceassertion=Just (b{aquantity=0}, nullsourcepos)
+                    ,pbalanceassertion=Just assertion{ baamount=b{aquantity=0} }
                     }
             |(a,_,_,mb) <- acctbals
             ,b <- amounts $ normaliseMixedAmountSquashPricesForDisplay mb

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -143,7 +143,7 @@ library
     , safe >=0.2
     , shakespeare >=2.0.2.2
     , split >=0.1
-    , statistics
+    , statistics <0.15
     , tabular >=0.2
     , temporary
     , text >=0.11
@@ -194,7 +194,7 @@ executable hledger
     , safe >=0.2
     , shakespeare >=2.0.2.2
     , split >=0.1
-    , statistics
+    , statistics <0.15
     , tabular >=0.2
     , temporary
     , text >=0.11
@@ -248,7 +248,7 @@ test-suite test
     , safe >=0.2
     , shakespeare >=2.0.2.2
     , split >=0.1
-    , statistics
+    , statistics <0.15
     , tabular >=0.2
     , temporary
     , test-framework
@@ -303,7 +303,7 @@ benchmark bench
     , safe >=0.2
     , shakespeare >=2.0.2.2
     , split >=0.1
-    , statistics
+    , statistics <0.15
     , tabular >=0.2
     , temporary
     , text >=0.11

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -104,7 +104,7 @@ dependencies:
 - safe >=0.2
 - shakespeare >=2.0.2.2
 - split >=0.1
-- statistics
+- statistics <=0.15
 - tabular >=0.2
 - temporary
 - text >=0.11

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -8,6 +8,7 @@ hledger is brought to you by:
 -   Roman Cheplyaka - "chart" command, "add" command improvements
 -   Michael Snoyman - some additions to the Yesod web interface
 -   Marko Kocić - hlint cleanup
+-   Samuel May - exact assertions
 
 Developers who have not yet signed the contributor agreement:
 

--- a/site/doc/1.11/journal.md
+++ b/site/doc/1.11/journal.md
@@ -446,6 +446,8 @@ Balance assertions don't work well across files specified with multiple
 -f options. Use include or [concatenate the
 files](/hledger.html#input-files) instead.
 
+<a name="exact-assertions"></a>
+
 #### Assertions and commodities
 
 The asserted balance must be a simple single-commodity amount, and in
@@ -549,7 +551,7 @@ or when adjusting a balance to reality:
 ``` {.journal}
 ; no cash left; update balance, record any untracked spending as a generic expense
 2016/1/15
-  assets:cash    = $0
+  assets:cash   == $0
   expenses:misc
 ```
 
@@ -559,6 +561,12 @@ commodity to that account since the last balance assertion or
 assignment). Note that using balance assignments makes your journal a
 little less explicit; to know the exact amount posted, you have to run
 hledger or do the calculations yourself, instead of just reading it.
+
+Note that, just as with [exact balance assertions](#exact-assertions),
+an assignment may be performed over all commodities by using a doubled
+equals sign; any unlisted commodities are set to 0. In other words, the
+second example above not only says that no dollars remain in pocket, but
+also no Euros, no rupees, etc.
 
 ### Transaction prices
 

--- a/site/doc/1.11/journal.md
+++ b/site/doc/1.11/journal.md
@@ -452,13 +452,49 @@ The asserted balance must be a simple single-commodity amount, and in
 fact the assertion checks only this commodity's balance within the
 (possibly multi-commodity) account balance. We could call this a partial
 balance assertion. This is compatible with Ledger, and makes it possible
-to make assertions about accounts containing multiple commodities.
+to make assertions about accounts containing multiple commodities. To
+assert the balance of more than a single commodity, you can add multiple
+postings (with amount 0 if necessary).
 
-To assert each commodity's balance in such a multi-commodity account,
-you can add multiple postings (with amount 0 if necessary). But note
-that no matter how many assertions you add, you can't be sure the
-account does not contain some unexpected commodity. (We'll add support
-for this kind of total balance assertion if there's demand.)
+To instead assert a commodity's balance to the exclusion of all others
+in an account, use the exact assertion form `==EXPECTEDBALANCE` (note
+the doubled equals sign). This, unlike multiple partial assertions,
+ensures that the account contains no unexpected commodities -- or
+equivalently, that the balance of any other commodity is 0.
+
+``` {.journal}
+2013/1/1
+  a   $1
+  a    1€
+  b  $-1
+  c   -1€
+
+2013/1/2  ; These assertions succeed
+  a    0  =  $1
+  a    0  =   1€
+  b    0 == $-1
+  c    0 ==  -1€
+
+2013/1/3  ; This assertion fails as 'a' also contains 1€
+  a    0 ==  $1
+```
+
+Unfortunately, as of now, there is no way to specify that an account
+contains exactly values of multiple commodities. Until and unless that
+capability is added, the best workaround is to isolate each commodity
+into individual subaccounts:
+
+``` {.journal}
+2013/1/1
+  a:usd   $1
+  a:euro   1€
+  b
+
+2013/1/2
+  a        0 ==  0
+  a:usd    0 == $1
+  a:euro   0 ==  1€
+```
 
 #### Assertions and subaccounts
 

--- a/tests/journal/balance-assertions.test
+++ b/tests/journal/balance-assertions.test
@@ -308,3 +308,51 @@ hledger -f - stats
 >>> /Transactions/
 >>>2
 >>>=0
+
+# 17. Exact assertions parse correctly
+hledger -f - stats
+<<<
+2016/1/1
+    a      $1
+    b
+
+2016/1/2
+    a         == $1
+>>> /Transactions/
+>>>2
+>>>=0
+
+# 18. Exact assertions consider entire account
+hledger -f - stats
+<<<
+2016/1/1
+    a      $1
+    b
+
+2016/1/2
+    a       1 zorkmids
+    b
+
+2016/1/3
+    a       0 == $1
+>>>2 /balance assertion error.*line 10, column 15/
+>>>=1
+
+# 19. Mix different commodities and exact assignments
+hledger -f - stats
+<<<
+2016/1/1
+    a      $1
+    a      -1 zorkmids
+    b
+
+2016/1/2
+    a         == $1
+    b      -1 zorkmids
+
+2016/1/3
+    b       0 = $-1
+    b       0 = 0 zorkmids
+>>> /Transactions/
+>>>2
+>>>=0


### PR DESCRIPTION
More focused PR derived from #871, containing only the changes required to allow assertions over the entire contents of an account.  Written primarily as groundwork and proof-of-concept for #556.