### PR TITLE
Fix incorrectly indented code blocks in web manuals

### DIFF
--- a/site/site.tmpl
+++ b/site/site.tmpl
@@ -59,7 +59,7 @@
       <div class="row">
         <div class="col-md-1"></div>
         <div class="col-md-10">
-        $body$
+$body$
         </div>
       </div>
 


### PR DESCRIPTION
Fixes incorrectly indented code block issue (#816) by removing all indentation from `body`.

This does also make the generated HTML uglier.
