### PR TITLE
[WIP] add always-convert subdirective of commodity

### DIFF
--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -195,8 +195,9 @@ instance NFData DigitGroupStyle
 type CommoditySymbol = Text
 
 data Commodity = Commodity {
-  csymbol :: CommoditySymbol,
-  cformat :: Maybe AmountStyle
+  csymbol        :: CommoditySymbol,
+  cformat        :: Maybe AmountStyle,
+  calwaysconvert :: Bool
   } deriving (Show,Eq,Data,Generic) --,Ord,Typeable,Data,Generic)
 
 instance NFData Commodity

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -348,9 +348,7 @@ flat_ = (==ALFlat) . accountlistmode_
 -- | Convert this journal's postings' amounts to the cost basis amounts if
 -- specified by options.
 journalSelectingAmountFromOpts :: ReportOpts -> Journal -> Journal
-journalSelectingAmountFromOpts opts
-    | cost_ opts = journalConvertAmountsToCost
-    | otherwise = id
+journalSelectingAmountFromOpts opts = journalConvertAmountsToCost $ cost_ opts
 
 -- | Convert report options and arguments to a query.
 queryFromOpts :: Day -> ReportOpts -> Query


### PR DESCRIPTION
After discussion in IRC, I started fiddling around with the concept of an "always-convert" subdirective for the commodity directive. It's still far from finished, but I'm opening this PR as a place for discussion.

## Idea

The `always-convert` concept would be implementing by either:
1. add a new subdirective to a commodity, marking it as always-convert; or
2. declare the `%` commodity as special syntax.

Example use of (1), to divide the costs of some expense (un)evenly:

```journal
commoditty parts
    always-convert

2019/02/20 Divide an amount evenly among two accounts
    expense:food       $30
    account1       -1 part
    account2       -1 part
```

Example use of (2), for the same reason:

```journal
2019/02/20 Divide an amount evenly among two accounts
    expense:food       $30
    account1           -50%
    account2           -50%
```

The main difference between (1) and (2) being that you either (1) don't have to calculate the part everyone gets or (2) can have hledger verify the percentages sum to 100%.

## Current state

- a parser for (1)
- a POC of (1) but without the parsed marked, hardcoding `%` as the always-converted commodity.

```journal
2019-02-20 Test
  p1         3%
  p2        97%
  other   -€100

2019/02/20 Divide an amount evenly among two accounts
    expense:food       $30
    account1            -1% ; using 1% here looks weird, but is valid for now
    account2            -1%
```

Questions I have:

- would we prefer (1) or (2)?
- would there be a way to access the complete commodity (not just the symbol) from e.g. `Hledger.Data.Transaction.inferBalancingPrices` without replacing them about everywhere in the library?
