### PR TITLE
cli, web, ui: Replace withJournalDo* variants

### DIFF
--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -175,9 +175,9 @@ main = do
             cmdaction opts (error "journal-less command tried to use the journal")
           "add" ->  -- should create the journal if missing
             (ensureJournalFileExists =<< (head <$> journalFilePathFromOpts opts)) >>
-            withJournalDo opts cmdaction
+            withJournalDo opts (cmdaction opts)
           _ ->      -- all other commands: read the journal or fail if missing
-            withJournalDo opts cmdaction
+            withJournalDo opts (cmdaction opts)
         )
         `orShowHelp` cmdmode
 

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -61,19 +61,19 @@ import Hledger.Utils
 -- | Parse the user's specified journal file(s) as a Journal, maybe apply some
 -- transformations according to options, and run a hledger command with it. 
 -- Or, throw an error.
-withJournalDo :: CliOpts -> (CliOpts -> Journal -> IO ()) -> IO ()
+withJournalDo :: CliOpts -> (Journal -> IO a) -> IO a
 withJournalDo opts cmd = do
   -- We kludgily read the file before parsing to grab the full text, unless
   -- it's stdin, or it doesn't exist and we are adding. We read it strictly
   -- to let the add command work.
   journalpaths <- journalFilePathFromOpts opts
-  readJournalFiles (inputopts_ opts) journalpaths 
+  readJournalFiles (inputopts_ opts) journalpaths
   >>= mapM (journalTransform opts)
-  >>= either error' (cmd opts)
+  >>= either error' cmd
 
 -- | Apply some transformations to the journal if specified by options.
 -- These include:
--- 
+--
 -- - adding forecast transactions (--forecast)
 -- - converting amounts to market value (--value)
 -- - pivoting account names (--pivot)


### PR DESCRIPTION
This finally removes the duplication between hledger-cli's, hledger-ui's and
hledger-web's entrypoints. I'd wanted to do this a long time ago, but only now
was I annoyed enough by the XXX's around those places to actually do it :)

On another note, this PR conflicts with my other one (#978). I didn't want to
create a PR against another PR, so whichever one you get around to merging
first, I'll just need to rebase the other one (for the three lines of worth of
conflicts, oh well).

There is just one thing I'm not sure about. The original hledger-ui's entrypoint
did some changes to `CLIOpts` that I've pulled out so that they are now sent to
both `withJournalDo` and to `runBrickUI`, which wasn't the case previously as
`runBrickUi` used the unchanged `UIOpts`. The two options affected are `auto_`
and `forecast_`. AFAICT, these pertain just to reading the journal, but the
change might affect a potential `reloadJournalIfChanged`, so I'm mentioning it
here...