### PR TITLE
fix parsing of < and > in add-on commands (#457)

### DIFF
--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -111,7 +111,7 @@ underline s = s' ++ replicate (length s) '-' ++ "\n"
 -- | Double-quote this string if it contains whitespace, single quotes
 -- or double-quotes, escaping the quotes as needed.
 quoteIfNeeded :: String -> String
-quoteIfNeeded s | any (`elem` s) (quotechars++whitespacechars) = "\"" ++ escapeDoubleQuotes s ++ "\""
+quoteIfNeeded s | any (`elem` s) (quotechars++whitespacechars++redirectchars) = "\"" ++ escapeDoubleQuotes s ++ "\""
                 | otherwise = s
 -- | Single-quote this string if it contains whitespace or double-quotes.
 -- No good for strings containing single quotes.
@@ -119,9 +119,10 @@ singleQuoteIfNeeded :: String -> String
 singleQuoteIfNeeded s | any (`elem` s) whitespacechars = "'"++s++"'"
                       | otherwise = s
 
-quotechars, whitespacechars :: [Char]
+quotechars, whitespacechars, redirectchars :: [Char]
 quotechars      = "'\""
 whitespacechars = " \t\n\r"
+redirectchars   = "<>"
 
 escapeDoubleQuotes :: String -> String
 escapeDoubleQuotes = regexReplace "\"" "\""

--- a/tests/addons/addons.test
+++ b/tests/addons/addons.test
@@ -23,26 +23,30 @@
 # PATH= ~/.local/bin/stack exec -- hledger
 #>>>=0
 
-############################    issue 457    #####################################
-# 5. test for `>` in https://github.com/simonmichael/hledger/issues/457          #
-# note a shelltest already provides one level of quoting, so amt:>0 not 'amt:>0' #
-#                                                                                #
-$ hledger -f - ui amt:>0                                                         #
->2 !/could not parse/                                                            #
->=1                                                                              #
-                                                                                 #
-# 6. test for `<` in https://github.com/simonmichael/hledger/issues/457          #
-$ hledger -f - ui amt:<0                                                         #
->2 !/could not parse/                                                            #
->=1                                                                              #
-                                                                                 #
-# 7. test for `>=` in https://github.com/simonmichael/hledger/issues/457         #
-$ hledger -f - ui amt:>=0                                                        #
->2 !/could not parse/                                                            #
->=1                                                                              #
-                                                                                 #
-# 8. test for `<=` in https://github.com/simonmichael/hledger/issues/457         #
-$ hledger -f - ui amt:<=0                                                        #
->2 !/could not parse/                                                            #
->=1                                                                              #
-##################################################################################
+# ############################    issue 457    #####################################
+#                                                                                  #
+# These tests are commented out, as they are not working properly. See:            #
+#  https://github.com/simonmichael/hledger/pull/1140#issuecomment-562793255        #
+#                                                                                  #
+# # 5. test for `>` in https://github.com/simonmichael/hledger/issues/457          #
+# # note a shelltest already provides one level of quoting, so amt:>0 not 'amt:>0' #
+# #                                                                                #
+# $ hledger -f - ui amt:>0                                                         #
+# >2 !/could not parse/                                                            #
+# >=1                                                                              #
+#                                                                                  #
+# # 6. test for `<` in https://github.com/simonmichael/hledger/issues/457          #
+# $ hledger -f - ui amt:<0                                                         #
+# >2 !/could not parse/                                                            #
+# >=1                                                                              #
+#                                                                                  #
+# # 7. test for `>=` in https://github.com/simonmichael/hledger/issues/457         #
+# $ hledger -f - ui amt:>=0                                                        #
+# >2 !/could not parse/                                                            #
+# >=1                                                                              #
+#                                                                                  #
+# # 8. test for `<=` in https://github.com/simonmichael/hledger/issues/457         #
+# $ hledger -f - ui amt:<=0                                                        #
+# >2 !/could not parse/                                                            #
+# >=1                                                                              #
+# ##################################################################################

--- a/tests/addons/addons.test
+++ b/tests/addons/addons.test
@@ -4,24 +4,24 @@
 # they always run the first hledger executable in PATH
 
 # 1. flags after an add-command are handled by the add-on
- PATH=$PATH:. hledger addon --help
->>> /hledger-addon/
->>>=0
+$ PATH=$PATH:. hledger addon --help
+> /hledger-addon/
+>=0
 
 # 2. add-on flags which are not also defined in the main executable are a problem
- PATH=$PATH:. hledger addon --addonflag
->>>2 /Unknown flag: --addonflag/
->>>=1
+$ PATH=$PATH:. hledger addon --addonflag
+>2 /Unknown flag: --addonflag/
+>=1
 
 # 3. hledger main executable ignores anything after -- (and hides the -- from the add-on)
- PATH=$PATH:. hledger addon --help -- --addonflag
->>> /hledger-addon/
->>>=0
+$ PATH=$PATH:. hledger addon --help -- --addonflag
+> /hledger-addon/
+>=0
 
 # TODO how to reliably ensure no addons but still find the hledger executable ?
 # 4. having no addons shouldn't break the commands list
-# PATH= ~/.local/bin/stack exec -- hledger
-#>>>=0
+# $ PATH= ~/.local/bin/stack exec -- hledger
+# >=0
 
 # ############################    issue 457    #####################################
 #                                                                                  #

--- a/tests/addons/addons.test
+++ b/tests/addons/addons.test
@@ -23,3 +23,26 @@
 # PATH= ~/.local/bin/stack exec -- hledger
 #>>>=0
 
+############################    issue 457    #####################################
+# 5. test for `>` in https://github.com/simonmichael/hledger/issues/457          #
+# note a shelltest already provides one level of quoting, so amt:>0 not 'amt:>0' #
+#                                                                                #
+$ hledger -f - ui amt:>0                                                         #
+>2 !/could not parse/                                                            #
+>=1                                                                              #
+                                                                                 #
+# 6. test for `<` in https://github.com/simonmichael/hledger/issues/457          #
+$ hledger -f - ui amt:<0                                                         #
+>2 !/could not parse/                                                            #
+>=1                                                                              #
+                                                                                 #
+# 7. test for `>=` in https://github.com/simonmichael/hledger/issues/457         #
+$ hledger -f - ui amt:>=0                                                        #
+>2 !/could not parse/                                                            #
+>=1                                                                              #
+                                                                                 #
+# 8. test for `<=` in https://github.com/simonmichael/hledger/issues/457         #
+$ hledger -f - ui amt:<=0                                                        #
+>2 !/could not parse/                                                            #
+>=1                                                                              #
+##################################################################################

--- a/tests/rewrite.test
+++ b/tests/rewrite.test
@@ -142,14 +142,14 @@ hledger rewrite -f- assets:bank and 'amt:<0' --add-posting 'expenses:fee  $5'  -
 2016/01/01 withdraw  ; modified:
     assets:cash              $20
     assets:bank
-    expenses:fee              $5  ; generated-posting: = assets:bank and amt:<0
-    assets:bank              $-5  ; generated-posting: = assets:bank and amt:<0
+    expenses:fee              $5  ; generated-posting: = assets:bank and "amt:<0"
+    assets:bank              $-5  ; generated-posting: = assets:bank and "amt:<0"
 
 2016/01/02 withdraw  ; modified:
     assets:cash
     assets:bank             $-30
-    expenses:fee              $5  ; generated-posting: = assets:bank and amt:<0
-    assets:bank              $-5  ; generated-posting: = assets:bank and amt:<0
+    expenses:fee              $5  ; generated-posting: = assets:bank and "amt:<0"
+    assets:bank              $-5  ; generated-posting: = assets:bank and "amt:<0"
 
 >>>2
 >>>=0
@@ -240,14 +240,14 @@ hledger rewrite --diff -f- assets:bank and 'amt:<0' --add-posting 'expenses:fee 
 +2016/01/01 withdraw  ; modified:
      assets:cash              $20
      assets:bank
-+    expenses:fee              $5  ; generated-posting: = assets:bank and amt:<0
-+    assets:bank              $-5  ; generated-posting: = assets:bank and amt:<0
++    expenses:fee              $5  ; generated-posting: = assets:bank and "amt:<0"
++    assets:bank              $-5  ; generated-posting: = assets:bank and "amt:<0"
 @@ -5,3 +7,5 @@
 -2016/01/02 withdraw
 +2016/01/02 withdraw  ; modified:
      assets:cash
      assets:bank             $-30
-+    expenses:fee              $5  ; generated-posting: = assets:bank and amt:<0
-+    assets:bank              $-5  ; generated-posting: = assets:bank and amt:<0
++    expenses:fee              $5  ; generated-posting: = assets:bank and "amt:<0"
++    assets:bank              $-5  ; generated-posting: = assets:bank and "amt:<0"
 >>>2
 >>>=0


### PR DESCRIPTION
This PR attemts to fix #457.

It contains 2 commits:

+ The first commit adds four shelltests demonstrating the problem. I am not sure what the best place is for these tests to live. Please advise.

+ The second commit solves the problem by using existing machinery (`String.quoteIfNeeded`) to quote arguments which contain the characters which seem to be causing the problem: `<` and `>`. While ad-hoc experiments on the command line suggest that this solution fixes the problem, the tests added in the first commit continue to fail. I'm guessing that this might be related to the extra level of quoting that `shelltest` injects.