### PR TITLE
allow account comments, tags, account types declared with tags

### DIFF
--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -210,15 +210,9 @@ sortAccountTreeByAmount normalsign a
 
 -- | Add extra info for this account derived from the Journal's
 -- account directives, if any (comment, tags, declaration order..).
--- Currently only sets declaration order.
--- Expects that this account is among the Journal's jdeclaredaccounts
--- (otherwise sets declaration order to 0).
 accountSetDeclarationInfo :: Journal -> Account -> Account
-accountSetDeclarationInfo j a@Account{..} = 
-  a{adeclarationinfo=Just nullaccountdeclarationinfo{
-       adideclarationorder = fromMaybe 0 $ findIndex (==aname) (jdeclaredaccounts j)
-       }
-   }
+accountSetDeclarationInfo j a@Account{..} =
+  a{ adeclarationinfo=lookup aname $ jdeclaredaccounts j }
 
 -- | Sort account names by the order in which they were declared in
 -- the journal, at each level of the account tree (ie within each

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -264,7 +264,7 @@ journalAccountNamesImplied = expandAccountNames . journalAccountNamesUsed
 
 -- | Sorted unique account names declared by account directives in this journal.
 journalAccountNamesDeclared :: Journal -> [AccountName]
-journalAccountNamesDeclared = nub . sort . jdeclaredaccounts
+journalAccountNamesDeclared = nub . sort . map fst . jdeclaredaccounts
 
 -- | Sorted unique account names declared by account directives or posted to
 -- by transactions in this journal.

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -446,7 +446,7 @@ data AccountDeclarationInfo = AccountDeclarationInfo {
   ,aditags             :: [Tag]  -- ^ tags extracted from the account comment, if any
   ,adideclarationorder :: Int    -- ^ the order in which this account was declared,
                                  --   relative to other account declarations, during parsing (1..)
-} deriving (Eq,Data,Generic)
+} deriving (Eq,Show,Data,Generic)
 
 instance NFData AccountDeclarationInfo
 

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -439,18 +439,33 @@ type ParsedJournal = Journal
 -- The --output-format option selects one of these for output.
 type StorageFormat = String
 
