### PR TITLE
Fix postings report averaging

### DIFF
--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -81,8 +81,10 @@ postingsReport opts q j = (totallabel, items)
           startbal | average_ opts = if historical then precedingavg else 0
                    | otherwise     = if historical then precedingsum else 0
           startnum = if historical then length precedingps + 1 else 1
-          runningcalc | average_ opts = \i avg amt -> divideMixedAmount (fromIntegral i) avg + amt - avg  -- running average
+          runningcalc | average_ opts = \i avg amt -> divideMixedAmount (fromIntegral i) (total i avg amt)-- running average
                       | otherwise     = \_ bal amt -> bal + amt                                           -- running total
+            where
+              total i avg amt = amt + (multiplyMixedAmount ((fromIntegral i) - 1) avg)
 
 totallabel = "Total"
 


### PR DESCRIPTION
`reg -A` was calculating incorrect averages. This patch should fix that.

Before (reg -f [test.txt](https://github.com/simonmichael/hledger/files/3050373/test.txt) income -A):

    2018/10/15 Test         income             EUR 1         EUR 1
    2018/10/16 Test         income             EUR 1             0
    2018/10/17 Test         income             EUR 1         EUR 1
    2018/10/18 Test         income             EUR 1             0

After:

    2018/10/15 Test         income             EUR 1         EUR 1
    2018/10/16 Test         income             EUR 1         EUR 1
    2018/10/17 Test         income             EUR 1         EUR 1
    2018/10/18 Test         income             EUR 1         EUR 1