### PR TITLE
Add a custom parse error for "re-parsing"

### DIFF
--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -533,17 +533,14 @@ periodictransactionp = do
     Nothing -> pure ()
   -- The line can end here, or it can continue with one or more spaces
   -- and then zero or more of the following fields. A bit awkward.
-  (status, code, description, (comment, tags)) <-
-    (lift eolof >> return (Unmarked, "", "", ("", [])))
-    <|>
-    (do
-      lift $ skipSome spacenonewline 
-      s         <- lift statusp
-      c         <- lift codep
-      desc      <- lift $ T.strip <$> descriptionp
-      (cmt, ts) <- lift transactioncommentp
+  (status, code, description, (comment, tags)) <- lift $
+    (<|>) (eolof >> return (Unmarked, "", "", ("", []))) $ do
+      skipSome spacenonewline
+      s         <- statusp
+      c         <- codep
+      desc      <- T.strip <$> descriptionp
+      (cmt, ts) <- transactioncommentp
       return (s,c,desc,(cmt,ts))
-    )
 
   -- next lines; use same year determined above
   postings <- postingsp (Just $ first3 $ toGregorian refdate)

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -1066,14 +1066,18 @@ Partial or relative dates (M/D, D, tomorrow, last week) in the period expression
 can work (useful or not). They will be relative to today's date, unless 
 a Y default year directive is in effect, in which case they will be relative to Y/1/1.
 
-If you write a transaction description or same-line comment, 
-it must be separated from the period expression by **two or more spaces**. Eg:
+Period expressions must be terminated by **two or more spaces** if
+followed by additional fields. For example, the periodic transaction given
+below includes a transaction description "paycheck", which is separated
+from the period expression by a double space. If not for the second space,
+hledger would attempt (and fail) to parse "paycheck" as a part of the
+period expression.
 
 ```
-;                              2 or more spaces
-;                                    ||
-;                                    vv
-~ every 2 weeks from 2018/6 to 2018/9  paycheck
+;                                2 or more spaces
+;                                      ||
+;                                      vv
+~ every 2 weeks from 2018/6/4 to 2018/9  paycheck
     assets:bank:checking   $1500
     income:acme inc
 ```

--- a/tests/budget/forecast.test
+++ b/tests/budget/forecast.test
@@ -111,7 +111,7 @@ hledger -f - print --forecast desc:forecast
 <<<
 Y 2000
 
-~ 2/1 forecast
+~ 2/1  forecast
 
 ; a real transaction to set the start of the forecast window
 2000/1/1 real
@@ -128,7 +128,7 @@ hledger -f - print --forecast desc:forecast
 <<<
 Y 2000
 
-~ 15 forecast
+~ 15  forecast
 
 ; a real transaction to set the start of the forecast window
 2000/1/1 real
@@ -145,7 +145,7 @@ hledger -f - print --forecast desc:forecast
 <<<
 Y 2000
 
-~ next month forecast
+~ next month  forecast
 
 ; a real transaction to set the start of the forecast window
 2000/1/1 real


### PR DESCRIPTION
This PR re-implements a subset of PR #823 on top of the current codebase, specifically for addressing issues raised in PR #807.

In particular, the failing examples in https://github.com/simonmichael/hledger/pull/807#issuecomment-396994403 now work properly.