### PR TITLE
Rename hledger-makeitso to hledger-flow

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -215,7 +215,7 @@ Making good software and documentation costs a lot.
 
 [[About real world setup docs]]  
 ["Full-fledged Hledger" tutorial](https://github.com/adept/full-fledged-hledger)&nbsp;&rarr;  
-["hledger: Make It So" tutorial & slideshow](https://github.com/apauley/hledger-makeitso)&nbsp;&rarr;  
+["Hledger Flow" tutorial & slideshow](https://github.com/apauley/hledger-flow)&nbsp;&rarr;  
 [[Simons setup]]  
 
 ### Accounting tasks


### PR DESCRIPTION
I've finally gotten round to giving `hledger-makeitso` a more serious name (as mentioned on the mailing list).

This PR just changes the name and the link to `hledger-flow`.

I see there is a similar link on https://plaintextaccounting.org/
I'll submit another PR on https://github.com/plaintextaccounting/plaintextaccounting.github.io

Are there any other places that needs updating?