### PR TITLE
Amount expressions, multi-commodity postings

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -166,7 +166,7 @@ instance Num Amount where
 
 -- | The empty simple amount.
 amount, nullamt :: Amount
-amount = Amount{acommodity="", aquantity=0, aprice=NoPrice, astyle=amountstyle, amultiplier=False}
+amount = Amount{acommodity="", aquantity=0, aprice=NoPrice, astyle=amountstyle}
 nullamt = amount
 
 -- | A temporary value for parsed transactions which had no amount specified.

--- a/hledger-lib/Hledger/Data/Commodity.hs
+++ b/hledger-lib/Hledger/Data/Commodity.hs
@@ -12,7 +12,6 @@ are thousands separated by comma, significant decimal places and so on.
 
 module Hledger.Data.Commodity
 where
-import Data.Char (isDigit)
 import Data.List
 import Data.Maybe (fromMaybe)
 #if !(MIN_VERSION_base(4,11,0))
@@ -26,13 +25,10 @@ import Hledger.Utils
 
 
 -- characters that may not be used in a non-quoted commodity symbol
-nonsimplecommoditychars = "0123456789-+.@*;\n \"{}=" :: [Char]
+nonsimplecommoditychars = "0123456789-+.@*;\n \"(){}=" :: [Char]
 
 isNonsimpleCommodityChar :: Char -> Bool
-isNonsimpleCommodityChar c = isDigit c || c `textElem` otherChars
- where
-   otherChars = "-+.@*;\n \"{}=" :: T.Text
-   textElem = T.any . (==)
+isNonsimpleCommodityChar = flip elem nonsimplecommoditychars
 
 quoteCommoditySymbolIfNeeded s | T.any (isNonsimpleCommodityChar) s = "\"" <> s <> "\""
                                | otherwise = s

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -105,7 +105,7 @@ nullsourcepos = JournalSourcePos "" (1,1)
 
 nullassertion, assertion :: BalanceAssertion
 nullassertion = BalanceAssertion
