### PR TITLE
Drop undecidable Ord instance for ParseError.

### DIFF
--- a/hledger-lib/Text/Megaparsec/Custom.hs
+++ b/hledger-lib/Text/Megaparsec/Custom.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Text.Megaparsec.Custom (
   -- * Custom parse error type
@@ -66,8 +65,6 @@ data CustomErr
 -- stored in a 'Set'. The actual instance is inconsequential, so we just
 -- derive it, but this requires an (orphan) instance for 'ParseError'.
 -- Hopefully this does not cause any trouble.
-
-deriving instance (Eq (Token c), Ord (Token c), Ord c, Ord e) => Ord (ParseError c e)
 
 instance ShowErrorComponent CustomErr where
   showErrorComponent (ErrorFailAt _ _ errMsg) = errMsg


### PR DESCRIPTION
That code fails to compile with ghc-8.6.1 because the instance is undecidable.
I suppose we could enable the appropriate compiler extension to support it, but
I've found that simply removing the instance causes no problems whatsoever: the
entire repository still compiles fine and it passes all test suites, too.