### PR TITLE
Docker build : small fixes and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM debian:stable-slim as dev
+FROM haskell as dev
 
-RUN apt-get update
-RUN apt-get install -y curl libtinfo-dev
-RUN (curl -sSL https://get.haskellstack.org/ | sh)
 RUN mkdir /root/hledger
 WORKDIR /root/hledger
 

--- a/site/download.md
+++ b/site/download.md
@@ -254,3 +254,16 @@ cabal users may find the `cabal-install.sh` or `cabal.project` files useful.
 The --version output of development builds has a .99 suffix meaning "dev".
 So 1.14.99 means "1.15-dev", the in-development version of 1.15.
 
+### Building the development version with docker
+
+You can also build development version in the docker container, which will take care of pulling
+all the necessary tools and dependencies:
+
+  **`git clone https://github.com/simonmichael/hledger`**\
+  **`cd hledger/docker`**\
+  **`./build.sh`**\
+
+This will build image tagged `hledger` with just the latest binaries inside.
+
+If you want to keep all the build artifacts and use the resulting image for hledger development, use
+`build-dev.sh` instead.


### PR DESCRIPTION
Dockerfile: use haskell as a base layer for faster build (stack, ghc preinstalled)
docs: mention the option of docker build from sources