### PR TITLE
print: differentiate line indent (4spc) from pre-comment space (2spc)

### DIFF
--- a/doc/mockups/entry-macros.txt
+++ b/doc/mockups/entry-macros.txt
@@ -10,7 +10,7 @@ $ ls *.entry
 laundry.entry  date.entry
 
 $ hledger entry laundry 20
-2015-05-06 laundry    ;  household:$20
+2015-05-06 laundry  ;  household:$20
     expenses:personal:home:laundry                            $10
     liabilities:personal:accounts payable:household           $10
     assets:personal:cash:wallet                              $-20

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -561,7 +561,7 @@ tests_Transaction =
                   ]
               } `is`
           unlines
-            [ "2012/05/14=2012/05/15 (code) desc    ; tcomment1"
+            [ "2012/05/14=2012/05/15 (code) desc  ; tcomment1"
             , "    ; tcomment2"
             , "    * a         $1.00"
             , "    ; pcomment2"
@@ -583,10 +583,10 @@ tests_Transaction =
                   , ptags = [("ptag1", "val1"), ("ptag2", "val2")]
                   }
            in postingAsLines False False [p] p `is`
-              [ "    * a         $1.00    ; pcomment1"
+              [ "    * a         $1.00  ; pcomment1"
               , "    ; pcomment2"
               , "    ;   tag3: val3  "
-              , "    * a         2.00h    ; pcomment1"
+              , "    * a         2.00h  ; pcomment1"
               , "    ; pcomment2"
               , "    ;   tag3: val3  "
               ]

--- a/hledger-lib/hledger_journal.5
+++ b/hledger-lib/hledger_journal.5
@@ -36,28 +36,28 @@ Here\[aq]s an example:
 \f[C]
 ; A sample journal file. This is a comment.
 
-2008/01/01 income               ; <- transaction\[aq]s first line starts in column 0, contains date and description
-    assets:bank:checking  $1    ; <- posting lines start with whitespace, each contains an account name
-    income:salary        $-1    ;    followed by at least two spaces and an amount
+2008/01/01 income             ; <- transaction\[aq]s first line starts in column 0, contains date and description
+    assets:bank:checking  $1  ; <- posting lines start with whitespace, each contains an account name
+    income:salary        $-1  ;    followed by at least two spaces and an amount
 
 2008/06/01 gift
-    assets:bank:checking  $1    ; <- at least two postings in a transaction
-    income:gifts         $-1    ; <- their amounts must balance to 0
+    assets:bank:checking  $1  ; <- at least two postings in a transaction
+    income:gifts         $-1  ; <- their amounts must balance to 0
 
 2008/06/02 save
     assets:bank:saving    $1
-    assets:bank:checking        ; <- one amount may be omitted; here $-1 is inferred
+    assets:bank:checking      ; <- one amount may be omitted; here $-1 is inferred
 
-2008/06/03 eat & shop           ; <- description can be anything
+2008/06/03 eat & shop         ; <- description can be anything
     expenses:food         $1
-    expenses:supplies     $1    ; <- this transaction debits two expense accounts
-    assets:cash                 ; <- $-2 inferred
+    expenses:supplies     $1  ; <- this transaction debits two expense accounts
+    assets:cash               ; <- $-2 inferred
 
 2008/10/01 take a loan
     assets:bank:checking  $1
     liabilities:debts    $-1
 
-2008/12/31 * pay off            ; <- an optional * or ! after the date means \[dq]cleared\[dq] (or anything you want)
+2008/12/31 * pay off          ; <- an optional * or ! after the date means \[dq]cleared\[dq] (or anything you want)
     liabilities:debts     $1
     assets:bank:checking
 \f[R]
@@ -185,8 +185,8 @@ reconciliation:
 .nf
 \f[C]
 2015/5/30
-    expenses:food     $10   ; food purchased on saturday 5/30
-    assets:checking         ; bank cleared it on monday, date:6/1
+    expenses:food     $10  ; food purchased on saturday 5/30
+    assets:checking        ; bank cleared it on monday, date:6/1
 \f[R]
 .fi
 .IP
@@ -727,7 +727,7 @@ Write the price per unit, as \f[C]\[at] UNITPRICE\f[R] after the amount:
 \f[C]
 2009/1/1
   assets:euros     \[Eu]100 \[at] $1.35  ; one hundred euros purchased at $1.35 each
-  assets:dollars                 ; balancing amount is -$135.00
+  assets:dollars               ; balancing amount is -$135.00
 \f[R]
 .fi
 .RE
@@ -752,8 +752,8 @@ hledger infer the price that balances the transaction:
 .nf
 \f[C]
 2009/1/1
-  assets:euros     \[Eu]100          ; one hundred euros purchased
-  assets:dollars  $-135          ; for $135
+  assets:euros     \[Eu]100        ; one hundred euros purchased
+  assets:dollars  $-135        ; for $135
 \f[R]
 .fi
 .RE
@@ -786,8 +786,8 @@ equivalent, -B shows something different:
 .nf
 \f[C]
 2009/1/1
-  assets:dollars  $-135               ; 135 dollars sold
-  assets:euros     \[Eu]100               ; for 100 euros
+  assets:dollars  $-135             ; 135 dollars sold
+  assets:euros     \[Eu]100             ; for 100 euros
 \f[R]
 .fi
 .IP
@@ -850,7 +850,7 @@ colon, written inside a transaction or posting comment line:
 .IP
 .nf
 \f[C]
-2017/1/16 bought groceries    ; sometag:
+2017/1/16 bought groceries  ; sometag:
 \f[R]
 .fi
 .PP
@@ -859,7 +859,7 @@ comma or end of line, with leading/trailing whitespace removed:
 .IP
 .nf
 \f[C]
-    expenses:food    $10   ; a-posting-tag: the tag value
+    expenses:food    $10 ; a-posting-tag: the tag value
 \f[R]
 .fi
 .PP
@@ -870,7 +870,7 @@ comma separated:
 .IP
 .nf
 \f[C]
-    assets:checking       ; a comment containing tag1:, tag2: some value ...
+    assets:checking      ; a comment containing tag1:, tag2: some value ...
 \f[R]
 .fi
 .PP
@@ -1098,19 +1098,19 @@ Eg:
 .IP
 .nf
 \f[C]
-Y2009      ; set default year to 2009
+Y2009  ; set default year to 2009
 
-12/15      ; equivalent to 2009/12/15
+12/15  ; equivalent to 2009/12/15
   expenses  1
   assets
 
-Y2010      ; change default year to 2010
+Y2010  ; change default year to 2010
 
 2009/1/30  ; specifies the year, not affected
   expenses  1
   assets
 
-1/31       ; equivalent to 2010/1/31
+1/31   ; equivalent to 2010/1/31
   expenses  1
   assets
 \f[R]
@@ -1172,7 +1172,7 @@ commodity-less amounts, or until the next \f[C]D\f[R] directive.
 D $1,000.00
 
 1/1
-  a     5    ; <- commodity-less amount, becomes $1
+  a     5  ; <- commodity-less amount, becomes $1
   b
 \f[R]
 .fi

--- a/hledger-lib/hledger_journal.info
+++ b/hledger-lib/hledger_journal.info
@@ -29,28 +29,28 @@ assisted by the helper modes for emacs or vim.
 
 ; A sample journal file. This is a comment.
 
-2008/01/01 income               ; <- transaction's first line starts in column 0, contains date and description
-    assets:bank:checking  $1    ; <- posting lines start with whitespace, each contains an account name
-    income:salary        $-1    ;    followed by at least two spaces and an amount
+2008/01/01 income             ; <- transaction's first line starts in column 0, contains date and description
+    assets:bank:checking  $1  ; <- posting lines start with whitespace, each contains an account name
+    income:salary        $-1  ;    followed by at least two spaces and an amount
 
 2008/06/01 gift
-    assets:bank:checking  $1    ; <- at least two postings in a transaction
-    income:gifts         $-1    ; <- their amounts must balance to 0
+    assets:bank:checking  $1  ; <- at least two postings in a transaction
+    income:gifts         $-1  ; <- their amounts must balance to 0
 
 2008/06/02 save
     assets:bank:saving    $1
-    assets:bank:checking        ; <- one amount may be omitted; here $-1 is inferred
+    assets:bank:checking      ; <- one amount may be omitted; here $-1 is inferred
 
-2008/06/03 eat & shop           ; <- description can be anything
+2008/06/03 eat & shop         ; <- description can be anything
     expenses:food         $1
-    expenses:supplies     $1    ; <- this transaction debits two expense accounts
-    assets:cash                 ; <- $-2 inferred
+    expenses:supplies     $1  ; <- this transaction debits two expense accounts
+    assets:cash               ; <- $-2 inferred
 
 2008/10/01 take a loan
     assets:bank:checking  $1
     liabilities:debts    $-1
 
-2008/12/31 * pay off            ; <- an optional * or ! after the date means "cleared" (or anything you want)
+2008/12/31 * pay off          ; <- an optional * or ! after the date means "cleared" (or anything you want)
     liabilities:debts     $1
     assets:bank:checking
 
@@ -214,8 +214,8 @@ reports, and the deduction from checking should be reported on 6/1 for
 easy bank reconciliation:
 
 2015/5/30
-    expenses:food     $10   ; food purchased on saturday 5/30
-    assets:checking         ; bank cleared it on monday, date:6/1
+    expenses:food     $10 ; food purchased on saturday 5/30
+    assets:checking       ; bank cleared it on monday, date:6/1
 
 $ hledger -f t.j register food
 2015/05/30                      expenses:food                  $10           $10
@@ -794,7 +794,7 @@ transactions, which you can then search or pivot on.
    A simple tag is a word (which may contain hyphens) followed by a full
 colon, written inside a transaction or posting comment line:
 
-2017/1/16 bought groceries    ; sometag:
+2017/1/16 bought groceries  ; sometag:
 
    Tags can have a value, which is the text after the colon, up to the
 next comma or end of line, with leading/trailing whitespace removed:

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -39,28 +39,28 @@ Here's an example:
 ```journal
 ; A sample journal file. This is a comment.
 
-2008/01/01 income               ; <- transaction's first line starts in column 0, contains date and description
-    assets:bank:checking  $1    ; <- posting lines start with whitespace, each contains an account name
-    income:salary        $-1    ;    followed by at least two spaces and an amount
+2008/01/01 income             ; <- transaction's first line starts in column 0, contains date and description
+    assets:bank:checking  $1  ; <- posting lines start with whitespace, each contains an account name
+    income:salary        $-1  ;    followed by at least two spaces and an amount
 
 2008/06/01 gift
-    assets:bank:checking  $1    ; <- at least two postings in a transaction
-    income:gifts         $-1    ; <- their amounts must balance to 0
+    assets:bank:checking  $1  ; <- at least two postings in a transaction
+    income:gifts         $-1  ; <- their amounts must balance to 0
 
 2008/06/02 save
     assets:bank:saving    $1
-    assets:bank:checking        ; <- one amount may be omitted; here $-1 is inferred
+    assets:bank:checking      ; <- one amount may be omitted; here $-1 is inferred
 
-2008/06/03 eat & shop           ; <- description can be anything
+2008/06/03 eat & shop         ; <- description can be anything
     expenses:food         $1
-    expenses:supplies     $1    ; <- this transaction debits two expense accounts
-    assets:cash                 ; <- $-2 inferred
+    expenses:supplies     $1  ; <- this transaction debits two expense accounts
+    assets:cash               ; <- $-2 inferred
 
 2008/10/01 take a loan
     assets:bank:checking  $1
     liabilities:debts    $-1
 
-2008/12/31 * pay off            ; <- an optional * or ! after the date means "cleared" (or anything you want)
+2008/12/31 * pay off          ; <- an optional * or ! after the date means "cleared" (or anything you want)
     liabilities:debts     $1
     assets:bank:checking
 ```
@@ -163,8 +163,8 @@ be reported on 6/1 for easy bank reconciliation:
 
 ```journal
 2015/5/30
-    expenses:food     $10   ; food purchased on saturday 5/30
-    assets:checking         ; bank cleared it on monday, date:6/1
+    expenses:food     $10  ; food purchased on saturday 5/30
+    assets:checking        ; bank cleared it on monday, date:6/1
 ```
 
 ```shell
@@ -582,8 +582,8 @@ is equivalent, -B shows something different:
 
 ```journal
 2009/1/1
-  assets:dollars  $-135               ; 135 dollars sold
-  assets:euros     €100               ; for 100 euros
+  assets:dollars  $-135              ; 135 dollars sold
+  assets:euros     €100              ; for 100 euros
 ```
 ```shell
 $ hledger bal -N --flat -B
@@ -639,18 +639,18 @@ which you can then [search](/hledger.html#queries) or [pivot](/hledger.html#pivo
 A simple tag is a word (which may contain hyphens) followed by a full colon,
 written inside a transaction or posting [comment](#comments) line:
 ```journal
-2017/1/16 bought groceries    ; sometag:
+2017/1/16 bought groceries  ; sometag:
 ```
 
 Tags can have a value, which is the text after the colon, up to the next comma or end of line, with leading/trailing whitespace removed:
 ```journal
-    expenses:food    $10   ; a-posting-tag: the tag value
+    expenses:food    $10 ; a-posting-tag: the tag value
 ```
 
 Note this means hledger's tag values can not contain commas or newlines.
 Ending at commas means you can write multiple short tags on one line, comma separated:
 ```journal
-    assets:checking       ; a comment containing tag1:, tag2: some value ...
+    assets:checking  ; a comment containing tag1:, tag2: some value ...
 ```
 Here,
 
@@ -774,19 +774,19 @@ You can set a default year to be used for subsequent dates which don't
 specify a year. This is a line beginning with `Y` followed by the year. Eg:
 
 ```journal
-Y2009      ; set default year to 2009
+Y2009  ; set default year to 2009
 
-12/15      ; equivalent to 2009/12/15
+12/15  ; equivalent to 2009/12/15
   expenses  1
   assets
 
-Y2010      ; change default year to 2010
+Y2010  ; change default year to 2010
 
 2009/1/30  ; specifies the year, not affected
   expenses  1
   assets
 
-1/31       ; equivalent to 2010/1/31
+1/31   ; equivalent to 2010/1/31
   expenses  1
   assets
 ```
@@ -845,7 +845,7 @@ The commodity and display format will be applied to all subsequent commodity-les
 D $1,000.00
 
 1/1
-  a     5    ; <- commodity-less amount, becomes $1
+  a     5  ; <- commodity-less amount, becomes $1
   b
 ```
 
@@ -976,11 +976,11 @@ If you ever override the types of those auto-detected english account names ment
 you might need to help the reports a bit. Eg:
 ```journal
 ; make "liabilities" not have the liability type - who knows why
-account liabilities   ; type:E
+account liabilities  ; type:E
 
 ; we need to ensure some other account has the liability type, 
 ; otherwise balancesheet would still show "liabilities" under Liabilities 
-account -             ; type:L
+account -            ; type:L
 ```
 
 #### Account display order

--- a/hledger-lib/hledger_journal.txt
+++ b/hledger-lib/hledger_journal.txt
@@ -30,28 +30,28 @@ DESCRIPTION
 
               ; A sample journal file. This is a comment.
 
-              2008/01/01 income               ; <- transaction's first line starts in column 0, contains date and description
-                  assets:bank:checking  $1    ; <- posting lines start with whitespace, each contains an account name
-                  income:salary        $-1    ;    followed by at least two spaces and an amount
+              2008/01/01 income             ; <- transaction's first line starts in column 0, contains date and description
+                  assets:bank:checking  $1  ; <- posting lines start with whitespace, each contains an account name
+                  income:salary        $-1  ;    followed by at least two spaces and an amount
 
               2008/06/01 gift
-                  assets:bank:checking  $1    ; <- at least two postings in a transaction
-                  income:gifts         $-1    ; <- their amounts must balance to 0
+                  assets:bank:checking  $1  ; <- at least two postings in a transaction
+                  income:gifts         $-1  ; <- their amounts must balance to 0
 
               2008/06/02 save
                   assets:bank:saving    $1
-                  assets:bank:checking        ; <- one amount may be omitted; here $-1 is inferred
+                  assets:bank:checking      ; <- one amount may be omitted; here $-1 is inferred
 
-              2008/06/03 eat & shop           ; <- description can be anything
+              2008/06/03 eat & shop         ; <- description can be anything
                   expenses:food         $1
-                  expenses:supplies     $1    ; <- this transaction debits two expense accounts
-                  assets:cash                 ; <- $-2 inferred
+                  expenses:supplies     $1  ; <- this transaction debits two expense accounts
+                  assets:cash               ; <- $-2 inferred
 
               2008/10/01 take a loan
                   assets:bank:checking  $1
                   liabilities:debts    $-1
 
-              2008/12/31 * pay off            ; <- an optional * or ! after the date means "cleared" (or anything you want)
+              2008/12/31 * pay off          ; <- an optional * or ! after the date means "cleared" (or anything you want)
                   liabilities:debts     $1
                   assets:bank:checking
 
@@ -154,8 +154,8 @@ FILE FORMAT
        easy bank reconciliation:
 
               2015/5/30
-                  expenses:food     $10   ; food purchased on saturday 5/30
-                  assets:checking         ; bank cleared it on monday, date:6/1
+                  expenses:food     $10  ; food purchased on saturday 5/30
+                  assets:checking        ; bank cleared it on monday, date:6/1
 
               $ hledger -f t.j register food
               2015/05/30                      expenses:food                  $10           $10
@@ -533,7 +533,7 @@ FILE FORMAT
 
                   2009/1/1
                     assets:euros     EUR100 @ $1.35  ; one hundred euros purchased at $1.35 each
-                    assets:dollars                 ; balancing amount is -$135.00
+                    assets:dollars                   ; balancing amount is -$135.00
 
        2. Write the total price, as @@ TOTALPRICE after the amount:
 
@@ -546,7 +546,7 @@ FILE FORMAT
 
                   2009/1/1
                     assets:euros     EUR100          ; one hundred euros purchased
-                    assets:dollars  $-135          ; for $135
+                    assets:dollars  $-135            ; for $135
 
        (Ledger users: Ledger uses a different syntax for fixed prices, {=UNIT-
        PRICE}, which hledger currently ignores).
@@ -568,8 +568,8 @@ FILE FORMAT
        is equivalent, -B shows something different:
 
               2009/1/1
-                assets:dollars  $-135               ; 135 dollars sold
-                assets:euros     EUR100               ; for 100 euros
+                assets:dollars  $-135                ; 135 dollars sold
+                assets:euros     EUR100              ; for 100 euros
 
               $ hledger bal -N --flat -B
                              EUR-100  assets:dollars  # <- the dollars' selling price
@@ -618,7 +618,7 @@ FILE FORMAT
        A  simple  tag is a word (which may contain hyphens) followed by a full
        colon, written inside a transaction or posting comment line:
 
-              2017/1/16 bought groceries    ; sometag:
+              2017/1/16 bought groceries  ; sometag:
 
        Tags can have a value, which is the text after the  colon,  up  to  the
        next comma or end of line, with leading/trailing whitespace removed:
@@ -827,7 +827,7 @@ FILE FORMAT
               D $1,000.00
 
               1/1
-                a     5    ; <- commodity-less amount, becomes $1
+                a     5 ; <- commodity-less amount, becomes $1
                 b
 
        As with the commodity directive, the amount must always be written with

--- a/tests/csv/csv-read.test
+++ b/tests/csv/csv-read.test
@@ -29,7 +29,7 @@ $  printf 'account1 Assets:MyAccount\ndate %%1\ndate-format %%d/%%Y/%%m\ndescrip
 
 # 3. handle conditions assigning multiple fields
 $  printf 'fields date, description, amount\ndate-format %%d/%%Y/%%m\ncurrency $\naccount1 assets:myacct\nif Flubber\n  account2 acct\n  comment cmt' >t.$$.csv.rules; printf '10/2009/09,Flubber Co,50\n' | hledger -f csv:- --rules-file t.$$.csv.rules print && rm -rf t.$$.csv.rules
-2009/09/10 Flubber Co    ; cmt
+2009/09/10 Flubber Co  ; cmt
     assets:myacct             $50
     acct                     $-50
 

--- a/tests/i18n/wide-char-layout.test
+++ b/tests/i18n/wide-char-layout.test
@@ -21,7 +21,7 @@ hledger -f - print
 >>>
 2000/01/01 transaction 1
     㐀       㐃㐃1 @ 2 㐂㐂㐂㐂㐂㐂㐂㐂㐂㐂㐂
-    㐀:㐁        ; 㐃㐃-1
+    㐀:㐁      ; 㐃㐃-1
 
 2000/01/02 transaction 2
     㐀:㐁:㐂              USD 1

--- a/tests/journal/auto-postings.test
+++ b/tests/journal/auto-postings.test
@@ -17,9 +17,9 @@
 $ hledger print -f- --auto
 2016/01/01 paycheck
     income:remuneration           $-100
-    (liabilities:tax)              $-33    ; income tax
+    (liabilities:tax)              $-33  ; income tax
     income:donations               $-15
-    (liabilities:tax)               $-5    ; income tax
+    (liabilities:tax)               $-5  ; income tax
     assets:bank
 
 2016/01/01 withdraw
@@ -266,9 +266,9 @@ $ hledger print -f- --auto --forecast -b 2016-01 -e 2016-03
 2016/02/01 paycheck
     ; recur: monthly from 2016-01
     income:remuneration           $-100
-    (liabilities:tax)              $-33    ; income tax
+    (liabilities:tax)              $-33  ; income tax
     income:donations               $-15
-    (liabilities:tax)               $-5    ; income tax
+    (liabilities:tax)               $-5  ; income tax
     assets:bank
 
 >=
@@ -311,13 +311,13 @@ $ hledger -f- register --auto
   taxes  *0.2
 
 2018/12/18
-  a    EUR -10.00    ; :tax20:
+  a    EUR -10.00  ; :tax20:
   b    EUR 12.00
 
 # 16. Transaction balancing sees auto postings ?
 # $ hledger -f- print -x --auto
 # 2018/12/18
-#     a          EUR -10.00    ; :tax20:
+#     a          EUR -10.00  ; :tax20:
 #     taxes       EUR -2.00
 #     b           EUR 12.00
 #

--- a/tests/journal/comments.test
+++ b/tests/journal/comments.test
@@ -15,7 +15,7 @@ hledger -f - print
 ; pre-transaction comment, ignored
 2009/1/1 x ; transaction same line comment
       ; transaction new line comment
-    a  1    ; posting 1 same line comment
+    a  1  ; posting 1 same line comment
     ; posting 1 new line comment
     a
       ; posting 2 new line comment
@@ -23,9 +23,9 @@ hledger -f - print
 
 ; trailing file comment, ignored
 >>>
-2009/01/01 x    ; transaction same line comment
+2009/01/01 x  ; transaction same line comment
     ; transaction new line comment
-    a               1    ; posting 1 same line comment
+    a               1  ; posting 1 same line comment
     ; posting 1 new line comment
     a
     ; posting 2 new line comment
@@ -38,7 +38,7 @@ hledger -f - print
 <<<
 2017/1/1 this # and * are not ; the comment
 >>>
-2017/01/01 this # and * are not    ; the comment
+2017/01/01 this # and * are not  ; the comment
 
 >>>2
 >>>=0

--- a/tests/journal/tags.test
+++ b/tests/journal/tags.test
@@ -12,12 +12,12 @@ hledger -f - print
   ; posting-2-tag-2:
 ; non-metadata:
 >>>
-2010/01/01    ; txntag1: txn val 1
+2010/01/01  ; txntag1: txn val 1
     ; txntag2: txn val 2
     a               1
     ; posting1tag1: posting 1 val 1
     ; posting1tag2:
-    b              -1    ; posting-2-tag-1: posting 2 val 1
+    b              -1  ; posting-2-tag-1: posting 2 val 1
     ; posting-2-tag-2:
 
 >>>2
@@ -26,11 +26,11 @@ hledger -f - print
 # 2. reports can filter by tag existence
 hledger -f - print tag:foo
 <<<
-2010/01/01    ; foo:bar
+2010/01/01  ; foo:bar
   a             1
   b            -1
 
-2010/01/02    ; foo:baz
+2010/01/02  ; foo:baz
   c             1
   d            -1
 
@@ -38,11 +38,11 @@ hledger -f - print tag:foo
     e             1
     f            -1
 >>>
-2010/01/01    ; foo:bar
+2010/01/01  ; foo:bar
     a               1
     b              -1
 
-2010/01/02    ; foo:baz
+2010/01/02  ; foo:baz
     c               1
     d              -1
 
@@ -52,7 +52,7 @@ hledger -f - print tag:foo
 # 3. or tag value
 hledger -f - print tag:foo=bar
 <<<
-2010/01/01    ; foo:bar
+2010/01/01  ; foo:bar
   a             1
   b            -1
 
@@ -65,7 +65,7 @@ hledger -f - print tag:foo=bar
     e             1
     f            -1
 >>>
-2010/01/01    ; foo:bar
+2010/01/01  ; foo:bar
     a               1
     b              -1
 
@@ -76,14 +76,14 @@ hledger -f - print tag:foo=bar
 hledger -f - register tag:foo=bar
 <<<
 2010/01/01
-  a             1    ; foo:bar
+  a             1  ; foo:bar
   b            -1
 
-2010/01/02    ; foo:baz
+2010/01/02  ; foo:baz
   c             1
   d            -1
 
-2010/01/03    ; foo:bar
+2010/01/03  ; foo:bar
   e             1
   f            -1
 >>>

--- a/tests/misc/amount-rendering.test
+++ b/tests/misc/amount-rendering.test
@@ -3,15 +3,15 @@
 hledger -f - print --explicit
 <<<
 2010/1/1
-    a  EUR 1    ; a euro
-    b  USD 1    ; a dollar
-    c           ; a euro and a dollar
+    a  EUR 1  ; a euro
+    b  USD 1  ; a dollar
+    c         ; a euro and a dollar
 >>>
 2010/01/01
-    a           EUR 1    ; a euro
-    b           USD 1    ; a dollar
-    c          EUR -1    ; a euro and a dollar
-    c          USD -1    ; a euro and a dollar
+    a           EUR 1  ; a euro
+    b           USD 1  ; a dollar
+    c          EUR -1  ; a euro and a dollar
+    c          USD -1  ; a euro and a dollar
 
 >>>=0
 
@@ -19,9 +19,9 @@ hledger -f - print --explicit
 hledger -f - register
 <<<
 2010/1/1
-    a  EUR 1    ; a euro
-    b  USD 1    ; a dollar
-    c           ; a euro and a dollar
+    a  EUR 1  ; a euro
+    b  USD 1  ; a dollar
+    c         ; a euro and a dollar
 >>>
 2010/01/01                      a                            EUR 1         EUR 1
                                 b                            USD 1         EUR 1
@@ -34,9 +34,9 @@ hledger -f - register
 hledger -f - balance
 <<<
 2010/1/1
-    a  EUR 1    ; a euro
-    b  USD 1    ; a dollar
-    c           ; a euro and a dollar
+    a  EUR 1  ; a euro
+    b  USD 1  ; a dollar
+    c         ; a euro and a dollar
 >>>
                EUR 1  a
                USD 1  b
@@ -90,20 +90,20 @@ D 1000,00€
 # <<<
 # 2010/1/1
 #     a  EUR 1 @ USD 1.1 ; a euro
-#     b  USD 1    ; a dollar
-#     c           ; a euro and a dollar
+#     b  USD 1  ; a dollar
+#     c         ; a euro and a dollar
 # >>>
 # 2010/01/01
-#     a  EUR 1 @ USD 1.1    ; a euro
-#     b         USD 1    ; a dollar
+#     a  EUR 1 @ USD 1.1  ; a euro
+#     b         USD 1  ; a dollar
 #        EUR -1 @ USD 1.1                       
-#     c            USD -1    ; a euro and a dollar
+#     c            USD -1  ; a euro and a dollar
 #
 ##
 # 2010/01/01
-#     a  EUR 1 @ USD 1.1    ; a euro
-#     b       USD 1.0    ; a dollar
-#     c      USD -2.1    ; a euro and a dollar
+#     a  EUR 1 @ USD 1.1  ; a euro
+#     b       USD 1.0  ; a dollar
+#     c      USD -2.1  ; a euro and a dollar
 #
 #>>>=0
 #
@@ -112,8 +112,8 @@ D 1000,00€
 # <<<
 # 2010/1/1
 #     a  EUR 1 @ USD 1.1 ; a euro
-#     b  USD 1    ; a dollar
-#     c           ; a euro and a dollar
+#     b  USD 1  ; a dollar
+#     c         ; a euro and a dollar
 # >>>
 # 2010/01/01                      a                             EUR 1        EUR 1
 #                                                                            EUR 1
@@ -127,8 +127,8 @@ D 1000,00€
 # <<<
 # 2010/1/1
 #     a  EUR 1 @ USD 1.1 ; a euro
-#     b  USD 1    ; a dollar
-#     c           ; a euro and a dollar
+#     b  USD 1  ; a dollar
+#     c         ; a euro and a dollar
 # >>>
 #                EUR 1  a
 #              USD 1.0  b

--- a/tests/misc/rewrite.test
+++ b/tests/misc/rewrite.test
@@ -14,9 +14,9 @@ hledger rewrite -f- ^income --add-posting '(liabilities:tax)  *.33  ; income tax
 >>>
 2016/01/01 paycheck
     income:remuneration           $-100
-    (liabilities:tax)              $-33    ; income tax
+    (liabilities:tax)              $-33  ; income tax
     income:donations               $-15
-    (liabilities:tax)               $-5    ; income tax
+    (liabilities:tax)               $-5  ; income tax
     assets:bank
 
 2016/01/01 withdraw
@@ -43,8 +43,8 @@ hledger rewrite -f- expenses:gifts --add-posting '(budget:gifts)  *-1'
 
 2016/01/01 gift
     assets:cash               $-15
-    expenses:gifts        ; [1/2]
-    (budget:gifts)            $-15    ; [2016/01/02]
+    expenses:gifts      ; [1/2]
+    (budget:gifts)            $-15  ; [2016/01/02]
 
 >>>2
 >>>=0
@@ -211,7 +211,7 @@ hledger rewrite -f- date:2017/1  --add-posting 'Here comes Santa  $0'
     Here comes Santa               0
     assets:bank
     assets:bank               $-1.60
-    expenses:fee               $1.60    ; cash withdraw fee
+    expenses:fee               $1.60  ; cash withdraw fee
     (budget:misc)             $-1.60
     Here comes Santa               0
 


### PR DESCRIPTION
Fixes #1047.

- [x] Split `indent` value so comment separation spaces can be different from posting indents
- [x] Update examples in documentation
- [x] Update output of tests

Optionally...

- [ ] Make number of spaces user configurable