### PR TITLE
print: allow decimal point aligning, like ledger-mode (WIP)

### DIFF
--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -59,7 +59,7 @@ printEntries opts@CliOpts{reportopts_=ropts} j = do
   writeOutput opts $ render $ entriesReport ropts' q j
 
 entriesReportAsText :: CliOpts -> EntriesReport -> String
-entriesReportAsText opts = concatMap (showTransactionUnelided . gettxn) 
+entriesReportAsText opts = concatMap (showTransactionUnelided2 . gettxn) 
   where
     gettxn | useexplicittxn = id                   -- use fully inferred amounts & txn prices 
            | otherwise      = originalTransaction  -- use original as-written amounts/txn prices


### PR DESCRIPTION
Part of #1045. I created showTransaction2 and helpers, with the immediate goal of (a) clarifying this code and (b) implementing output like ledger-mode's :decimal setting.

What I had in mind: for postingAsLines to do decimal mark alignment, it needs to know which part of each rendered amount is to left and which to the right of the decimal mark. The decimal mark can be period or comma, and that character can also appear in a (double quoted) commodity symbol, so parsing the rendered amount seems a bit fiddly with potential to get out of sync with rendering code. I thought instead to have helpers like showMixedAmountLR & showMixedAmountOneLineLR which return the left and right parts; possibly showMixedAmount[OneLine] would use these also. These would need a showAmountLR :: Amount -> (String,String).