### PR TITLE
;lib: store raw opts unquoted

### DIFF
--- a/hledger-lib/Hledger/Data/RawOptions.hs
+++ b/hledger-lib/Hledger/Data/RawOptions.hs
@@ -23,7 +23,6 @@ module Hledger.Data.RawOptions (
 where
 
 import Data.Maybe
-import qualified Data.Text as T
 import Safe
 
 import Hledger.Utils
@@ -33,7 +32,7 @@ import Hledger.Utils
 type RawOpts = [(String,String)]
 
 setopt :: String -> String -> RawOpts -> RawOpts
-setopt name val = (++ [(name, quoteIfNeeded $ val)])
+setopt name val = (++ [(name, val)])
 
 setboolopt :: String -> RawOpts -> RawOpts
 setboolopt name = (++ [(name,"")])
@@ -46,7 +45,7 @@ boolopt :: String -> RawOpts -> Bool
 boolopt = inRawOpts
 
 maybestringopt :: String -> RawOpts -> Maybe String
-maybestringopt name = fmap (T.unpack . stripquotes . T.pack) . lookup name . reverse
+maybestringopt name = lookup name . reverse
 
 stringopt :: String -> RawOpts -> String
 stringopt name = fromMaybe "" . maybestringopt name

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -178,11 +178,11 @@ definputopts = InputOpts def def ',' def def def def True def def
 
 rawOptsToInputOpts :: RawOpts -> InputOpts
 rawOptsToInputOpts rawopts = InputOpts{
-   -- files_             = map (T.unpack . stripquotes . T.pack) $ listofstringopt "file" rawopts
+   -- files_             = listofstringopt "file" rawopts
    mformat_           = Nothing
   ,mrules_file_       = maybestringopt "rules-file" rawopts
   ,separator_         = fromMaybe ',' (maybecharopt "separator" rawopts)
-  ,aliases_           = map (T.unpack . stripquotes . T.pack) $ listofstringopt "alias" rawopts
+  ,aliases_           = listofstringopt "alias" rawopts
   ,anon_              = boolopt "anon" rawopts
   ,ignore_assertions_ = boolopt "ignore-assertions" rawopts
   ,new_               = boolopt "new" rawopts

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -98,7 +98,8 @@ data ReportOpts = ReportOpts {
     ,no_elide_       :: Bool
     ,real_           :: Bool
     ,format_         :: Maybe FormatStr
-    ,query_          :: String -- all arguments, as a string
+    ,query_          :: String -- ^ All query arguments space sepeareted
+                               --   and quoted if needed (see 'quoteIfNeeded')
     --
     ,average_        :: Bool
     -- register command only
@@ -175,7 +176,7 @@ rawOptsToReportOpts rawopts = checkReportOpts <$> do
     ,no_elide_    = boolopt "no-elide" rawopts'
     ,real_        = boolopt "real" rawopts'
     ,format_      = maybestringopt "format" rawopts' -- XXX move to CliOpts or move validation from Cli.CliOptions to here
-    ,query_       = unwords $ listofstringopt "args" rawopts' -- doesn't handle an arg like "" right
+    ,query_       = unwords . map quoteIfNeeded $ listofstringopt "args" rawopts' -- doesn't handle an arg like "" right
     ,average_     = boolopt "average" rawopts'
     ,related_     = boolopt "related" rawopts'
     ,balancetype_ = balancetypeopt rawopts'

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -97,7 +97,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportopts_=rop
             depth_ =depthfromoptsandargs,
             period_=periodfromoptsandargs,
             query_ =unwords -- as in ReportOptions, with same limitations
-                    [v | (k,v) <- rawopts_ copts, k=="args", not $ any (`isPrefixOf` v) ["depth","date"]],
+                    [quoteIfNeeded v | (k,v) <- rawopts_ copts, k=="args", not $ any (`isPrefixOf` v) ["depth","date"]],
             -- always disable boring account name eliding, unlike the CLI, for a more regular tree
             no_elide_=True,
             -- flip the default for items with zero amounts, show them by default

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -430,7 +430,7 @@ rawOptsToCliOpts rawopts = checkCliOpts <$> do
   return defcliopts {
               rawopts_         = rawopts
              ,command_         = stringopt "command" rawopts
-             ,file_            = map (T.unpack . stripquotes . T.pack) $ listofstringopt "file" rawopts
+             ,file_            = listofstringopt "file" rawopts
              ,inputopts_       = iopts
              ,reportopts_      = ropts
              ,output_file_     = maybestringopt "output-file" rawopts

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -92,7 +92,7 @@ add opts j
         showHelp
         today <- getCurrentDay
         let es = defEntryState{esOpts=opts
-                              ,esArgs=map (T.unpack . stripquotes . T.pack) $ listofstringopt "args" $ rawopts_ opts
+                              ,esArgs=listofstringopt "args" $ rawopts_ opts
                               ,esToday=today
                               ,esDefDate=today
                               ,esJournal=j

--- a/hledger/Hledger/Cli/Commands/Import.hs
+++ b/hledger/Hledger/Cli/Commands/Import.hs
@@ -29,7 +29,7 @@ importcmd opts@CliOpts{rawopts_=rawopts,inputopts_=iopts} j = do
   -- XXX could be helpful to show the last-seen date, and number of old transactions, too
   let
     inputfiles = listofstringopt "args" rawopts
-    inputstr = intercalate ", " inputfiles
+    inputstr = intercalate ", " $ map quoteIfNeeded inputfiles
     catchup = boolopt "catchup" rawopts
     dryrun = boolopt "dry-run" rawopts
     iopts' = iopts{new_=True, new_save_=not dryrun}

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -50,7 +50,7 @@ transactionModifierFromOpts CliOpts{rawopts_=rawopts,reportopts_=ropts} =
   TransactionModifier{tmquerytxt=q, tmpostingrules=ps}
   where
     q = T.pack $ query_ ropts
-    ps = map (parseposting . stripquotes . T.pack) $ listofstringopt "add-posting" rawopts
+    ps = map (parseposting . T.pack) $ listofstringopt "add-posting" rawopts
     parseposting t = either (error' . errorBundlePretty) id ep
       where
         ep = runIdentity (runJournalParser (postingp Nothing <* eof) t')

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -30,7 +30,7 @@ tags CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
     mtagpat   = headMay args
     queryargs = drop 1 args
     values    = boolopt "values" rawopts
-    q = queryFromOpts d $ ropts{query_ = unwords queryargs}
+    q = queryFromOpts d $ ropts{query_ = unwords $ map quoteIfNeeded queryargs}
     txns = filter (q `matchesTransaction`) $ jtxns $ journalSelectingAmountFromOpts ropts j
     tagsorvalues =
       nubSort $

--- a/tests/cli/date-options.test
+++ b/tests/cli/date-options.test
@@ -59,3 +59,7 @@ $ hledger -f- register date:2019-02 date:2019-01-01-
 ## Date options override date queries
 #$ hledger -f- register date:2019-02 -p 2019
 #> /2019\/01\/01/
+
+# Smart dates https://github.com/simonmichael/hledger/issues/1079
+$ hledger -f- activity -b 2019-02-01 -e 'next year'
+> /2019-02-01 \*/


### PR DESCRIPTION
It looks like we only need quote when we build query and in some
messages.

Fixes simonmichael/hledger#1079

_(here was big a banner)_