### PR TITLE
Fix options in markdown doc, to prevent -- to become – in HTML

### DIFF
--- a/hledger-ui/hledger-ui.m4.md
+++ b/hledger-ui/hledger-ui.m4.md
@@ -46,8 +46,8 @@ It is easier than hledger's command-line interface, and
 sometimes quicker and more convenient than the web interface.
 
 Note hledger-ui has some different defaults:
-- it generates rule-based transactions and postings by default (--forecast and --auto are always on). 
-- it hides transactions dated in the future by default (change this with --future or the F key).
+- it generates rule-based transactions and postings by default (`--forecast` and `--auto` are always on). 
+- it hides transactions dated in the future by default (change this with `--future` or the F key).
 Experimental.
 
 Like hledger, it reads _files_

--- a/hledger/hledger_balance.m4.md
+++ b/hledger/hledger_balance.m4.md
@@ -54,7 +54,7 @@ txt, csv, html.
 : show performance compared to budget goals defined by [periodic transactions](journal.html#periodic-transactions)
 
 `--show-unbudgeted`
-: with --budget, show unbudgeted accounts also
+: with `--budget`, show unbudgeted accounts also
 
 The balance command is hledger's most versatile command.
 Note, despite the name, it is not always used for showing real-world account balances;
@@ -72,7 +72,7 @@ For a real-world account, typically you won't have all transactions in the journ
 instead you'll have all transactions after a certain date, and an "opening balances"
 transaction setting the correct starting balance on that date.
 Then the balance command will show real-world account balances.
-In some cases the -H/--historical flag is used to ensure this (more below).
+In some cases the `-H`/`--historical` flag is used to ensure this (more below).
 
 The balance command can produce several styles of report:
 
@@ -343,7 +343,7 @@ balance report, is not yet supported in multicolumn reports.
 With `--budget`, extra columns are displayed showing budget goals for each account and period, if any.
 Budget goals are defined by [periodic transactions](journal.html#periodic-transactions).
 This is very useful for comparing planned and actual income, expenses, time usage, etc.
---budget is most often combined with a [report interval](manual.html#report-intervals).
+`--budget` is most often combined with a [report interval](manual.html#report-intervals).
 
 For example, you can take average monthly expenses in the common expense categories to construct a minimal monthly budget:
 ```journal

--- a/hledger/hledger_commands.m4.md
+++ b/hledger/hledger_commands.m4.md
@@ -42,7 +42,7 @@ Show account names. Alias: a.
 : in flat mode: omit N leading account name parts
 
 This command lists account names, either declared with account directives
-(--declared), posted to (--used), or both (default).
+(`--declared`), posted to (`--used`), or both (default).
 With query arguments, only matched account names and account names 
 referenced by matched postings are shown.
 It shows a flat list by default. With `--tree`, it uses indentation to
@@ -366,7 +366,7 @@ Print closing/opening transactions that bring some or all account balances to ze
 Can be useful for bringing asset/liability balances across file boundaries,
 or for closing out income/expenses for a period.
 This was formerly called "equity", as in Ledger, and that alias is also accepted.
-See close --help for more.   
+See close `--help` for more.   
 
 ## files
 List all files included in the journal. With a REGEX argument,
@@ -414,15 +414,15 @@ the main journal file.
 `--dry-run`
 : just show the transactions to be imported
 
-The input files are specified as arguments - no need to write -f before each one.
+The input files are specified as arguments - no need to write `-f` before each one.
 So eg to add new transactions from all CSV files to the main journal, it's just: 
 `hledger import *.csv`
 
-New transactions are detected in the same way as print --new: 
+New transactions are detected in the same way as print `--new`: 
 by assuming transactions are always added to the input files in increasing date order,
 and by saving `.latest.FILE` state files.
 
-The --dry-run output is in journal format, so you can filter it, eg 
+The `--dry-run` output is in journal format, so you can filter it, eg 
 to see only uncategorised transactions: 
 ```shell
 $ hledger import --dry ... | hledger -f- print unknown --ignore-assertions
@@ -511,8 +511,8 @@ This command also supports [output destination](/manual.html#output-destination)
 
 ## prices
 Print [market price directives](/manual#market-prices) from the journal.
-With --costs, also print synthetic market prices based on [transaction prices](/manual#transaction-prices).
-With --inverted-costs, also print inverse prices based on transaction prices.
+With `--costs`, also print synthetic market prices based on [transaction prices](/manual#transaction-prices).
+With `--inverted-costs`, also print inverse prices based on transaction prices.
 Prices (and postings providing prices) can be filtered by a query.
 
 ## print
@@ -631,7 +631,7 @@ Show postings and their running total. Aliases: r, reg.
 : show historical running total/balance (includes postings before report start date)
 
 `-A --average`
-: show running average of posting amounts instead of total (implies --empty)
+: show running average of posting amounts instead of total (implies `--empty`)
 
 `-r --related`
 : show postings' siblings instead
@@ -730,7 +730,7 @@ or by using the `--width`/`-w` option.
 
 The description and account columns normally share the space equally
 (about half of (width - 40) each). You can adjust this by adding a
-description width as part of --width's argument, comma-separated:
+description width as part of `--width`'s argument, comma-separated:
 `--width W,D` . Here's a diagram:
 ```
 <--------------------------------- width (W) ---------------------------------->

--- a/hledger/hledger_options.m4.md
+++ b/hledger/hledger_options.m4.md
@@ -487,7 +487,7 @@ it uses the market prices on the report end date for all columns.
 
 ## Combining -B and -V
 
-Using -B/--cost and -V/--value together is currently allowed, but the
+Using `-B`/`--cost` and `-V`/`--value` together is currently allowed, but the
 results are probably not meaningful. Let us know if you find a use for this. 
 
 ## Output destination


### PR DESCRIPTION
I quoted `-f`/`--flag`, to prevent it from becoming –flag in HTML doc.

I haven't compiled the doc to nroff, info, ... but it should work, right?