### PR TITLE
Make resolver in hledger-install.sh consistent with that in stack.yaml

### DIFF
--- a/hledger-install/hledger-install.sh
+++ b/hledger-install/hledger-install.sh
@@ -56,7 +56,7 @@ HLEDGER_INSTALL_VERSION=20190905
 # You can try specifying a different stackage version here, or 
 # commenting out this line to use your current global resolver,
 # to avoid unnecessary building.
-RESOLVER="--resolver=lts-14.3"
+RESOLVER="--resolver=lts-14.4"
 
 # things to be installed
 


### PR DESCRIPTION
All three results in "git grep resolver | grep 14" now say 14.4.
