### PR TITLE
Tiny re-factor RawOpts to hide internal representation

### DIFF
--- a/hledger-lib/Hledger/Utils.hs
+++ b/hledger-lib/Hledger/Utils.hs
@@ -29,7 +29,7 @@ module Hledger.Utils (---- provide these frequently used modules - or not, for c
                           -- Debug.Trace.trace,
                           -- module Data.PPrint,
                           -- module Hledger.Utils.UTF8IOCompat
-                          SystemString,fromSystemString,toSystemString,error',userError',usageError,
+                          error',userError',usageError,
                           -- the rest need to be done in each module I think
                           )
 where
@@ -66,7 +66,7 @@ import Hledger.Utils.Color
 import Hledger.Utils.Tree
 -- import Prelude hiding (readFile,writeFile,appendFile,getContents,putStr,putStrLn)
 -- import Hledger.Utils.UTF8IOCompat   (readFile,writeFile,appendFile,getContents,putStr,putStrLn)
-import Hledger.Utils.UTF8IOCompat (SystemString,fromSystemString,toSystemString,error',userError',usageError)
+import Hledger.Utils.UTF8IOCompat (error',userError',usageError)
 
 
 -- tuples

--- a/hledger-lib/Hledger/Utils/UTF8IOCompat.hs
+++ b/hledger-lib/Hledger/Utils/UTF8IOCompat.hs
@@ -15,6 +15,9 @@ Example usage:
 do the right thing, so this file is a no-op and on its way to being removed.
 Not carefully tested.
 
+2019/10/20 update: all packages have base>=4.9 which corresponds to GHC v8.0.1
+and higher. Tear this file apart!
+
 -}
 -- TODO obsolete ?
 
