### PR TITLE
Constrain easytest dependency to fix cabal build

### DIFF
--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e2c444e055dd9ef61f9cbddeeddf69ce3274e6c2eef4b64301b7107144d7d84b
+-- hash: c3d364a1b6c518c28f158056c77b07a1d5f77ce81b78bbc5eef793acda6e95bb
 
 name:           hledger-lib
 version:        1.14
@@ -119,7 +119,7 @@ library
     , data-default >=0.5
     , deepseq
     , directory
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , extra
     , file-embed >=0.0.10
     , filepath
@@ -221,7 +221,7 @@ test-suite doctests
     , deepseq
     , directory
     , doctest >=0.16
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , extra
     , file-embed >=0.0.10
     , filepath
@@ -322,7 +322,7 @@ test-suite easytests
     , data-default >=0.5
     , deepseq
     , directory
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , extra
     , file-embed >=0.0.10
     , filepath

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -54,7 +54,7 @@ dependencies:
 - Decimal
 - deepseq
 - directory
-- easytest
+- easytest >= 0.2.1 && <0.3
 - file-embed >=0.0.10
 - filepath
 - hashtables >=1.2.3.1

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c936fb07d9099bcceeb59ad6e75b91aae6928718a53608affb3d9e7b6c4fe89d
+-- hash: 2268c7796f5cb9b049cc817c572e0d69a4d784a1b4bfa9df98dca771963e6b2c
 
 name:           hledger
 version:        1.14.1
@@ -152,7 +152,7 @@ library
     , containers
     , data-default >=0.5
     , directory
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , filepath
     , hashable >=1.2.4
     , haskeline >=0.6
@@ -202,7 +202,7 @@ executable hledger
     , containers
     , data-default >=0.5
     , directory
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , filepath
     , haskeline >=0.6
     , hledger
@@ -254,7 +254,7 @@ test-suite test
     , containers
     , data-default >=0.5
     , directory
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , filepath
     , haskeline >=0.6
     , hledger
@@ -306,7 +306,7 @@ benchmark bench
     , criterion
     , data-default >=0.5
     , directory
-    , easytest
+    , easytest >=0.2.1 && <0.3
     , filepath
     , haskeline >=0.6
     , hledger

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -115,7 +115,7 @@ dependencies:
 - data-default >=0.5
 - Decimal
 - directory
-- easytest
+- easytest >= 0.2.1 && <0.3
 - filepath
 - haskeline >=0.6
 - megaparsec >=7.0.0 && <8


### PR DESCRIPTION
This constraints the easytest dependency to <0.3, because hledger and
hledger-lib currently don't build with 0.3.

Of course the better solution would be to fix the build errors, but easytest-0.3
is not even in stackage nightly yet and I just need it to build right now :-)