--- | An account, with name, balances and links to parent/subaccounts
--- which let you walk up or down the account tree.
+-- | Extra information about an account that can be derived from
+-- its account directive (and the other account directives).
+data AccountDeclarationInfo = AccountDeclarationInfo {
+   adicomment          :: Text   -- ^ any comment lines following an account directive for this account
+  ,aditags             :: [Tag]  -- ^ tags extracted from the account comment, if any
+  ,adideclarationorder :: Int    -- ^ the relative position of this account's account directive, if any. Normally a natural number.
+} deriving (Data)
+
+nullaccountdeclarationinfo = AccountDeclarationInfo {
+   adicomment          = ""
+  ,aditags             = []
+  ,adideclarationorder = 0
+}
+
+-- | An account, with its balances, parent/subaccount relationships, etc.
+-- Only the name is required; the other fields are added when needed.
 data Account = Account {
-  aname                     :: AccountName,   -- ^ this account's full name
-  adeclarationorder         :: Maybe Int  ,   -- ^ the relative position of this account's account directive, if any. Normally a natural number. 
-  aebalance                 :: MixedAmount,   -- ^ this account's balance, excluding subaccounts
-  asubs                     :: [Account],     -- ^ sub-accounts
-  anumpostings              :: Int,           -- ^ number of postings to this account
-  -- derived from the above :
-  aibalance                 :: MixedAmount,   -- ^ this account's balance, including subaccounts
-  aparent                   :: Maybe Account, -- ^ parent account
-  aboring                   :: Bool           -- ^ used in the accounts report to label elidable parents
+   aname                     :: AccountName    -- ^ this account's full name
+  ,adeclarationinfo          :: Maybe AccountDeclarationInfo  -- ^ optional extra info from account directives
+  -- relationships in the tree
+  ,asubs                     :: [Account]      -- ^ this account's sub-accounts
+  ,aparent                   :: Maybe Account  -- ^ parent account
+  ,aboring                   :: Bool           -- ^ used in the accounts report to label elidable parents
+  -- balance information
+  ,anumpostings              :: Int            -- ^ the number of postings to this account
+  ,aebalance                 :: MixedAmount    -- ^ this account's balance, excluding subaccounts
+  ,aibalance                 :: MixedAmount    -- ^ this account's balance, including subaccounts
   } deriving (Typeable, Data, Generic)
 
 -- | Whether an account's balance is normally a positive number (in 

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -410,7 +410,7 @@ data Journal = Journal {
   ,jparsetimeclockentries :: [TimeclockEntry]                       -- ^ timeclock sessions which have not been clocked out
   ,jincludefilestack      :: [FilePath]
   -- principal data
-  ,jdeclaredaccounts      :: [AccountName]                          -- ^ Accounts declared by account directives, in parse order (after journal finalisation) 
+  ,jdeclaredaccounts      :: [(AccountName,AccountDeclarationInfo)] -- ^ Accounts declared by account directives, in parse order (after journal finalisation) 
   ,jdeclaredaccounttypes  :: M.Map AccountType [AccountName]        -- ^ Accounts whose type has been declared in account directives (usually 5 top-level accounts) 
   ,jcommodities           :: M.Map CommoditySymbol Commodity        -- ^ commodities and formats declared by commodity directives
   ,jinferredcommodities   :: M.Map CommoditySymbol AmountStyle      -- ^ commodities and formats inferred from journal amounts  TODO misnamed - jusedstyles
@@ -444,8 +444,11 @@ type StorageFormat = String
 data AccountDeclarationInfo = AccountDeclarationInfo {
    adicomment          :: Text   -- ^ any comment lines following an account directive for this account
   ,aditags             :: [Tag]  -- ^ tags extracted from the account comment, if any
-  ,adideclarationorder :: Int    -- ^ the relative position of this account's account directive, if any. Normally a natural number.
-} deriving (Data)
+  ,adideclarationorder :: Int    -- ^ the order in which this account was declared,
+                                 --   relative to other account declarations, during parsing (1..)
+} deriving (Eq,Data,Generic)
+
+instance NFData AccountDeclarationInfo
 
 nullaccountdeclarationinfo = AccountDeclarationInfo {
    adicomment          = ""

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -42,7 +42,6 @@ module Hledger.Read.Common (
   getDefaultCommodityAndStyle,
   getDefaultAmountStyle,
   getAmountStyle,
-  pushDeclaredAccount,
   addDeclaredAccountType,
   pushParentAccount,
   popParentAccount,
@@ -351,9 +350,6 @@ getAmountStyle commodity = do
     defaultStyle <- fmap snd <$> getDefaultCommodityAndStyle
     let effectiveStyle = listToMaybe $ catMaybes [specificStyle, defaultStyle]
     return effectiveStyle
-
-pushDeclaredAccount :: AccountName -> JournalParser m ()
-pushDeclaredAccount acct = modify' (\j -> j{jdeclaredaccounts = acct : jdeclaredaccounts j})
 
 addDeclaredAccountType :: AccountName -> AccountType -> JournalParser m ()
 addDeclaredAccountType acct atype = 

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -263,10 +263,8 @@ accountdirectivep = do
   matype :: Maybe AccountType <- lift $ fmap (fromMaybe Nothing) $ optional $ try $ do
     skipSome spacenonewline -- at least one more space in addition to the one consumed by modifiedaccountp 
     choice [
-      -- a numeric account code, as supported in 1.9-1.10 ? currently ignored
-       some digitChar >> return Nothing
       -- a letter account type code (ALERX), as added in 1.11 ?
-      ,char 'A' >> return (Just Asset) 
+       char 'A' >> return (Just Asset) 
       ,char 'L' >> return (Just Liability) 
       ,char 'E' >> return (Just Equity) 
       ,char 'R' >> return (Just Revenue) 
@@ -827,7 +825,6 @@ tests_JournalReader = tests "JournalReader" [
   ,test "accountdirectivep" $ do
     test "with-comment" $ expectParse accountdirectivep "account a:b  ; a comment\n"
     test "does-not-support-!" $ expectParseError accountdirectivep "!account a:b\n" ""
-    test "account-sort-code" $ expectParse accountdirectivep "account a:b  1000\n"
     test "account-type-code" $ expectParse accountdirectivep "account a:b  A\n"
     test "account-type-tag" $ expectParse accountdirectivep "account a:b  ; type:asset\n"
 

--- a/hledger/Hledger/Cli/Commands/Accounts.hs
+++ b/hledger/Hledger/Cli/Commands/Accounts.hs
@@ -74,7 +74,7 @@ accounts CliOpts{rawopts_=rawopts, reportopts_=ropts} j = do
       -- just the acct: part of the query will be reapplied later, after clipping
       acctq    = dbg1 "acctq" $ filterQuery queryIsAcct q
       depth    = dbg1 "depth" $ queryDepth $ filterQuery queryIsDepth q
-      matcheddeclaredaccts = dbg1 "matcheddeclaredaccts" $ filter (matchesAccount nodepthq) $ jdeclaredaccounts j
+      matcheddeclaredaccts = dbg1 "matcheddeclaredaccts" $ filter (matchesAccount nodepthq) $ map fst $ jdeclaredaccounts j
       matchedusedaccts     = dbg5 "matchedusedaccts" $ map paccount $ journalPostings $ filterJournalPostings nodepthq j
       accts                = dbg5 "accts to show" $ -- no need to nub/sort, accountTree will
         if | declared     && not used -> matcheddeclaredaccts


### PR DESCRIPTION
Account directives can now have comments and tags. Account types can be declared with a `type:` tag, and the account type syntax introduced in hledger 1.12 is deprecated (I guess ?). Docs have been improved. Account tags are not used for anything else (eg queries) yet.

Previous discussion: #877