### PR TITLE
web: Re-add 'balanced transaction' validation to add form

### DIFF
--- a/hledger-web/templates/add-form.hamlet
+++ b/hledger-web/templates/add-form.hamlet
@@ -40,7 +40,7 @@
     <div .col-md-9 .col-xs-6 .col-sm-6>
 
 <div .account-postings>
-  $forall (n, (acc, amt, accE, amtE)) <- msgs
+  $forall (n, (acc, amt, accE, amtE)) <- displayRows
     <div .form-group .row .account-group>
       <div .col-md-8 .col-xs-8 .col-sm-8 :isJust accE:.has-error>
         <input .account-input.form-control.input-lg.typeahead type=text


### PR DESCRIPTION
Fixes #951.

The main purpose of this PR is just adding a `balanceTransaction Nothing txn`
validation, but I've also taken the liberty of cleaning up the mess I'd made in
add form validation half a year ago.

I've tried to rework the basic algorithm two or three times but I had to leave
it at an `unfoldr` as that was the only version that could account for all
corner cases. So instead I've restructured the rest of the code and added
comments and type annotations in hope of making the code in AddForm.hs more
accessible even to casual readers.