### PR TITLE
Support stdin journal (web), create journal file if not exists (ui, web)

### DIFF
--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -129,6 +129,7 @@ requireJournalFileExists f = do
 
 -- | Ensure there is a journal file at the given path, creating an empty one if needed.
 ensureJournalFileExists :: FilePath -> IO ()
+ensureJournalFileExists "-" = return ()
 ensureJournalFileExists f = do
   exists <- doesFileExist f
   when (not exists) $ do

--- a/hledger-web/Hledger/Web/Handler/EditR.hs
+++ b/hledger-web/Hledger/Web/Handler/EditR.hs
@@ -10,6 +10,8 @@ module Hledger.Web.Handler.EditR
   , postEditR
   ) where
 
+import Data.IORef (writeIORef)
+
 import Hledger.Web.Import
 import Hledger.Web.Widget.Common
        (fromFormSuccess, helplink, journalFile404, writeValidJournal)
@@ -28,6 +30,7 @@ getEditR = postEditR
 postEditR :: FilePath -> Handler ()
 postEditR f = do
   VD {caps, j} <- getViewData
+  App { appJournal } <- getYesod
   when (CapManage `notElem` caps) (permissionDenied "Missing the 'manage' capability")
 
   (f', txt) <- journalFile404 f j
@@ -37,7 +40,9 @@ postEditR f = do
     Left e -> do
       setMessage $ "Failed to load journal: " <> toHtml e
       showForm view enctype
-    Right () -> do
+    Right j' -> do
+      -- explicitly write to IORef for journals read from stdin
+      liftIO $ writeIORef appJournal j'
       setMessage $ "Saved journal " <> toHtml f <> "\n"
       redirect JournalR
   where

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -48,13 +48,14 @@ fromFormSuccess h FormMissing = h
 fromFormSuccess h (FormFailure _) = h
 fromFormSuccess _ (FormSuccess a) = pure a
 
-writeValidJournal :: MonadHandler m => FilePath -> Text -> m (Either String ())
+writeValidJournal :: MonadHandler m => FilePath -> Text -> m (Either String Journal)
+writeValidJournal "-" txt = liftIO (readJournal def Nothing txt)
 writeValidJournal f txt =
   liftIO (readJournal def (Just f) txt) >>= \case
     Left e -> return (Left e)
-    Right _ -> do
+    Right j -> do
       _ <- liftIO (writeFileWithBackupIfChanged f txt)
-      return (Right ())
+      return (Right j)
 
 
 -- | Link to a topic in the manual.

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -219,6 +219,7 @@ journalFileIsNewer j@Journal{jlastreadtime=tread} = do
 -- | Has the specified file (presumably one of journal's data files)
 -- changed since journal was last read ?
 journalSpecifiedFileIsNewer :: Journal -> FilePath -> IO Bool
+journalSpecifiedFileIsNewer _ "-" = return False
 journalSpecifiedFileIsNewer Journal{jlastreadtime=tread} f = do
   tmod <- fileModificationTime f
   return $ diffClockTimes tmod tread > (TimeDiff 0 0 0 0 0 0 0)


### PR DESCRIPTION
Closes #855. The hledger-web half of #950.

This also fixes some oversights regarding `"-"` journal files in hledger-lib and
hledger (some, not all).

The behavior with `-f -` is currently the following: the journal is loaded into
memory, and any /add commands append to the in-memory journal. /edit doesn't do
anything yet as `readJournalFiles` uses `readFileOrStdinPortably` and assumes
the file is either `-` or a file, so there's some postprocessing (filters, anon,
...) that would need to be reimplemented.

The #950 part is just using `ensureJournalFileExists` in place of
`requireJournalFileExists`.