### PR TITLE
Fix CLI help text

### DIFF
--- a/hledger/Hledger/Cli/Commands/Registermatch.hs
+++ b/hledger/Hledger/Cli/Commands/Registermatch.hs
@@ -19,7 +19,7 @@ registermatchmode = hledgerCommandMode
   []
   [generalflagsgroup1]
   []
-  ([], Just $ argsFlag "[QUERY]")
+  ([], Just $ argsFlag "DESC")
 
 registermatch :: CliOpts -> Journal -> IO ()
 registermatch opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do


### PR DESCRIPTION
As discussed in #956 , just the `[QUERY]` in the usage text was wrong. It must be `DESC` (part of a description text) and it must be not optional.