### PR TITLE
Increase use of PeriodicReport

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -3,7 +3,19 @@ New common report types, used by the BudgetReport for now, perhaps all reports l
 -}
 
 module Hledger.Reports.ReportTypes
-where
+( PeriodicReport(..)
+, PeriodicReportRow
+
+, Percentage
+, Change
+, Balance
+, Total
+, Average
+
+, periodicReportSpan
+, prNegate
+, prNormaliseSign
+) where
 
 import Data.Decimal
 import Hledger.Data
@@ -15,11 +27,35 @@ type Balance = MixedAmount  -- ^ An ending balance as of some date.
 type Total   = MixedAmount  -- ^ The sum of 'Change's in a report or a report row. Does not make sense for 'Balance's.
 type Average = MixedAmount  -- ^ The average of 'Change's or 'Balance's in a report or report row.
 
--- | A generic tabular report of some value, where each row corresponds to an account
--- and each column is a date period. The column periods are usually consecutive subperiods
--- formed by splitting the overall report period by some report interval (daily, weekly, etc.)
--- Depending on the value type, this can be a report of balance changes, ending balances,
--- budget performance, etc. Successor to MultiBalanceReport.
+-- | A periodic report is a generic tabular report, where each row corresponds
+-- to an account and each column to a date period. The column periods are
+-- usually consecutive subperiods formed by splitting the overall report period
+-- by some report interval (daily, weekly, etc.). It has:
+--
+-- 1. a list of each column's period (date span)
+--
+-- 2. a list of rows, each containing:
+--
+--   * the full account name
+--
+--   * the leaf account name
+--
+--   * the account's depth
+--
+--   * A list of amounts, one for each column. Depending on the value type,
+--     these can represent balance changes, ending balances, budget
+--     performance, etc. (for example, see 'BalanceType' and
+--     "Hledger.Cli.Commands.Balance").
+--
+--   * the total of the row's amounts for a periodic report,
+--     or zero for cumulative/historical reports (since summing
+--     end balances generally doesn't make sense).
+--
+--   * the average of the row's amounts
+--
+-- 3. the column totals, and the overall grand total (or zero for
+-- cumulative/historical reports) and grand average.
+
 data PeriodicReport a =
   PeriodicReport
     ( [DateSpan]            -- The subperiods formed by splitting the overall report period by the report interval.
@@ -38,3 +74,22 @@ type PeriodicReportRow a =
   , a            -- The total of this row's values.
   , a            -- The average of this row's values.
   )
+
+-- | Figure out the overall date span of a PeridicReport
+periodicReportSpan :: PeriodicReport a -> DateSpan
+periodicReportSpan (PeriodicReport ([], _, _))       = DateSpan Nothing Nothing
+periodicReportSpan (PeriodicReport (colspans, _, _)) = DateSpan (spanStart $ head colspans) (spanEnd $ last colspans)
+
+-- | Given a PeriodicReport and its normal balance sign,
+-- if it is known to be normally negative, convert it to normally positive.
+prNormaliseSign :: Num a => NormalSign -> PeriodicReport a -> PeriodicReport a
+prNormaliseSign NormallyNegative = prNegate
+prNormaliseSign _ = id
+
+-- | Flip the sign of all amounts in a PeriodicReport.
+prNegate :: Num a => PeriodicReport a -> PeriodicReport a
+prNegate (PeriodicReport (colspans, rows, totalsrow)) =
+    PeriodicReport (colspans, map rowNegate rows, rowNegate totalsrow)
+  where
+    rowNegate (acct, acct', indent, amts, tot, avg) =
+        (acct, acct', indent, map negate amts, -tot, -avg)

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -458,18 +458,19 @@ renderComponent1 opts (acctname, depth, total) (FormatField ljust min max field)
 -- The CSV will always include the initial headings row,
 -- and will include the final totals row unless --no-total is set.
 multiBalanceReportAsCsv :: ReportOpts -> MultiBalanceReport -> CSV
-multiBalanceReportAsCsv opts@ReportOpts{average_, row_total_} (MultiBalanceReport (colspans, items, (coltotals,tot,avg))) =
+multiBalanceReportAsCsv opts@ReportOpts{average_, row_total_}
+    (PeriodicReport colspans items (PeriodicReportRow _ _ coltotals tot avg)) =
   maybetranspose $
   ("Account" : map showDateSpan colspans
    ++ ["Total"   | row_total_]
    ++ ["Average" | average_]
   ) :
-  [T.unpack (maybeAccountNameDrop opts a) :
+  [T.unpack (maybeAccountNameDrop opts $ acctFull a) :
    map showMixedAmountOneLineWithoutPrice
    (amts
     ++ [rowtot | row_total_]
     ++ [rowavg | average_])
-  | (a, _, _, amts, rowtot, rowavg) <- items]
+  | PeriodicReportRow a _ amts rowtot rowavg <- items]
   ++
   if no_total_ opts
   then []
@@ -583,7 +584,7 @@ multiBalanceReportAsText ropts@ReportOpts{..} r =
         PeriodChange       -> "Balance changes"
         CumulativeChange   -> "Ending balances (cumulative)"
         HistoricalBalance  -> "Ending balances (historical)")
-      (showDateSpan $ multiBalanceReportSpan r)
+      (showDateSpan $ periodicReportSpan r)
       (case value_ of
         Just (AtCost _mc)   -> ", valued at cost"
         Just (AtEnd _mc)    -> ", valued at period ends"
@@ -596,7 +597,8 @@ multiBalanceReportAsText ropts@ReportOpts{..} r =
 
 -- | Build a 'Table' from a multi-column balance report.
 balanceReportAsTable :: ReportOpts -> MultiBalanceReport -> Table String String MixedAmount
-balanceReportAsTable opts@ReportOpts{average_, row_total_, balancetype_} (MultiBalanceReport (colspans, items, (coltotals,tot,avg))) =
+balanceReportAsTable opts@ReportOpts{average_, row_total_, balancetype_}
+    (PeriodicReport colspans items (PeriodicReportRow _ _ coltotals tot avg)) =
    maybetranspose $
    addtotalrow $
    Table
@@ -612,10 +614,10 @@ balanceReportAsTable opts@ReportOpts{average_, row_total_, balancetype_} (MultiB
                   ++ ["  Total" | totalscolumn]
                   ++ ["Average" | average_]
     accts = map renderacct items
-    renderacct (a,a',i,_,_,_)
+    renderacct (PeriodicReportRow (AccountLeaf a a') i _ _ _)
       | tree_ opts = replicate ((i-1)*2) ' ' ++ T.unpack a'
       | otherwise  = T.unpack $ maybeAccountNameDrop opts a
-    rowvals (_,_,_,as,rowtot,rowavg) = as
+    rowvals (PeriodicReportRow _ _ as rowtot rowavg) = as
                              ++ [rowtot | totalscolumn]
                              ++ [rowavg | average_]
     addtotalrow | no_total_ opts = id

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -151,15 +151,15 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportopts_=r
       subreports =
         map (\CBCSubreportSpec{..} ->
                 (cbcsubreporttitle
-                ,mbrNormaliseSign cbcsubreportnormalsign $ -- <- convert normal-negative to normal-positive
+                ,prNormaliseSign cbcsubreportnormalsign $ -- <- convert normal-negative to normal-positive
                   compoundBalanceSubreport ropts' userq j priceoracle cbcsubreportquery cbcsubreportnormalsign
                 ,cbcsubreportincreasestotal
                 ))
             cbcqueries
 
       subtotalrows =
-        [(coltotals, increasesoveralltotal)
-        | (_, MultiBalanceReport (_,_,(coltotals,_,_)), increasesoveralltotal) <- subreports
+        [(prrAmounts $ prTotals report, increasesoveralltotal)
+        | (_, report, increasesoveralltotal) <- subreports
         ]
 
       -- Sum the subreport totals by column. Handle these cases:
@@ -186,7 +186,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportopts_=r
 
       colspans =
         case subreports of
-          (_, MultiBalanceReport (ds,_,_), _):_ -> ds
+          (_, PeriodicReport ds _ _, _):_ -> ds
           [] -> []
 
       title =
@@ -261,20 +261,20 @@ compoundBalanceSubreport ropts@ReportOpts{..} userq j priceoracle subreportqfn s
     ropts' = ropts { empty_=True, normalbalance_=Just subreportnormalsign }
     -- run the report
     q = And [subreportqfn j, userq]
-    r@(MultiBalanceReport (dates, rows, totals)) = multiBalanceReportWith ropts' q j priceoracle
+    r@(PeriodicReport dates rows totals) = multiBalanceReportWith ropts' q j priceoracle
     -- if user didn't specify --empty, now remove the all-zero rows, unless they have non-zero subaccounts
     -- in this report
     r' | empty_    = r
-       | otherwise = MultiBalanceReport (dates, rows', totals)
+       | otherwise = PeriodicReport dates rows' totals
           where
             nonzeroaccounts =
               dbg1 "nonzeroaccounts" $
-              catMaybes $ map (\(act,_,_,amts,_,_) ->
-                            if not (all isZeroMixedAmount amts) then Just act else Nothing) rows
+              mapMaybe (\(PeriodicReportRow act _ amts _ _) ->
+                            if not (all isZeroMixedAmount amts) then Just (acctFull act) else Nothing) rows
             rows' = filter (not . emptyRow) rows
               where
-                emptyRow (act,_,_,amts,_,_) =
-                  all isZeroMixedAmount amts && all (not . (act `isAccountNamePrefixOf`)) nonzeroaccounts
+                emptyRow (PeriodicReportRow act _ amts _ _) =
+                  all isZeroMixedAmount amts && all (not . (acctFull act `isAccountNamePrefixOf`)) nonzeroaccounts
 
 -- | Render a compound balance report as plain text suitable for console output.
 {- Eg:
@@ -367,8 +367,7 @@ compoundBalanceReportAsCsv ropts (title, colspans, subreports, (coltotals, grand
             (if row_total_ ropts then (1+) else id) $
             (if average_ ropts then (1+) else id) $
             maximum $ -- depends on non-null subreports
-            map (\(MultiBalanceReport (amtcolheadings, _, _)) -> length amtcolheadings) $
-            map second3 subreports
+            map (length . prDates . second3) subreports
     addtotals
       | no_total_ ropts || length subreports == 1 = id
       | otherwise = (++


### PR DESCRIPTION
Use PeriodicReport for MultiBalanceReport, and a new datatype for BalanceReport, to ease readability and reduce reliance on anonymous tuples. Also generalise PeriodicReport to allow for different labels than the usual (AccountName, AccountName).