### PR TITLE
Add separator to config

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -50,7 +50,6 @@ module Hledger.Read.Common (
   getAccountAliases,
   clearAccountAliases,
   journalAddFile,
-  getSpecialSeparators,
 
   -- * parsers
   -- ** transaction bits
@@ -163,7 +162,6 @@ data InputOpts = InputOpts {
      mformat_           :: Maybe StorageFormat  -- ^ a file/storage format to try, unless overridden
                                                 --   by a filename prefix. Nothing means try all.
     ,mrules_file_       :: Maybe FilePath       -- ^ a conversion rules file to use (when reading CSV)
-    ,separator_         :: Maybe Char           -- ^ the separator to use (when reading CSV)
     ,aliases_           :: [String]             -- ^ account name aliases to apply
     ,anon_              :: Bool                 -- ^ do light anonymisation/obfuscation of the data
     ,ignore_assertions_ :: Bool                 -- ^ don't check balance assertions
@@ -176,14 +174,13 @@ data InputOpts = InputOpts {
 instance Default InputOpts where def = definputopts
 
 definputopts :: InputOpts
-definputopts = InputOpts def def def def def def def True def def
+definputopts = InputOpts def def def def def def True def def
 
 rawOptsToInputOpts :: RawOpts -> InputOpts
 rawOptsToInputOpts rawopts = InputOpts{
    -- files_             = listofstringopt "file" rawopts
    mformat_           = Nothing
   ,mrules_file_       = maybestringopt "rules-file" rawopts
-  ,separator_         = maybestringopt "separator" rawopts >>= getSpecialSeparators
   ,aliases_           = listofstringopt "alias" rawopts
   ,anon_              = boolopt "anon" rawopts
   ,ignore_assertions_ = boolopt "ignore-assertions" rawopts
@@ -194,14 +191,6 @@ rawOptsToInputOpts rawopts = InputOpts{
   }
 
 --- * parsing utilities
-
--- | Parse special separator names TAB and SPACE, or return the first
--- character. Return Nothing on empty string
-getSpecialSeparators :: String -> Maybe Char
-getSpecialSeparators "SPACE" = Just ' '
-getSpecialSeparators "TAB" = Just '\t'
-getSpecialSeparators (x:_) = Just x
-getSpecialSeparators [] = Nothing
 
 -- | Run a text parser in the identity monad. See also: parseWithState.
 runTextParser, rtp

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -105,17 +105,18 @@ parse iopts f t = do
 
 -- | Parse special separator names TAB and SPACE, or return the first
 -- character. Return Nothing on empty string
-getSpecialSeparators :: String -> Maybe Char
-getSpecialSeparators "SPACE" = Just ' '
-getSpecialSeparators "TAB" = Just '\t'
-getSpecialSeparators (x:_) = Just x
-getSpecialSeparators [] = Nothing
+parseSeparator :: String -> Maybe Char
+parseSeparator = specials . map toLower
+  where specials "space" = Just ' '
+        specials "tab"   = Just '\t'
+        specials (x:_)   = Just x
+        specials []      = Nothing
 
 -- | Decide which separator to get.
 -- If the external separator is provided, take it. Otherwise, look at the rules. Finally, return ','.
 getSeparator :: CsvRules -> Char
 getSeparator rules = head $
-  catMaybes [ getDirective "separator" rules >>= getSpecialSeparators
+  catMaybes [ getDirective "separator" rules >>= parseSeparator
             , Just ',']
 
 -- | Read a Journal from the given CSV data (and filename, used for error

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -453,8 +453,8 @@ parseAndValidateCsvRules rulesfile s =
     Right rules -> first makeFancyParseError $ validateRules rules
   where
     makeFancyParseError :: String -> String
-    makeFancyParseError s = 
-      parseErrorPretty (FancyError 0 (S.singleton $ ErrorFail s) :: ParseError Text String)
+    makeFancyParseError errorString =
+      parseErrorPretty (FancyError 0 (S.singleton $ ErrorFail errorString) :: ParseError Text String)
 
 -- | Parse this text as CSV conversion rules. The file path is for error messages.
 parseCsvRules :: FilePath -> T.Text -> Either (ParseErrorBundle T.Text CustomErr) CsvRules

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -131,7 +131,7 @@ readJournalFromCsv separator mrulesfile csvfile csvdata =
     then do
       dbg1IO "using conversion rules file" rulesfile
       readFilePortably rulesfile >>= expandIncludes (takeDirectory rulesfile)
-    else 
+    else
       return $ defaultRulesText rulesfile
   rules <- either throwerr return $ parseAndValidateCsvRules rulesfile rulestext
   dbg2IO "rules" rules

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -512,6 +512,7 @@ directivep = (do
 directives :: [String]
 directives =
   ["date-format"
+  ,"separator"
   -- ,"default-account1"
   -- ,"default-currency"
   -- ,"skip-lines" -- old

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -509,6 +509,7 @@ directivep = (do
   return (d, v)
   ) <?> "directive"
 
+directives :: [String]
 directives =
   ["date-format"
   -- ,"default-account1"

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -104,6 +104,14 @@ parse iopts f t = do
                 -- better preemptively reverse them once more. XXX inefficient
                 pj' = journalReverse pj
 
+getSeparatorFromRules :: Char -> CsvRules -> Char
+getSeparatorFromRules defaultSeparator rules =
+  maybe defaultSeparator id (getSeparator <$> getDirective "separator" rules)
+  where getSeparator :: String -> Char
+        getSeparator "SPACE" = ' '
+        getSeparator "TAB" = '\t'
+        getSeparator x = head x
+
 -- | Read a Journal from the given CSV data (and filename, used for error
 -- messages), or return an error. Proceed as follows:
 -- @
@@ -148,7 +156,7 @@ readJournalFromCsv separator mrulesfile csvfile csvdata =
   records <- (either throwerr id .
               dbg2 "validateCsv" . validateCsv rules skiplines .
               dbg2 "parseCsv")
-             `fmap` parseCsv separator parsecfilename csvdata
+             `fmap` parseCsv (getSeparatorFromRules separator rules) parsecfilename csvdata
   dbg1IO "first 3 csv records" $ take 3 records
 
   -- identify header lines

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -474,7 +474,7 @@ validateRules rules = do
 
 rulesp :: CsvRulesParser CsvRules
 rulesp = do
-  many $ choiceInState
+  _ <- many $ choiceInState
     [blankorcommentlinep                                                <?> "blank or comment line"
     ,(directivep        >>= modify' . addDirective)                     <?> "directive"
     ,(fieldnamelistp    >>= modify' . setIndexesAndAssignmentsFromList) <?> "field name list"

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -115,9 +115,7 @@ parseSeparator = specials . map toLower
 -- | Decide which separator to get.
 -- If the external separator is provided, take it. Otherwise, look at the rules. Finally, return ','.
 getSeparator :: CsvRules -> Char
-getSeparator rules = head $
-  catMaybes [ getDirective "separator" rules >>= parseSeparator
-            , Just ',']
+getSeparator rules = maybe ',' id (getDirective "separator" rules >>= parseSeparator)
 
 -- | Read a Journal from the given CSV data (and filename, used for error
 -- messages), or return an error. Proceed as follows:

--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -40,6 +40,7 @@ these are described more fully below, after the examples:
 [**`skip`**](#skip)                         skip one or more header lines or matched CSV records
 [**`fields`**](#fields)                     name CSV fields, assign them to hledger fields
 [**field assignment**](#field-assignment)    assign a value to one hledger field, with interpolation
+[**`separator`**](#separator)               a custom field separator
 [**`if`**](#if)                             apply some rules to matched CSV records
 [**`end`**](#end)                           skip the remaining CSV records
 [**`date-format`**](#date-format)           describe the format of CSV dates
@@ -405,7 +406,7 @@ Fields you don't care about can be left unnamed.
 Currently there must be least two items (there must be at least one comma).
 
 Note, always use comma in the fields list, even if your CSV uses
-[another separator character](#other-separator-characters).
+[another separator character](#separator).
 
 Here are the standard hledger field/pseudo-field names. 
 For more about the transaction parts they refer to, see the manual for hledger's journal format.
@@ -473,6 +474,21 @@ Interpolation strips outer whitespace (so a CSV value like `" 1 "`
 becomes `1` when interpolated)
 ([#1051](https://github.com/simonmichael/hledger/issues/1051)).
 See TIPS below for more about referencing other fields.
+
+## `separator`
+
+You can use the `separator` directive to read other kinds of
+character-separated data. Eg to read SSV (Semicolon Separated Values), use:
+```
+separator ;
+```
+
+The separator directive accepts exactly one single byte character as a
+separator. To specify whitespace characters, you may use the special
+words `TAB` or `SPACE`. Eg to read TSV (Tab Separated Values), use:
+```
+separator TAB
+```
 
 
 ## `if`
@@ -660,23 +676,6 @@ When CSV values are enclosed in quotes, note:
 
 - they must be double quotes (not single quotes)
 - spaces outside the quotes are [not allowed](https://stackoverflow.com/questions/4863852/space-before-quote-in-csv-field)
-
-## Other separator characters
-
-You can use the `--separator 'CHAR'` command line option
-(experimental) to read other kinds of character-separated data. 
-Eg to read SSV (Semicolon Separated Values), use:
-```shell
-$ hledger -f foo.tsv --separator ';' print
-```
-Note the semicolon is quoted because it's a 
-[special shell character](hledger.html#special-characters-in-arguments-and-queries).
-
-To read TSV (Tab Separated Values), use:
-```shell
-$ hledger -f foo.tsv --separator '	' print
-```
-Note, that's a real tab character in quotes, not `\t`.
 
 ## Reading multiple CSV files
 

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -122,7 +122,6 @@ inputflags :: [Flag RawOpts]
 inputflags = [
   flagReq  ["file","f"]      (\s opts -> Right $ setopt "file" s opts) "FILE" "use a different input file. For stdin, use - (default: $LEDGER_FILE or $HOME/.hledger.journal)"
  ,flagReq  ["rules-file"]    (\s opts -> Right $ setopt "rules-file" s opts) "RFILE" "CSV conversion rules file (default: FILE.rules)"
- ,flagReq  ["separator"]     (\s opts -> Right $ setopt "separator" s opts) "SEP" "CSV separator (default: ,)"
  ,flagReq  ["alias"]         (\s opts -> Right $ setopt "alias" s opts)  "OLD=NEW" "rename accounts named OLD to NEW"
  ,flagNone ["anon"]          (setboolopt "anon") "anonymize accounts and payees"
  ,flagReq  ["pivot"]         (\s opts -> Right $ setopt "pivot" s opts)  "TAGNAME" "use some other field/tag for account names"

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -527,6 +527,21 @@ $  ./hledger-csv
 
 >=0
 
+# 25. specify alternative delimiter in rules
+<
+2009/10/01	Flubber Co	50	123
+
+RULES
+fields date, description, amount, balance
+currency $
+account1 (assets:myacct)
+separator TAB
+
+$  ./hledger-csv
+2009/10/01 Flubber Co
+   (assets:myacct)                $50 = $123
+>=0
+
 ## 25. A single unbalanced posting with number other than 1 also should not generate a balancing posting.
 #<
 #2019-01-01,1

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -575,7 +575,7 @@ $  ./hledger-csv --separator 'TAB'
 
 >=0
 
-## 25. A single unbalanced posting with number other than 1 also should not generate a balancing posting.
+## 28. A single unbalanced posting with number other than 1 also should not generate a balancing posting.
 #<
 #2019-01-01,1
 #
@@ -589,7 +589,7 @@ $  ./hledger-csv --separator 'TAB'
 #
 #>=0
 #
-## 26. A single posting that's zero also should not generate a balancing posting.
+## 29. A single posting that's zero also should not generate a balancing posting.
 #<
 #2019-01-01,0
 #
@@ -603,7 +603,7 @@ $  ./hledger-csv --separator 'TAB'
 #
 #>=0
 
-## 27. With a bracketed account name, the auto-generated second posting should also be bracketed.
+## 30. With a bracketed account name, the auto-generated second posting should also be bracketed.
 #<
 #2019-01-01,1
 #

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -152,13 +152,14 @@ $  ./hledger-csv
 RULES
 account1 Assets:MyAccount
 date %1
+separator ;
 date-format %d/%Y/%m
 description %2
 amount-in %3
 amount-out %4
 currency $
 
-$  ./hledger-csv --separator ';'
+$  ./hledger-csv
 2009/09/10 Flubber Co🎅
     Assets:MyAccount             $50
     income:unknown              $-50
@@ -527,7 +528,7 @@ $  ./hledger-csv
 
 >=0
 
-# 25. specify alternative whitespace delimiter in rules
+# 25. specify reserved word whitespace separator in rules
 <
 2009/10/01	Flubber Co	50	123
 
@@ -543,39 +544,7 @@ $  ./hledger-csv
 
 >=0
 
-# 26. specify char delimiter in rules
-<
-2009/10/01;Flubber Co;50;123
-
-RULES
-fields date, description, amount, balance
-currency $
-account1 (assets:myacct)
-separator ;
-
-$  ./hledger-csv
-2009/10/01 Flubber Co
-    (assets:myacct)             $50 = $123
-
->=0
-
-# 27. command line delimiter overrides configuration file
-<
-2009/10/01	Flubber Co	50	123
-
-RULES
-fields date, description, amount, balance
-currency $
-account1 (assets:myacct)
-separator ;
-
-$  ./hledger-csv --separator 'TAB'
-2009/10/01 Flubber Co
-    (assets:myacct)             $50 = $123
-
->=0
-
-## 28. A single unbalanced posting with number other than 1 also should not generate a balancing posting.
+## 26. A single unbalanced posting with number other than 1 also should not generate a balancing posting.
 #<
 #2019-01-01,1
 #
@@ -589,7 +558,7 @@ $  ./hledger-csv --separator 'TAB'
 #
 #>=0
 #
-## 29. A single posting that's zero also should not generate a balancing posting.
+## 27. A single posting that's zero also should not generate a balancing posting.
 #<
 #2019-01-01,0
 #
@@ -603,7 +572,7 @@ $  ./hledger-csv --separator 'TAB'
 #
 #>=0
 
-## 30. With a bracketed account name, the auto-generated second posting should also be bracketed.
+## 28. With a bracketed account name, the auto-generated second posting should also be bracketed.
 #<
 #2019-01-01,1
 #

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -527,7 +527,7 @@ $  ./hledger-csv
 
 >=0
 
-# 25. specify alternative delimiter in rules
+# 25. specify alternative whitespace delimiter in rules
 <
 2009/10/01	Flubber Co	50	123
 
@@ -539,7 +539,40 @@ separator TAB
 
 $  ./hledger-csv
 2009/10/01 Flubber Co
-   (assets:myacct)                $50 = $123
+    (assets:myacct)             $50 = $123
+
+>=0
+
+# 26. specify char delimiter in rules
+<
+2009/10/01;Flubber Co;50;123
+
+RULES
+fields date, description, amount, balance
+currency $
+account1 (assets:myacct)
+separator ;
+
+$  ./hledger-csv
+2009/10/01 Flubber Co
+    (assets:myacct)             $50 = $123
+
+>=0
+
+# 27. command line delimiter overrides configuration file
+<
+2009/10/01	Flubber Co	50	123
+
+RULES
+fields date, description, amount, balance
+currency $
+account1 (assets:myacct)
+separator ;
+
+$  ./hledger-csv --separator 'TAB'
+2009/10/01 Flubber Co
+    (assets:myacct)             $50 = $123
+
 >=0
 
 ## 25. A single unbalanced posting with number other than 1 also should not generate a balancing posting.


### PR DESCRIPTION
Hi @simonmichael, I've added a new config directive `separator`, with its behaviour outlined in my comment in #868. The command line flag `--separator` can be used to override the rules directive `separator`. If neither is specified, the separator defaults to `,`.

I have *not* yet added the documentation, (this is a draft PR) as I first wanted to check back with you on the semantics of the new feature. Please try it out and send me your comments, and I'll add the docs.