-                  {baamount=nullamt
+                  {baamount=nullmixedamt
                   ,baexact=False
                   ,baposition=nullsourcepos
                   }

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -90,6 +90,7 @@ nullposting = Posting
                 ,pcomment=""
                 ,ptype=RegularPosting
                 ,ptags=[]
+                ,pmultiplier=Nothing
                 ,pbalanceassertion=Nothing
                 ,ptransaction=Nothing
                 ,porigin=Nothing

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -222,7 +222,7 @@ postingAsLines elideamount onelineamounts pstoalignwith p = concat [
     | postingblock <- postingblocks]
   where
     postingblocks = [map rstrip $ lines $ concatTopPadded [statusandaccount, "  ", amount, assertion, samelinecomment] | amount <- shownAmounts]
-    assertion = maybe "" ((" = " ++) . showAmountWithZeroCommodity . baamount) $ pbalanceassertion p
+    assertion = maybe "" ((" = " ++) . showMixedAmountWithZeroCommodity . baamount) $ pbalanceassertion p
     statusandaccount = indent $ fitString (Just $ minwidth) Nothing False True $ pstatusandacct p
         where
           -- pad to the maximum account name width, plus 2 to leave room for status flags, to keep amounts aligned  

--- a/hledger-lib/Hledger/Data/TransactionModifier.hs
+++ b/hledger-lib/Hledger/Data/TransactionModifier.hs
@@ -91,7 +91,7 @@ tmPostingRuleToFunction pr =
   where
     amount' = case pmultiplier pr of
         Nothing -> const $ pamount pr
-        Just n  -> \p ->
+        Just n  -> \p -> pamount pr +
           -- Multiply the old posting's amount by the posting rule's multiplier.
           let
             matchedamount = dbg6 "matchedamount" $ pamount p

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -238,7 +238,7 @@ instance Show Status where -- custom show.. bad idea.. don't do it..
 -- | The amount to compare an account's balance to, to verify that the history
 -- leading to a given point is correct or to set the account to a known value.
 data BalanceAssertion = BalanceAssertion {
-      baamount   :: Amount,             -- ^ the expected value of a particular commodity
+      baamount   :: MixedAmount,        -- ^ the expected value of particular commodities
       baexact    :: Bool,               -- ^ whether the assertion is exclusive, and doesn't allow other commodities alongside 'baamount'
       baposition :: GenericSourcePos
     } deriving (Eq,Typeable,Data,Generic,Show)

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -204,9 +204,7 @@ data Amount = Amount {
       acommodity  :: CommoditySymbol,
       aquantity   :: Quantity,
       aprice      :: Price,           -- ^ the (fixed) price for this amount, if any
-      astyle      :: AmountStyle,
-      amultiplier :: Bool             -- ^ kludge: a flag marking this amount and posting as a multiplier
-                                      --   in a TMPostingRule. In a regular Posting, should always be false.
+      astyle      :: AmountStyle
     } deriving (Eq,Ord,Typeable,Data,Generic,Show)
 
 instance NFData Amount
@@ -256,6 +254,7 @@ data Posting = Posting {
       pcomment          :: Text,              -- ^ this posting's comment lines, as a single non-indented multi-line string
       ptype             :: PostingType,
       ptags             :: [Tag],                   -- ^ tag names and values, extracted from the comment
+      pmultiplier       :: Maybe Amount,            -- ^ optional: the proportion of the base value to use in a 'TransactionModifier'
       pbalanceassertion :: Maybe BalanceAssertion,  -- ^ optional: the expected balance in this commodity in the account after this posting
       ptransaction      :: Maybe Transaction,       -- ^ this posting's parent transaction (co-recursive types).
                                                     --   Tying this knot gets tedious, Maybe makes it easier/optional.
@@ -271,7 +270,7 @@ instance NFData Posting
 -- identity, to avoid recuring ad infinitum.
 -- XXX could check that it's Just or Nothing.
 instance Eq Posting where
-    (==) (Posting a1 b1 c1 d1 e1 f1 g1 h1 i1 _ _) (Posting a2 b2 c2 d2 e2 f2 g2 h2 i2 _ _) =  a1==a2 && b1==b2 && c1==c2 && d1==d2 && e1==e2 && f1==f2 && g1==g2 && h1==h2 && i1==i2
+    (==) (Posting a1 b1 c1 d1 e1 f1 g1 h1 i1 j1 _ _) (Posting a2 b2 c2 d2 e2 f2 g2 h2 i2 j2 _ _) =  a1==a2 && b1==b2 && c1==c2 && d1==d2 && e1==e2 && f1==f2 && g1==g2 && h1==h2 && i1==i2 && j1==j2
 
 -- | Posting's show instance elides the parent transaction so as not to recurse forever.
 instance Show Posting where
@@ -284,6 +283,7 @@ instance Show Posting where
     ,("pcomment="          ++ show pcomment)
     ,("ptype="             ++ show ptype)
     ,("ptags="             ++ show ptags)
+    ,("pmultiplier="       ++ show pmultiplier)
     ,("pbalanceassertion=" ++ show pbalanceassertion)
     ,("ptransaction="      ++ show (const "<txn>" <$> ptransaction))
     ,("porigin="           ++ show porigin)

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -76,6 +76,7 @@ module Hledger.Read.Common (
   priceamountp,
   balanceassertionp,
   fixedlotpricep,
+  modifierp,
   numberp,
   fromRawNumber,
   rawnumberp,
@@ -604,21 +605,24 @@ spaceandamountormissingp =
 -- right, optional unit or total price, and optional (ignored)
 -- ledger-style balance assertion or fixed lot price declaration.
 amountp :: JournalParser m Amount
-amountp = label "amount" $ do
-  amount <- amountwithoutpricep
+amountp = label "amount" $ amountormultiplierp False
+
+amountormultiplierp :: Bool -> JournalParser m Amount
+amountormultiplierp isMultiplier = do
+  amount <- amountwithoutpricep isMultiplier
   lift $ skipMany spacenonewline
   price <- priceamountp
   pure $ amount { aprice = price }
 
-amountwithoutpricep :: JournalParser m Amount
-amountwithoutpricep = do
-  (mult, sign) <- lift $ (,) <$> multiplierp <*> signp
-  leftsymbolamountp mult sign <|> rightornosymbolamountp mult sign
+amountwithoutpricep :: Bool -> JournalParser m Amount
+amountwithoutpricep isMultiplier = do
+  sign <- lift $ signp
+  leftsymbolamountp sign <|> rightornosymbolamountp sign
 
   where
 
-  leftsymbolamountp :: Bool -> (Decimal -> Decimal) -> JournalParser m Amount
-  leftsymbolamountp mult sign = label "amount" $ do
+  leftsymbolamountp :: (Decimal -> Decimal) -> JournalParser m Amount
+  leftsymbolamountp sign = label "amount" $ do
     c <- lift commoditysymbolp
     suggestedStyle <- getAmountStyle c
     commodityspaced <- lift $ skipMany' spacenonewline
@@ -630,10 +634,10 @@ amountwithoutpricep = do
     let numRegion = (offBeforeNum, offAfterNum)
     (q,prec,mdec,mgrps) <- lift $ interpretNumber numRegion suggestedStyle ambiguousRawNum mExponent
     let s = amountstyle{ascommodityside=L, ascommodityspaced=commodityspaced, asprecision=prec, asdecimalpoint=mdec, asdigitgroups=mgrps}
-    return $ Amount c (sign (sign2 q)) NoPrice s mult
+    return $ Amount c (sign (sign2 q)) NoPrice s
 
-  rightornosymbolamountp :: Bool -> (Decimal -> Decimal) -> JournalParser m Amount
-  rightornosymbolamountp mult sign = label "amount" $ do
+  rightornosymbolamountp :: (Decimal -> Decimal) -> JournalParser m Amount
+  rightornosymbolamountp sign = label "amount" $ do
     offBeforeNum <- getOffset
     ambiguousRawNum <- lift rawnumberp
     mExponent <- lift $ optional $ try exponentp
@@ -646,7 +650,7 @@ amountwithoutpricep = do
         suggestedStyle <- getAmountStyle c
         (q,prec,mdec,mgrps) <- lift $ interpretNumber numRegion suggestedStyle ambiguousRawNum mExponent
         let s = amountstyle{ascommodityside=R, ascommodityspaced=commodityspaced, asprecision=prec, asdecimalpoint=mdec, asdigitgroups=mgrps}
-        return $ Amount c (sign q) NoPrice s mult
+        return $ Amount c (sign q) NoPrice s
       -- no symbol amount
       Nothing -> do
         suggestedStyle <- getDefaultAmountStyle
@@ -654,10 +658,10 @@ amountwithoutpricep = do
         -- if a default commodity has been set, apply it and its style to this amount
         -- (unless it's a multiplier in an automated posting)
         defcs <- getDefaultCommodityAndStyle
-        let (c,s) = case (mult, defcs) of
+        let (c,s) = case (isMultiplier, defcs) of
               (False, Just (defc,defs)) -> (defc, defs{asprecision=max (asprecision defs) prec})
               _ -> ("", amountstyle{asprecision=prec, asdecimalpoint=mdec, asdigitgroups=mgrps})
-        return $ Amount c (sign q) NoPrice s mult
+        return $ Amount c (sign q) NoPrice s
 
   -- For reducing code duplication. Doesn't parse anything. Has the type
   -- of a parser only in order to throw parse errors (for convenience).
@@ -688,8 +692,14 @@ mamountp' = Mixed . (:[]) . amountp'
 signp :: Num a => TextParser m (a -> a)
 signp = char '-' *> pure negate <|> char '+' *> pure id <|> pure id
 
-multiplierp :: TextParser m Bool
-multiplierp = option False $ char '*' *> pure True
+-- | Parse a value used as a multiplier in a 'TransactionModifier' (a
+-- @*@ character followed by a value following the rules of 'amountp',
+-- except that it never takes the default commodity).
+modifierp :: JournalParser m Amount
+modifierp = label "modifier" $ do
+  char '*'
+  lift $ skipMany spacenonewline
+  amountormultiplierp True
 
 -- | This is like skipMany but it returns True if at least one element
 -- was skipped. This is helpful if you’re just using many to check if
@@ -721,7 +731,7 @@ priceamountp = option NoPrice $ do
   priceConstructor <- char '@' *> pure TotalPrice <|> pure UnitPrice
 
   lift (skipMany spacenonewline)
-  priceAmount <- amountwithoutpricep <?> "amount (as a price)"
+  priceAmount <- amountwithoutpricep False <?> "amount (as a price)"
 
   pure $ priceConstructor priceAmount
 

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -743,7 +743,7 @@ balanceassertionp = do
   lift (skipMany spacenonewline)
   a <- amountp <?> "amount (for a balance assertion or assignment)" -- XXX should restrict to a simple amount
   return BalanceAssertion
-    { baamount = a
+    { baamount = Mixed [a]
     , baexact = isJust exact
     , baposition = sourcepos
     }

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -753,7 +753,7 @@ transactionFromCsvRecord sourcepos rules record = t
         ]
       }
     toAssertion (a, b) = assertion{
-      baamount   = a,
+      baamount   = Mixed [a],
       baposition = b
       }
 

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -68,6 +68,7 @@ import qualified Control.Exception as C
 import Control.Monad
 import Control.Monad.Except (ExceptT(..))
 import Control.Monad.State.Strict
+import Data.Either (fromLeft, fromRight)
 import Data.Maybe
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
@@ -482,7 +483,7 @@ transactionmodifierp = do
   lift (skipMany spacenonewline)
   querytxt <- lift $ T.strip <$> descriptionp
   (_comment, _tags) <- lift transactioncommentp   -- TODO apply these to modified txns ?
-  postings <- postingsp Nothing
+  postings <- postingsp Nothing True
   return $ TransactionModifier querytxt postings
 
 -- | Parse a periodic transaction
@@ -543,7 +544,7 @@ periodictransactionp = do
       return (s,c,desc,(cmt,ts))
 
   -- next lines; use same year determined above
-  postings <- postingsp (Just $ first3 $ toGregorian refdate)
+  postings <- postingsp (Just $ first3 $ toGregorian refdate) False
 
   return $ nullperiodictransaction{
      ptperiodexpr=periodtxt
@@ -570,7 +571,7 @@ transactionp = do
   description <- lift $ T.strip <$> descriptionp
   (comment, tags) <- lift transactioncommentp
   let year = first3 $ toGregorian date
-  postings <- postingsp (Just year)
+  postings <- postingsp (Just year) False
   endpos <- getSourcePos
   let sourcepos = journalSourcePos startpos endpos
   return $ txnTieKnot $ Transaction 0 sourcepos date edate status code description comment tags postings ""
@@ -579,8 +580,8 @@ transactionp = do
 
 -- Parse the following whitespace-beginning lines as postings, posting
 -- tags, and/or comments (inferring year, if needed, from the given date).
-postingsp :: Maybe Year -> JournalParser m [Posting]
-postingsp mTransactionYear = many (postingp mTransactionYear) <?> "postings"
+postingsp :: Maybe Year -> Bool -> JournalParser m [Posting]
+postingsp mTransactionYear allowCommodityMult = many (postingp mTransactionYear allowCommodityMult) <?> "postings"
 
 -- linebeginningwithspaces :: JournalParser m String
 -- linebeginningwithspaces = do
@@ -589,8 +590,8 @@ postingsp mTransactionYear = many (postingp mTransactionYear) <?> "postings"
 --   cs <- lift restofline
 --   return $ sp ++ (c:cs) ++ "\n"
 
-postingp :: Maybe Year -> JournalParser m Posting
-postingp mTransactionYear = do
+postingp :: Maybe Year -> Bool -> JournalParser m Posting
+postingp mTransactionYear allowCommodityMult = do
   -- lift $ dbgparse 0 "postingp"
   (status, account) <- try $ do
     lift (skipSome spacenonewline)
@@ -600,7 +601,10 @@ postingp mTransactionYear = do
     return (status, account)
   let (ptype, account') = (accountNamePostingType account, textUnbracket account)
   lift (skipMany spacenonewline)
-  amount <- option missingmixedamt $ Mixed . (:[]) <$> amountp
+  value <- (if allowCommodityMult
+      then (<|>) $ Left . Just <$> try modifierp
+      else id
+    ) $ Right <$> (option missingmixedamt $ Mixed . (:[]) <$> amountp)
   lift (skipMany spacenonewline)
   massertion <- optional $ balanceassertionp
   _ <- fixedlotpricep
@@ -611,10 +615,11 @@ postingp mTransactionYear = do
    , pdate2=mdate2
    , pstatus=status
    , paccount=account'
-   , pamount=amount
+   , pamount=fromRight nullmixedamt value
    , pcomment=comment
    , ptype=ptype
    , ptags=tags
+   , pmultiplier=fromLeft Nothing value
    , pbalanceassertion=massertion
    }
 
@@ -696,7 +701,7 @@ tests_JournalReader = tests "JournalReader" [
     ]
 
   ,tests "postingp" [
-     test "basic" $ expectParseEq (postingp Nothing) 
+     test "basic" $ expectParseEq (postingp Nothing False)
       "  expenses:food:dining  $10.00   ; a: a a \n   ; b: b b \n"
       posting{
         paccount="expenses:food:dining", 
@@ -705,7 +710,7 @@ tests_JournalReader = tests "JournalReader" [
         ptags=[("a","a a"), ("b","b b")]
         }
 
-    ,test "posting dates" $ expectParseEq (postingp Nothing) 
+    ,test "posting dates" $ expectParseEq (postingp Nothing False)
       " a  1. ; date:2012/11/28, date2=2012/11/29,b:b\n"
       nullposting{
          paccount="a"
@@ -716,7 +721,7 @@ tests_JournalReader = tests "JournalReader" [
         ,pdate2=Nothing  -- Just $ fromGregorian 2012 11 29
         }
 
-    ,test "posting dates bracket syntax" $ expectParseEq (postingp Nothing) 
+    ,test "posting dates bracket syntax" $ expectParseEq (postingp Nothing False)
       " a  1. ; [2012/11/28=2012/11/29]\n"
       nullposting{
          paccount="a"
@@ -727,20 +732,27 @@ tests_JournalReader = tests "JournalReader" [
         ,pdate2=Just $ fromGregorian 2012 11 29
         }
 
-    ,test "quoted commodity symbol with digits" $ expectParse (postingp Nothing) "  a  1 \"DE123\"\n"
+    ,test "quoted commodity symbol with digits" $ expectParse (postingp Nothing False) "  a  1 \"DE123\"\n"
 
-    ,test "balance assertion and fixed lot price" $ expectParse (postingp Nothing) "  a  1 \"DE123\" =$1 { =2.2 EUR} \n"
+    ,test "balance assertion and fixed lot price" $ expectParse (postingp Nothing False) "  a  1 \"DE123\" =$1 { =2.2 EUR} \n"
 
-    ,test "balance assertion over entire contents of account" $ expectParse (postingp Nothing) "  a  $1 == $1\n"
+    ,test "balance assertion over entire contents of account" $ expectParse (postingp Nothing False) "  a  $1 == $1\n"
     ]
 
   ,tests "transactionmodifierp" [
 
-    test "basic" $ expectParseEq transactionmodifierp 
+     test "basic" $ expectParseEq transactionmodifierp 
       "= (some value expr)\n some:postings  1.\n"
       nulltransactionmodifier {
         tmquerytxt = "(some value expr)"
        ,tmpostingrules = [nullposting{paccount="some:postings", pamount=Mixed[num 1]}]
+      }
+
+    ,test "multiplier" $ expectParseEq transactionmodifierp 
+      "= (some value expr)\n some:postings  *.33\n"
+      nulltransactionmodifier {
+        tmquerytxt = "(some value expr)"
+       ,tmpostingrules = [nullposting{paccount="some:postings", pmultiplier=Just $ (num 0.33) {astyle=amountstyle{asprecision=2}}}]
       }
     ]
 

--- a/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReports.hs
@@ -314,7 +314,7 @@ tests_MultiBalanceReports = tests "MultiBalanceReports" [
       (map showw aitems) `is` (map showw eitems)
       ((\(_, b, _) -> showMixedAmountDebug b) atotal) `is` (showMixedAmountDebug etotal) -- we only check the sum of the totals
     usd0 = usd 0
-    amount0 = Amount {acommodity="$", aquantity=0, aprice=NoPrice, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}, amultiplier=False}
+    amount0 = amount {acommodity="$", aquantity=0, astyle=amountstyle {asprecision = 2}}
   in 
    tests "multiBalanceReport" [
       test "null journal"  $

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -85,7 +85,7 @@ close CliOpts{rawopts_=rawopts, reportopts_=ropts} j = do
       balancingamt = negate $ sum $ map (\(_,_,_,b) -> normaliseMixedAmountSquashPricesForDisplay b) acctbals
       ps = [posting{paccount=a
                    ,pamount=mixed [b]
-                   ,pbalanceassertion=Just assertion{ baamount=b }
+                   ,pbalanceassertion=Just assertion{ baamount=mixed [b] }
                    }
            |(a,_,_,mb) <- acctbals
            ,b <- amounts $ normaliseMixedAmountSquashPricesForDisplay mb
@@ -93,7 +93,7 @@ close CliOpts{rawopts_=rawopts, reportopts_=ropts} j = do
            ++ [posting{paccount="equity:opening balances", pamount=balancingamt}]
       nps = [posting{paccount=a
                     ,pamount=mixed [negate b]
-                    ,pbalanceassertion=Just assertion{ baamount=b{aquantity=0} }
+                    ,pbalanceassertion=Just assertion{ baamount=mixed [b{aquantity=0}] }
                     }
             |(a,_,_,mb) <- acctbals
             ,b <- amounts $ normaliseMixedAmountSquashPricesForDisplay mb

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -195,7 +195,7 @@ transactionModifierFromOpts CliOpts{rawopts_=rawopts,reportopts_=ropts} =
     ps = map (parseposting . stripquotes . T.pack) $ listofstringopt "add-posting" rawopts
     parseposting t = either (error' . errorBundlePretty) id ep
       where
-        ep = runIdentity (runJournalParser (postingp Nothing <* eof) t')
+        ep = runIdentity (runJournalParser (postingp Nothing True <* eof) t')
         t' = " " <> t <> "\n" -- inject space and newline for proper parsing
 
 printOrDiff :: RawOpts -> (CliOpts -> Journal -> Journal -> IO ())

--- a/tests/journal/amount-expressions.test
+++ b/tests/journal/amount-expressions.test
@@ -135,7 +135,27 @@ hledger -f - print --auto
 >>>2
 >>>=0
 
-# 9. Standard postings may not be headed by multipliers
+# 9. Modifiers operate on all commodities in a posting
+hledger -f - print --auto
+<<<
+= a
+    (c)           *-1 + $8
+
+2018-01-01
+    a              $5 - 5 CAD
+    b
+>>>
+2018/01/01
+    a                $5
+    a            -5 CAD
+    (c)              $3
+    (c)           5 CAD
+    b
+
+>>>2
+>>>=0
+
+# 10. Standard postings may not be headed by multipliers
 hledger -f - print
 <<<
 2018-01-01
@@ -145,7 +165,7 @@ hledger -f - print
 >>>2 /unexpected '*'/
 >>>=1
 
-# 10. Auto-postings require an operator between multiplier and expression
+# 11. Auto-postings require an operator between multiplier and expression
 # The error message could be a bit more helpful, but at least it mentions
 # expecting a mixed amount
 hledger -f - print --auto
@@ -160,4 +180,149 @@ hledger -f - print --auto
 >>>
 >>>2 /unexpected '8'/
 >>>=1
+
+# 12. Multiplication by plain values works as expected
+hledger -f - print
+<<<
+2018-01-01
+    a              $1 * 2
+    b             -$2 * 0.5
+    c              $2 * -1
+    d             -$1 * -1
+>>>
+2018/01/01
+    a              $2
+    b             $-1
+    c             $-2
+    d              $1
+
+>>>2
+>>>=0
+
+# 13. ... as does division
+hledger -f - print
+<<<
+2018-01-01
+    a           $2.00 / 2
+    b          -$1.00 / 0.5
+    c           $2.00 / -1
+    d          -$3.00 / -1
+>>>
+2018/01/01
+    a           $1.00
+    b          $-2.00
+    c          $-2.00
+    d           $3.00
+
+>>>2
+>>>=0
+
+# 14. Multiplication disallows commodities before the multiplier
+hledger -f - print
+<<<
+2018-01-01
+    a              $1 * $2
+    c
+>>>
+>>>2 /unexpected '\$'/
+>>>=1
+
+# 15. ... and after
+hledger -f - print
+<<<
+2018-01-01
+    a              $1 * 2 CAD
+    c
+>>>
+>>>2 /unexpected 'C'/
+>>>=1
+
+# 16. Division prevents divide-by-zero errors
+hledger -f - print
+<<<
+2018-01-01
+    a              $1 / 0
+    b
+>>>
+>>>2 /division by 0/
+>>>=1
+
+# 17. ... but multiplication just simplifies them
+hledger -f - print
+<<<
+2018-01-01
+    a              $1 * 0
+    b
+>>>
+2018/01/01
+    a               0
+    b
+
+>>>2
+>>>=0
+
+# 18. Multiplication and division rounds values according to the multiplicand precision
+hledger -f - print
+<<<
+2018-01-01
+    a              $3 * 0.5
+    b              $1 / 3
+    c
+>>>
+2018/01/01
+    a              $2
+    b               0
+    c
+
+>>>2
+>>>=0
+
+# 19. Commodity directives affect multiplication and division rounding
+hledger -f - print
+<<<
+commodity $1,000.00
+
+2018-01-01
+    a              $3 * 0.5
+    b              $1 / 3
+    c
+>>>
+2018/01/01
+    a           $1.50
+    b           $0.33
+    c
+
+>>>2
+>>>=0
+
+# 20. Expressions respect order of operations
+hledger -f - print
+<<<
+2018-01-01
+    a              $1 + $2  * 3 - $4
+    b             ($1 + $2) * 3 - $4
+    c
+>>>
+2018/01/01
+    a              $3
+    b              $5
+    c
+
+>>>2
+>>>=0
+
+# 21. Multiplication and division work over multiple commodities
+hledger -f - print
+<<<
+2018-01-01
+    a             ($1 + 2 CAD) * 3
+    b
+>>>
+2018/01/01
+    a              $3
+    a           6 CAD
+    b
+
+>>>2
+>>>=0
 

--- a/tests/journal/amount-expressions.test
+++ b/tests/journal/amount-expressions.test
@@ -1,0 +1,163 @@
+#!/usr/bin/env shelltest
+# 1. Compatibiltiy with the example in Ledger docs
+hledger -f - print
+<<<
+2017-03-10 * KFC
+    Expenses:Food         ($10.00 + $20.00)
+    Assets:Cash
+>>>
+2017/03/10 * KFC
+    Expenses:Food          $30.00
+    Assets:Cash
+
+>>>2
+>>>=0
+
+# 2. Expressions don't require parentheses
+hledger -f - print
+<<<
+2017-03-10 * KFC
+    Expenses:Food          $10.00 + $20.00
+    Assets:Cash
+>>>
+2017/03/10 * KFC
+    Expenses:Food          $30.00
+    Assets:Cash
+
+>>>2
+>>>=0
+
+# 3. Subtraction is distributive
+hledger -f - print
+<<<
+2018-01-01
+    a             $10 -  $5 + $2  + $3
+    b             $10 - ($5 + $2) + $7
+    c
+>>>
+2018/01/01
+    a             $10
+    b             $10
+    c
+
+>>>2
+>>>=0
+
+# 4. Expressions consider the default commodity
+hledger -f - print
+<<<
+D $1,000.00
+
+2018-01-01
+    a           $10 - 5
+    b
+>>>
+2018/01/01
+    a           $5.00
+    b
+
+>>>2
+>>>=0
+
+# 5. Expressions enable multi-commodity postings
+hledger -f - print
+<<<
+2018-01-01
+    a:usd             $10
+    a:coupon                10 OMD
+    b               -($10 + 10 OMD)
+>>>
+2018/01/01
+    a:usd                $10
+    a:coupon          10 OMD
+    b                   $-10
+    b                -10 OMD
+
+>>>2
+>>>=0
+
+# 6. Expressions enable multi-commodity assertions
+hledger -f - stats
+<<<
+2018-01-01
+    a:usd             $10
+    a:coupon           10 OMD
+    b
+
+2018-01-02
+    b                   0 = -$10 - 10 OMD
+>>> /Transactions/
+>>>2
+>>>=0
+
+# 7. Default commodities are treated alongside their explicit counterpart
+hledger -f - print
+<<<
+D $1,000.00
+
+2018-01-01
+    a          $10 + 2 - 4 CAD
+    b
+>>>
+2018/01/01
+    a          $12.00
+    a          -4 CAD
+    b
+
+>>>2
+>>>=0
+
+# 8. Auto-postings respect expressions
+hledger -f - print --auto
+<<<
+= a
+    c             *-1 + $8
+    d              *1 - $8
+    e             *-1
+    f              *1
+    g              $8
+    h             -$8
+
+2018-01-01
+    a              $5
+    b
+>>>
+2018/01/01
+    a              $5
+    c              $3
+    d             $-3
+    e             $-5
+    f              $5
+    g              $8
+    h             $-8
+    b
+
+>>>2
+>>>=0
+
+# 9. Standard postings may not be headed by multipliers
+hledger -f - print
+<<<
+2018-01-01
+    a             *-1 + $8
+    b              *1 - $8
+>>>
+>>>2 /unexpected '*'/
+>>>=1
+
+# 10. Auto-postings require an operator between multiplier and expression
+# The error message could be a bit more helpful, but at least it mentions
+# expecting a mixed amount
+hledger -f - print --auto
+<<<
+= a
+    c             *-1 $8
+    d              *1 - $8
+
+2018-01-01
+    a              $5
+    b
+>>>
+>>>2 /unexpected '8'/
+>>>=1
+


### PR DESCRIPTION
This PR comes out of #913, which was closed as it both was only a small change (fixing before-unnoticed undefined behaviour) and was written in a way that was oriented more toward (this) future work than toward simply fixing that bug.  Besides the larger scope here eclipsing that minor fix, some unclean commits and unfortunate naming resulted in the discussion there becoming confused; while the latter in itself would not be enough to close the earlier PR, I felt that taking it along with the former resulted in it making more sense to focus the conversation on the features introduced in later commits.

On that topic, this adds the ability to write postings usiing basic arithmatic operations inline, implementing #183 and #923, in a way that isn't hopelessly entangled with cruft, WIP code, and other features (as my first attempt #871 was).  To separate out all its effects:

* Posting amounts and assertations/assignments may be written as multiple amounts (whether of the same commodity or not) connected via addition or subtraction: `$1 + $2`
    * If multiple amounts of the same commodity are given, they are condensed into a single value: the above is equivalent to `$3`
    * If amounts of different commodities are given, they're equivalent to having put the individual amounts on separate lines, *except* that any transaction modifiers applied to that posting will only add static values once: `= a ... *1 + $2` applied to `a  $3 + 4 CAD` results in `$3 + 4 CAD` *not* `$5 + 4 CAD`
* Commodities using parentheses now must be quoted: `1 "(XYZ)"`
* Standard postings are now no longer permitted to begin with a modifier-style multiplier

And, non-user-facing:

* A `Posting`'s amount is stored as a `MixedAmount` rather than a simple `Amount`
* `Amount` no longer has the field `amultiplier`; its role is taken over by storing an `Amount` object in the new field `Posting.pmultiplier`
* `Hledger.Read.Common` exports a new parser `mamountp` handling the amount expression logic
* It also exports `modifierp` which functions mostly the same as `amountp`, except that its values are preceded by a `*` and never assigned the default commodity
* The internal function `multiplierp` (previously only checking the presence of a single character) was rewritten to return the value of the (unitless) multiplier(s) and/or divisior(s) it matched
* `postingsp`, `postingp`, and `amountwithoutpricep` now take a `Bool` argument indicating whether they're being parsed from within a `TransactionModifier`