### PR TITLE
disregard over-specified version constraints in brick and config-ini

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,7 @@ packages: hledger-lib
           hledger-ui
           hledger-web
           hledger-api
+
+allow-newer:
+  brick:base
+  config-ini:containers


### PR DESCRIPTION
These packages work fine with the latest version of their dependencies.
They just don't say so on Hackage.