### PR TITLE
cli: if abs(return on investment)<0.01% display it as zero

### DIFF
--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -117,14 +117,15 @@ roi CliOpts{rawopts_=rawopts, reportopts_=ropts} j = do
     irr <- internalRateOfReturn showCashFlow prettyTables thisSpan
     twr <- timeWeightedReturn showCashFlow prettyTables investmentsQuery trans thisSpan
     let cashFlowAmt = negate $ sum $ map snd cashFlow
+    let smallIsZero x = if abs x < 0.01 then 0.0 else x
     return [ showDate spanBegin
            , showDate (addDays (-1) spanEnd)
            , show valueBefore
            , show cashFlowAmt
            , show valueAfter
            , show (valueAfter - (valueBefore + cashFlowAmt))
-           , printf "%0.2f%%" irr
-           , printf "%0.2f%%" twr ]
+           , printf "%0.2f%%" $ smallIsZero irr
+           , printf "%0.2f%%" $ smallIsZero twr ]
 
   let table = Table 
               (Tbl.Group NoLine (map (Header . show) (take (length tableBody) [1..]))) 

--- a/tests/misc/roi.test
+++ b/tests/misc/roi.test
@@ -147,39 +147,38 @@ hledger -f- roi --inv investment --pnl pnl -b 2017 -e 2018 -Y
 >>>=0
 
 # 6. Check that deposits/withdrawals and profit/loss are reflected in the right periods
-# XXX https://github.com/simonmichael/hledger/issues/937, "-0.00%"
-# hledger -f- roi --inv investment --pnl pnl -b 2017 -e 2018 -Q
-# <<<
-# 2017-01-01 investment
-#    assets:cash  -$100
-#    investment
+hledger -f- roi --inv investment --pnl pnl -b 2017 -e 2018 -Q
+<<<
+2017-01-01 investment
+   assets:cash  -$100
+   investment
 
-# 2017-06-30 investment valuation
-#    investment  = $110
-#    pnl
+2017-06-30 investment valuation
+   investment  = $110
+   pnl
 
-# 2017-07-01 investment
-#    assets:cash  -$100
-#    investment
+2017-07-01 investment
+   assets:cash  -$100
+   investment
 
-# 2017-10-01 withdrawal
-#    assets:cash  $50
-#    investment
+2017-10-01 withdrawal
+   assets:cash  $50
+   investment
 
-# 2017-12-31 investment valuation
-#    investment  = $155
-#    pnl
-# >>>
-# +---++------------+------------++---------------+----------+-------------+-----++---------+---------+
-# |   ||      Begin |        End || Value (begin) | Cashflow | Value (end) | PnL ||     IRR |     TWR |
-# +===++============+============++===============+==========+=============+=====++=========+=========+
-# | 1 || 2017/01/01 | 2017/03/31 ||             0 |      100 |         100 |   0 ||   0.00% |   0.00% |
-# | 2 || 2017/04/01 | 2017/06/30 ||           100 |        0 |         110 |  10 ||  46.56% |  46.56% |
-# | 3 || 2017/07/01 | 2017/09/30 ||           110 |      100 |         210 |   0 ||   0.00% |   0.00% |
-# | 4 || 2017/10/01 | 2017/12/31 ||           210 |      -50 |         155 |  -5 || -11.83% | -11.82% |
-# +---++------------+------------++---------------+----------+-------------+-----++---------+---------+
+2017-12-31 investment valuation
+   investment  = $155
+   pnl
+>>>
++---++------------+------------++---------------+----------+-------------+-----++---------+---------+
+|   ||      Begin |        End || Value (begin) | Cashflow | Value (end) | PnL ||     IRR |     TWR |
++===++============+============++===============+==========+=============+=====++=========+=========+
+| 1 || 2017/01/01 | 2017/03/31 ||             0 |      100 |         100 |   0 ||   0.00% |   0.00% |
+| 2 || 2017/04/01 | 2017/06/30 ||           100 |        0 |         110 |  10 ||  46.56% |  46.56% |
+| 3 || 2017/07/01 | 2017/09/30 ||           110 |      100 |         210 |   0 ||   0.00% |   0.00% |
+| 4 || 2017/10/01 | 2017/12/31 ||           210 |      -50 |         155 |  -5 || -11.83% | -11.82% |
++---++------------+------------++---------------+----------+-------------+-----++---------+---------+
 
-# >>>=0
+>>>=0
 
 # 7. Check that reporting for the part of the total history of investment works
 hledger -f- roi --inv investment --pnl pnl -b 2017-06 -e 2018


### PR DESCRIPTION
Fixes #937 

When return on investment is very small, numerical solvers can jump around zero, sometimes producing very small negative numbers. Let's show everything smaller than 0.01% as 0%
