### PR TITLE
Fix typos

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ install:
 #
 # install latest stack master
 #- set PATH=C:\Users\appveyor\AppData\Roaming\local\bin;%PATH%
-# show the stack-installed binares that were restored from cache, can vary by instance
+# show the stack-installed binaries that were restored from cache, can vary by instance
 #- dir C:\Users\appveyor\AppData\Roaming\local\bin
 # - stack-release upgrade --git
 #- copy C:\Users\appveyor\AppData\Roaming\local\bin\stack.exe C:\Users\appveyor\AppData\Roaming\local\bin\stack-master.exe

--- a/hledger-install/hledger-install.sh
+++ b/hledger-install/hledger-install.sh
@@ -327,7 +327,7 @@ do_osx_install() {
   echo ""
 }
 
-# Attempts to insall on FreeBSD.  Installs dependencies with
+# Attempts to install on FreeBSD.  Installs dependencies with
 # 'pkg install' and then downloads bindist.
 do_freebsd_install() {
   install_dependencies() {

--- a/hledger-lib/CHANGES.md
+++ b/hledger-lib/CHANGES.md
@@ -159,7 +159,7 @@ Changes include:
 
 -   showTransaction: fix a case showing multiple missing amounts
     showTransaction could sometimes hide the last posting's amount even if
-    one of the other posting amounts was already implcit, producing invalid
+    one of the other posting amounts was already implicit, producing invalid
     transaction output.
 
 -   plog, plogAt: add missing newline

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -800,7 +800,7 @@ transactionFromCsvRecord sourcepos rules record = t
       case postings' of
         -- To be compatible with the behavior of the old code which allowed two postings only, we enforce
         -- second posting when rules generated just first of them, and posting is of type that should be balanced.
-        -- When we have srictly first and second posting, but second posting does not have amount, we fill it in.
+        -- When we have strictly first and second posting, but second posting does not have amount, we fill it in.
         [("1",posting1)] ->
           case ptype posting1 of
             VirtualPosting -> [posting1]

--- a/hledger-web/static/js/jquery.flot.js
+++ b/hledger-web/static/js/jquery.flot.js
@@ -517,7 +517,7 @@ Licensed under the MIT license.
                 colors: ["#edc240", "#afd8f8", "#cb4b4b", "#4da74d", "#9440ed"],
                 legend: {
                     show: true,
-                    noColumns: 1, // number of colums in legend table
+                    noColumns: 1, // number of columns in legend table
                     labelFormatter: null, // fn: string -> string
                     labelBoxBorderColor: "#ccc", // border color for the little label boxes
                     container: null, // container (as jQuery object) to put legend in, null means default on top of graph

--- a/hledger/Hledger/Cli/Anon.hs
+++ b/hledger/Hledger/Cli/Anon.hs
@@ -35,7 +35,7 @@ instance Anon Journal where
 instance Anon Posting where
     anon p = p { paccount = anonAccount . paccount $ p
                , pcomment = T.empty
-               , ptransaction = fmap anon . ptransaction $ p  -- Note that this will be overriden
+               , ptransaction = fmap anon . ptransaction $ p  -- Note that this will be overridden
                , poriginal = anon <$> poriginal p
                }
 

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -448,7 +448,7 @@ To illustrate this, consider the following budget:
     liabilities
 ```
 
-With this, monthly budget for electronics is defined to be $100 and budget for personal expenses is an additional $1000, which implicity means
+With this, monthly budget for electronics is defined to be $100 and budget for personal expenses is an additional $1000, which implicitly means
 that budget for both `expenses:personal` and `expenses` is $1100.
 
 Transactions in `expenses:personal:electronics` will be counted both towards its $100 budget and $1100 of `expenses:personal` , and transactions in any other subaccount of `expenses:personal` would be

--- a/hledger/Hledger/Cli/Commands/Balance.txt
+++ b/hledger/Hledger/Cli/Commands/Balance.txt
@@ -432,7 +432,7 @@ To illustrate this, consider the following budget:
     liabilities
 
 With this, monthly budget for electronics is defined to be $100 and
-budget for personal expenses is an additional $1000, which implicity
+budget for personal expenses is an additional $1000, which implicitly
 means that budget for both expenses:personal and expenses is $1100.
 
 Transactions in expenses:personal:electronics will be counted both

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -2411,7 +2411,7 @@ To illustrate this, consider the following budget:
 .fi
 .PP
 With this, monthly budget for electronics is defined to be $100 and
-budget for personal expenses is an additional $1000, which implicity
+budget for personal expenses is an additional $1000, which implicitly
 means that budget for both \f[C]expenses:personal\f[R] and
 \f[C]expenses\f[R] is $1100.
 .PP

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -1952,7 +1952,7 @@ account, all its parents would have budget as well.
     liabilities
 
    With this, monthly budget for electronics is defined to be $100 and
-budget for personal expenses is an additional $1000, which implicity
+budget for personal expenses is an additional $1000, which implicitly
 means that budget for both 'expenses:personal' and 'expenses' is $1100.
 
    Transactions in 'expenses:personal:electronics' will be counted both


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.