### PR TITLE
Allow CORS to be enabled in hledger-web

### DIFF
--- a/hledger-web/Hledger/Web/Application.hs
+++ b/hledger-web/Hledger/Web/Application.hs
@@ -10,6 +10,7 @@ module Hledger.Web.Application
 
 import Data.IORef (newIORef, writeIORef)
 import Network.Wai.Middleware.RequestLogger (logStdoutDev, logStdout)
+import Network.Wai.Middleware.Cors
 import Network.HTTP.Client (defaultManagerSettings)
 import Network.HTTP.Conduit (newManager)
 import Yesod.Default.Config
@@ -23,7 +24,7 @@ import Hledger.Web.Handler.UploadR
 import Hledger.Web.Handler.JournalR
 import Hledger.Web.Handler.RegisterR
 import Hledger.Web.Import
-import Hledger.Web.WebOptions (WebOpts(serve_,serve_api_))
+import Hledger.Web.WebOptions (WebOpts(serve_,serve_api_,cors_))
 
 -- This line actually creates our YesodDispatch instance. It is the second half
 -- of the call to mkYesodData which occurs in Foundation.hs. Please see the
@@ -38,11 +39,13 @@ makeApplication :: WebOpts -> Journal -> AppConfig DefaultEnv Extra -> IO Applic
 makeApplication opts' j' conf' = do
     foundation <- makeFoundation conf' opts'
     writeIORef (appJournal foundation) j'
-    logWare <$> toWaiApp foundation
+    (logWare . corsWare) <$> toWaiApp foundation
   where
     logWare | development  = logStdoutDev
             | serve_ opts' || serve_api_ opts' = logStdout
             | otherwise    = id
+    corsWare | cors_ opts' = simpleCors
+             | otherwise = id
 
 makeFoundation :: AppConfig DefaultEnv Extra -> WebOpts -> IO App
 makeFoundation conf opts' = do

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -35,6 +35,10 @@ webflags =
       ["serve-api"]
       (setboolopt "serve-api")
       "like --serve, but serve only the JSON web API, without the server-side web UI"
+  , flagNone
+      ["cors"]
+      (setboolopt "cors")
+      ("allow cross-origin requests, setting the Access-Control-Allow-Origin HTTP header to *")
   , flagReq
       ["host"]
       (\s opts -> Right $ setopt "host" s opts)
@@ -94,6 +98,7 @@ webmode =
 data WebOpts = WebOpts
   { serve_ :: Bool
   , serve_api_ :: Bool
+  , cors_ :: Bool
   , host_ :: String
   , port_ :: Int
   , base_url_ :: String
@@ -104,7 +109,7 @@ data WebOpts = WebOpts
   } deriving (Show)
 
 defwebopts :: WebOpts
-defwebopts = WebOpts def def def def def def [CapView, CapAdd] Nothing def
+defwebopts = WebOpts def def def def def def def [CapView, CapAdd] Nothing def
 
 instance Default WebOpts where def = defwebopts
 
@@ -126,6 +131,7 @@ rawOptsToWebOpts rawopts =
       defwebopts
       { serve_ = boolopt "serve" rawopts
       , serve_api_ = boolopt "serve-api" rawopts
+      , cors_ = boolopt "cors" rawopts
       , host_ = h
       , port_ = p
       , base_url_ = b

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bb22226fe2d7562c91dc7dabb7767a786db0ea4441bb79b9016c414c0d5edf59
+-- hash: 4595326c17d463479b0d80c19012ffd367ef2cedbbdee610e8792fd88d4e4c4c
 
 name:           hledger-web
 version:        1.15.99
@@ -183,6 +183,7 @@ library
     , text >=1.2
     , time >=1.5
     , transformers
+    , utf8-string
     , wai
     , wai-cors
     , wai-extra

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2039eae28649153b671940fd3813fa48b76193a9948b1bd466a7ef86575af9cd
+-- hash: bb22226fe2d7562c91dc7dabb7767a786db0ea4441bb79b9016c414c0d5edf59
 
 name:           hledger-web
 version:        1.15.99
@@ -184,6 +184,7 @@ library
     , time >=1.5
     , transformers
     , wai
+    , wai-cors
     , wai-extra
     , wai-handler-launch >=1.3
     , warp

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -132,9 +132,10 @@ library:
   - wai
   - wai-extra
   - wai-handler-launch >=1.3
+  - wai-cors
   - warp
   - yaml
-  # on mac Sierra or greater, ghc 7 will fail to build yesod; don't try  
+  # on mac Sierra or greater, ghc 7 will fail to build yesod; don't try
   when:
     - condition: os(darwin) && impl(ghc < 8.0)
       then:

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -129,6 +129,7 @@ library:
   - text >=1.2
   - time >=1.5
   - transformers
+  - utf8-string
   - wai
   - wai-extra
   - wai-handler-launch >=1.3


### PR DESCRIPTION
This PR adds a `--cors` option to the hledger-web command, which enables a simple CORS policy: it returns the `Access-Control-Allow-Origin: *` HTTP header.

The implementation was proposed by @MisterY in #1031. I just added the management of the CLI option.

Please, review thoroughly as this is my first ever PR in a Haskell project.

Fixes #1031.