### PR TITLE
Change the '<' command to go back one step during addition

### DIFF
--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -222,8 +222,7 @@ confirmedTransactionWizard prevInput es@EntryState{..} stack@(currentStage : _) 
             EnterAmountAndComment _ _ -> False
             EnterDescAndComment _ -> False
             _ -> True
-          prevAccount' = take (length esPostings) (prevAccount prevInput)
-      confirmedTransactionWizard prevInput{prevAccount=prevAccount'} es{esPostings=init esPostings} (dropWhile notPrevAmountAndNotEnterDesc stack)
+      confirmedTransactionWizard prevInput es{esPostings=init esPostings} (dropWhile notPrevAmountAndNotEnterDesc stack)
 
   EnterAmountAndComment txnParams account -> amountAndCommentWizard prevInput es >>= \case
     Just (amount, comment) -> do
@@ -236,7 +235,7 @@ confirmedTransactionWizard prevInput es@EntryState{..} stack@(currentStage : _) 
           prevAmountAndCmnt' = replaceNthOrAppend (length esPostings) amountAndCommentString (prevAmountAndCmnt prevInput)
           es' = es{esPostings=esPostings++[posting], esArgs=drop 2 esArgs}
       confirmedTransactionWizard prevInput{prevAmountAndCmnt=prevAmountAndCmnt'} es' (EnterNewPosting txnParams (Just posting) : stack)
-    Nothing -> confirmedTransactionWizard prevInput{prevAmountAndCmnt=take (length esPostings) (prevAmountAndCmnt prevInput)} es (drop 1 stack)
+    Nothing -> confirmedTransactionWizard prevInput es (drop 1 stack)
 
   EndStage t -> do
     output $ showTransaction t

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -105,7 +105,7 @@ showHelp = hPutStr stderr $ unlines [
     ,"Use tab key to complete, readline keys to edit, enter to accept defaults."
     ,"An optional (CODE) may follow transaction dates."
     ,"An optional ; COMMENT may follow descriptions or amounts."
-    ,"If you make a mistake, enter < at any prompt to restart the transaction."
+    ,"If you make a mistake, enter < at any prompt to go one step backward."
     ,"To end a transaction, enter . when prompted."
     ,"To quit, enter . at a date prompt or press control-d or control-c."
     ]

--- a/hledger/Hledger/Cli/Commands/Add.md
+++ b/hledger/Hledger/Cli/Commands/Add.md
@@ -28,7 +28,7 @@ Features:
   it will be added to any bare numbers entered.
 - A parenthesised transaction [code](#entries) may be entered following a date.
 - [Comments](#comments) and tags may be entered following a description or amount.
-- If you make a mistake, enter `<` at any prompt to restart the transaction.
+- If you make a mistake, enter `<` at any prompt to go one step backward.
 - Input prompts are displayed in a different colour when the terminal supports it.
 
 Example (see the [tutorial](step-by-step.html#record-a-transaction-with-hledger-add) for a detailed explanation):
@@ -40,7 +40,7 @@ Any command line arguments will be used as defaults.
 Use tab key to complete, readline keys to edit, enter to accept defaults.
 An optional (CODE) may follow transaction dates.
 An optional ; COMMENT may follow descriptions or amounts.
-If you make a mistake, enter < at any prompt to restart the transaction.
+If you make a mistake, enter < at any prompt to go one step backward.
 To end a transaction, enter . when prompted.
 To quit, enter . at a date prompt or press control-d or control-c.
 Date [2015/05/22]: 

--- a/hledger/Hledger/Cli/Commands/Add.txt
+++ b/hledger/Hledger/Cli/Commands/Add.txt
@@ -29,8 +29,8 @@ Features:
     bare numbers entered.
 -   A parenthesised transaction code may be entered following a date.
 -   Comments and tags may be entered following a description or amount.
--   If you make a mistake, enter < at any prompt to restart the
-    transaction.
+-   If you make a mistake, enter < at any prompt to go one step
+    backward.
 -   Input prompts are displayed in a different colour when the terminal
     supports it.
 
@@ -42,7 +42,7 @@ Any command line arguments will be used as defaults.
 Use tab key to complete, readline keys to edit, enter to accept defaults.
 An optional (CODE) may follow transaction dates.
 An optional ; COMMENT may follow descriptions or amounts.
-If you make a mistake, enter < at any prompt to restart the transaction.
+If you make a mistake, enter < at any prompt to go one step backward.
 To end a transaction, enter . when prompted.
 To quit, enter . at a date prompt or press control-d or control-c.
 Date [2015/05/22]: 

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -1843,8 +1843,8 @@ A parenthesised transaction code may be entered following a date.
 .IP \[bu] 2
 Comments and tags may be entered following a description or amount.
 .IP \[bu] 2
-If you make a mistake, enter \f[C]<\f[R] at any prompt to restart the
-transaction.
+If you make a mistake, enter \f[C]<\f[R] at any prompt to go one step
+backward.
 .IP \[bu] 2
 Input prompts are displayed in a different colour when the terminal
 supports it.
@@ -1859,7 +1859,7 @@ Any command line arguments will be used as defaults.
 Use tab key to complete, readline keys to edit, enter to accept defaults.
 An optional (CODE) may follow transaction dates.
 An optional ; COMMENT may follow descriptions or amounts.
-If you make a mistake, enter < at any prompt to restart the transaction.
+If you make a mistake, enter < at any prompt to go one step backward.
 To end a transaction, enter . when prompted.
 To quit, enter . at a date prompt or press control-d or control-c.
 Date [2015/05/22]: 

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -1424,8 +1424,8 @@ or press control-d or control-c to exit.
      bare numbers entered.
    * A parenthesised transaction code may be entered following a date.
    * Comments and tags may be entered following a description or amount.
-   * If you make a mistake, enter '<' at any prompt to restart the
-     transaction.
+   * If you make a mistake, enter '<' at any prompt to go one step
+     backward.
    * Input prompts are displayed in a different colour when the terminal
      supports it.
 
@@ -1437,7 +1437,7 @@ Any command line arguments will be used as defaults.
 Use tab key to complete, readline keys to edit, enter to accept defaults.
 An optional (CODE) may follow transaction dates.
 An optional ; COMMENT may follow descriptions or amounts.
-If you make a mistake, enter < at any prompt to restart the transaction.
+If you make a mistake, enter < at any prompt to go one step backward.
 To end a transaction, enter . when prompted.
 To quit, enter . at a date prompt or press control-d or control-c.
 Date [2015/05/22]: 

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -1253,8 +1253,8 @@ COMMANDS
 
        o Comments and tags may be entered following a description or amount.
 
-       o If  you make a mistake, enter < at any prompt to restart the transac-
-         tion.
+       o If  you make a mistake, enter < at any prompt to go one step
+         backward.
 
        o Input prompts are displayed in a different colour when  the  terminal
          supports it.
@@ -1267,7 +1267,7 @@ COMMANDS
               Use tab key to complete, readline keys to edit, enter to accept defaults.
               An optional (CODE) may follow transaction dates.
               An optional ; COMMENT may follow descriptions or amounts.
-              If you make a mistake, enter < at any prompt to restart the transaction.
+              If you make a mistake, enter < at any prompt to go one step backward.
               To end a transaction, enter . when prompted.
               To quit, enter . at a date prompt or press control-d or control-c.
               Date [2015/05/22]:


### PR DESCRIPTION
This PR changes the `confirmedTransactionWizard` function to accept a list that is used as a stack to store the stages of the addition command so that the back command can go back to the right stage.

Is this a good approach towards implementing a back command for `add`?

Closes #577 