@@ -29,9 +32,6 @@ module Hledger.Utils.UTF8IOCompat (
   hPutStr,
   hPutStrLn,
   --
-  SystemString,
-  fromSystemString,
-  toSystemString,
   error',
   userError',
   usageError,
@@ -85,37 +85,19 @@ import System.IO -- (Handle)
 -- bs_hPutStr        = B8.hPut
 -- bs_hPutStrLn h bs = B8.hPut h bs >> B8.hPut h (B.singleton 0x0a)
 
-
--- | A string received from or being passed to the operating system, such
--- as a file path, command-line argument, or environment variable name or
--- value. With GHC versions before 7.2 on some platforms (posix) these are
--- typically encoded. When converting, we assume the encoding is UTF-8 (cf
--- <http://www.dwheeler.com/essays/fixing-unix-linux-filenames.html#UTF8>).
-type SystemString = String
-
--- | Convert a system string to an ordinary string, decoding from UTF-8 if
--- it appears to be UTF8-encoded and GHC version is less than 7.2.
-fromSystemString :: SystemString -> String
-fromSystemString = id
-
--- | Convert a unicode string to a system string, encoding with UTF-8 if
--- we are on a posix platform with GHC < 7.2.
-toSystemString :: String -> SystemString
-toSystemString = id
-
 -- | A SystemString-aware version of error.
 error' :: String -> a
 error' =
 #if __GLASGOW_HASKELL__ < 800
 -- (easier than if base < 4.9)
-  error . toSystemString
+  error
 #else
-  errorWithoutStackTrace . toSystemString
+  errorWithoutStackTrace
 #endif
 
 -- | A SystemString-aware version of userError.
 userError' :: String -> IOError
-userError' = userError . toSystemString
+userError' = userError
 
 -- | A SystemString-aware version of error that adds a usage hint.
 usageError :: String -> a

--- a/hledger-ui/Hledger/UI/UIOptions.hs
+++ b/hledger-ui/Hledger/UI/UIOptions.hs
@@ -106,10 +106,10 @@ checkUIOpts opts =
 
 -- XXX some refactoring seems due
 getHledgerUIOpts :: IO UIOpts
---getHledgerUIOpts = processArgs uimode >>= return . decodeRawOpts >>= rawOptsToUIOpts
+--getHledgerUIOpts = processArgs uimode >>= return >>= rawOptsToUIOpts
 getHledgerUIOpts = do
   args <- getArgs >>= expandArgsAt
   let args' = replaceNumericFlags args
   let cmdargopts = either usageError id $ process uimode args'
-  rawOptsToUIOpts $ decodeRawOpts cmdargopts
+  rawOptsToUIOpts cmdargopts
 

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -28,7 +28,7 @@ version = ""
 prognameandversion :: String
 prognameandversion = progname ++ " " ++ version :: String
 
-webflags :: [Flag [(String, String)]]
+webflags :: [Flag RawOpts]
 webflags =
   [ flagNone
       ["serve", "server"]
@@ -75,11 +75,11 @@ webflags =
       "read capabilities to enable from a HTTP header, like X-Sandstorm-Permissions (default: disabled)"
   ]
 
-webmode :: Mode [(String, String)]
+webmode :: Mode RawOpts
 webmode =
   (mode
      "hledger-web"
-     [("command", "web")]
+     (setopt "command" "web" def)
      "start serving the hledger web interface"
      (argsFlag "[PATTERNS]")
      [])

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -157,7 +157,7 @@ checkWebOpts wopts = do
 getHledgerWebOpts :: IO WebOpts
 getHledgerWebOpts = do
   args <- fmap replaceNumericFlags . expandArgsAt =<< getArgs
-  rawOptsToWebOpts . decodeRawOpts . either usageError id $ process webmode args
+  rawOptsToWebOpts . either usageError id $ process webmode args
 
 data Capability
   = CapView

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -223,7 +223,7 @@ defMode = Mode {
    ,groupHidden  = []             --  flags not displayed in the usage
    }
  ,modeArgs        = ([], Nothing) -- description of arguments accepted by the command
- ,modeValue       = []            -- value returned when this mode is used to parse a command line
+ ,modeValue       = def           -- value returned when this mode is used to parse a command line
  ,modeCheck       = Right         -- whether the mode's value is correct
  ,modeReform      = const Nothing -- function to convert the value back to a command line arguments
  ,modeExpandAt    = True          -- expand @ arguments for program ?
@@ -245,7 +245,7 @@ defCommandMode names = defMode {
     ,groupHidden  = []             --  flags not displayed in the usage
     }
   ,modeArgs = ([], Just $ argsFlag "[QUERY]")
-  ,modeValue=[("command", headDef "" names)]
+  ,modeValue=setopt "command" (headDef "" names) def
   }
 
 -- | A cmdargs mode representing the hledger add-on command with the

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -396,7 +396,7 @@ defcliopts = CliOpts
 
 -- | Convert possibly encoded option values to regular unicode strings.
 decodeRawOpts :: RawOpts -> RawOpts
-decodeRawOpts = map (\(name',val) -> (name', fromSystemString val))
+decodeRawOpts = id  -- TODO: drop usage of this
 
 -- | Default width for hledger console output, when not otherwise specified.
 defaultWidth :: Int

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -35,7 +35,6 @@ module Hledger.Cli.CliOptions (
   CliOpts(..),
   defcliopts,
   getHledgerCliOpts,
-  decodeRawOpts,
   rawOptsToCliOpts,
   checkCliOpts,
   outputFormats,
@@ -394,10 +393,6 @@ defcliopts = CliOpts
     def
     defaultWidth
 
--- | Convert possibly encoded option values to regular unicode strings.
-decodeRawOpts :: RawOpts -> RawOpts
-decodeRawOpts = id  -- TODO: drop usage of this
-
 -- | Default width for hledger console output, when not otherwise specified.
 defaultWidth :: Int
 defaultWidth = 80
@@ -477,7 +472,7 @@ checkCliOpts opts =
 getHledgerCliOpts :: Mode RawOpts -> IO CliOpts
 getHledgerCliOpts mode' = do
   args' <- getArgs >>= expandArgsAt
-  let rawopts = either usageError decodeRawOpts $ process mode' args'
+  let rawopts = either usageError id $ process mode' args'
   opts <- rawOptsToCliOpts rawopts
   debugArgs args' opts
   when ("help" `inRawOpts` rawopts_ opts) $ putStr shorthelp >> exitSuccess

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, LambdaCase #-}
 {-|
 
 Common helpers for making multi-section balance report commands
@@ -124,11 +124,12 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportopts_=r
     let
       -- use the default balance type for this report, unless the user overrides
       mBalanceTypeOverride =
-        case reverse $ filter (`elem` ["change","cumulative","historical"]) $ map fst rawopts of
-          "historical":_ -> Just HistoricalBalance
-          "cumulative":_ -> Just CumulativeChange
-          "change":_     -> Just PeriodChange
-          _              -> Nothing
+        choiceopt parse rawopts where
+          parse = \case
+            "historical" -> Just HistoricalBalance
+            "cumulative" -> Just CumulativeChange
+            "change"     -> Just PeriodChange
+            _            -> Nothing
       balancetype = fromMaybe cbctype mBalanceTypeOverride
       -- Set balance type in the report options.
       -- Also, use tree mode (by default, at least?) if --cumulative/--historical

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -207,8 +207,7 @@ argsToCliOpts args addons = do
   let
     args'        = moveFlagsAfterCommand $ replaceNumericFlags args
     cmdargsopts  = either usageError id $ C.process (mainmode addons) args'
-    cmdargsopts' = decodeRawOpts cmdargsopts
-  rawOptsToCliOpts cmdargsopts'
+  rawOptsToCliOpts cmdargsopts
 
 -- | A hacky workaround for cmdargs not accepting flags before the
 -- subcommand name: try to detect and move such flags after the


### PR DESCRIPTION
This was triggered by hardships of addressing #1104 .

- Hide `RawOpts` so no one can mess with it other than using `RawOptions` module.
- Remove obsolete `decodeRawOpts` and `SystemString`.
- Factor out few common ways of accessing `RawOpts` to `choiceopt` and `collectopts` in `RawOptions`.

With these changes confirmed that we use quotes only to build query string.

_(here was a big banner)_
