### PR TITLE
Add exit status code to check-dates

### DIFF
--- a/hledger/Hledger/Cli/Commands/Checkdates.hs
+++ b/hledger/Hledger/Cli/Commands/Checkdates.hs
@@ -9,6 +9,7 @@ module Hledger.Cli.Commands.Checkdates (
 import Hledger
 import Hledger.Cli.CliOptions
 import System.Console.CmdArgs.Explicit
+import System.Exit
 import Text.Printf
 
 checkdatesmode :: Mode RawOpts
@@ -33,10 +34,10 @@ checkdates CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
         then date a <  date b
         else date a <= date b
   case checkTransactions compare ts of
-   FoldAcc{fa_previous=Nothing} -> putStrLn "ok (empty journal)"
-   FoldAcc{fa_error=Nothing}    -> putStrLn "ok"
+   FoldAcc{fa_previous=Nothing} -> putStrLn "ok (empty journal)" >> exitSuccess
+   FoldAcc{fa_error=Nothing}    -> putStrLn "ok" >> exitSuccess
    FoldAcc{fa_error=Just error, fa_previous=Just previous} ->
-    putStrLn $ printf ("ERROR: transaction out of%s date order"
+    (putStrLn $ printf ("ERROR: transaction out of%s date order"
      ++ "\nPrevious date: %s"
      ++ "\nDate: %s"
      ++ "\nLocation: %s"
@@ -45,7 +46,7 @@ checkdates CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
      (show $ date previous)
      (show $ date error)
      (show $ tsourcepos error)
-     (showTransaction error)
+     (showTransaction error)) >> exitFailure
 
 data FoldAcc a b = FoldAcc
  { fa_error    :: Maybe a


### PR DESCRIPTION
Currently check-dates doesn't send a proper exist status.

This means we cannot rely on the status for automatic checks. For example
![image](https://user-images.githubusercontent.com/125707/69485214-05bc9a00-0e45-11ea-8271-7efb9a4e8bb3.png)

PR wraps the output of the command with the needed status codes.