### PR TITLE
Don't allow assignments for accounts in transaction modifiers.

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -97,6 +97,7 @@ import Data.Tree
 import System.Time (ClockTime(TOD))
 import Text.Printf
 import qualified Data.Map as M
+import qualified Data.Set as S
 
 import Hledger.Utils 
 import Hledger.Data.Types
@@ -630,6 +631,7 @@ journalBalanceTransactionsST assrt j createStore storeIn extract =
                   (storeIn txStore) 
                   assrt
                   (Just $ journalCommodityStyles j)
+                  S.empty
     flip R.runReaderT env $ do
       dated <- fmap snd . sortBy (comparing fst) . concat
                 <$> mapM' discriminateByDate (jtxns j)
@@ -644,10 +646,11 @@ journalBalanceTransactionsST assrt j createStore storeIn extract =
 type CurrentBalancesModifier s = R.ReaderT (Env s) (ExceptT String (ST s))
 
 -- | Environment for 'CurrentBalancesModifier'
-data Env s = Env { eBalances :: HT.HashTable s AccountName MixedAmount
-                 , eStoreTx  :: Transaction -> ST s ()
-                 , eAssrt    :: Bool
-                 , eStyles   :: Maybe (M.Map CommoditySymbol AmountStyle) 
+data Env s = Env { eBalances     :: HT.HashTable s AccountName MixedAmount
+                 , eStoreTx      :: Transaction -> ST s ()
+                 , eAssrt        :: Bool
+                 , eStyles       :: Maybe (M.Map CommoditySymbol AmountStyle)
+                 , eUnassignable :: S.Set AccountName
                  }
 
 -- | This converts a transaction into a list of transactions or

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -694,7 +694,13 @@ checkUnassignablePosting :: Posting -> CurrentBalancesModifier s ()
 checkUnassignablePosting p = do
   unassignable <- R.asks eUnassignable
   if (isAssignment p && paccount p `S.member` unassignable)
-    then throwError $ "Can't assign to account: " ++ (T.unpack $ paccount p)
+    then throwError $ unlines $
+         [ "cannot assign amount to account "
+         , ""
+         , "    " ++ (T.unpack $ paccount p)
+         , ""
+         , "because it is also included in transaction modifiers."
+         ]
     else return ()
 
 

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -631,7 +631,7 @@ journalBalanceTransactionsST assrt j createStore storeIn extract =
                   (storeIn txStore) 
                   assrt
                   (Just $ journalCommodityStyles j)
-                  S.empty
+                  (getModifierAccountNames j)
     flip R.runReaderT env $ do
       dated <- fmap snd . sortBy (comparing fst) . concat
                 <$> mapM' discriminateByDate (jtxns j)
@@ -639,6 +639,14 @@ journalBalanceTransactionsST assrt j createStore storeIn extract =
     lift $ extract txStore
     where 
       size = genericLength $ journalPostings j
+
+
+-- | Collect account names in account modifiers into a set
+getModifierAccountNames :: Journal -> S.Set AccountName
+getModifierAccountNames j = S.fromList $
+                            map paccount $
+                            concatMap tmpostings $
+                            jtxnmodifiers j
 
 -- | Monad transformer stack with a reference to a mutable hashtable
 -- of current account balances and a mutable array of finished

--- a/tests/budget/auto.test
+++ b/tests/budget/auto.test
@@ -110,3 +110,65 @@ hledger print -f- --auto
 
 >>>2
 >>>=0
+
+hledger print -f- --auto
+<<<
+= ^expenses:foo
+    budget:available   *-1
+    assets:checking     *1
+
+2018/10/17 * INITIAL
+    budget:available   $100
+    equity:opening
+
+2018/10/17 * SOME EXPENSE
+    expenses:foo                                 $50
+    assets:checking
+
+2018/10/17 * ASSERT
+    budget:other
+    budget:available                              =$0
+>>>
+>>>2
+hledger: cannot assign amount to account 
+
+    budget:available
+
+because it is also included in transaction modifiers.
+
+>>>=1
+
+hledger print -f- --auto
+<<<
+= ^expenses:foo
+    budget:available   *-1
+    assets:checking     *1
+
+2018/10/17 * INITIAL
+    budget:available   $100
+    equity:opening
+
+2018/10/17 * SOME EXPENSE
+    expenses:foo                                 $50
+    assets:checking
+
+2018/10/17 * ASSERT
+    budget:other
+    budget:available                            $-50=$0
+>>>
+2018/10/17 * INITIAL
+    budget:available            $100
+    equity:opening
+
+2018/10/17 * SOME EXPENSE
+    expenses:foo                 $50
+    budget:available            $-50
+    assets:checking              $50
+    assets:checking
+
+2018/10/17 * ASSERT
+    budget:other
+    budget:available            $-50 = $0
+
+>>>2
+>>>=0


### PR DESCRIPTION
As discussed in comments for #908, this throws an error if there is an attempt to assign to an account that is also present in a transaction modifier.

Note that this currently works whether or not `--auto` is set, so that it doesn't produce a regression in rewrites (which also use the `jtxnmodifier` list).