### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN stack install
 
 FROM debian:stable-slim
 
-RUN apt-get update && apt-get install libgmp10 && rm -rf /var/lib/apt/lists
+RUN apt-get update && apt-get install libtinfo5 libgmp10 && rm -rf /var/lib/apt/lists
 
 COPY --from=dev /root/.local/bin/hledger* /usr/bin/
 


### PR DESCRIPTION
```
root@d579ecf6dca7:/# hledger
hledger: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
Needs package libtinfo5 for hledger
```
I know you are busy.  Hope this trivial change is ok.
