### PR TITLE
Improve font display on different OS

### DIFF
--- a/hledger-web/static/hledger.css
+++ b/hledger-web/static/hledger.css
@@ -18,6 +18,12 @@
 }
 
 /*------------------------------------------------------------------------------------------*/
+/* 2. fonts */
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+/*------------------------------------------------------------------------------------------*/
 /* 4. typeahead styles */
 
 .tt-hint {


### PR DESCRIPTION
I opened this PR to improve the font on different operating system. The new css chooses OS-specific font at first and fallback to Helvetic Neue, Helvetic, and Arial. I am new hledger new and this is my first contribution and I am not familiar with Haskell, so user interface at first.

Here is the difference, based on hledger-web demo on macOS:

Before

<img width="1033" alt="before" src="https://user-images.githubusercontent.com/1425636/71777698-3cf29f00-2fde-11ea-973a-b832c41d1036.png">

After

<img width="1033" alt="after" src="https://user-images.githubusercontent.com/1425636/71777697-39f7ae80-2fde-11ea-921c-44acb6386977.png">

I Windows and Linux screenshots are needed, I will post later. Thanks.