### PR TITLE
Add a basic example of rule parsing for the output of csb2format.

### DIFF
--- a/examples/csv/csb43.csv
+++ b/examples/csv/csb43.csv
@@ -1,0 +1,3 @@
+bank_code,branch_code,account_key,account_number,information_mode,short_name,currency,initial_date,final_date,initial_balance,final_balance,income,expenses,income_entries,expenses_entries,branch_code,document_number,shared_item,own_item,item1,item2,reference1,reference2,transaction_date,value_date,amount,original_currency,original_amount
+1234,5678,90,1234567890,3,N.SURNAME,EUR,2019-11-01,2019-11-30,000.00,1000.00,1500.00,500.0,1,1,1234,567890123,12,000,MY_INCOME_LINE,,456789012345,,2019-11-02,2019-11-02,1500.00,,
+1234,5678,90,1234567890,3,N.SURNAME,EUR,2019-11-01,2019-11-30,000.00,1000.00,1500.00,500.0,1,1,1234,567890123,12,000,MY_EXPENSE_LINE,,456789012345,,2019-11-10,2019-11-10,-500.00,,

--- a/examples/csv/csb43.csv.rules
+++ b/examples/csv/csb43.csv.rules
@@ -1,0 +1,15 @@
+# csb43.csv.rules
+# Rules for csb2format -f csv "${CSV_FILE}" -
+# Using https://pypi.org/project/csb43/
+
+# Skip header
+skip 1
+
+# Change to your taste
+account1 assets:bank:csb43
+
+# These appear to be the useful columns for hledger
+fields _,_,_,_,_,_,currency,_,_,_,_,_,_,_,_,_,_,_,_,item1,item2,reference1,reference2,date,_,amount,_,_
+
+# Merge items for the description
+description %item1 %item2 %reference1 %reference2


### PR DESCRIPTION
csb2format deals with the CSB43/AEB43 format, which all banks operating in
Spain must support.
Having these example rules enables easens bootstraping for users with a
Spanish bank account.