### PR TITLE
Only calculate posting date once for each posting.

### DIFF
--- a/hledger-lib/Hledger/Data/Ledger.hs
+++ b/hledger-lib/Hledger/Data/Ledger.hs
@@ -34,8 +34,9 @@ import Text.Printf
 import Hledger.Utils.Test
 import Hledger.Data.Types
 import Hledger.Data.Account
+import Hledger.Data.Dates (daysSpan)
 import Hledger.Data.Journal
-import Hledger.Data.Posting
+import Hledger.Data.Posting (postingDate)
 import Hledger.Query
 
 
@@ -100,7 +101,7 @@ ledgerPostings = journalPostings . ljournal
 -- | The (fully specified) date span containing all the ledger's (filtered) transactions,
 -- or DateSpan Nothing Nothing if there are none.
 ledgerDateSpan :: Ledger -> DateSpan
-ledgerDateSpan = postingsDateSpan . ledgerPostings
+ledgerDateSpan = daysSpan . map postingDate . ledgerPostings
 
 -- | All commodities used in this ledger.
 ledgerCommodities :: Ledger -> [CommoditySymbol]

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -42,8 +42,6 @@ module Hledger.Data.Posting (
   postingDate2,
   isPostingInDateSpan,
   isPostingInDateSpan',
-  postingsDateSpan,
-  postingsDateSpan',
   -- * account name operations
   accountNamesFromPostings,
   accountNamePostingType,
@@ -69,6 +67,8 @@ module Hledger.Data.Posting (
   tests_Posting
 )
 where
+
+import Data.Foldable (asum)
 import Data.List
 import qualified Data.Map as M
 import Data.Maybe
@@ -204,20 +204,19 @@ removePrices p = p{ pamount = Mixed $ remove <$> amounts (pamount p) }
 -- otherwise the parent transaction's primary date, or the null date if
 -- there is no parent transaction.
 postingDate :: Posting -> Day
-postingDate p = fromMaybe txndate $ pdate p
-    where
-      txndate = maybe nulldate tdate $ ptransaction p
+postingDate p = fromMaybe nulldate $ asum dates
+    where dates = [ pdate p, tdate <$> ptransaction p ]
 
 -- | Get a posting's secondary (secondary) date, which is the first of:
 -- posting's secondary date, transaction's secondary date, posting's
 -- primary date, transaction's primary date, or the null date if there is
 -- no parent transaction.
 postingDate2 :: Posting -> Day
-postingDate2 p = headDef nulldate $ catMaybes dates
-  where dates = [pdate2 p
-                ,maybe Nothing tdate2 $ ptransaction p
-                ,pdate p
-                ,fmap tdate (ptransaction p)
+postingDate2 p = fromMaybe nulldate $ asum dates
+  where dates = [ pdate2 p
+                , tdate2 =<< ptransaction p
+                , pdate p
+                , tdate <$> ptransaction p
                 ]
 
 -- | Get a posting's status. This is cleared or pending if those are
@@ -246,7 +245,7 @@ relatedPostings _ = []
 
 -- | Does this posting fall within the given date span ?
 isPostingInDateSpan :: DateSpan -> Posting -> Bool
-isPostingInDateSpan s = spanContainsDate s . postingDate
+isPostingInDateSpan = isPostingInDateSpan' PrimaryDate
 
 -- --date2-sensitive version, separate for now to avoid disturbing multiBalanceReport.
 isPostingInDateSpan' :: WhichDate -> DateSpan -> Posting -> Bool
@@ -255,21 +254,6 @@ isPostingInDateSpan' SecondaryDate s = spanContainsDate s . postingDate2
 
 isEmptyPosting :: Posting -> Bool
 isEmptyPosting = isZeroMixedAmount . pamount
-
--- | Get the minimal date span which contains all the postings, or the
--- null date span if there are none.
-postingsDateSpan :: [Posting] -> DateSpan
-postingsDateSpan [] = DateSpan Nothing Nothing
-postingsDateSpan ps = DateSpan (Just $ postingDate $ head ps') (Just $ addDays 1 $ postingDate $ last ps')
-    where ps' = sortOn postingDate ps
-
--- --date2-sensitive version, as above.
-postingsDateSpan' :: WhichDate -> [Posting] -> DateSpan
-postingsDateSpan' _  [] = DateSpan Nothing Nothing
-postingsDateSpan' wd ps = DateSpan (Just $ postingdate $ head ps') (Just $ addDays 1 $ postingdate $ last ps')
-    where
-      ps' = sortOn postingdate ps
-      postingdate = if wd == PrimaryDate then postingDate else postingDate2
 
 -- AccountName stuff that depends on PostingType
 


### PR DESCRIPTION
Previously, `multiBalanceReportWith` had been calculating the date of each posting once for every column. This resulted in quite significant slowdown when calculating for many postings and many `DateSpans`. This commit calculates the posting date of each posting only once and re-uses it. It also calculates the columns for each posting rather than searching through the whole colspan list every time.