### PR TITLE
Fix #1008

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -283,7 +283,7 @@ intervalFromRawOpts = lastDef NoInterval . catMaybes . map intervalfromrawopt
           either
             (\e -> usageError $ "could not parse period option: "++customErrorBundlePretty e)
             extractIntervalOrNothing $
-            parsePeriodExpr nulldate (stripquotes $ T.pack v) -- reference date does not affect the interval
+            parsePeriodExpr undefined (stripquotes $ T.pack v) -- reference date does not affect the interval
       | n == "daily"     = Just $ Days 1
       | n == "weekly"    = Just $ Weeks 1
       | n == "monthly"   = Just $ Months 1


### PR DESCRIPTION
This fixes #1008 

@simonmichael , I can remove the last commit (argument "undefined"). But I think it make sense and it is good coding style.

```
parsePeriodExpr undefined (stripquotes $ T.pack v) -- reference date does not affect the interval
-- before, undefined was nulldate (= `fromGregorian 0 1 1`)
```
Consider this case: due to a bug, the first arg *does* affect the interval. Then the program crashes (without a usefull error message) but at least we know that there is a bug. If we pass `nulldate` instead, the bug might not be obvious but produces wrong reports.