### PR TITLE
lib: csv reader gets balance-style directive

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -523,7 +523,7 @@ directives =
   ,"newest-first"
    -- ,"base-account"
    -- ,"base-currency"
-  , "balance-style"
+  , "balance-type"
   ]
 
 directivevalp :: CsvRulesParser String
@@ -823,14 +823,14 @@ transactionFromCsvRecord sourcepos rules record = t
       }
 
     defaultAssertion =
-      case mdirective "balance-style" of
+      case mdirective "balance-type" of
         Nothing -> assertion
         Just "=" -> assertion
         Just "==" -> assertion {batotal=True}
         Just "=*" -> assertion {bainclusive=True}
         Just "==*" -> assertion{batotal=True, bainclusive=True}
         Just x -> error' $ unlines
-          [ "balance-style \"" ++ x ++"\" is invalid. Use =, ==, =* or ==*." 
+          [ "balance-type \"" ++ x ++"\" is invalid. Use =, ==, =* or ==*." 
           , showRecord record
           , showRules rules record
           ]

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -523,6 +523,7 @@ directives =
   ,"newest-first"
    -- ,"base-account"
    -- ,"base-currency"
+  , "balance-style"
   ]
 
 directivevalp :: CsvRulesParser String
@@ -820,7 +821,21 @@ transactionFromCsvRecord sourcepos rules record = t
       tprecedingcomment        = T.pack precomment,
       tpostings                = postings
       }
-    toAssertion (a, b) = assertion{
+
+    defaultAssertion =
+      case mdirective "balance-style" of
+        Nothing -> assertion
+        Just "=" -> assertion
+        Just "==" -> assertion {batotal=True}
+        Just "=*" -> assertion {bainclusive=True}
+        Just "==*" -> assertion{batotal=True, bainclusive=True}
+        Just x -> error' $ unlines
+          [ "balance-style \"" ++ x ++"\" is invalid. Use =, ==, =* or ==*." 
+          , showRecord record
+          , showRules rules record
+          ]
+        
+    toAssertion (a, b) = defaultAssertion{
       baamount   = a,
       baposition = b
       }

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -475,6 +475,24 @@ $  ./hledger-csv
 
 >=0
 
+# 22. read CSV with balance-style directive
+<
+10/2009/09,Flubber Co,50,123
+
+RULES
+fields date, description, amount, balance
+date-format %d/%Y/%m
+balance-style ==*
+currency $
+account1 assets:myacct
+
+$  ./hledger-csv
+2009/09/10 Flubber Co
+    assets:myacct              $50 ==* $123
+    income:unknown            $-50
+
+>=0
+
 
 # . TODO: without --separator gives obscure error
 #   |

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -475,14 +475,14 @@ $  ./hledger-csv
 
 >=0
 
-# 22. read CSV with balance-style directive
+# 22. read CSV with balance-type directive
 <
 10/2009/09,Flubber Co,50,123
 
 RULES
 fields date, description, amount, balance
 date-format %d/%Y/%m
-balance-style ==*
+balance-type ==*
 currency $
 account1 assets:myacct
 


### PR DESCRIPTION
This implements a suggestion from #1000: balance assertion style in CSV reader is now fully configurable