### PR TITLE
Fix periodictxn generation

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -60,7 +60,6 @@ module Hledger.Data.Dates (
   spansSpan,
   spanIntersect,
   spansIntersect,
-  spanIntervalIntersect,
   spanDefaultsFrom,
   spanUnion,
   spansUnion,
@@ -262,27 +261,6 @@ spanIntersect (DateSpan b1 e1) (DateSpan b2 e2) = DateSpan b e
     where
       b = latest b1 b2
       e = earliest e1 e2
-
--- | Calculate the intersection of two DateSpans, adjusting the start date so
--- the interval is preserved.
---
--- >>> let intervalIntersect = spanIntervalIntersect (Days 3)
--- >>> mkdatespan "2018-01-01" "2018-01-03" `intervalIntersect` mkdatespan "2018-01-01" "2018-01-05"
--- DateSpan 2018/01/01-2018/01/02
--- >>> mkdatespan "2018-01-01" "2018-01-05" `intervalIntersect` mkdatespan "2018-01-02" "2018-01-05"
--- DateSpan 2018/01/04
--- >>> mkdatespan "2018-01-01" "2018-01-05" `intervalIntersect` mkdatespan "2018-01-03" "2018-01-05"
--- DateSpan 2018/01/04
--- >>> mkdatespan "2018-01-01" "2018-01-05" `intervalIntersect` mkdatespan "2018-01-04" "2018-01-05"
--- DateSpan 2018/01/04
--- >>> mkdatespan "2018-01-01" "2018-01-05" `intervalIntersect` mkdatespan "2017-12-01" "2018-01-05"
--- DateSpan 2018/01/01-2018/01/04
-spanIntervalIntersect :: Interval -> DateSpan -> DateSpan -> DateSpan
-spanIntervalIntersect (Days n) (DateSpan (Just b1) e1) sp2@(DateSpan (Just b2) _) =
-      DateSpan (Just b) e1 `spanIntersect` sp2
-    where
-      b = if b1 < b2 then addDays (diffDays b1 b2 `mod` toInteger n) b2 else b1
-spanIntervalIntersect _ sp1 sp2 = sp1 `spanIntersect` sp2
 
 -- | Fill any unspecified dates in the first span with the dates from
 -- the second one. Sort of a one-way spanIntersect.

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -286,11 +286,11 @@ budgetReportAsText ropts@ReportOpts{..} budgetr@(PeriodicReport ( _, rows, _)) =
         Just (AtDate d _mc) -> ", valued at "++showDate d
         Nothing             -> "")
     actualwidth =
-      maximum [ maybe 0 (length . showMixedAmountOneLineWithoutPrice) amt
+      maximum' [ maybe 0 (length . showMixedAmountOneLineWithoutPrice) amt
       | (_, _, _, amtandgoals, _, _) <- rows
       , (amt, _) <- amtandgoals ]
     budgetwidth =
-      maximum [ maybe 0 (length . showMixedAmountOneLineWithoutPrice) goal
+      maximum' [ maybe 0 (length . showMixedAmountOneLineWithoutPrice) goal
       | (_, _, _, amtandgoals, _, _) <- rows
       , (_, goal) <- amtandgoals ]
     -- XXX lay out actual, percentage and/or goal in the single table cell for now, should probably use separate cells

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -81,8 +81,8 @@ budgetReport ropts' assrt reportspan d j =
       concatMap tpostings $
       concatMap (flip runPeriodicTransaction reportspan) $
       jperiodictxns j
-    actualj = dbg1 "actualj" $ budgetRollUp budgetedaccts showunbudgeted j
-    budgetj = dbg1 "budgetj" $ budgetJournal assrt ropts reportspan j
+    actualj = dbg1With (("actualj"++).show.jtxns)  $ budgetRollUp budgetedaccts showunbudgeted j
+    budgetj = dbg1With (("budgetj"++).show.jtxns)  $ budgetJournal assrt ropts reportspan j
     actualreport@(MultiBalanceReport (actualspans, _, _)) = dbg1 "actualreport" $ multiBalanceReport ropts  q actualj
     budgetgoalreport@(MultiBalanceReport (_, budgetgoalitems, budgetgoaltotals)) = dbg1 "budgetgoalreport" $ multiBalanceReport (ropts{empty_=True}) q budgetj
     budgetgoalreport'


### PR DESCRIPTION
This fixes #1085 

runPeriodicTransaction tried really hard to avoid generating all instances of periodic transaction since specified start date, trying instead to figure out closest start date before the requested span. Turns out that this is hard, and all attempts done so far (two of them by me) failed on some corner case or other.

Lets make it right, and then see if we need to make it fast :) If we generate all instances of transaction from its start date and up to the end of reporting interval, and then only take those that fall inside reporting interval, code becomes refreshingly simple :)

I added some tests from #1085 and commit 129f6e6839db91fb17c13aa9ce0718f168b5a193