### PR TITLE
Finish removing journalFinalise

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -22,8 +22,7 @@ module Hledger.Data.Journal (
   journalCommodityStyles,
   journalConvertAmountsToCost,
   journalReverse,
-  journalSetTime,
-  journalSetFilePath,
+  journalSetLastReadTime,
   journalPivot,
   -- * Filtering
   filterJournalTransactions,
@@ -534,13 +533,10 @@ journalReverse j =
     ,jmarketprices     = reverse $ jmarketprices j
     }
 
--- | Set clock time in journal
-journalSetTime :: ClockTime -> Journal -> Journal
-journalSetTime t j = j{ jlastreadtime = t }
+-- | Set this journal's last read time, ie when its files were last read.
+journalSetLastReadTime :: ClockTime -> Journal -> Journal
+journalSetLastReadTime t j = j{ jlastreadtime = t }
 
--- | See filepath in journal
-journalSetFilePath :: FilePath -> Text -> Journal -> Journal
-journalSetFilePath path txt j = j {jfiles = (path,txt) : jfiles j}
 
 journalNumberAndTieTransactions = journalTieTransactions . journalNumberTransactions
 

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -262,13 +262,21 @@ parseAndFinaliseJournal parser iopts f txt = do
         -- be false pending modifiers) and we don't reorder the second
         -- time. If we are only running once, we reorder and follow
         -- the options for checking assertions.
-        let runFin :: Bool -> Bool -> (ParsedJournal -> Either String Journal)
-            runFin reorder ignore = journalFinalise t f txt reorder ignore
-            fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
+        let fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                  then applyTransactionModifiers <$>
-                      runFin True False pj >>=
-                      runFin False (not $ ignore_assertions_ iopts)
-                 else runFin True (not $ ignore_assertions_ iopts) pj
+                      (journalBalanceTransactions False $
+                       journalReverse $
+                       journalApplyCommodityStyles pj) >>=
+                      (\j -> journalBalanceTransactions (not $ ignore_assertions_ iopts) $
+                             journalSetTime t $
+                             journalSetFilePath f txt $
+                             j)
+                 else journalBalanceTransactions (not $ ignore_assertions_ iopts) $
+                      journalReverse $
+                      journalApplyCommodityStyles $
+                      journalSetTime t $
+                      journalSetFilePath f txt $
+                      pj
         in
           case fj of
             Right j -> return j

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -265,17 +265,17 @@ parseAndFinaliseJournal parser iopts f txt = do
         let fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                  then applyTransactionModifiers <$>
                       (journalBalanceTransactions False $
+                       journalSetFilePath f txt $
                        journalReverse $
                        journalApplyCommodityStyles pj) >>=
                       (\j -> journalBalanceTransactions (not $ ignore_assertions_ iopts) $
                              journalSetTime t $
-                             journalSetFilePath f txt $
                              j)
                  else journalBalanceTransactions (not $ ignore_assertions_ iopts) $
+                      journalSetFilePath f txt $
                       journalReverse $
                       journalApplyCommodityStyles $
                       journalSetTime t $
-                      journalSetFilePath f txt $
                       pj
         in
           case fj of
@@ -304,17 +304,17 @@ parseAndFinaliseJournal' parser iopts f txt = do
       let fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                then applyTransactionModifiers <$>
                     (journalBalanceTransactions False $
+                      journalSetFilePath f txt $
                      journalReverse $
                      journalApplyCommodityStyles pj) >>=
                     (\j -> journalBalanceTransactions (not $ ignore_assertions_ iopts) $
                            journalSetTime t $
-                           journalSetFilePath f txt $
                            j)
                else journalBalanceTransactions (not $ ignore_assertions_ iopts) $
+                    journalSetFilePath f txt $
                     journalReverse $
                     journalApplyCommodityStyles $
                     journalSetTime t $
-                    journalSetFilePath f txt $
                     pj
       in
         case fj of

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -265,17 +265,17 @@ parseAndFinaliseJournal parser iopts f txt = do
         let fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                  then applyTransactionModifiers <$>
                       (journalBalanceTransactions False $
-                       journalSetFilePath f txt $
                        journalReverse $
                        journalApplyCommodityStyles pj) >>=
                       (\j -> journalBalanceTransactions (not $ ignore_assertions_ iopts) $
-                             journalSetTime t $
+                             journalAddFile (f, txt) $
+                             journalSetLastReadTime t $
                              j)
                  else journalBalanceTransactions (not $ ignore_assertions_ iopts) $
-                      journalSetFilePath f txt $
                       journalReverse $
+                      journalAddFile (f, txt) $
                       journalApplyCommodityStyles $
-                      journalSetTime t $
+                      journalSetLastReadTime t $
                       pj
         in
           case fj of
@@ -304,17 +304,17 @@ parseAndFinaliseJournal' parser iopts f txt = do
       let fj = if auto_ iopts && (not . null . jtxnmodifiers) pj
                then applyTransactionModifiers <$>
                     (journalBalanceTransactions False $
-                      journalSetFilePath f txt $
                      journalReverse $
                      journalApplyCommodityStyles pj) >>=
                     (\j -> journalBalanceTransactions (not $ ignore_assertions_ iopts) $
-                           journalSetTime t $
+                           journalAddFile (f, txt) $
+                           journalSetLastReadTime t $
                            j)
                else journalBalanceTransactions (not $ ignore_assertions_ iopts) $
-                    journalSetFilePath f txt $
                     journalReverse $
+                    journalAddFile (f, txt) $
                     journalApplyCommodityStyles $
-                    journalSetTime t $
+                    journalSetLastReadTime t $
                     pj
       in
         case fj of


### PR DESCRIPTION
This finishes removing `journalFinalise`, and adds a fix in the order of operations.

[Followon from [#893](https://github.com/simonmichael/hledger/pull/893), [#900](https://github.com/simonmichael/hledger/pull/900)]