### PR TITLE
WIP: Adopt pretty rendering

### DIFF
--- a/hledger-lib/Hledger/Utils/Pretty.hs
+++ b/hledger-lib/Hledger/Utils/Pretty.hs
@@ -1,0 +1,69 @@
+module Hledger.Utils.Pretty
+( module Hledger.Utils.Pretty
+  -- * Re-export some stuff to avoid ugly imports
+, Doc
+, flatAlt
+, encloseSep
+, annotate
+, AnsiStyle
+, Color(..)
+, colorDull
+, color
+)  where
+
+import Data.String
+import Safe (maximumDef)
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc hiding (Pretty(..))
+import Data.Text.Prettyprint.Doc.Render.String
+import Data.Text.Prettyprint.Doc.Render.Terminal
+
+class Pretty a where
+    pretty :: a -> Doc AnsiStyle
+
+-- | Align multiple documents joined vertically to the right
+--
+-- You may want to override flat representation.
+--
+-- >>> vcatRight ["abc", "defg", "hi"]
+--  abc
+-- defg
+--   hi
+vcatRight :: [Doc a] -> Doc a
+vcatRight docs = vcat [indent (totalWidth - width) doc | (width, doc) <- measured]
+  where
+    measured = [(docWidth doc, doc) | doc <- docs]
+    totalWidth = maximumDef 0 $ map fst measured
+
+-- | Try to re-group 'Doc' horizontally.
+hgroup :: Doc a -> Doc a
+hgroup = group
+
+-- | Simple estimation of 'Doc' width given that there is no width limit
+--
+-- >>> docWidth "abc\ndefg\nhi"
+-- 4
+--
+-- Note that current implementation is really dummy...
+docWidth :: Doc a -> Int
+docWidth = maximumDef 0 . map length . lines . renderString . layoutWide where
+
+layoutWide :: Doc a -> SimpleDocStream a
+layoutWide = layoutPretty defaultLayoutOptions{layoutPageWidth = Unbounded}
+
+-- Some compatibility between various pretty-printers
+
+plain :: Doc a -> Doc b
+plain = unAnnotate
+
+text :: String -> Doc ann
+text = fromString
+
+-- Temporary utility for show*/cshow* functions.
+-- TODO: drop once fully migrated to 'Doc'
+showPretty, cshowPretty :: Pretty a => a -> String
+showPretty = showWide . plain . pretty
+cshowPretty = showWide . pretty
+
+showWide :: Doc AnsiStyle -> String
+showWide = T.unpack . renderStrict . layoutWide

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4b32c89e49ba64c66ca8552bb3ac2d54099cff23f9950b7fe294a32297a9b01a
+-- hash: 9abd74785f943d93fc234129fc59b1f48cd61d34d86e1cb6845e93623175d5ba
 
 name:           hledger-lib
 version:        1.15.99
@@ -106,6 +106,7 @@ library
       Decimal
     , Glob >=0.9
     , ansi-terminal >=0.6.2.3
+    , ansi-wl-pprint >=0.6.9
     , array
     , base >=4.9 && <4.13
     , base-compat-batteries >=0.10.1 && <0.12
@@ -159,6 +160,7 @@ test-suite doctests
       Decimal
     , Glob >=0.7
     , ansi-terminal >=0.6.2.3
+    , ansi-wl-pprint >=0.6.9
     , array
     , base >=4.9 && <4.13
     , base-compat-batteries >=0.10.1 && <0.12
@@ -216,6 +218,7 @@ test-suite easytests
       Decimal
     , Glob >=0.9
     , ansi-terminal >=0.6.2.3
+    , ansi-wl-pprint >=0.6.9
     , array
     , base >=4.9 && <4.13
     , base-compat-batteries >=0.10.1 && <0.12

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9abd74785f943d93fc234129fc59b1f48cd61d34d86e1cb6845e93623175d5ba
+-- hash: 04c852c9a08aecf07c48a3567a66ef336d19b14e771802589239ee2810e4b9d9
 
 name:           hledger-lib
 version:        1.15.99
@@ -89,6 +89,7 @@ library
       Hledger.Utils.Color
       Hledger.Utils.Debug
       Hledger.Utils.Parse
+      Hledger.Utils.Pretty
       Hledger.Utils.Regex
       Hledger.Utils.String
       Hledger.Utils.Test
@@ -106,7 +107,6 @@ library
       Decimal
     , Glob >=0.9
     , ansi-terminal >=0.6.2.3
-    , ansi-wl-pprint >=0.6.9
     , array
     , base >=4.9 && <4.13
     , base-compat-batteries >=0.10.1 && <0.12
