### PR TITLE
Calculate account leaf name at point of consumption.

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -5,7 +5,6 @@ New common report types, used by the BudgetReport for now, perhaps all reports l
 module Hledger.Reports.ReportTypes
 ( PeriodicReport(..)
 , PeriodicReportRow(..)
-, AccountLeaf(..)
 
 , Percentage
 , Change
@@ -16,9 +15,6 @@ module Hledger.Reports.ReportTypes
 , periodicReportSpan
 , prNegate
 , prNormaliseSign
-
-, prrFullName
-, prrLeaf
 ) where
 
 import Data.Decimal
@@ -78,16 +74,6 @@ data PeriodicReportRow a b =
   , prrAverage :: b    -- The average of this row's values.
   } deriving (Show)
 
--- | A combination of a full account name and a shortened form, used for display
--- purposes.
-data AccountLeaf = AccountLeaf
-  { acctFull :: AccountName  -- A full account name.
-  , acctLeaf :: AccountName  -- Shortened form of the account name to display
-                             -- in tree mode. Usually the leaf name, possibly
-                             -- with parent accounts prefixed.
-  }
-  deriving (Show)
-
 -- | Figure out the overall date span of a PeridicReport
 periodicReportSpan :: PeriodicReport a b -> DateSpan
 periodicReportSpan (PeriodicReport [] _ _)       = DateSpan Nothing Nothing
@@ -106,11 +92,3 @@ prNegate (PeriodicReport colspans rows totalsrow) =
   where
     rowNegate (PeriodicReportRow name indent amts tot avg) =
         PeriodicReportRow name indent (map negate amts) (-tot) (-avg)
-
--- | Get the full account name for a `PeriodicReport AccountLeaf`>
-prrFullName :: PeriodicReportRow AccountLeaf b -> AccountName
-prrFullName = acctFull . prrName
-
--- | Get the shortened form of the account name for a `PeriodicReport AccountLeaf`>
-prrLeaf :: PeriodicReportRow AccountLeaf b -> AccountName
-prrLeaf = acctLeaf . prrName

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -465,7 +465,7 @@ multiBalanceReportAsCsv opts@ReportOpts{average_, row_total_}
    ++ ["Total"   | row_total_]
    ++ ["Average" | average_]
   ) :
-  [T.unpack (maybeAccountNameDrop opts $ acctFull a) :
+  [T.unpack (maybeAccountNameDrop opts a) :
    map showMixedAmountOneLineWithoutPrice
    (amts
     ++ [rowtot | row_total_]
@@ -606,7 +606,7 @@ balanceReportAsTable opts@ReportOpts{average_, row_total_, balancetype_}
      (T.Group NoLine $ map Header colheadings)
      (map rowvals items)
   where
-    totalscolumn = row_total_ && not (balancetype_ `elem` [CumulativeChange, HistoricalBalance])
+    totalscolumn = row_total_ && balancetype_ `notElem` [CumulativeChange, HistoricalBalance]
     mkDate = case balancetype_ of
        PeriodChange -> showDateSpanMonthAbbrev
        _            -> maybe "" (showDate . prevday) . spanEnd
@@ -614,8 +614,8 @@ balanceReportAsTable opts@ReportOpts{average_, row_total_, balancetype_}
                   ++ ["  Total" | totalscolumn]
                   ++ ["Average" | average_]
     accts = map renderacct items
-    renderacct (PeriodicReportRow (AccountLeaf a a') i _ _ _)
-      | tree_ opts = replicate ((i-1)*2) ' ' ++ T.unpack a'
+    renderacct (PeriodicReportRow a i _ _ _)
+      | tree_ opts = replicate ((i-1)*2) ' ' ++ T.unpack (accountLeafName a)
       | otherwise  = T.unpack $ maybeAccountNameDrop opts a
     rowvals (PeriodicReportRow _ _ as rowtot rowavg) = as
                              ++ [rowtot | totalscolumn]

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -270,11 +270,11 @@ compoundBalanceSubreport ropts@ReportOpts{..} userq j priceoracle subreportqfn s
             nonzeroaccounts =
               dbg1 "nonzeroaccounts" $
               mapMaybe (\(PeriodicReportRow act _ amts _ _) ->
-                            if not (all isZeroMixedAmount amts) then Just (acctFull act) else Nothing) rows
+                            if not (all isZeroMixedAmount amts) then Just act else Nothing) rows
             rows' = filter (not . emptyRow) rows
               where
                 emptyRow (PeriodicReportRow act _ amts _ _) =
-                  all isZeroMixedAmount amts && all (not . (acctFull act `isAccountNamePrefixOf`)) nonzeroaccounts
+                  all isZeroMixedAmount amts && not (any (act `isAccountNamePrefixOf`) nonzeroaccounts)
 
 -- | Render a compound balance report as plain text suitable for console output.
 {- Eg:


### PR DESCRIPTION
I think this cleans up a lot of clutter, and I doubt it results in much of a performance hit at all. It also removes any ambiguity about what is the proper label for a row in a MultiBalanceReport.