### PR TITLE
re-enable doctests and easytests

### DIFF
--- a/hledger-lib/Hledger/Data/RawOptions.hs
+++ b/hledger-lib/Hledger/Data/RawOptions.hs
@@ -55,15 +55,19 @@ inRawOpts name = isJust . lookup name . unRawOpts
 boolopt :: String -> RawOpts -> Bool
 boolopt = inRawOpts
 
--- | Get latests successfully parsed flag
+-- | Get latests successfully parsed flag.
+--
+-- Expected to be used for exclusive choice flags like "--json" vs "--csv".
 --
 -- >>> choiceopt Just (RawOpts [("a",""), ("b",""), ("c","")])
 -- Just "c"
 -- >>> choiceopt (const Nothing) (RawOpts [("a","")])
 -- Nothing
--- >>> choiceopt (listToMaybe . filter (`elem` ["a","b"])) (RawOpts [("a",""), ("b",""), ("c","")])
--- Just "b"
-choiceopt :: (String -> Maybe a) -> RawOpts -> Maybe a
+-- >>> choiceopt readMay (RawOpts [("LT",""),("EQ",""),("Neither","")]) :: Maybe Ordering
+-- Just EQ
+choiceopt :: (String -> Maybe a) -- ^ "parser" that returns 'Just' value for valid choice
+          -> RawOpts             -- ^ actual options where to look for flag
+          -> Maybe a             -- ^ exclusive choice among those returned as 'Just' from "parser"
 choiceopt f = lastMay . collectopts (f . fst)
 
 -- | Collects processed and filtered list of options preserving their order


### PR DESCRIPTION
Use a work-around described in https://github.com/sol/hpack/issues/188 .

Unfortunately for `easytests` this produces ugly warning `-Wmissing-home-modules` ~~that I simply don't understand since the only difference between `doctests` and `easytests` is that last one include `hledger-lib` in dependencies to build simple CLI that is equivalent to `hledger test`~~.  
I had to use work-around to ensure that Cabal understand that we want to get `tests_Hledger` via library that we built.