### PR TITLE
Fix build badges for Travis and AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 
 [![license](https://img.shields.io/badge/license-GPLv3+-brightgreen.svg)](http://www.gnu.org/licenses/gpl.html)
 
-[![OpenCollective](https://opencollective.com/hledger/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/hledger/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/hledger/sponsors/badge.svg)](#sponsors)
 [![bountysource](https://api.bountysource.com/badge/team?team_id=75979&style=bounties_received)](https://github.com/simonmichael/hledger/issues?q=label:bounty)
 [![github issues](https://img.shields.io/github/issues/simonmichael/hledger.svg)](http://bugs.hledger.org)
@@ -115,10 +115,9 @@ downloads](https://img.shields.io/github/downloads/simonmichael/hledger/latest/t
 --> <!-- [![gratipay](https://img.shields.io/gratipay/hledger.svg)]()
 -->
 
-[![travis build status](https://img.shields.io/travis/simonmichael/hledger.svg)](https://travis.hledger.org)
-[![appveyor windows build status](https://ci.appveyor.com/api/projects/status/5vejw0w5n5igdr42?svg=true)](https://appveyor.hledger.org)
+[![Build Status](https://travis-ci.org/simonmichael/hledger.svg?branch=master)](https://travis-ci.org/simonmichael/hledger)
+[![Build Status](https://ci.appveyor.com/api/projects/status/5vejw0w5n5igdr42?svg=true)](https://ci.appveyor.com/project/simonmichael/hledger)
 [![](https://img.shields.io/hackage-deps/v/hledger-lib.svg?label=hledger-lib+bounds)](http://packdeps.haskellers.com/feed?needle=hledger-lib)
 [![](https://img.shields.io/hackage-deps/v/hledger.svg?label=hledger+bounds)](http://packdeps.haskellers.com/feed?needle=hledger)
 [![](https://img.shields.io/hackage-deps/v/hledger-ui.svg?label=hledger-ui+bounds)](http://packdeps.haskellers.com/feed?needle=hledger-ui)
 [![](https://img.shields.io/hackage-deps/v/hledger-web.svg?label=hledger-web+bounds)](http://packdeps.haskellers.com/feed?needle=hledger-web)
-


### PR DESCRIPTION
Fixes #1141

It looks like the subdomain links do not quite work, hence replacing them with the links to the Travis and AppVeyor links.