### PR TITLE
Support register --invert option to negate amounts

### DIFF
--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -116,7 +116,8 @@ matchedPostingsBeforeAndDuring opts q j (DateSpan mstart mend) =
   where
     beforestartq = dbg1 "beforestartq" $ dateqtype $ DateSpan Nothing mstart
     beforeandduringps =
-      dbg1 "ps4" $ sortBy (comparing sortdate) $                               -- sort postings by date or date2
+      dbg1 "ps5" $ sortBy (comparing sortdate) $                               -- sort postings by date or date2
+      dbg1 "ps4" $ (if invert_ opts then map negatePostingAmount else id) $    -- with --invert, invert amounts
       dbg1 "ps3" $ map (filterPostingAmount symq) $                            -- remove amount parts which the query's cur: terms would exclude
       dbg1 "ps2" $ (if related_ opts then concatMap relatedPostings else id) $ -- with -r, replace each with its sibling postings
       dbg1 "ps1" $ filter (beforeandduringq `matchesPosting`) $                -- filter postings by the query, with no start date or depth limit
@@ -134,6 +135,9 @@ matchedPostingsBeforeAndDuring opts q j (DateSpan mstart mend) =
       | otherwise = Date
       where
         dateq = dbg1 "dateq" $ filterQuery queryIsDateOrDate2 $ dbg1 "q" q  -- XXX confused by multiple date:/date2: ?
+
+negatePostingAmount :: Posting -> Posting
+negatePostingAmount p = p { pamount = negate $ pamount p }
 
 -- | Generate postings report line items from a list of postings or (with
 -- non-Nothing dates attached) summary postings.

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -36,6 +36,7 @@ registermode = hledgerCommandMode
   ,flagNone ["average","A"] (setboolopt "average")
      "show running average of posting amounts instead of total (implies --empty)"
   ,flagNone ["related","r"] (setboolopt "related") "show postings' siblings instead"
+  ,flagNone ["invert"] (setboolopt "invert") "display all amounts with reversed sign"
   ,flagReq  ["width","w"] (\s opts -> Right $ setopt "width" s opts) "N"
      ("set output width (default: " ++
 #ifdef mingw32_HOST_OS

--- a/hledger/Hledger/Cli/Commands/Register.md
+++ b/hledger/Hledger/Cli/Commands/Register.md
@@ -40,6 +40,16 @@ It works best when showing just one account and one commodity.
 The `--related`/`-r` flag shows the *other* postings in the transactions
 of the postings which would normally be shown.
 
+The `--invert` flag negates all amounts.
+For example, it can be used on an income account where amounts are normally
+displayed as negative numbers.
+It's also useful to show postings on the checking account together with the
+related account:
+
+```
+$ hledger register --related --invert assets:checking
+```
+
 With a [reporting interval](#reporting-interval), register shows
 summary postings, one per interval, aggregating the postings to each account:
 


### PR DESCRIPTION
[Related to #307.]

Open questions:

- Can we introduce a shorthand for `--invert`? I'd prefer `-v` like in grep. `-i` often stands for in-place or ignore. `-v` would be available in balance and register.

- Do we better apply the `amt:` filter before or after negating the amounts? In balance, `--invert` seems to be applied only the the printed output, so after all filters. I think we should keep the meaning of `--invert` to only apply to the output.

And I don't understand the line
```
newtype MixedAmount = Mixed [Amount] deriving ...
```
  Why are there multiple amounts possible for one posting and what is `Mixed`?