### PR TITLE
Fix auto postings test.

### DIFF
--- a/tests/journal/auto-postings.test
+++ b/tests/journal/auto-postings.test
@@ -299,7 +299,7 @@ $ hledger print -f- --forecast -b 2016-01 -e 2016-03
 
 # 15.
 $ hledger -f- register --auto
-2019/10/07 MARKET               ex:groceries:food              $20           $20
+2020/10/07 MARKET               ex:groceries:food              $20           $20
                                 [budget:groceries]            $-20             0
                                 [as:bank:checking]             $20           $20
                                 assets:bank:checking          $-20             0


### PR DESCRIPTION
Happy new year!

Since my PR #1159 failed (pure documentation) I checked what the problem was. Unfortunately, I don't really have a way of interpolating the current year in the result, so I figured adjusting the year manually would at least make the tests pass again!