@@ -133,6 +133,8 @@ library
     , parsec >=3
     , parser-combinators >=0.4.0
     , pretty-show >=1.6.4
+    , prettyprinter <1.6
+    , prettyprinter-ansi-terminal >=1.1 && <1.2
     , regex-tdfa
     , safe >=0.2
     , split >=0.1
@@ -160,7 +162,6 @@ test-suite doctests
       Decimal
     , Glob >=0.7
     , ansi-terminal >=0.6.2.3
-    , ansi-wl-pprint >=0.6.9
     , array
     , base >=4.9 && <4.13
     , base-compat-batteries >=0.10.1 && <0.12
@@ -188,6 +189,8 @@ test-suite doctests
     , parsec >=3
     , parser-combinators >=0.4.0
     , pretty-show >=1.6.4
+    , prettyprinter <1.6
+    , prettyprinter-ansi-terminal >=1.1 && <1.2
     , regex-tdfa
     , safe >=0.2
     , split >=0.1
@@ -218,7 +221,6 @@ test-suite easytests
       Decimal
     , Glob >=0.9
     , ansi-terminal >=0.6.2.3
-    , ansi-wl-pprint >=0.6.9
     , array
     , base >=4.9 && <4.13
     , base-compat-batteries >=0.10.1 && <0.12
@@ -246,6 +248,8 @@ test-suite easytests
     , parsec >=3
     , parser-combinators >=0.4.0
     , pretty-show >=1.6.4
+    , prettyprinter <1.6
+    , prettyprinter-ansi-terminal >=1.1 && <1.2
     , regex-tdfa
     , safe >=0.2
     , split >=0.1

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -41,7 +41,8 @@ extra-source-files:
 dependencies:
 - base >=4.9 && <4.13
 - base-compat-batteries >=0.10.1 && <0.12
-- ansi-wl-pprint >= 0.6.9
+- prettyprinter <1.6
+- prettyprinter-ansi-terminal >=1.1 && <1.2
 - ansi-terminal >=0.6.2.3
 - array
 - blaze-markup >=0.5.1
@@ -145,6 +146,7 @@ library:
   - Hledger.Utils.Color
   - Hledger.Utils.Debug
   - Hledger.Utils.Parse
+  - Hledger.Utils.Pretty
   - Hledger.Utils.Regex
   - Hledger.Utils.String
   - Hledger.Utils.Test

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -41,6 +41,7 @@ extra-source-files:
 dependencies:
 - base >=4.9 && <4.13
 - base-compat-batteries >=0.10.1 && <0.12
+- ansi-wl-pprint >= 0.6.9
 - ansi-terminal >=0.6.2.3
 - array
 - blaze-markup >=0.5.1


### PR DESCRIPTION
## Purpose of PR
Unify how we render colorful and plain reports in `hledger` so there is no need to have them implemented twice.

## Libraries considered
This is only my quick look and opinion. Maybe someone have more to add.

* [`pretty`](http://hackage.haskell.org/package/pretty). Quiet old and no recent changes, but used by Cabal. Colors need to be introduced via annotations like in [`wl-pprint-terminfo`](http://hackage.haskell.org/package/wl-pprint-terminfo).
* [`ansi-wl-pprint`](http://hackage.haskell.org/package/ansi-wl-pprint). Have support for colors out of the box via [`ansi-terminal`](http://hackage.haskell.org/package/ansi-terminal) that we use right now.
* [`prettyprinter`](http://hackage.haskell.org/package/prettyprinter). Seems to be fresh. As in `pretty` colors need to be supported via annotations, but there is already [`prettyprinter-ansi-terminal`](http://hackage.haskell.org/package/prettyprinter-ansi-terminal) that use [`ansi-terminal`](http://hackage.haskell.org/package/ansi-terminal).
* [`annotated-wl-pprint`](http://hackage.haskell.org/package/annotated-wl-pprint). Apparently stripped version `ansi-wl-pprint`. Used by [`rio-prettyprint`](http://hackage.haskell.org/package/rio-prettyprint) (authored by Michael Snoyman).
* [`boxes`](http://hackage.haskell.org/package/boxes). Highly oriented on layout management. Nothing 
* [`table-layout`](hackage.haskell.org/package/table-layout). Looks to be highly oriented on how to render tables. No clear composition of primitive objects.


## Progress

- [x] `Hledger.Data.Amount`.
- [ ] `Hledger.Commands.Balance`.
- [ ] `Hledger.Commands.Register`.
- [ ] `Hledger.Reports.BalanceReport`.
- [ ] Benchmark added overhead for rendering.
- [ ] Review `hledger-ui` for potential re-use.
