### PR TITLE
[WIP] web: Add option --socket to use UNIX socket file

### DIFF
--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.32.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 194a16a30440803cd2bef5d5df0b6115ad66076c44407ed31efea9c4602e5e95
+-- hash: a9a6dea39ea5c963970cda9f595e7c4251332954aacd137fb6638a1e7640ee59
 
 name:           hledger-web
 version:        1.16.99
@@ -176,12 +176,14 @@ library
     , http-types
     , megaparsec >=7.0.0 && <8
     , mtl >=2.2.1
+    , network
     , semigroups
     , shakespeare >=2.0.2.2
     , template-haskell
     , text >=1.2
     , time >=1.5
     , transformers
+    , unix-compat
     , utf8-string
     , wai
     , wai-cors

--- a/hledger-web/hledger-web.m4.md
+++ b/hledger-web/hledger-web.m4.md
@@ -72,6 +72,10 @@ as shown in the synopsis above.
 `--port=PORT`
 : listen on this TCP port (default: 5000)
 
+`--socket=SOCKETFILE`
+: use a unix domain socket file to listen for requests instead of a TCP socket. Implies
+`--serve`. It can only be used if the operating system can provide this type of socket.
+
 `--base-url=URL`
 : set the base url (default: http://IPADDR:PORT).
 You would change this when sharing over the network, or integrating within a larger website.
@@ -118,6 +122,20 @@ You can use `--host` to change this, eg `--host 0.0.0.0` to listen on all config
 
 Similarly, use `--port` to set a TCP port other than 5000, eg if you are
 running multiple hledger-web instances.
+
+Both of these options are ignored when `--socket` is used. In this case, it 
+creates an `AF_UNIX` socket file at the supplied path and uses that for communication.
+This is an alternative way of running multiple hledger-web instances behind 
+a reverse proxy that handles authentication for different users.
+The path can be derived in a predictable way, eg by using the username within the path.
+As an example, `nginx` as reverse proxy can use the variabel `$remote_user` to 
+derive a path from the username used in a [HTTP basic authentication](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/). 
+The following `proxy_pass` directive allows access to all `hledger-web` 
+instances that created a socket in `/tmp/hledger/`:
+
+```
+  proxy_pass http://unix:/tmp/hledger/${remote_user}.socket;
+```
 
 You can use `--base-url` to change the protocol, hostname, port and path that appear in hyperlinks,
 useful eg for integrating hledger-web within a larger website.

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -120,12 +120,14 @@ library:
   - http-types
   - megaparsec >=7.0.0 && <8
   - mtl >=2.2.1
+  - network
   - semigroups
   - shakespeare >=2.0.2.2
   - template-haskell
   - text >=1.2
   - time >=1.5
   - transformers
+  - unix-compat
   - utf8-string
   - wai
   - wai-extra


### PR DESCRIPTION
# Motivation and Use-Cases

I wanted to run multiple instances of `hledger-web` behind an nginx reverse proxy, but wanted to get around an arbitrary `user -> port`-mapping.
Thus, my idea was to use unix socket files in a scheme like `/tmp/hledger-$username.socket`. This would allow to use an nginx directive like the following:
```
  proxy_pass http://unix:/tmp/hledger-${remote_user}.socket;
```

Other usecases were also given in the IRC channel:
 - `hpd_> maybe because unix sockets allow for proper access control`
 - `alerque[m]> A socket would also be useful for local GUI wrappers.`

# Changes

The main changes are:
 - The code now requires Network.Socket (and thus `network` as a dependency)
   - This gives us the functions to create a socket
 - Introduces `--socket=/path/to/socket` option
   - This implies `--serve`, as most browsers probably won't handle socket files that well
 - Conditionally use the warp handler `runSettingsSocket` instead of `runSettings`

# Problems

While testing, I also found small problems where I do not know how to approach it.

Sockets are not cleaned up properly when quitting. So restarting directly after quitting results in:
```
hledger-web: Network.Socket.bind: resource busy (Address already in use)
```
As far as I can see, this can be solved by just deleting the socket file when quitting. One code to solve this might be here: https://stackoverflow.com/a/36421958 but I did not want to introduce too many requirements (unsure regarding the code organization and style).

As an obvious workaround, one can just `rm` the socket file.

Another problem is that sockets are not supported on windows, so there is probably some conditional inclusion of this code required, so that the option is not available at all on windows systems.

Also, more documentation besides the option description is probably missing