### PR TITLE
docs update, including ISO date formatting for doc/mockups

### DIFF
--- a/doc/mockups/budget-reporting.txt
+++ b/doc/mockups/budget-reporting.txt
@@ -3,7 +3,7 @@ budget report mockups
 $ hledger bal ^expenses -M --depth 1 --average  # add average & total columns
 Change of balance (flow):
 
-          ||  2014/01/01-2014/01/31  2014/02/01-2014/02/28  2014/03/01-2014/03/31    average      total
+          ||  2014-01-01-2014-01-31  2014-02-01-2014-02-28  2014-03-01-2014-03-31    average      total
 ==========++============================================================================================
  expenses ||               $3500.00               $3400.00               $4200.00   $3700.00  $11100.00
 ----------++--------------------------------------------------------------------------------------------
@@ -12,7 +12,7 @@ Change of balance (flow):
 $ hledger bal ^expenses -M --depth 1 --budget-simple  # assume a fixed budget
 Change of balance (flow, with simple budget):
 
-          ||          | 2014/01/01-2014/01/31  2014/02/01-2014/02/28  2014/03/01-2014/03/31  |   average     total
+          ||          | 2014-01-01-2014-01-31  2014-02-01-2014-02-28  2014-03-01-2014-03-31  |   average     total
           ||  budget  |      actual      over       actual      over       actual      over  |      over      over
 ==========++=======================================================================================================
  expenses ||   $4000  |    $3500.00  $-500.00     $3400.00  $-600.00     $4200.00   $200.00  |  $-300.00  $-900.00
@@ -22,7 +22,7 @@ Change of balance (flow, with simple budget):
 $ hledger bal ^expenses -M --depth 1 --budget  # budget can change per period
 Change of balance (flow, with budget):
 
-          ||          2014/01/01-2014/01/31            2014/02/01-2014/02/28            2014/03/01-2014/03/31      average     total
+          ||          2014-01-01-2014-01-31            2014-02-01-2014-02-28            2014-03-01-2014-03-31      average     total
           ||      budget     actual      over      budget     actual      over      budget     actual      over       over      over
 ==========++=========================================================================================================================
  expenses ||       $4000   $3500.00  $-500.00       $4000   $3400.00  $-600.00       $4000   $4200.00   $200.00   $-300.00  $-900.00
@@ -32,7 +32,7 @@ Change of balance (flow, with budget):
 $ hledger bal ^expenses -M --depth 1 --budget --cumulative
 Ending balance (cumulative, with budget):
 
-          ||          2014/01/01-2014/01/31            2014/02/01-2014/02/28            2014/03/01-2014/03/31       average     final
+          ||          2014-01-01-2014-01-31            2014-02-01-2014-02-28            2014-03-01-2014-03-31       average     final
           ||      budget     actual      over      budget     actual       over      budget     actual      over       over      over
 ==========++==========================================================================================================================
  expenses ||       $4000   $3500.00  $-500.00       $8000   $6900.00  $-1100.00      $12000  $11100.00  $-900.00   $-833.33  $-900.00
@@ -42,7 +42,7 @@ Ending balance (cumulative, with budget):
 $ hledger bal ^expenses -M --depth 1 --budget --historical  # assume $10000 budget, $20000 expenses starting balances
 Ending balance (historical, with budget):
 
-          ||          2014/01/01-2014/01/31            2014/02/01-2014/02/28            2014/03/01-2014/03/31       average     final
+          ||          2014-01-01-2014-01-31            2014-02-01-2014-02-28            2014-03-01-2014-03-31       average     final
           ||      budget     actual      over      budget     actual       over      budget     actual      over       over      over
 ==========++==========================================================================================================================
  expenses ||      $14000  $23500.00  $9500.00      $18000  $26900.00   $8900.00      $22000  $31100.00  $9100.00   $9166.66  $9100.00

--- a/doc/mockups/entry-macros.txt
+++ b/doc/mockups/entry-macros.txt
@@ -16,7 +16,7 @@ $ hledger entry laundry 20
     assets:personal:cash:wallet                              $-20
 
 $ hledger entry date 5/3 23.24
-2015/05/03 date  ; date:$23.24
+2015-05-03 date  ; date:$23.24
     expenses:personal:food:dining                  $11.62
     expenses:personal:gifts:eleonore               $11.62
     assets:personal:bank:wf:checking:food         $-11.62
@@ -32,7 +32,7 @@ $ cat t.j
 2015/04/29 * trader joes personal  0 1 18 2.07 50
 
 $ hledger expand < t.j
-2015/04/29 * trader joes
+2015-04-29 * trader joes
     expenses:personal:food:snacks                      $1.00
     expenses:personal:gifts:eleonore                  $18.00
     expenses:personal:spiritual:lodge                  $2.07
@@ -59,7 +59,7 @@ entry trader joes personal  GROCERIES SNACKS ELEONORE LODGE CASH
 2015/04/29 * trader joes personal  0 1 18 2.07 50
 
 $ hledger print -f t.j
-2015/04/29 * trader joes personal
+2015-04-29 * trader joes personal
     expenses:personal:gifts:eleonore                  $18.00
     expenses:personal:spiritual:lodge                  $2.07
     expenses:personal:food:snacks                      $1.00

--- a/hledger-lib/hledger_csv.txt
+++ b/hledger-lib/hledger_csv.txt
@@ -23,8 +23,8 @@ DESCRIPTION
        layout, date format etc.), and how to construct hledger journal entries
        (transactions) from it.  Often there will also be a list of conditional
        rules  for  categorising  transactions  based  on  their  descriptions.
-       Here's an overview of the CSV rules; these are described more fully be-
-       low, after the examples:
+       Here's  an  overview  of  the CSV rules; these are described more fully
+       below, after the examples:
 
        skip               skip one  or  more  header
                           lines   or   matched   CSV
@@ -367,8 +367,8 @@ CSV RULES
        can be left unnamed.  Currently there must be least  two  items  (there
        must be at least one comma).
 
-       Note,  always  use  comma in the fields list, even if your CSV uses an-
-       other separator character.
+       Note,  always  use  comma  in  the  fields  list, even if your CSV uses
+       another separator character.
 
        Here are the standard hledger field/pseudo-field names.  For more about
        the transaction parts they refer to, see the manual for hledger's jour-
@@ -380,10 +380,10 @@ CSV RULES
 
    Posting field names
        accountN,  where  N  is  1 to 9, generates a posting, with that account
-       name.  Most often there are two postings, so you'll  want  to  set  ac-
-       count1 and account2.  If a posting's account name is left unset but its
-       amount is set, a default account name will be chosen (like expenses:un-
-       known or income:unknown).
+       name.  Most often there  are  two  postings,  so  you'll  want  to  set
+       account1  and  account2.  If a posting's account name is left unset but
+       its amount is  set,  a  default  account  name  will  be  chosen  (like
+       expenses:unknown or income:unknown).
 
        amountN  sets  posting  N's  amount.  Or, amount with no N sets posting
        1's.  If the CSV  has  debits  and  credits  in  separate  fields,  use
@@ -396,8 +396,8 @@ CSV RULES
        cating an unbalanced posting.)
 
        If  the  CSV  has  the currency symbol in a separate field, you can use
-       currencyN to prepend it to posting N's amount.  currency with no N  af-
-       fects ALL postings.
+       currencyN to prepend it to posting N's  amount.   currency  with  no  N
+       affects ALL postings.
 
        balanceN  sets  a balance assertion amount (or if the posting amount is
        left empty, a balance assignment).  You may need to  adjust  this  with
@@ -411,8 +411,8 @@ CSV RULES
    field assignment
               HLEDGERFIELDNAME FIELDVALUE
 
-       Instead of or in addition to a fields list, you can use  a  "field  as-
-       signment"  rule  to set the value of a single hledger field, by writing
+       Instead of or in addition to a  fields  list,  you  can  use  a  "field
+       assignment" rule to set the value of a single hledger field, by writing
        its name (any of the standard hledger field names above) followed by  a
        text  value.  The value may contain interpolated CSV fields, referenced
        by their 1-based position in the CSV record (%N), or by the  name  they
@@ -424,9 +424,9 @@ CSV RULES
               # combine three fields to make a comment, containing note: and date: tags
               comment note: %somefield - %anotherfield, date: %1
 
-       Interpolation  strips  outer  whitespace (so a CSV value like " 1 " be-
-       comes 1 when interpolated) (#1051).  See TIPS below for more about ref-
-       erencing other fields.
+       Interpolation  strips  outer  whitespace  (so  a  CSV  value like " 1 "
+       becomes 1 when interpolated) (#1051).  See TIPS below  for  more  about
+       referencing other fields.
 
    separator
        You  can  use the separator directive to read other kinds of character-
@@ -459,8 +459,8 @@ CSV RULES
        ple patterns can be written on the following lines, non-indented.  Mul-
        tiple patterns are OR'd (any one of  them  can  match).   Patterns  are
        case-insensitive regular expressions which try to match anywhere within
-       the whole CSV record (POSIX extended regular expressions with some  ad-
-       ditions,   see   https://hledger.org/hledger.html#regular-expressions).
+       the whole CSV record (POSIX  extended  regular  expressions  with  some
+       additions,  see  https://hledger.org/hledger.html#regular-expressions).
        Note the CSV record they see is close to, but not identical to, the one
        in the CSV file; enclosing double quotes will be removed, and the sepa-
        rator character is always comma.
@@ -471,9 +471,9 @@ CSV RULES
               # match "foo" in the fourth field
               if ^([^,]*,){3}foo
 
-       After  the patterns there should be one or more rules to apply, all in-
-       dented by at least one space.  Three kinds of rule are allowed in  con-
-       ditional blocks:
+       After  the  patterns  there  should  be one or more rules to apply, all
+       indented by at least one space.  Three kinds of  rule  are  allowed  in
+       conditional blocks:
 
        o field assignments (to set a hledger field)
 
@@ -600,8 +600,8 @@ TIPS
        read the output.
 
    Valid CSV
-       hledger accepts CSV conforming to RFC 4180.  When CSV  values  are  en-
-       closed in quotes, note:
+       hledger accepts CSV conforming  to  RFC  4180.   When  CSV  values  are
+       enclosed in quotes, note:
 
        o they must be double quotes (not single quotes)
 
@@ -622,8 +622,8 @@ TIPS
 
        There is one exception: balance assertions, if you have generated them,
        will  not  be checked, since normally these will work only when the CSV
-       data is part of the main journal.  If you do need to check balance  as-
-       sertions generated from CSV right away, pipe into another hledger:
+       data is part of the main journal.  If you  do  need  to  check  balance
+       assertions generated from CSV right away, pipe into another hledger:
 
               $ hledger -f file.csv print | hledger -f- print
 
@@ -739,8 +739,8 @@ TIPS
          (At each include point the file is inlined and  scanned  for  further
          includes, recursively, before proceeding.)
 
-       Then  "global"  rules  are  evaluated, top to bottom.  If a rule is re-
-       peated, the last one wins:
+       Then  "global"  rules  are  evaluated,  top  to  bottom.   If a rule is
+       repeated, the last one wins:
 
        o skip (at top level)
 
@@ -753,8 +753,8 @@ TIPS
 
        Then for each CSV record in turn:
 
-       o test  all if blocks.  If any of them contain a end rule, skip all re-
-         maining CSV records.  Otherwise if any of them contain a  skip  rule,
+       o test  all  if  blocks.   If  any of them contain a end rule, skip all
+         remaining CSV records.  Otherwise if any of them contain a skip rule,
          skip  that  many  CSV  records.   If  there are multiple matched skip
          rules, the first one wins.
 
@@ -762,9 +762,9 @@ TIPS
          When  there  are multiple assignments for a field, keep only the last
          one.
 
-       o compute a value for each hledger field - either the one that was  as-
-         signed to it (and interpolate the %CSVFIELDNAME references), or a de-
-         fault
+       o compute a value for each hledger field -  either  the  one  that  was
+         assigned  to  it (and interpolate the %CSVFIELDNAME references), or a
+         default
 
        o generate a synthetic hledger transaction from these values.
 

--- a/hledger-lib/hledger_journal.txt
+++ b/hledger-lib/hledger_journal.txt
@@ -7,9 +7,9 @@ NAME
        Journal - hledger's default file format, representing a General Journal
 
 DESCRIPTION
-       hledger's usual data source is a plain text file containing journal en-
-       tries in hledger journal format.  This file represents a  standard  ac-
-       counting  general  journal.   I  use file names ending in .journal, but
+       hledger's  usual  data  source  is a plain text file containing journal
+       entries in hledger journal format.  This  file  represents  a  standard
+       accounting  general  journal.  I use file names ending in .journal, but
        that's not required.  The journal file contains a number of transaction
        entries, each describing a transfer of money (or any commodity) between
        two or more named accounts, in a simple format readable by both hledger
@@ -23,8 +23,8 @@ DESCRIPTION
 
        You can use hledger without learning any more about this file; just use
        the add or web commands to create and update it.  Many  users,  though,
-       also  edit  the  journal  file directly with a text editor, perhaps as-
-       sisted by the helper modes for emacs or vim.
+       also  edit  the  journal  file  directly  with  a  text editor, perhaps
+       assisted by the helper modes for emacs or vim.
 
        Here's an example:
 
@@ -58,9 +58,9 @@ DESCRIPTION
 FILE FORMAT
    Transactions
        Transactions are movements of  some  quantity  of  commodities  between
-       named accounts.  Each transaction is represented by a journal entry be-
-       ginning with a simple date in column 0.  This can be followed by any of
-       the following, separated by spaces:
+       named  accounts.   Each  transaction  is represented by a journal entry
+       beginning with a simple date in column 0.  This can be followed by  any
+       of the following, separated by spaces:
 
        o (optional) a status character (empty, !, or *)
 
@@ -104,16 +104,16 @@ FILE FORMAT
    Simple dates
        Within a journal file, transaction dates use Y/M/D (or Y-M-D or  Y.M.D)
        Leading  zeros are optional.  The year may be omitted, in which case it
-       will be inferred from the context - the current  transaction,  the  de-
-       fault  year set with a default year directive, or the current date when
-       the command is  run.   Some  examples:  2010/01/31,  1/31,  2010-01-31,
+       will be inferred from  the  context  -  the  current  transaction,  the
+       default  year  set  with  a default year directive, or the current date
+       when the command is run.  Some examples: 2010/01/31, 1/31,  2010-01-31,
        2010.1.31.
 
    Secondary dates
        Real-life  transactions  sometimes  involve more than one date - eg the
        date you write a cheque, and the date it clears in your bank.  When you
-       want  to model this, eg for more accurate balances, you can specify in-
-       dividual posting dates, which I recommend.  Or, you can  use  the  sec-
+       want  to  model  this,  eg  for more accurate balances, you can specify
+       individual posting dates, which I recommend.  Or, you can use the  sec-
        ondary  dates  (aka  auxiliary/effective  dates) feature, supported for
        compatibility with Ledger.
 
@@ -142,15 +142,15 @@ FILE FORMAT
        Secondary dates require some effort; you must use them consistently  in
        your journal entries and remember whether to use or not use the --date2
        flag for your reports.  They are included in hledger for Ledger compat-
-       ibility,  but  posting dates are a more powerful and less confusing al-
-       ternative.
+       ibility,  but  posting  dates  are  a  more powerful and less confusing
+       alternative.
 
    Posting dates
        You can give individual postings a different  date  from  their  parent
        transaction,  by  adding a posting comment containing a tag (see below)
        like date:DATE.  This is probably the best way to control posting dates
-       precisely.   Eg  in  this  example the expense should appear in May re-
-       ports, and the deduction from checking should be reported  on  6/1  for
+       precisely.   Eg  in  this  example  the  expense  should  appear in May
+       reports, and the deduction from checking should be reported on 6/1  for
        easy bank reconciliation:
 
               2015/5/30
@@ -177,9 +177,9 @@ FILE FORMAT
 
    Status
        Transactions,  or  individual postings within a transaction, can have a
-       status mark, which is a single character  before  the  transaction  de-
-       scription  or posting account name, separated from it by a space, indi-
-       cating one of three statuses:
+       status mark,  which  is  a  single  character  before  the  transaction
+       description  or  posting  account  name,  separated from it by a space,
+       indicating one of three statuses:
 
        mark     status
        ------------------
@@ -192,8 +192,8 @@ FILE FORMAT
        status:* queries; or the U, P, C keys in hledger-ui.
 
        Note, in Ledger and in older versions of hledger, the "unmarked"  state
-       is  called  "uncleared".   As  of hledger 1.3 we have renamed it to un-
-       marked for clarity.
+       is  called  "uncleared".   As  of  hledger  1.3  we  have renamed it to
+       unmarked for clarity.
 
        To replicate Ledger and old hledger's behaviour of also matching  pend-
        ing, combine -U and -P.
@@ -215,8 +215,8 @@ FILE FORMAT
                     rect
 
        With  this scheme, you would use -PC to see the current balance at your
-       bank, -U to see things which will probably hit your bank soon (like un-
-       cashed  checks),  and no flags to see the most up-to-date state of your
+       bank, -U to see things which will probably hit  your  bank  soon  (like
+       uncashed checks), and no flags to see the most up-to-date state of your
        finances.
 
    Description
@@ -229,9 +229,9 @@ FILE FORMAT
    Payee and note
        You can optionally include a | (pipe) character in descriptions to sub-
        divide the description into separate fields for payee/payer name on the
-       left (up to the first |) and an additional note field on the right (af-
-       ter  the  first |).  This may be worthwhile if you need to do more pre-
-       cise querying and pivoting by payee or by note.
+       left (up to the first |) and an additional  note  field  on  the  right
+       (after  the  first  |).   This may be worthwhile if you need to do more
+       precise querying and pivoting by payee or by note.
 
    Account names
        Account names typically have several parts separated by a  full  colon,
@@ -246,8 +246,8 @@ FILE FORMAT
        Account names can be aliased.
 
    Amounts
-       After  the  account  name, there is usually an amount.  (Important: be-
-       tween account name and amount, there must be two or more spaces.)
+       After  the  account  name,  there  is  usually  an amount.  (Important:
+       between account name and amount, there must be two or more spaces.)
 
        hledger's amount format is flexible, supporting  several  international
        formats.   Here  are  some examples.  Amounts have a number (the "quan-
@@ -301,10 +301,10 @@ FILE FORMAT
 
        hledger will treat them both as decimal marks by default (cf #793).  If
        you use digit group marks, to prevent confusion and undetected typos we
-       recommend  you write commodity directives at the top of the file to ex-
-       plicitly declare the decimal mark (and optionally a digit group  mark).
-       Note,  these  formats ("amount styles") are specific to each commodity,
-       so if your data uses multiple formats, hledger can handle it:
+       recommend  you  write  commodity  directives  at the top of the file to
+       explicitly declare the decimal  mark  (and  optionally  a  digit  group
+       mark).  Note, these formats ("amount styles") are specific to each com-
+       modity, so if your data uses multiple formats, hledger can handle it:
 
               commodity $1,000.00
               commodity EUR 1.000,00
@@ -591,11 +591,11 @@ FILE FORMAT
        nodes to be ignored, allowing emacs users to fold  and  navigate  their
        journals with org-mode or orgstruct-mode.)
 
-       You  can attach comments to a transaction by writing them after the de-
-       scription and/or indented on the following lines (before the postings).
-       Similarly,  you can attach comments to an individual posting by writing
-       them after the amount and/or indented on the following lines.  Transac-
-       tion and posting comments must begin with a semicolon (;).
+       You  can  attach  comments  to  a transaction by writing them after the
+       description and/or indented on the following lines  (before  the  post-
+       ings).   Similarly, you can attach comments to an individual posting by
+       writing them after the amount and/or indented on the  following  lines.
+       Transaction and posting comments must begin with a semicolon (;).
 
        Some examples:
 
@@ -671,28 +671,28 @@ FILE FORMAT
        here  is  a  table  summarising  the directives and their effects, with
        links to more detailed docs.
 
-       direc-     end   di-   subdi-    purpose                        can affect  (as  of
-       tive       rective     rec-                                     2018/06)
+       direc-     end         subdi-    purpose                        can affect  (as  of
+       tive       directive   rec-                                     2018/06)
                               tives
        ------------------------------------------------------------------------------------
-       account                any       document account names,  de-   all entries in  all
-                              text      clare  account  types & dis-   files,   before  or
+       account                any       document   account    names,   all entries in  all
+                              text      declare account types & dis-   files,   before  or
                                         play order                     after
-       alias      end                   rewrite account names          following       in-
-                  aliases                                              line/included   en-
-                                                                       tries  until end of
-                                                                       current file or end
-                                                                       directive
-       apply      end apply             prepend  a  common parent to   following       in-
-       account    account               account names                  line/included   en-
-                                                                       tries until end  of
-                                                                       current file or end
-                                                                       directive
-       comment    end  com-             ignore part of journal         following       in-
-                  ment                                                 line/included   en-
-                                                                       tries  until end of
-                                                                       current file or end
-                                                                       directive
+       alias      end                   rewrite account names          following
+                  aliases                                              inline/included
+                                                                       entries  until  end
+                                                                       of current file  or
+                                                                       end directive
+       apply      end apply             prepend  a  common parent to   following
+       account    account               account names                  inline/included
+                                                                       entries  until  end
+                                                                       of  current file or
+                                                                       end directive
+       comment    end  com-             ignore part of journal         following
+                  ment                                                 inline/included
+                                                                       entries  until  end
+                                                                       of current file  or
+                                                                       end directive
        commod-                format    declare a commodity and  its   number    notation:
        ity                              number  notation  &  display   following   entries
                                         style                          in  that  commodity
@@ -702,34 +702,35 @@ FILE FORMAT
                                                                        in reports
        D                                declare a  commodity  to  be   default  commodity:
                                         used    for    commodityless   following   commod-
-                                        amounts, and its number  no-   ityless entries un-
-                                        tation & display style         til end of  current
-                                                                       file;  number nota-
-                                                                       tion: following en-
-                                                                       tries  in that com-
-                                                                       modity until end of
-                                                                       current  file; dis-
-                                                                       play style: amounts
-                                                                       of  that  commodity
-                                                                       in reports
+                                        amounts,  and   its   number   ityless     entries
+                                        notation & display style       until end  of  cur-
+                                                                       rent  file;  number
+                                                                       notation: following
+                                                                       entries   in   that
+                                                                       commodity until end
+                                                                       of   current  file;
+                                                                       display      style:
+                                                                       amounts   of   that
+                                                                       commodity        in
+                                                                       reports
        include                          include   entries/directives   what  the  included
                                         from another file              directives affect
        P                                declare a market price for a   amounts   of   that
-                                        commodity                      commodity  in   re-
-                                                                       ports,  when  -V is
+                                        commodity                      commodity        in
+                                                                       reports, when -V is
                                                                        used
-       Y                                declare a year for  yearless   following       in-
-                                        dates                          line/included   en-
-                                                                       tries  until end of
-                                                                       current file
+       Y                                declare  a year for yearless   following
+                                        dates                          inline/included
+                                                                       entries  until  end
+                                                                       of current file
 
        And some definitions:
 
        subdirec-   optional indented directive line immediately following a par-
        tive        ent directive
-       number      how  to  interpret  numbers when parsing journal entries (the
-       notation    identity of the  decimal  separator  character).   (Currently
-                   each  commodity  can  have its own notation, even in the same
+       number      how to interpret numbers when parsing  journal  entries  (the
+       notation    identity  of  the  decimal  separator character).  (Currently
+                   each commodity can have its own notation, even  in  the  same
                    file.)
        display     how to display amounts of a commodity in reports (symbol side
        style       and spacing, digit groups, decimal separator, decimal places)
@@ -737,37 +738,37 @@ FILE FORMAT
        scope       are affected by a directive
 
        As you can see, directives vary in which journal entries and files they
-       affect, and whether they are focussed on input (parsing) or output (re-
-       ports).  Some directives have multiple effects.
+       affect, and whether they are focussed  on  input  (parsing)  or  output
+       (reports).  Some directives have multiple effects.
 
-       If you have a journal made up of multiple files, or  pass  multiple  -f
-       options  on  the  command line, note that directives which affect input
-       typically last only until the end of their defining  file.   This  pro-
+       If  you  have  a journal made up of multiple files, or pass multiple -f
+       options on the command line, note that directives  which  affect  input
+       typically  last  only  until the end of their defining file.  This pro-
        vides more simplicity and predictability, eg reports are not changed by
-       writing file options in a different order.  It  can  be  surprising  at
+       writing  file  options  in  a different order.  It can be surprising at
        times though.
 
    Comment blocks
-       A  line  containing just comment starts a commented region of the file,
+       A line containing just comment starts a commented region of  the  file,
        and a line containing just end comment (or the end of the current file)
        ends it.  See also comments.
 
    Including other files
-       You  can  pull in the content of additional files by writing an include
+       You can pull in the content of additional files by writing  an  include
        directive, like this:
 
               include path/to/file.journal
 
-       If the path does not begin with a slash, it is relative to the  current
-       file.   The  include  file  path may contain common glob patterns (e.g.
+       If  the path does not begin with a slash, it is relative to the current
+       file.  The include file path may contain  common  glob  patterns  (e.g.
        *).
 
-       The include directive can only be used in journal files.   It  can  in-
-       clude journal, timeclock or timedot files, but not CSV files.
+       The  include  directive  can  only  be  used  in journal files.  It can
+       include journal, timeclock or timedot files, but not CSV files.
 
    Default year
-       You  can set a default year to be used for subsequent dates which don't
-       specify a year.  This is a line beginning with Y followed by the  year.
+       You can set a default year to be used for subsequent dates which  don't
+       specify  a year.  This is a line beginning with Y followed by the year.
        Eg:
 
               Y2009  ; set default year to 2009
@@ -789,19 +790,19 @@ FILE FORMAT
    Declaring commodities
        The commodity directive has several functions:
 
-       1. It  declares  commodities which may be used in the journal.  This is
+       1. It declares commodities which may be used in the journal.   This  is
           currently not enforced, but can serve as documentation.
 
        2. It declares what decimal mark character to expect when parsing input
-          -  useful to disambiguate international number formats in your data.
+          - useful to disambiguate international number formats in your  data.
           (Without this, hledger will parse both 1,000 and 1.000 as 1).
 
        3. It declares the amount display format to use in output - decimal and
           digit group marks, number of decimal places, symbol placement etc.
 
-       You  are likely to run into one of the problems solved by commodity di-
-       rectives, sooner or later, so it's a good idea to just always use  them
-       to declare your commodities.
+       You are likely to run into one of  the  problems  solved  by  commodity
+       directives,  sooner  or  later,  so it's a good idea to just always use
+       them to declare your commodities.
 
        A commodity directive is just the word commodity followed by an amount.
        It may be written on a single line, like this:
@@ -813,8 +814,8 @@ FILE FORMAT
               ; separating thousands with comma.
               commodity 1,000.0000 AAAA
 
-       or on multiple lines, using the "format" subdirective.  (In  this  case
-       the  commodity  symbol  appears  twice  and  should be the same in both
+       or  on  multiple lines, using the "format" subdirective.  (In this case
+       the commodity symbol appears twice and  should  be  the  same  in  both
        places.):
 
               ; commodity SYMBOL
@@ -827,14 +828,14 @@ FILE FORMAT
                 format INR 1,00,00,000.00
 
        The quantity of the amount does not matter; only the format is signifi-
-       cant.   The  number  must  include a decimal mark: either a period or a
+       cant.  The number must include a decimal mark: either  a  period  or  a
        comma, followed by 0 or more decimal digits.
 
    Default commodity
-       The D directive sets a default commodity (and display  format),  to  be
+       The  D  directive  sets a default commodity (and display format), to be
        used for amounts without a commodity symbol (ie, plain numbers).  (Note
-       this differs from Ledger's default commodity directive.) The  commodity
-       and  display  format  will  be applied to all subsequent commodity-less
+       this  differs from Ledger's default commodity directive.) The commodity
+       and display format will be applied  to  all  subsequent  commodity-less
        amounts, or until the next D directive.
 
               ; commodity-less amounts should be treated as dollars
@@ -849,9 +850,9 @@ FILE FORMAT
        a decimal point.
 
    Market prices
-       The  P directive declares a market price, which is an exchange rate be-
-       tween two commodities on a certain date.  (In Ledger, they  are  called
-       "historical  prices".)  These are often obtained from a stock exchange,
+       The P directive declares a market price,  which  is  an  exchange  rate
+       between two commodities on a certain date.  (In Ledger, they are called
+       "historical prices".) These are often obtained from a  stock  exchange,
        cryptocurrency exchange, or the foreign exchange market.
 
        Here is the format:
@@ -862,39 +863,39 @@ FILE FORMAT
 
        o COMMODITYA is the symbol of the commodity being priced
 
-       o COMMODITYBAMOUNT is an amount (symbol and quantity) in a second  com-
+       o COMMODITYBAMOUNT  is an amount (symbol and quantity) in a second com-
          modity, giving the price in commodity B of one unit of commodity A.
 
-       These  two  market price directives say that one euro was worth 1.35 US
+       These two market price directives say that one euro was worth  1.35  US
        dollars during 2009, and $1.40 from 2010 onward:
 
               P 2009/1/1 EUR $1.35
               P 2010/1/1 EUR $1.40
 
-       The -V/--value flag can be used to convert reported amounts to  another
+       The  -V/--value flag can be used to convert reported amounts to another
        commodity using these prices.
 
    Declaring accounts
-       account directives can be used to pre-declare accounts.  Though not re-
-       quired, they can provide several benefits:
+       account directives can be used to  pre-declare  accounts.   Though  not
+       required, they can provide several benefits:
 
        o They can document your intended chart of accounts, providing a refer-
          ence.
 
-       o They  can  store  extra  information about accounts (account numbers,
+       o They can store extra information  about  accounts  (account  numbers,
          notes, etc.)
 
-       o They can help hledger know your accounts'  types  (asset,  liability,
-         equity,  revenue,  expense), useful for reports like balancesheet and
+       o They  can  help  hledger know your accounts' types (asset, liability,
+         equity, revenue, expense), useful for reports like  balancesheet  and
          incomestatement.
 
-       o They control account display order in  reports,  allowing  non-alpha-
+       o They  control  account  display order in reports, allowing non-alpha-
          betic sorting (eg Revenues to appear above Expenses).
 
-       o They  help  with account name completion in the add command, hledger-
+       o They help with account name completion in the add  command,  hledger-
          iadd, hledger-web, ledger-mode etc.
 
-       The simplest form is just the word account followed by a  hledger-style
+       The  simplest form is just the word account followed by a hledger-style
        account name, eg:
 
               account assets:bank:checking
@@ -912,7 +913,7 @@ FILE FORMAT
        the next line instead.
 
    Account subdirectives
-       We also allow (and ignore) Ledger-style  indented  subdirectives,  just
+       We  also  allow  (and ignore) Ledger-style indented subdirectives, just
        for compatibility.:
 
               account assets:bank:checking
@@ -925,18 +926,18 @@ FILE FORMAT
                 [LEDGER-STYLE SUBDIRECTIVES, IGNORED]
 
    Account types
-       hledger  recognises  five types (or classes) of account: Asset, Liabil-
-       ity, Equity, Revenue, Expense.  This is used by a few  accounting-aware
+       hledger recognises five types (or classes) of account:  Asset,  Liabil-
+       ity,  Equity, Revenue, Expense.  This is used by a few accounting-aware
        reports such as balancesheet, incomestatement and cashflow.
 
    Auto-detected account types
        If you name your top-level accounts with some variation of assets, lia-
-       bilities/debts, equity, revenues/income, or expenses, their  types  are
+       bilities/debts,  equity,  revenues/income, or expenses, their types are
        detected automatically.
 
    Account types declared with tags
-       More  generally,  you can declare an account's type with an account di-
-       rective, by writing a type: tag in a comment, followed by  one  of  the
+       More generally, you can declare  an  account's  type  with  an  account
+       directive,  by writing a type: tag in a comment, followed by one of the
        words Asset, Liability, Equity, Revenue, Expense, or one of the letters
        ALERX (case insensitive):
 
@@ -947,8 +948,8 @@ FILE FORMAT
               account expenses     ; type:Expenses
 
    Account types declared with account type codes
-       Or, you can write one of those letters separated from the account  name
-       by  two  or  more spaces, but this should probably be considered depre-
+       Or,  you can write one of those letters separated from the account name
+       by two or more spaces, but this should probably  be  considered  depre-
        cated as of hledger 1.13:
 
               account assets       A
@@ -958,7 +959,7 @@ FILE FORMAT
               account expenses     X
 
    Overriding auto-detected types
-       If you ever override the types of those auto-detected  english  account
+       If  you  ever override the types of those auto-detected english account
        names mentioned above, you might need to help the reports a bit.  Eg:
 
               ; make "liabilities" not have the liability type - who knows why
@@ -969,8 +970,8 @@ FILE FORMAT
               account -            ; type:L
 
    Account display order
-       Account  directives also set the order in which accounts are displayed,
-       eg in reports, the hledger-ui  accounts  screen,  and  the  hledger-web
+       Account directives also set the order in which accounts are  displayed,
+       eg  in  reports,  the  hledger-ui  accounts screen, and the hledger-web
        sidebar.  By default accounts are listed in alphabetical order.  But if
        you have these account directives in the journal:
 
@@ -992,16 +993,16 @@ FILE FORMAT
 
        Undeclared accounts, if any, are displayed last, in alphabetical order.
 
-       Note  that  sorting  is  done at each level of the account tree (within
-       each group of sibling accounts under the same parent).  And  currently,
+       Note that sorting is done at each level of  the  account  tree  (within
+       each  group of sibling accounts under the same parent).  And currently,
        this directive:
 
               account other:zoo
 
-       would  influence the position of zoo among other's subaccounts, but not
-       the position of other among the top-level accounts.  This means: -  you
-       will  sometimes  declare  parent accounts (eg account other above) that
-       you don't intend to post to, just to customize their  display  order  -
+       would influence the position of zoo among other's subaccounts, but  not
+       the  position of other among the top-level accounts.  This means: - you
+       will sometimes declare parent accounts (eg account  other  above)  that
+       you  don't  intend  to post to, just to customize their display order -
        sibling accounts stay together (you couldn't display x:y in between a:b
        and a:c).
 
@@ -1020,14 +1021,14 @@ FILE FORMAT
        o customising reports
 
        Account aliases also rewrite account names in account directives.  They
-       do not affect account names being entered via hledger add  or  hledger-
+       do  not  affect account names being entered via hledger add or hledger-
        web.
 
        See also Rewrite account names.
 
    Basic aliases
-       To  set an account alias, use the alias directive in your journal file.
-       This affects all subsequent journal entries in the current file or  its
+       To set an account alias, use the alias directive in your journal  file.
+       This  affects all subsequent journal entries in the current file or its
        included files.  The spaces around the = are optional:
 
               alias OLD = NEW
@@ -1035,49 +1036,49 @@ FILE FORMAT
        Or, you can use the --alias 'OLD=NEW' option on the command line.  This
        affects all entries.  It's useful for trying out aliases interactively.
 
-       OLD and NEW are case sensitive full account names.   hledger  will  re-
-       place  any occurrence of the old account name with the new one.  Subac-
-       counts are also affected.  Eg:
+       OLD  and  NEW  are  case  sensitive  full  account names.  hledger will
+       replace any occurrence of the old account name with the new one.   Sub-
+       accounts are also affected.  Eg:
 
               alias checking = assets:bank:wells fargo:checking
               ; rewrites "checking" to "assets:bank:wells fargo:checking", or "checking:a" to "assets:bank:wells fargo:checking:a"
 
    Regex aliases
-       There is also a more powerful variant that uses a  regular  expression,
+       There  is  also a more powerful variant that uses a regular expression,
        indicated by the forward slashes:
 
               alias /REGEX/ = REPLACEMENT
 
        or --alias '/REGEX/=REPLACEMENT'.
 
-       REGEX  is  a  case-insensitive regular expression.  Anywhere it matches
-       inside an account name, the matched part will be replaced  by  REPLACE-
-       MENT.   If REGEX contains parenthesised match groups, these can be ref-
+       REGEX is a case-insensitive regular expression.   Anywhere  it  matches
+       inside  an  account name, the matched part will be replaced by REPLACE-
+       MENT.  If REGEX contains parenthesised match groups, these can be  ref-
        erenced by the usual numeric backreferences in REPLACEMENT.  Eg:
 
               alias /^(.+):bank:([^:]+)(.*)/ = \1:\2 \3
               ; rewrites "assets:bank:wells fargo:checking" to  "assets:wells fargo checking"
 
-       Also note that REPLACEMENT continues to the end of line (or on  command
-       line,  to  end  of  option argument), so it can contain trailing white-
+       Also  note that REPLACEMENT continues to the end of line (or on command
+       line, to end of option argument), so it  can  contain  trailing  white-
        space.
 
    Combining aliases
-       You can define as many aliases as you like,  using  journal  directives
+       You  can  define  as many aliases as you like, using journal directives
        and/or command line options.
 
-       Recursive  aliases  -  where an account name is rewritten by one alias,
-       then by another alias, and so on - are allowed.  Each  alias  sees  the
+       Recursive aliases - where an account name is rewritten  by  one  alias,
+       then  by  another  alias, and so on - are allowed.  Each alias sees the
        effect of previously applied aliases.
 
-       In  such  cases it can be important to understand which aliases will be
-       applied and in which order.  For (each account name  in)  each  journal
+       In such cases it can be important to understand which aliases  will  be
+       applied  and  in  which order.  For (each account name in) each journal
        entry, we apply:
 
-       1. alias  directives  preceding the journal entry, most recently parsed
+       1. alias directives preceding the journal entry, most  recently  parsed
           first (ie, reading upward from the journal entry, bottom to top)
 
-       2. --alias options, in the order they  appeared  on  the  command  line
+       2. --alias  options,  in  the  order  they appeared on the command line
           (left to right).
 
        In other words, for (an account name in) a given journal entry:
@@ -1088,23 +1089,23 @@ FILE FORMAT
 
        o aliases defined after/below the entry do not affect it.
 
-       This  gives nearby aliases precedence over distant ones, and helps pro-
-       vide semantic stability - aliases will keep working the same way  inde-
+       This gives nearby aliases precedence over distant ones, and helps  pro-
+       vide  semantic stability - aliases will keep working the same way inde-
        pendent of which files are being read and in which order.
 
-       In  case  of  trouble,  adding  --debug=6 to the command line will show
+       In case of trouble, adding --debug=6 to  the  command  line  will  show
        which aliases are being applied when.
 
    end aliases
-       You can clear (forget) all  currently  defined  aliases  with  the  end
+       You  can  clear  (forget)  all  currently  defined aliases with the end
        aliases directive:
 
               end aliases
 
    Default parent account
-       You  can  specify  a  parent account which will be prepended to all ac-
-       counts within a section of the journal.  Use the apply account and  end
-       apply account directives like so:
+       You can specify a  parent  account  which  will  be  prepended  to  all
+       accounts  within  a  section of the journal.  Use the apply account and
+       end apply account directives like so:
 
               apply account home
 
@@ -1120,7 +1121,7 @@ FILE FORMAT
                   home:food           $10
                   home:cash          $-10
 
-       If  end  apply  account  is omitted, the effect lasts to the end of the
+       If end apply account is omitted, the effect lasts to  the  end  of  the
        file.  Included files are also affected, eg:
 
               apply account business
@@ -1129,50 +1130,50 @@ FILE FORMAT
               apply account personal
               include personal.journal
 
-       Prior to hledger 1.0, legacy account and end spellings were  also  sup-
+       Prior  to  hledger 1.0, legacy account and end spellings were also sup-
        ported.
 
-       A  default parent account also affects account directives.  It does not
-       affect account names being entered via hledger add or hledger-web.   If
-       account  aliases are present, they are applied after the default parent
+       A default parent account also affects account directives.  It does  not
+       affect  account names being entered via hledger add or hledger-web.  If
+       account aliases are present, they are applied after the default  parent
        account.
 
    Periodic transactions
-       Periodic transaction rules describe transactions that recur.  They  al-
-       low  hledger  to  generate  temporary  future transactions to help with
-       forecasting, so you don't have to write out each one  in  the  journal,
-       and  it's easy to try out different forecasts.  Secondly, they are also
+       Periodic  transaction  rules  describe  transactions  that recur.  They
+       allow hledger to generate temporary future transactions  to  help  with
+       forecasting,  so  you  don't have to write out each one in the journal,
+       and it's easy to try out different forecasts.  Secondly, they are  also
        used to define the budgets shown in budget reports.
 
-       Periodic transactions can be a little tricky, so before you  use  them,
+       Periodic  transactions  can be a little tricky, so before you use them,
        read this whole section - or at least these tips:
 
-       1. Two  spaces  accidentally  added or omitted will cause you trouble -
+       1. Two spaces accidentally added or omitted will cause  you  trouble  -
           read about this below.
 
-       2. For troubleshooting, show the generated  transactions  with  hledger
-          print   --forecast  tag:generated  or  hledger  register  --forecast
+       2. For  troubleshooting,  show  the generated transactions with hledger
+          print  --forecast  tag:generated  or  hledger  register   --forecast
           tag:generated.
 
-       3. Forecasted transactions will begin only  after  the  last  non-fore-
+       3. Forecasted  transactions  will  begin  only after the last non-fore-
           casted transaction's date.
 
-       4. Forecasted  transactions  will  end 6 months from today, by default.
+       4. Forecasted transactions will end 6 months from  today,  by  default.
           See below for the exact start/end rules.
 
-       5. period expressions can be tricky.   Their  documentation  needs  im-
-          provement, but is worth studying.
+       5. period   expressions  can  be  tricky.   Their  documentation  needs
+          improvement, but is worth studying.
 
-       6. Some  period  expressions  with a repeating interval must begin on a
-          natural boundary of that interval.  Eg in  weekly  from  DATE,  DATE
-          must  be a monday.  ~ weekly from 2019/10/1 (a tuesday) will give an
+       6. Some period expressions with a repeating interval must  begin  on  a
+          natural  boundary  of  that  interval.  Eg in weekly from DATE, DATE
+          must be a monday.  ~ weekly from 2019/10/1 (a tuesday) will give  an
           error.
 
        7. Other period expressions with an interval are automatically expanded
-          to  cover a whole number of that interval.  (This is done to improve
+          to cover a whole number of that interval.  (This is done to  improve
           reports, but it also affects periodic transactions.  Yes, it's a bit
-          inconsistent  with  the  above.)  Eg: ~ every 10th day of month from
-          2020/01, which is equivalent to ~  every  10th  day  of  month  from
+          inconsistent with the above.) Eg: ~ every 10th  day  of  month  from
+          2020/01,  which  is  equivalent  to  ~  every 10th day of month from
           2020/01/01, will be adjusted to start on 2019/12/10.
 
    Periodic rule syntax
@@ -1184,17 +1185,17 @@ FILE FORMAT
                   expenses:rent          $2000
                   assets:bank:checking
 
-       There  is  an additional constraint on the period expression: the start
-       date must fall on a natural boundary of the interval.  Eg monthly  from
+       There is an additional constraint on the period expression:  the  start
+       date  must fall on a natural boundary of the interval.  Eg monthly from
        2018/1/1 is valid, but monthly from 2018/1/15 is not.
 
-       Partial  or  relative dates (M/D, D, tomorrow, last week) in the period
-       expression can work (useful or not).  They will be relative to  today's
-       date,  unless  a  Y  default year directive is in effect, in which case
+       Partial or relative dates (M/D, D, tomorrow, last week) in  the  period
+       expression  can work (useful or not).  They will be relative to today's
+       date, unless a Y default year directive is in  effect,  in  which  case
        they will be relative to Y/1/1.
 
    Two spaces between period expression and description!
-       If the period expression is  followed  by  a  transaction  description,
+       If  the  period  expression  is  followed by a transaction description,
        these must be separated by two or more spaces.  This helps hledger know
        where the period expression ends, so that descriptions can not acciden-
        tally alter their meaning, as in this example:
@@ -1208,82 +1209,82 @@ FILE FORMAT
 
        So,
 
-       o Do  write two spaces between your period expression and your transac-
+       o Do write two spaces between your period expression and your  transac-
          tion description, if any.
 
-       o Don't accidentally write two spaces in the middle of your period  ex-
-         pression.
+       o Don't  accidentally  write  two  spaces  in the middle of your period
+         expression.
 
    Forecasting with periodic transactions
-       With  the --forecast flag, each periodic transaction rule generates fu-
-       ture transactions recurring at the specified interval.  These  are  not
-       saved  in  the journal, but appear in all reports.  They will look like
+       With the --forecast flag,  each  periodic  transaction  rule  generates
+       future transactions recurring at the specified interval.  These are not
+       saved in the journal, but appear in all reports.  They will  look  like
        normal transactions, but with an extra tag:
 
-       o generated-transaction:~ PERIODICEXPR - shows that this was  generated
+       o generated-transaction:~  PERIODICEXPR - shows that this was generated
          by a periodic transaction rule, and the period
 
-       There  is  also a hidden tag, with an underscore prefix, which does not
+       There is also a hidden tag, with an underscore prefix, which  does  not
        appear in hledger's output:
 
        o _generated-transaction:~ PERIODICEXPR
 
-       This can be used to match transactions  generated  "just  now",  rather
+       This  can  be  used  to match transactions generated "just now", rather
        than generated in the past and saved to the journal.
 
-       Forecast  transactions  start  on  the first occurrence, and end on the
-       last occurrence, of their interval within  the  forecast  period.   The
+       Forecast transactions start on the first occurrence,  and  end  on  the
+       last  occurrence,  of  their  interval within the forecast period.  The
        forecast period:
 
        o begins on the later of
 
          o the report start date if specified with -b/-p/date:
 
-         o the  day  after the latest normal (non-periodic) transaction in the
+         o the day after the latest normal (non-periodic) transaction  in  the
            journal, or today if there are no normal transactions.
 
-       o ends on the report end date if specified  with  -e/-p/date:,  or  180
+       o ends  on  the  report  end date if specified with -e/-p/date:, or 180
          days from today.
 
-       where  "today"  means  the current date at report time.  The "later of"
-       rule ensures that forecast transactions do not overlap normal  transac-
+       where "today" means the current date at report time.   The  "later  of"
+       rule  ensures that forecast transactions do not overlap normal transac-
        tions in time; they will begin only after normal transactions end.
 
-       Forecasting  can be useful for estimating balances into the future, and
-       experimenting with different scenarios.   Note  the  start  date  logic
+       Forecasting can be useful for estimating balances into the future,  and
+       experimenting  with  different  scenarios.   Note  the start date logic
        means that forecasted transactions are automatically replaced by normal
        transactions as you add those.
 
        Forecasting can also help with data entry: describe most of your trans-
-       actions  with  periodic  rules,  and  every so often copy the output of
+       actions with periodic rules, and every so  often  copy  the  output  of
        print --forecast to the journal.
 
        You can generate one-time transactions too: just write a period expres-
-       sion  specifying a date with no report interval.  (You could also write
-       a normal transaction with a future date,  but  remember  this  disables
+       sion specifying a date with no report interval.  (You could also  write
+       a  normal  transaction  with  a future date, but remember this disables
        forecast transactions on previous dates.)
 
    Budgeting with periodic transactions
-       With  the  --budget  flag,  currently supported by the balance command,
-       each periodic transaction rule declares recurring budget goals for  the
-       specified  accounts.   Eg  the  first  example above declares a goal of
-       spending $2000 on rent (and also,  a  goal  of  depositing  $2000  into
-       checking)  every  month.  Goals and actual performance can then be com-
+       With the --budget flag, currently supported  by  the  balance  command,
+       each  periodic transaction rule declares recurring budget goals for the
+       specified accounts.  Eg the first example  above  declares  a  goal  of
+       spending  $2000  on  rent  (and  also,  a goal of depositing $2000 into
+       checking) every month.  Goals and actual performance can then  be  com-
        pared in budget reports.
 
-       For more details, see: balance: Budget report and Budgeting  and  Fore-
+       For  more  details, see: balance: Budget report and Budgeting and Fore-
        casting.
 
    Auto postings / transaction modifiers
        Transaction modifier rules, AKA auto posting rules, describe changes to
-       be applied automatically to certain  matched  transactions.   Currently
-       just  one  kind of change is possible - adding extra postings, which we
-       call "automated postings" or just "auto postings".  These rules  become
+       be  applied  automatically  to certain matched transactions.  Currently
+       just one kind of change is possible - adding extra postings,  which  we
+       call  "automated postings" or just "auto postings".  These rules become
        active when you use the --auto flag.
 
        A transaction modifier rule looks much like a normal transaction except
-       the first line is an equals sign followed by a query that matches  cer-
-       tain  postings  (mnemonic: = suggests matching).  And each "posting" is
+       the  first line is an equals sign followed by a query that matches cer-
+       tain postings (mnemonic: = suggests matching).  And each  "posting"  is
        actually a posting-generating rule:
 
               = QUERY
@@ -1291,20 +1292,20 @@ FILE FORMAT
                   ACCT  [AMT]
                   ...
 
-       These posting-generating rules look like normal  postings,  except  the
+       These  posting-generating  rules  look like normal postings, except the
        amount can be:
 
-       o a  normal  amount  with a commodity symbol, eg $2.  This will be used
+       o a normal amount with a commodity symbol, eg $2.  This  will  be  used
          as-is.
 
        o a number, eg 2.  The commodity symbol (if any) from the matched post-
          ing will be added to this.
 
-       o a  numeric  multiplier,  eg  *2 (a star followed by a number N).  The
+       o a numeric multiplier, eg *2 (a star followed by  a  number  N).   The
          matched posting's amount (and total price, if any) will be multiplied
          by N.
 
-       o a  multiplier  with a commodity symbol, eg *$2 (a star, number N, and
+       o a multiplier with a commodity symbol, eg *$2 (a star, number  N,  and
          symbol S).  The matched posting's amount will be multiplied by N, and
          its commodity symbol will be replaced with S.
 
@@ -1344,20 +1345,20 @@ FILE FORMAT
                   assets:checking            $20
 
    Auto postings and dates
-       A  posting  date (or secondary date) in the matched posting, or (taking
-       precedence) a posting date in the auto posting rule itself,  will  also
+       A posting date (or secondary date) in the matched posting,  or  (taking
+       precedence)  a  posting date in the auto posting rule itself, will also
        be used in the generated posting.
 
    Auto postings and transaction balancing / inferred amounts / balance asser-
        tions
        Currently, transaction modifiers are applied / auto postings are added:
 
-       o after missing amounts are inferred, and transactions are checked  for
+       o after  missing amounts are inferred, and transactions are checked for
          balancedness,
 
        o but before balance assertions are checked.
 
-       Note  this  means that journal entries must be balanced both before and
+       Note this means that journal entries must be balanced both  before  and
        after auto postings are added.  This changed in hledger 1.12+; see #893
        for background.
 
@@ -1367,11 +1368,11 @@ FILE FORMAT
        o generated-posting:= QUERY - shows this was generated by an auto post-
          ing rule, and the query
 
-       o _generated-posting:= QUERY - a hidden tag, which does not  appear  in
+       o _generated-posting:=  QUERY  - a hidden tag, which does not appear in
          hledger's output.  This can be used to match postings generated "just
          now", rather than generated in the past and saved to the journal.
 
-       Also, any transaction that has been  changed  by  transaction  modifier
+       Also,  any  transaction  that  has been changed by transaction modifier
        rules will have these tags added:
 
        o modified: - this transaction was modified
@@ -1380,18 +1381,18 @@ FILE FORMAT
          tion was modified "just now".
 
 EDITOR SUPPORT
-       Helper modes exist for popular text editors, which  make  working  with
+       Helper  modes  exist  for popular text editors, which make working with
        journal files easier.  They add colour, formatting, tab completion, and
-       helpful commands, and are quite recommended if you  edit  your  journal
-       with  a  text  editor.   They  include  ledger-mode or hledger-mode for
-       Emacs, vim-ledger for Vim, hledger-vscode for Visual Studio  Code,  and
-       others.  See the Editor configuration at hledger.org for the latest in-
-       formation.
+       helpful  commands,  and  are quite recommended if you edit your journal
+       with a text editor.   They  include  ledger-mode  or  hledger-mode  for
+       Emacs,  vim-ledger  for Vim, hledger-vscode for Visual Studio Code, and
+       others.  See the Editor configuration at  hledger.org  for  the  latest
+       information.
 
 
 
 REPORTING BUGS
-       Report bugs at http://bugs.hledger.org (or on the #hledger IRC  channel
+       Report  bugs at http://bugs.hledger.org (or on the #hledger IRC channel
        or hledger mail list)
 
 
@@ -1405,7 +1406,7 @@ COPYRIGHT
 
 
 SEE ALSO
-       hledger(1),      hledger-ui(1),     hledger-web(1),     hledger-api(1),
+       hledger(1),     hledger-ui(1),     hledger-web(1),      hledger-api(1),
        hledger_csv(5), hledger_journal(5), hledger_timeclock(5), hledger_time-
        dot(5), ledger(1)
 

--- a/hledger-lib/hledger_timedot.txt
+++ b/hledger-lib/hledger_timedot.txt
@@ -28,8 +28,8 @@ FILE FORMAT
 
        Quantities can be written as:
 
-       o a  sequence  of  dots (.) representing quarter hours.  Spaces may op-
-         tionally be used for grouping and readability.  Eg: ....  ..
+       o a  sequence  of  dots  (.)  representing  quarter  hours.  Spaces may
+         optionally be used for grouping and readability.  Eg: ....  ..
 
        o an integral or decimal number, representing hours.  Eg: 1.5
 

--- a/hledger-ui/hledger-ui.txt
+++ b/hledger-ui/hledger-ui.txt
@@ -118,8 +118,8 @@ OPTIONS
               using period expressions syntax
 
        --date2
-              match the secondary date instead (see command help for other ef-
-              fects)
+              match  the  secondary  date  instead (see command help for other
+              effects)
 
        -U --unmarked
               include only unmarked postings/txns (can combine with -P or -C)
@@ -205,8 +205,8 @@ KEYS
        BACKSPACE or DELETE removes all filters, showing all transactions.
 
        As mentioned above, hledger-ui shows auto-generated  periodic  transac-
-       tions,  and  hides  future  transactions (auto-generated or not) by de-
-       fault.  F toggles showing and hiding these future  transactions.   This
+       tions,  and  hides  future  transactions  (auto-generated  or  not)  by
+       default.  F toggles showing and hiding these future transactions.  This
        is  similar  to using a query like date:-tomorrow, but more convenient.
        (experimental)
 
@@ -274,35 +274,36 @@ SCREENS
 
        Account names are shown as a flat list by default.  Press T  to  toggle
        tree  mode.   In  flat  mode,  account balances are exclusive of subac-
-       counts, except where subaccounts are hidden by a depth limit  (see  be-
-       low).  In tree mode, all account balances are inclusive of subaccounts.
+       counts, except where subaccounts are  hidden  by  a  depth  limit  (see
+       below).   In  tree  mode,  all account balances are inclusive of subac-
+       counts.
 
-       To  see  less detail, press a number key, 1 to 9, to set a depth limit.
+       To see less detail, press a number key, 1 to 9, to set a  depth  limit.
        Or use - to decrease and +/= to increase the depth limit.  0 shows even
-       less  detail, collapsing all accounts to a single total.  To remove the
-       depth limit, set it higher than the maximum account depth, or press ES-
-       CAPE.
+       less detail, collapsing all accounts to a single total.  To remove  the
+       depth  limit,  set  it  higher than the maximum account depth, or press
+       ESCAPE.
 
        H toggles between showing historical balances or period balances.  His-
-       torical balances (the default) are ending balances at the  end  of  the
-       report  period,  taking  into account all transactions before that date
-       (filtered by the filter query if any),  including  transactions  before
-       the  start  of  the report period.  In other words, historical balances
-       are what you would see on a bank statement  for  that  account  (unless
-       disturbed  by a filter query).  Period balances ignore transactions be-
-       fore the report start date, so they show the change in  balance  during
+       torical  balances  (the  default) are ending balances at the end of the
+       report period, taking into account all transactions  before  that  date
+       (filtered  by  the  filter query if any), including transactions before
+       the start of the report period.  In other  words,  historical  balances
+       are  what  you  would  see on a bank statement for that account (unless
+       disturbed by a filter  query).   Period  balances  ignore  transactions
+       before the report start date, so they show the change in balance during
        the report period.  They are more useful eg when viewing a time log.
 
        U toggles filtering by unmarked status, including or excluding unmarked
        postings in the balances.  Similarly, P toggles pending postings, and C
-       toggles  cleared postings.  (By default, balances include all postings;
-       if you activate one or two status filters, only those postings are  in-
-       cluded; and if you activate all three, the filter is removed.)
+       toggles cleared postings.  (By default, balances include all  postings;
+       if  you  activate  one  or  two status filters, only those postings are
+       included; and if you activate all three, the filter is removed.)
 
        R toggles real mode, in which virtual postings are ignored.
 
-       Z  toggles  nonzero  mode, in which only accounts with nonzero balances
-       are shown (hledger-ui shows zero items by default, unlike  command-line
+       Z toggles nonzero mode, in which only accounts  with  nonzero  balances
+       are  shown (hledger-ui shows zero items by default, unlike command-line
        hledger).
 
        Press right or enter to view an account's transactions register.
@@ -311,63 +312,63 @@ SCREENS
        This screen shows the transactions affecting a particular account, like
        a check register.  Each line represents one transaction and shows:
 
-       o the other account(s) involved, in abbreviated form.   (If  there  are
-         both  real  and virtual postings, it shows only the accounts affected
+       o the  other  account(s)  involved, in abbreviated form.  (If there are
+         both real and virtual postings, it shows only the  accounts  affected
          by real postings.)
 
-       o the overall change to the current account's balance; positive for  an
+       o the  overall change to the current account's balance; positive for an
          inflow to this account, negative for an outflow.
 
        o the running historical total or period total for the current account,
-         after the transaction.  This can be toggled with H.  Similar  to  the
-         accounts  screen,  the  historical  total is affected by transactions
-         (filtered by the filter query) before the report  start  date,  while
+         after  the  transaction.  This can be toggled with H.  Similar to the
+         accounts screen, the historical total  is  affected  by  transactions
+         (filtered  by  the  filter query) before the report start date, while
          the period total is not.  If the historical total is not disturbed by
-         a filter query, it will be the running historical balance  you  would
+         a  filter  query, it will be the running historical balance you would
          see on a bank register for the current account.
 
-       Transactions  affecting  this account's subaccounts will be included in
+       Transactions affecting this account's subaccounts will be  included  in
        the register if the accounts screen is in tree mode, or if it's in flat
-       mode  but  this  account  has  subaccounts which are not shown due to a
-       depth limit.  In other words, the register always  shows  the  transac-
+       mode but this account has subaccounts which are  not  shown  due  to  a
+       depth  limit.   In  other words, the register always shows the transac-
        tions contributing to the balance shown on the accounts screen.
        Tree mode/flat mode can be toggled with T here also.
 
-       U  toggles  filtering  by  unmarked  status, showing or hiding unmarked
+       U toggles filtering by unmarked  status,  showing  or  hiding  unmarked
        transactions.  Similarly, P toggles pending transactions, and C toggles
-       cleared  transactions.  (By default, transactions with all statuses are
-       shown; if you activate one or two status filters, only  those  transac-
+       cleared transactions.  (By default, transactions with all statuses  are
+       shown;  if  you activate one or two status filters, only those transac-
        tions are shown; and if you activate all three, the filter is removed.)
 
        R toggles real mode, in which virtual postings are ignored.
 
-       Z  toggles  nonzero  mode, in which only transactions posting a nonzero
-       change are shown (hledger-ui shows zero items by default,  unlike  com-
+       Z toggles nonzero mode, in which only transactions  posting  a  nonzero
+       change  are  shown (hledger-ui shows zero items by default, unlike com-
        mand-line hledger).
 
        Press right (or enter) to view the selected transaction in detail.
 
    Transaction screen
-       This  screen  shows  a  single transaction, as a general journal entry,
-       similar to hledger's print command and  journal  format  (hledger_jour-
+       This screen shows a single transaction, as  a  general  journal  entry,
+       similar  to  hledger's  print command and journal format (hledger_jour-
        nal(5)).
 
-       The  transaction's  date(s) and any cleared flag, transaction code, de-
-       scription, comments, along with all of its account postings are  shown.
-       Simple  transactions  have  two  postings, but there can be more (or in
-       certain cases, fewer).
+       The transaction's date(s)  and  any  cleared  flag,  transaction  code,
+       description,  comments,  along  with  all  of  its account postings are
+       shown.  Simple transactions have two postings, but there  can  be  more
+       (or in certain cases, fewer).
 
-       up and down will step through all transactions listed in  the  previous
-       account  register screen.  In the title bar, the numbers in parentheses
-       show your position within that account register.  They  will  vary  de-
-       pending on which account register you came from (remember most transac-
-       tions appear in multiple account registers).  The #N  number  preceding
+       up  and  down will step through all transactions listed in the previous
+       account register screen.  In the title bar, the numbers in  parentheses
+       show  your  position  within  that  account  register.   They will vary
+       depending on which account register you came from (remember most trans-
+       actions appear in multiple account registers).  The #N number preceding
        them is the transaction's position within the complete unfiltered jour-
        nal, which is a more stable id (at least until the next reload).
 
    Error screen
-       This screen will appear if there is a problem, such as a  parse  error,
-       when  you  press g to reload.  Once you have fixed the problem, press g
+       This  screen  will appear if there is a problem, such as a parse error,
+       when you press g to reload.  Once you have fixed the problem,  press  g
        again to reload and resume normal operation.  (Or, you can press escape
        to cancel the reload attempt.)
 
@@ -375,17 +376,17 @@ ENVIRONMENT
        COLUMNS The screen width to use.  Default: the full terminal width.
 
        LEDGER_FILE The journal file path when not specified with -f.  Default:
-       ~/.hledger.journal (on  windows,  perhaps  C:/Users/USER/.hledger.jour-
+       ~/.hledger.journal  (on  windows,  perhaps C:/Users/USER/.hledger.jour-
        nal).
 
 FILES
-       Reads  data from one or more files in hledger journal, timeclock, time-
-       dot,  or  CSV  format  specified   with   -f,   or   $LEDGER_FILE,   or
-       $HOME/.hledger.journal           (on          windows,          perhaps
+       Reads data from one or more files in hledger journal, timeclock,  time-
+       dot,   or   CSV   format   specified   with  -f,  or  $LEDGER_FILE,  or
+       $HOME/.hledger.journal          (on          windows,           perhaps
        C:/Users/USER/.hledger.journal).
 
 BUGS
-       The need to precede options with -- when invoked from hledger  is  awk-
+       The  need  to precede options with -- when invoked from hledger is awk-
        ward.
 
        -f- doesn't work (hledger-ui can't read from stdin).
@@ -393,24 +394,24 @@ BUGS
        -V affects only the accounts screen.
 
        When you press g, the current and all previous screens are regenerated,
-       which may cause a noticeable pause with large files.  Also there is  no
+       which  may cause a noticeable pause with large files.  Also there is no
        visual indication that this is in progress.
 
-       --watch  is  not yet fully robust.  It works well for normal usage, but
-       many file changes in a short time (eg  saving  the  file  thousands  of
-       times  with an editor macro) can cause problems at least on OSX.  Symp-
-       toms include: unresponsive UI, periodic resetting of the  cursor  posi-
+       --watch is not yet fully robust.  It works well for normal  usage,  but
+       many  file  changes  in  a  short time (eg saving the file thousands of
+       times with an editor macro) can cause problems at least on OSX.   Symp-
+       toms  include:  unresponsive UI, periodic resetting of the cursor posi-
        tion, momentary display of parse errors, high CPU usage eventually sub-
        siding, and possibly a small but persistent build-up of CPU usage until
        the program is restarted.
 
-       Also,  if  you  are viewing files mounted from another machine, --watch
+       Also, if you are viewing files mounted from  another  machine,  --watch
        requires that both machine clocks are roughly in step.
 
 
 
 REPORTING BUGS
-       Report bugs at http://bugs.hledger.org (or on the #hledger IRC  channel
+       Report  bugs at http://bugs.hledger.org (or on the #hledger IRC channel
        or hledger mail list)
 
 
@@ -424,7 +425,7 @@ COPYRIGHT
 
 
 SEE ALSO
-       hledger(1),      hledger-ui(1),     hledger-web(1),     hledger-api(1),
+       hledger(1),     hledger-ui(1),     hledger-web(1),      hledger-api(1),
        hledger_csv(5), hledger_journal(5), hledger_timeclock(5), hledger_time-
        dot(5), ledger(1)
 

--- a/hledger-web/hledger-web.txt
+++ b/hledger-web/hledger-web.txt
@@ -19,9 +19,9 @@ DESCRIPTION
        hledger-web is hledger's web interface.  It starts a simple web  appli-
        cation for browsing and adding transactions, and optionally opens it in
        a web browser window if possible.  It provides a more user-friendly  UI
-       than the hledger CLI or hledger-ui interface, showing more at once (ac-
-       counts, the current account register, balance charts) and allowing his-
-       tory-aware data entry, interactive searching, and bookmarking.
+       than  the  hledger  CLI  or  hledger-ui interface, showing more at once
+       (accounts, the current account register, balance charts)  and  allowing
+       history-aware data entry, interactive searching, and bookmarking.
 
        hledger-web  also  lets you share a ledger with multiple users, or even
        the public web.  There is no access control, so if you  need  that  you
@@ -128,8 +128,8 @@ OPTIONS
               using period expressions syntax
 
        --date2
-              match the secondary date instead (see command help for other ef-
-              fects)
+              match the secondary date instead (see  command  help  for  other
+              effects)
 
        -U --unmarked
               include only unmarked postings/txns (can combine with -P or -C)
@@ -215,8 +215,8 @@ PERMISSIONS
        You can restrict who can reach it by
 
        o setting  the IP address it listens on (see --host above).  By default
-         it listens on 127.0.0.1, accessible to all users  on  the  local  ma-
-         chine.
+         it listens on  127.0.0.1,  accessible  to  all  users  on  the  local
+         machine.
 
        o putting it behind an authenticating proxy, using eg apache or nginx
 
@@ -232,8 +232,8 @@ PERMISSIONS
 
          o add - allows adding new transactions to the main journal file
 
-         o manage  -  allows editing, uploading or downloading the main or in-
-           cluded files
+         o manage  -  allows  editing,  uploading  or  downloading the main or
+           included files
 
        o using the --capabilities-header=HTTPHEADER flag  to  specify  a  HTTP
          header  from  which it will read capabilities to enable.  hledger-web
@@ -243,8 +243,8 @@ PERMISSIONS
 EDITING, UPLOADING, DOWNLOADING
        If  you  enable the manage capability mentioned above, you'll see a new
        "spanner" button to the right of the search form.  Clicking  this  will
-       let  you edit, upload, or download the journal file or any files it in-
-       cludes.
+       let  you  edit,  upload,  or  download the journal file or any files it
+       includes.
 
        Note, unlike any other hledger command, in this mode you (or any  visi-
        tor) can alter or wipe the data files.
@@ -263,8 +263,8 @@ RELOADING
        hledger-web detects changes made to the files by other means (eg if you
        edit it directly, outside of hledger-web), and it  will  show  the  new
        data  when  you reload the page or navigate to a new page.  If a change
-       makes a file unparseable, hledger-web will display an error message un-
-       til the file has been fixed.
+       makes a file unparseable, hledger-web will  display  an  error  message
+       until the file has been fixed.
 
        (Note: if you are viewing files mounted from another machine, make sure
        that both machine clocks are roughly in step.)

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -20,8 +20,8 @@ DESCRIPTION
        tool for daily use.
 
        This  is  hledger's command-line interface (there are also terminal and
-       web interfaces).  Its basic function is to read a plain text  file  de-
-       scribing  financial  transactions (in accounting terms, a general jour-
+       web interfaces).  Its basic function is  to  read  a  plain  text  file
+       describing financial transactions (in accounting terms, a general jour-
        nal) and print useful reports on standard output,  or  export  them  as
        CSV.   hledger can also read some other file formats such as CSV files,
        translating them to journal format.  Additionally, hledger lists  other
@@ -177,8 +177,8 @@ OPTIONS
               using period expressions syntax
 
        --date2
-              match the secondary date instead (see command help for other ef-
-              fects)
+              match  the  secondary  date  instead (see command help for other
+              effects)
 
        -U --unmarked
               include only unmarked postings/txns (can combine with -P or -C)
@@ -219,14 +219,14 @@ OPTIONS
        Some reporting options can also be written as query arguments.
 
    Command options
-       To see options for a particular command, including command-specific op-
-       tions, run: hledger COMMAND -h.
+       To  see  options  for  a particular command, including command-specific
+       options, run: hledger COMMAND -h.
 
        Command-specific options must be written after the  command  name,  eg:
        hledger print -x.
 
-       Additionally,  if  the command is an addon, you may need to put its op-
-       tions after a double-hyphen, eg: hledger ui -- --watch.   Or,  you  can
+       Additionally,  if  the  command  is  an  addon, you may need to put its
+       options after a double-hyphen, eg: hledger ui -- --watch.  Or, you  can
        run the addon executable directly: hledger-ui --watch.
 
    Command arguments
@@ -347,8 +347,8 @@ OPTIONS
 
        This requires a well-configured environment.  Here are some tips:
 
-       o A  system  locale must be configured, and it must be one that can de-
-         code the characters being used.  In bash, you can set a  locale  like
+       o A  system  locale  must  be  configured,  and it must be one that can
+         decode the characters being used.  In bash, you can set a locale like
          this:  export LANG=en_US.UTF-8.  There are some more details in Trou-
          bleshooting.  This step is essential - without it, hledger will  quit
          on  encountering a non-ascii character (as with all GHC-compiled pro-
@@ -448,8 +448,8 @@ OPTIONS
        201812                       6 digit YYYYMM with  valid
                                     year and month
 
-       Counterexamples  -  malformed digit sequences might give surprising re-
-       sults:
+       Counterexamples  -  malformed  digit  sequences  might  give surprising
+       results:
 
        201813      6 digits with  an  invalid
                    month  is  parsed as start
@@ -495,9 +495,9 @@ OPTIONS
                          ber  1st  of  the  current
                          year  (11/30  will  be the
                          last date included)
-       -b thismonth      all transactions on or af-
-                         ter the 1st of the current
-                         month
+       -b thismonth      all  transactions  on   or
+                         after  the 1st of the cur-
+                         rent month
        -p thismonth      all  transactions  in  the
                          current month
        date:2016/3/17-   the   above   written   as
@@ -511,8 +511,8 @@ OPTIONS
        ance  and  activity will divide their reports into multiple subperiods.
        The  basic  intervals  can  be  selected  with   one   of   -D/--daily,
        -W/--weekly,  -M/--monthly,  -Q/--quarterly, or -Y/--yearly.  More com-
-       plex intervals may be specified with a period expression.   Report  in-
-       tervals can not be specified with a query.
+       plex intervals may be  specified  with  a  period  expression.   Report
+       intervals can not be specified with a query.
 
    Period expressions
        The  -p/--period  option accepts period expressions, a shorthand way of
@@ -562,11 +562,11 @@ OPTIONS
        -p "2009/1/1"   just that day;  equivalent
                        to "2009/1/1 to 2009/1/2"
 
-       The  argument  of  -p can also begin with, or be, a report interval ex-
-       pression.  The basic report intervals are daily, weekly, monthly, quar-
-       terly,  or yearly, which have the same effect as the -D,-W,-M,-Q, or -Y
-       flags.  Between report interval and start/end dates (if any), the  word
-       in is optional.  Examples:
+       The  argument  of  -p  can  also  begin  with, or be, a report interval
+       expression.  The basic report intervals  are  daily,  weekly,  monthly,
+       quarterly, or yearly, which have the same effect as the -D,-W,-M,-Q, or
+       -Y flags.  Between report interval and start/end dates  (if  any),  the
+       word in is optional.  Examples:
 
        -p "weekly from 2009/1/1 to 2009/4/1"
        -p "monthly in 2008"
@@ -574,8 +574,8 @@ OPTIONS
 
        Note  that  weekly, monthly, quarterly and yearly intervals will always
        start on the first day on week, month, quarter or year accordingly, and
-       will  end on the last day of same period, even if associated period ex-
-       pression specifies different explicit start and end date.
+       will  end  on  the  last  day of same period, even if associated period
+       expression specifies different explicit start and end date.
 
        For example:
 
@@ -591,8 +591,8 @@ OPTIONS
        -p "yearly from 2009-12-29" - starts on
        2009/01/01, first day of 2009
 
-       The  following  more  complex  report intervals are also supported: bi-
-       weekly,   bimonthly,   every   day|week|month|quarter|year,   every   N
+       The  following  more  complex  report  intervals  are  also  supported:
+       biweekly,  bimonthly,  every   day|week|month|quarter|year,   every   N
        days|weeks|months|quarters|years.
 
        All  of  these  will start on the first day of the requested period and
@@ -605,8 +605,8 @@ OPTIONS
        2008/03/01, ...
        -p "every 2 weeks" -- starts on closest
        preceding Monday
-       -p  "every 5 month from 2009/03" -- pe-
-       riods   will   have    boundaries    on
+       -p  "every  5  month  from  2009/03" --
+       periods   will   have   boundaries   on
        2009/03/01, 2009/08/01, ...
 
        If  you want intervals that start on arbitrary day of your choosing and
@@ -644,9 +644,9 @@ OPTIONS
    Depth limiting
        With the --depth N option (short form: -N), commands like account, bal-
        ance and register will show only the uppermost accounts in the  account
-       tree,  down to level N.  Use this when you want a summary with less de-
-       tail.  This flag has the same effect as a depth: query argument (so -2,
-       --depth=2 or depth:2 are basically equivalent).
+       tree,  down  to  level  N.   Use this when you want a summary with less
+       detail.  This flag has the same effect as a depth: query  argument  (so
+       -2, --depth=2 or depth:2 are basically equivalent).
 
    Pivoting
        Normally hledger sums amounts, and organizes them in a hierarchy, based
@@ -684,8 +684,8 @@ OPTIONS
               --------------------
                                  0
 
-       One way to show only amounts with a member: value (using a  query,  de-
-       scribed below):
+       One way to show only amounts with  a  member:  value  (using  a  query,
+       described below):
 
               $ hledger balance --pivot member tag:member=.
                             -2 EUR  John Doe
@@ -713,8 +713,8 @@ OPTIONS
        is  today  (equivalent  to --value=now); for multiperiod reports, it is
        the last day of each subperiod (equivalent to --value=end).
 
-       The default valuation commodity is the one referenced in the latest ap-
-       plicable  market  price dated on or before the valuation date.  If most
+       The default valuation commodity is the one  referenced  in  the  latest
+       applicable market price dated on or before the valuation date.  If most
        of your P declarations lead to a single home currency, this  will  usu-
        ally be what you want.  (To specify the commodity, see -X below.)
 
@@ -804,8 +804,8 @@ OPTIONS
        o reverse prices (declared prices from valuation to  source  commodity,
          inverted)
 
-       o indirect  prices  (prices  calculated  from the shortest chain of de-
-         clared or reverse prices from source to valuation commodity)
+       o indirect  prices  (prices  calculated  from  the  shortest  chain  of
+         declared or reverse prices from source to valuation commodity)
 
        in that order.
 
@@ -884,8 +884,8 @@ OPTIONS
               2000/03/01
                   (a)             1 B
 
-       You may need to explicitly set a commodity's display  style,  when  re-
-       verse prices are used.  Eg this output might be surprising:
+       You may need to  explicitly  set  a  commodity's  display  style,  when
+       reverse prices are used.  Eg this output might be surprising:
 
               P 2000-01-01 A 2B
 
@@ -919,8 +919,8 @@ OPTIONS
    Effect of --value on reports
        Here  is  a  reference  for  how --value currently affects each part of
        hledger's reports.  It's work in progress, but may be useful for  trou-
-       bleshooting  or reporting bugs.  See also the definitions and notes be-
-       low.  If you find problems, please report them, ideally with  a  repro-
+       bleshooting  or  reporting  bugs.   See  also the definitions and notes
+       below.  If you find problems, please report them, ideally with a repro-
        ducible example.  Related: #329, #1083.
 
        Report type      -B,              -V, -X            --value=end        --value=DATE,
@@ -930,8 +930,8 @@ OPTIONS
        posting          cost             value at report   value at report    value      at
        amounts                           end or today      or journal end     DATE/today
        balance asser-   unchanged        unchanged         unchanged          unchanged
-       tions  /   as-
-       signments
+       tions        /
+       assignments
 
        register
        starting  bal-   cost             value  at   day   value   at  day    value      at
@@ -946,8 +946,8 @@ OPTIONS
        ing    amounts   cost             ends              ends               DATE/today
        (with   report
        interval)
-       running    to-   sum/average of   sum/average  of   sum/average  of    sum/average
-       tal/average      displayed val-   displayed  val-   displayed  val-    of  displayed
+       running          sum/average of   sum/average  of   sum/average  of    sum/average
+       total/average    displayed val-   displayed  val-   displayed  val-    of  displayed
                         ues              ues               ues                values
 
        balance   (bs,
@@ -961,56 +961,57 @@ OPTIONS
        val)                              postings          postings           sums of post-
                                                                               ings
        starting  bal-   sums  of costs   sums  of  post-   sums  of  post-    sums of post-
-       ances    (with   of    postings   ings before re-   ings before re-    ings   before
-       report  inter-   before  report   port start        port start         report start
+       ances    (with   of    postings   ings     before   ings     before    ings   before
+       report  inter-   before  report   report start      report start       report start
        val and -H)      start
        budget amounts   like balances    like balances     like balances      like balances
        with --budget
        grand    total   sum   of  dis-   sum   of   dis-   sum   of   dis-    sum  of  dis-
-       (no report in-   played values    played values     played values      played values
-       terval)
+       (no     report   played values    played values     played values      played values
+       interval)
 
 
 
 
-       row totals/av-   sums/averages    sums/averages     sums/averages      sums/averages
-       erages   (with   of   displayed   of    displayed   of    displayed    of  displayed
-       report  inter-   values           values            values             values
+       row              sums/averages    sums/averages     sums/averages      sums/averages
+       totals/aver-     of   displayed   of    displayed   of    displayed    of  displayed
+       ages     (with   values           values            values             values
+       report  inter-
        val)
-       column totals    sums  of  dis-   sums   of  dis-   sums  of   dis-    sums  of dis-
+       column totals    sums  of  dis-   sums  of   dis-   sums   of  dis-    sums of  dis-
                         played values    played values     played values      played values
-       grand      to-   sum/average of   sum/average  of   sum/average  of    sum/average
-       tal/average      column totals    column totals     column totals      of column to-
-                                                                              tals
+       grand            sum/average of   sum/average  of   sum/average  of    sum/average
+       total/average    column totals    column totals     column totals      of     column
+                                                                              totals
 
 
        Additional notes
 
        cost   calculated using price(s) recorded in the transaction(s).
 
-       value  market value using available market price declarations,  or  the
+       value  market  value  using available market price declarations, or the
               unchanged amount if no conversion rate can be found.
 
        report start
-              the  first  day  of the report period specified with -b or -p or
+              the first day of the report period specified with -b  or  -p  or
               date:, otherwise today.
 
        report or journal start
-              the first day of the report period specified with -b  or  -p  or
-              date:,  otherwise  the earliest transaction date in the journal,
+              the  first  day  of the report period specified with -b or -p or
+              date:, otherwise the earliest transaction date in  the  journal,
               otherwise today.
 
        report end
-              the last day of the report period specified with  -e  or  -p  or
+              the  last  day  of  the report period specified with -e or -p or
               date:, otherwise today.
 
        report or journal end
-              the  last  day  of  the report period specified with -e or -p or
-              date:, otherwise the latest transaction  date  in  the  journal,
+              the last day of the report period specified with  -e  or  -p  or
+              date:,  otherwise  the  latest  transaction date in the journal,
               otherwise today.
 
        report interval
-              a  flag (-D/-W/-M/-Q/-Y) or period expression that activates the
+              a flag (-D/-W/-M/-Q/-Y) or period expression that activates  the
               report's multi-period mode (whether showing one or many subperi-
               ods).
 
@@ -1018,16 +1019,16 @@ OPTIONS
        The rightmost of these flags wins.
 
    Output destination
-       Some  commands (print, register, stats, the balance commands) can write
-       their output to a destination other than the  console.   This  is  con-
+       Some commands (print, register, stats, the balance commands) can  write
+       their  output  to  a  destination other than the console.  This is con-
        trolled by the -o/--output-file option.
 
               $ hledger balance -o -     # write to stdout (the default)
               $ hledger balance -o FILE  # write to FILE
 
    Output format
-       Some  commands  can  write their output in other formats.  Eg print and
-       register can output CSV, and the balance commands  can  output  CSV  or
+       Some commands can write their output in other formats.   Eg  print  and
+       register  can  output  CSV,  and the balance commands can output CSV or
        HTML.  This is controlled by the -O/--output-format option, or by spec-
        ifying a .csv or .html file extension with -o/--output-file.
 
@@ -1037,56 +1038,56 @@ OPTIONS
    Regular expressions
        hledger uses regular expressions in a number of places:
 
-       o query terms, on the command line and in the hledger-web search  form:
+       o query  terms, on the command line and in the hledger-web search form:
          REGEX, desc:REGEX, cur:REGEX, tag:...=REGEX
 
        o CSV rules conditional blocks: if REGEX ...
 
-       o account  alias  directives  and options: alias /REGEX/ = REPLACEMENT,
+       o account alias directives and options: alias  /REGEX/  =  REPLACEMENT,
          --alias /REGEX/=REPLACEMENT
 
-       hledger's regular expressions come from  the  regex-tdfa  library.   In
+       hledger's  regular  expressions  come  from the regex-tdfa library.  In
        general they:
 
        o are case insensitive
 
-       o are  infix  matching  (do  not  need  to match the entire thing being
+       o are infix matching (do not need  to  match  the  entire  thing  being
          matched)
 
        o are POSIX extended regular expressions
 
        o also support GNU word boundaries (\<, \>, \b, \B)
 
-       o and parenthesised capturing groups and numeric backreferences in  re-
-         placement strings
+       o and  parenthesised  capturing  groups  and  numeric backreferences in
+         replacement strings
 
        o do not support mode modifiers like (?s)
 
        Some things to note:
 
-       o In  the  alias directive and --alias option, regular expressions must
-         be enclosed in forward  slashes  (/REGEX/).   Elsewhere  in  hledger,
+       o In the alias directive and --alias option, regular  expressions  must
+         be  enclosed  in  forward  slashes  (/REGEX/).  Elsewhere in hledger,
          these are not required.
 
-       o In  queries,  to match a regular expression metacharacter like $ as a
-         literal character, prepend a backslash.  Eg  to  search  for  amounts
+       o In queries, to match a regular expression metacharacter like $  as  a
+         literal  character,  prepend  a  backslash.  Eg to search for amounts
          with the dollar sign in hledger-web, write cur:\$.
 
-       o On  the command line, some metacharacters like $ have a special mean-
+       o On the command line, some metacharacters like $ have a special  mean-
          ing to the shell and so must be escaped at least once more.  See Spe-
          cial characters.
 
 QUERIES
-       One  of  hledger's strengths is being able to quickly report on precise
-       subsets of your data.  Most commands accept an optional  query  expres-
-       sion,  written  as arguments after the command name, to filter the data
-       by date, account name or other criteria.  The syntax is  similar  to  a
+       One of hledger's strengths is being able to quickly report  on  precise
+       subsets  of  your data.  Most commands accept an optional query expres-
+       sion, written as arguments after the command name, to filter  the  data
+       by  date,  account  name or other criteria.  The syntax is similar to a
        web search: one or more space-separated search terms, quotes to enclose
-       whitespace, prefixes to match specific fields, a not: prefix to  negate
+       whitespace,  prefixes to match specific fields, a not: prefix to negate
        the match.
 
-       We  do  not yet support arbitrary boolean combinations of search terms;
-       instead most commands show transactions/postings/accounts  which  match
+       We do not yet support arbitrary boolean combinations of  search  terms;
+       instead  most  commands show transactions/postings/accounts which match
        (or negatively match):
 
        o any of the description terms AND
@@ -1107,31 +1108,31 @@ QUERIES
 
        o match all the other terms.
 
-       The  following  kinds  of search terms can be used.  Remember these can
+       The following kinds of search terms can be used.   Remember  these  can
        also be prefixed with not:, eg to exclude a particular subaccount.
 
        REGEX, acct:REGEX
-              match account names by this regular expression.  (With  no  pre-
+              match  account  names by this regular expression.  (With no pre-
               fix, acct: is assumed.)  same as above
 
        amt:N, amt:<N, amt:<=N, amt:>N, amt:>=N
-              match  postings with a single-commodity amount that is equal to,
-              less than, or greater than N.  (Multi-commodity amounts are  not
+              match postings with a single-commodity amount that is equal  to,
+              less  than, or greater than N.  (Multi-commodity amounts are not
               tested, and will always match.) The comparison has two modes: if
               N is preceded by a + or - sign (or is 0), the two signed numbers
-              are  compared.  Otherwise, the absolute magnitudes are compared,
+              are compared.  Otherwise, the absolute magnitudes are  compared,
               ignoring sign.
 
        code:REGEX
               match by transaction code (eg check number)
 
        cur:REGEX
-              match postings or transactions including any amounts whose  cur-
-              rency/commodity  symbol  is fully matched by REGEX.  (For a par-
+              match  postings or transactions including any amounts whose cur-
+              rency/commodity symbol is fully matched by REGEX.  (For  a  par-
               tial match, use .*REGEX.*).  Note, to match characters which are
               regex-significant, like the dollar sign ($), you need to prepend
-              \.  And when using the command line you need  to  add  one  more
-              level  of  quoting  to hide it from the shell, so eg do: hledger
+              \.   And  when  using  the command line you need to add one more
+              level of quoting to hide it from the shell, so  eg  do:  hledger
               print cur:'\$' or hledger print cur:\\$.
 
        desc:REGEX
@@ -1139,20 +1140,20 @@ QUERIES
 
        date:PERIODEXPR
               match dates within the specified period.  PERIODEXPR is a period
-              expression  (with  no  report  interval).   Examples: date:2016,
-              date:thismonth,  date:2000/2/1-2/15,  date:lastweek-.   If   the
-              --date2  command  line  flag  is present, this matches secondary
+              expression (with  no  report  interval).   Examples:  date:2016,
+              date:thismonth,   date:2000/2/1-2/15,  date:lastweek-.   If  the
+              --date2 command line flag is  present,  this  matches  secondary
               dates instead.
 
        date2:PERIODEXPR
               match secondary dates within the specified period.
 
        depth:N
-              match (or display, depending on command) accounts  at  or  above
+              match  (or  display,  depending on command) accounts at or above
               this depth
 
        note:REGEX
-              match  transaction  notes  (part  of  description right of |, or
+              match transaction notes (part of  description  right  of  |,  or
               whole description when there's no |)
 
        payee:REGEX
@@ -1166,51 +1167,51 @@ QUERIES
               match unmarked, pending, or cleared transactions respectively
 
        tag:REGEX[=REGEX]
-              match  by  tag  name,  and optionally also by tag value.  Note a
-              tag: query is considered to match a transaction  if  it  matches
-              any  of  the  postings.  Also remember that postings inherit the
+              match by tag name, and optionally also by  tag  value.   Note  a
+              tag:  query  is  considered to match a transaction if it matches
+              any of the postings.  Also remember that  postings  inherit  the
               tags of their parent transaction.
 
        The following special search term is used automatically in hledger-web,
        only:
 
        inacct:ACCTNAME
-              tells  hledger-web to show the transaction register for this ac-
-              count.  Can be filtered further with acct etc.
+              tells hledger-web to show  the  transaction  register  for  this
+              account.  Can be filtered further with acct etc.
 
        Some of these can also be expressed as command-line options (eg depth:2
-       is  equivalent  to --depth 2).  Generally you can mix options and query
-       arguments, and the resulting query will be their intersection  (perhaps
+       is equivalent to --depth 2).  Generally you can mix options  and  query
+       arguments,  and the resulting query will be their intersection (perhaps
        excluding the -p/--period option).
 
 COMMANDS
-       hledger  provides  a  number  of subcommands; hledger with no arguments
+       hledger provides a number of subcommands;  hledger  with  no  arguments
        shows a list.
 
        If you install additional hledger-* packages, or if you put programs or
-       scripts  named  hledger-NAME in your PATH, these will also be listed as
+       scripts named hledger-NAME in your PATH, these will also be  listed  as
        subcommands.
 
-       Run a subcommand by writing its name as first argument (eg hledger  in-
-       comestatement).   You  can also write one of the standard short aliases
-       displayed in parentheses in the command list (hledger b),  or  any  any
+       Run  a  subcommand  by  writing  its name as first argument (eg hledger
+       incomestatement).  You can also write one of the standard short aliases
+       displayed  in  parentheses  in the command list (hledger b), or any any
        unambiguous prefix of a command name (hledger inc).
 
-       Here  are  all  the  builtin  commands in alphabetical order.  See also
-       hledger for a more organised command list, and hledger CMD -h  for  de-
-       tailed command help.
+       Here are all the builtin commands  in  alphabetical  order.   See  also
+       hledger  for  a  more  organised  command  list, and hledger CMD -h for
+       detailed command help.
 
    accounts
        accounts, a
        Show account names.
 
-       This  command  lists account names, either declared with account direc-
-       tives (--declared), posted to (--used), or both  (the  default).   With
-       query  arguments,  only  matched account names and account names refer-
-       enced by matched postings are shown.  It shows a flat list by  default.
-       With  --tree,  it  uses  indentation to show the account hierarchy.  In
-       flat mode you can add --drop N to omit the first few account name  com-
-       ponents.   Account names can be depth-clipped with depth:N or --depth N
+       This command lists account names, either declared with  account  direc-
+       tives  (--declared),  posted  to (--used), or both (the default).  With
+       query arguments, only matched account names and  account  names  refer-
+       enced  by matched postings are shown.  It shows a flat list by default.
+       With --tree, it uses indentation to show  the  account  hierarchy.   In
+       flat  mode you can add --drop N to omit the first few account name com-
+       ponents.  Account names can be depth-clipped with depth:N or --depth  N
        or -N.
 
        Examples:
@@ -1229,8 +1230,8 @@ COMMANDS
        activity
        Show an ascii barchart of posting counts per interval.
 
-       The activity command displays an ascii  histogram  showing  transaction
-       counts  by  day, week, month or other reporting interval (by day is the
+       The  activity  command  displays an ascii histogram showing transaction
+       counts by day, week, month or other reporting interval (by day  is  the
        default).  With query arguments, it counts only matched transactions.
 
        Examples:
@@ -1245,22 +1246,22 @@ COMMANDS
        add
        Prompt for transactions and add them to the journal.
 
-       Many hledger users edit their journals directly with a text editor,  or
-       generate  them from CSV.  For more interactive data entry, there is the
-       add command, which prompts interactively on the console for new  trans-
+       Many  hledger users edit their journals directly with a text editor, or
+       generate them from CSV.  For more interactive data entry, there is  the
+       add  command, which prompts interactively on the console for new trans-
        actions, and appends them to the journal file (if there are multiple -f
-       FILE options, the first file is used.) Existing  transactions  are  not
-       changed.   This  is the only hledger command that writes to the journal
+       FILE  options,  the  first file is used.) Existing transactions are not
+       changed.  This is the only hledger command that writes to  the  journal
        file.
 
        To use it, just run hledger add and follow the prompts.  You can add as
-       many  transactions as you like; when you are finished, enter . or press
+       many transactions as you like; when you are finished, enter . or  press
        control-d or control-c to exit.
 
        Features:
 
-       o add tries to provide useful defaults, using the most similar (by  de-
-         scription)  recent  transaction  (filtered by the query, if any) as a
+       o add  tries  to  provide  useful  defaults, using the most similar (by
+         description) recent transaction (filtered by the query, if any) as  a
          template.
 
        o You can also set the initial defaults with command line arguments.
@@ -1268,10 +1269,10 @@ COMMANDS
        o Readline-style edit keys can be used during data entry.
 
        o The tab key will auto-complete whenever possible - accounts, descrip-
-         tions,  dates  (yesterday,  today,  tomorrow).   If the input area is
+         tions, dates (yesterday, today, tomorrow).   If  the  input  area  is
          empty, it will insert the default value.
 
-       o If the journal defines a default commodity, it will be added  to  any
+       o If  the  journal defines a default commodity, it will be added to any
          bare numbers entered.
 
        o A parenthesised transaction code may be entered following a date.
@@ -1280,7 +1281,7 @@ COMMANDS
 
        o If you make a mistake, enter < at any prompt to go one step backward.
 
-       o Input  prompts  are displayed in a different colour when the terminal
+       o Input prompts are displayed in a different colour when  the  terminal
          supports it.
 
        Example (see the tutorial for a detailed explanation):
@@ -1310,8 +1311,8 @@ COMMANDS
               Starting the next transaction (. or ctrl-D/ctrl-C to quit)
               Date [2015/05/22]: <CTRL-D> $
 
-       On Microsoft Windows, the add command makes sure that no  part  of  the
-       file  path  ends with a period, as it can cause data loss on that plat-
+       On  Microsoft  Windows,  the add command makes sure that no part of the
+       file path ends with a period, as it can cause data loss on  that  plat-
        form (cf #1056).
 
    balance
@@ -1319,29 +1320,29 @@ COMMANDS
        Show accounts and their balances.
 
        The balance command is hledger's most versatile command.  Note, despite
-       the  name,  it  is  not always used for showing real-world account bal-
-       ances; the more accounting-aware balancesheet and  incomestatement  may
+       the name, it is not always used for  showing  real-world  account  bal-
+       ances;  the  more accounting-aware balancesheet and incomestatement may
        be more convenient for that.
 
        By default, it displays all accounts, and each account's change in bal-
        ance during the entire period of the journal.  Balance changes are cal-
-       culated  by  adding up the postings in each account.  You can limit the
-       postings matched, by a query, to see fewer  accounts,  changes  over  a
+       culated by adding up the postings in each account.  You can  limit  the
+       postings  matched,  by  a  query, to see fewer accounts, changes over a
        different time period, changes from only cleared transactions, etc.
 
        If you include an account's complete history of postings in the report,
-       the balance change is equivalent to the account's current  ending  bal-
-       ance.   For a real-world account, typically you won't have all transac-
+       the  balance  change is equivalent to the account's current ending bal-
+       ance.  For a real-world account, typically you won't have all  transac-
        tions in the journal; instead you'll have all transactions after a cer-
-       tain  date,  and  an "opening balances" transaction setting the correct
-       starting balance on that date.  Then  the  balance  command  will  show
+       tain date, and an "opening balances" transaction  setting  the  correct
+       starting  balance  on  that  date.   Then the balance command will show
        real-world account balances.  In some cases the -H/--historical flag is
        used to ensure this (more below).
 
        The balance command can produce several styles of report:
 
    Classic balance report
-       This is the original balance report, as found in  Ledger.   It  usually
+       This  is  the  original balance report, as found in Ledger.  It usually
        looks like this:
 
               $ hledger balance
@@ -1358,23 +1359,23 @@ COMMANDS
               --------------------
                                  0
 
-       By default, accounts are displayed hierarchically, with subaccounts in-
-       dented below their parent.  At each level of  the  tree,  accounts  are
-       sorted  by  account  code  if  any,  then  by  account  name.   Or with
+       By default, accounts are  displayed  hierarchically,  with  subaccounts
+       indented  below  their parent.  At each level of the tree, accounts are
+       sorted by  account  code  if  any,  then  by  account  name.   Or  with
        -S/--sort-amount, by their balance amount.
 
        "Boring" accounts, which contain a single interesting subaccount and no
-       balance  of their own, are elided into the following line for more com-
-       pact output.  (Eg above, the "liabilities" account.) Use --no-elide  to
+       balance of their own, are elided into the following line for more  com-
+       pact  output.  (Eg above, the "liabilities" account.) Use --no-elide to
        prevent this.
 
-       Account  balances  are  "inclusive"  - they include the balances of any
+       Account balances are "inclusive" - they include  the  balances  of  any
        subaccounts.
 
-       Accounts which have zero balance  (and  no  non-zero  subaccounts)  are
+       Accounts  which  have  zero  balance  (and no non-zero subaccounts) are
        omitted.  Use -E/--empty to show them.
 
-       A  final  total  is displayed by default; use -N/--no-total to suppress
+       A final total is displayed by default; use  -N/--no-total  to  suppress
        it, eg:
 
               $ hledger balance -p 2008/6 expenses --no-total
@@ -1383,7 +1384,7 @@ COMMANDS
                                 $1    supplies
 
    Customising the classic balance report
-       You can customise the layout of classic balance reports  with  --format
+       You  can  customise the layout of classic balance reports with --format
        FMT:
 
               $ hledger balance --format "%20(account) %12(total)"
@@ -1401,7 +1402,7 @@ COMMANDS
                                               0
 
        The FMT format string (plus a newline) specifies the formatting applied
-       to each account/balance pair.  It may contain any suitable  text,  with
+       to  each  account/balance pair.  It may contain any suitable text, with
        data fields interpolated like so:
 
        %[MIN][.MAX](FIELDNAME)
@@ -1412,14 +1413,14 @@ COMMANDS
 
        o FIELDNAME must be enclosed in parentheses, and can be one of:
 
-         o depth_spacer  - a number of spaces equal to the account's depth, or
+         o depth_spacer - a number of spaces equal to the account's depth,  or
            if MIN is specified, MIN * depth spaces.
 
          o account - the account's name
 
          o total - the account's balance/posted total, right justified
 
-       Also, FMT can begin with an optional prefix to control  how  multi-com-
+       Also,  FMT  can begin with an optional prefix to control how multi-com-
        modity amounts are rendered:
 
        o %_ - render on multiple lines, bottom-aligned (the default)
@@ -1428,22 +1429,22 @@ COMMANDS
 
        o %, - render on one line, comma-separated
 
-       There are some quirks.  Eg in one-line mode, %(depth_spacer) has no ef-
-       fect, instead %(account) has indentation built in.  Experimentation may
-       be needed to get pleasing results.
+       There are some quirks.  Eg in one-line  mode,  %(depth_spacer)  has  no
+       effect,  instead  %(account) has indentation built in.  Experimentation
+       may be needed to get pleasing results.
 
        Some example formats:
 
        o %(total) - the account's total
 
-       o %-20.20(account)  -  the account's name, left justified, padded to 20
+       o %-20.20(account) - the account's name, left justified, padded  to  20
          characters and clipped at 20 characters
 
-       o %,%-50(account)  %25(total) - account name padded to  50  characters,
-         total  padded to 20 characters, with multiple commodities rendered on
+       o %,%-50(account)   %25(total)  - account name padded to 50 characters,
+         total padded to 20 characters, with multiple commodities rendered  on
          one line
 
-       o %20(total)  %2(depth_spacer)%-(account) - the default format for  the
+       o %20(total)   %2(depth_spacer)%-(account) - the default format for the
          single-column balance report
 
    Colour support
@@ -1454,9 +1455,9 @@ COMMANDS
        o the output is not being redirected or piped anywhere
 
    Flat mode
-       To  see  a  flat  list instead of the default hierarchical display, use
-       --flat.  In this mode, accounts (unless depth-clipped) show their  full
-       names  and  "exclusive" balance, excluding any subaccount balances.  In
+       To see a flat list instead of the  default  hierarchical  display,  use
+       --flat.   In this mode, accounts (unless depth-clipped) show their full
+       names and "exclusive" balance, excluding any subaccount  balances.   In
        this mode, you can also use --drop N to omit the first few account name
        components.
 
@@ -1465,8 +1466,8 @@ COMMANDS
                                 $1  supplies
 
    Depth limited balance reports
-       With  --depth  N  or  depth:N or just -N, balance reports show accounts
-       only to the specified numeric depth.  This is very useful to  summarise
+       With --depth N or depth:N or just -N,  balance  reports  show  accounts
+       only  to the specified numeric depth.  This is very useful to summarise
        a complex set of accounts and get an overview.
 
               $ hledger balance -N -1
@@ -1479,9 +1480,9 @@ COMMANDS
        inclusive balances at the depth limit.
 
    Percentages
-       With -% or --percent, balance reports show  each  account's  value  ex-
-       pressed  as  a percentage of the column's total.  This is useful to get
-       an overview of the relative sizes of account balances.  For example  to
+       With  -%  or  --percent,  balance  reports  show  each  account's value
+       expressed as a percentage of the column's total.  This is useful to get
+       an  overview of the relative sizes of account balances.  For example to
        obtain an overview of expenses:
 
               $ hledger balance expenses -%
@@ -1491,32 +1492,32 @@ COMMANDS
               --------------------
                            100.0 %
 
-       Note  that  --tree  does not have an effect on -%.  The percentages are
-       always relative to the total sum of each column, they are  never  rela-
+       Note that --tree does not have an effect on -%.   The  percentages  are
+       always  relative  to the total sum of each column, they are never rela-
        tive to the parent account.
 
-       Since  the  percentages  are relative to the columns sum, it is usually
-       not useful to calculate percentages if the signs  of  the  amounts  are
-       mixed.   Although  the  results  are technically correct, they are most
-       likely useless.  Especially in a balance report that sums  up  to  zero
+       Since the percentages are relative to the columns sum,  it  is  usually
+       not  useful  to  calculate  percentages if the signs of the amounts are
+       mixed.  Although the results are technically  correct,  they  are  most
+       likely  useless.   Especially  in a balance report that sums up to zero
        (eg hledger balance -B) all percentage values will be zero.
 
-       This  flag does not work if the report contains any mixed commodity ac-
-       counts.  If there are mixed commodity accounts in the report be sure to
-       use -V or -B to coerce the report into using a single commodity.
+       This flag does not work if the  report  contains  any  mixed  commodity
+       accounts.   If there are mixed commodity accounts in the report be sure
+       to use -V or -B to coerce the report into using a single commodity.
 
    Multicolumn balance report
-       Multicolumn  or  tabular balance reports are a very useful hledger fea-
-       ture, and usually the preferred style.  They share many  of  the  above
-       features,  but they show the report as a table, with columns represent-
-       ing time periods.  This mode is activated by providing a reporting  in-
-       terval.
+       Multicolumn or tabular balance reports are a very useful  hledger  fea-
+       ture,  and  usually  the preferred style.  They share many of the above
+       features, but they show the report as a table, with columns  represent-
+       ing  time  periods.   This  mode  is activated by providing a reporting
+       interval.
 
-       There  are three types of multicolumn balance report, showing different
+       There are three types of multicolumn balance report, showing  different
        information:
 
        1. By default: each column shows the sum of postings in that period, ie
-          the  account's  change of balance in that period.  This is useful eg
+          the account's change of balance in that period.  This is  useful  eg
           for a monthly income statement:
 
                   $ hledger balance --quarterly income expenses -E
@@ -1531,8 +1532,8 @@ COMMANDS
                   -------------------++---------------------------------
                                      ||     $-1      $1       0       0
 
-       2. With --cumulative: each column shows the ending balance for that pe-
-          riod,  accumulating  the  changes across periods, starting from 0 at
+       2. With  --cumulative:  each  column  shows the ending balance for that
+          period, accumulating the changes across periods, starting from 0  at
           the report start date:
 
                   $ hledger balance --quarterly income expenses -E --cumulative
@@ -1548,8 +1549,8 @@ COMMANDS
                                      ||         $-1           0           0           0
 
        3. With --historical/-H: each column shows the actual historical ending
-          balance  for  that  period, accumulating the changes across periods,
-          starting from the actual balance at the report start date.  This  is
+          balance for that period, accumulating the  changes  across  periods,
+          starting  from the actual balance at the report start date.  This is
           useful eg for a multi-period balance sheet, and when you are showing
           only the data after a certain start date:
 
@@ -1568,26 +1569,26 @@ COMMANDS
        Note that --cumulative or --historical/-H disable --row-total/-T, since
        summing end balances generally does not make sense.
 
-       Multicolumn  balance  reports display accounts in flat mode by default;
+       Multicolumn balance reports display accounts in flat mode  by  default;
        to see the hierarchy, use --tree.
 
-       With  a  reporting  interval  (like  --quarterly  above),  the   report
-       start/end  dates  will  be adjusted if necessary so that they encompass
+       With   a  reporting  interval  (like  --quarterly  above),  the  report
+       start/end dates will be adjusted if necessary so  that  they  encompass
        the displayed report periods.  This is so that the first and last peri-
        ods will be "full" and comparable to the others.
 
-       The  -E/--empty  flag  does  two things in multicolumn balance reports:
-       first, the report will show all columns within the specified report pe-
-       riod  (without -E, leading and trailing columns with all zeroes are not
-       shown).  Second, all accounts which existed at the  report  start  date
-       will  be  considered, not just the ones with activity during the report
-       period (use -E to include low-activity accounts which  would  otherwise
-       would be omitted).
+       The -E/--empty flag does two things  in  multicolumn  balance  reports:
+       first,  the  report  will  show all columns within the specified report
+       period (without -E, leading and trailing columns with  all  zeroes  are
+       not  shown).   Second,  all  accounts which existed at the report start
+       date will be considered, not just the ones  with  activity  during  the
+       report period (use -E to include low-activity accounts which would oth-
+       erwise would be omitted).
 
        The -T/--row-total flag adds an additional column showing the total for
        each row.
 
-       The -A/--average flag adds a column showing the average value  in  each
+       The  -A/--average  flag adds a column showing the average value in each
        row.
 
        Here's an example of all three:
@@ -1611,21 +1612,21 @@ COMMANDS
        Limitations:
 
        In multicolumn reports the -V/--value flag uses the market price on the
-       report end date, for all columns (not the price on  each  column's  end
+       report  end  date,  for all columns (not the price on each column's end
        date).
 
-       Eliding  of boring parent accounts in tree mode, as in the classic bal-
+       Eliding of boring parent accounts in tree mode, as in the classic  bal-
        ance report, is not yet supported in multicolumn reports.
 
    Budget report
-       With --budget, extra columns are displayed  showing  budget  goals  for
-       each  account and period, if any.  Budget goals are defined by periodic
-       transactions.  This is very useful for comparing planned and actual in-
-       come,  expenses, time usage, etc.  --budget is most often combined with
-       a report interval.
+       With  --budget,  extra  columns  are displayed showing budget goals for
+       each account and period, if any.  Budget goals are defined by  periodic
+       transactions.   This  is  very  useful for comparing planned and actual
+       income, expenses, time usage, etc.  --budget  is  most  often  combined
+       with a report interval.
 
-       For example, you can take average monthly expenses in  the  common  ex-
-       pense categories to construct a minimal monthly budget:
+       For  example,  you  can  take  average  monthly  expenses in the common
+       expense categories to construct a minimal monthly budget:
 
               ;; Budget
               ~ monthly
@@ -1671,25 +1672,25 @@ COMMANDS
 
        Note this is different from a normal balance report in several ways:
 
-       o Only  accounts  with budget goals during the report period are shown,
+       o Only accounts with budget goals during the report period  are  shown,
          by default.
 
-       o In each column, in square brackets after the actual amount,  budgeted
+       o In  each column, in square brackets after the actual amount, budgeted
          amounts are shown, along with the percentage of budget used.
 
-       o All  parent accounts are always shown, even in flat mode.  Eg assets,
+       o All parent accounts are always shown, even in flat mode.  Eg  assets,
          assets:bank, and expenses above.
 
-       o Amounts always include all subaccounts, budgeted or unbudgeted,  even
+       o Amounts  always include all subaccounts, budgeted or unbudgeted, even
          in flat mode.
 
        This means that the numbers displayed will not always add up! Eg above,
-       the expenses actual amount includes the  gifts  and  supplies  transac-
-       tions,  but  the  expenses:gifts and expenses:supplies accounts are not
+       the  expenses  actual  amount  includes the gifts and supplies transac-
+       tions, but the expenses:gifts and expenses:supplies  accounts  are  not
        shown, as they have no budget amounts declared.
 
-       This can be confusing.  When you need to make things clearer,  use  the
-       -E/--empty  flag,  which  will reveal all accounts including unbudgeted
+       This  can  be confusing.  When you need to make things clearer, use the
+       -E/--empty flag, which will reveal all  accounts  including  unbudgeted
        ones, giving the full picture.  Eg:
 
               $ hledger balance -M --budget --empty
@@ -1731,12 +1732,12 @@ COMMANDS
        For more examples, see Budgeting and Forecasting.
 
    Nested budgets
-       You can add budgets to any account in your account hierarchy.   If  you
+       You  can  add budgets to any account in your account hierarchy.  If you
        have budgets on both parent account and some of its children, then bud-
-       get(s) of the child account(s) would be added to the  budget  of  their
+       get(s)  of  the  child account(s) would be added to the budget of their
        parent, much like account balances behave.
 
-       In  the  most  simple case this means that once you add a budget to any
+       In the most simple case this means that once you add a  budget  to  any
        account, all its parents would have budget as well.
 
        To illustrate this, consider the following budget:
@@ -1746,14 +1747,14 @@ COMMANDS
                   expenses:personal:electronics    $100.00
                   liabilities
 
-       With this, monthly budget for electronics is defined  to  be  $100  and
-       budget  for  personal expenses is an additional $1000, which implicitly
+       With  this,  monthly  budget  for electronics is defined to be $100 and
+       budget for personal expenses is an additional $1000,  which  implicitly
        means that budget for both expenses:personal and expenses is $1100.
 
-       Transactions in expenses:personal:electronics will be counted both  to-
-       wards its $100 budget and $1100 of expenses:personal , and transactions
-       in any other subaccount of expenses:personal would be  counted  towards
-       only towards the budget of expenses:personal.
+       Transactions  in  expenses:personal:electronics  will  be  counted both
+       towards its $100 budget and $1100 of expenses:personal ,  and  transac-
+       tions  in  any  other  subaccount of expenses:personal would be counted
+       towards only towards the budget of expenses:personal.
 
        For example, let's consider these transactions:
 
@@ -1778,9 +1779,9 @@ COMMANDS
                   expenses:personal          $30.00
                   liabilities
 
-       As  you  can  see,  we have transactions in expenses:personal:electron-
-       ics:upgrades and expenses:personal:train tickets,  and  since  both  of
-       these  accounts  are  without explicitly defined budget, these transac-
+       As you can see, we  have  transactions  in  expenses:personal:electron-
+       ics:upgrades  and  expenses:personal:train  tickets,  and since both of
+       these accounts are without explicitly defined  budget,  these  transac-
        tions would be counted towards budgets of expenses:personal:electronics
        and expenses:personal accordingly:
 
@@ -1796,7 +1797,7 @@ COMMANDS
               -------------------------------++-------------------------------
                                              ||        0 [                 0]
 
-       And  with --empty, we can get a better picture of budget allocation and
+       And with --empty, we can get a better picture of budget allocation  and
        consumption:
 
               $ hledger balance --budget -M --empty
@@ -1814,17 +1815,17 @@ COMMANDS
                                                       ||        0 [                 0]
 
    Output format
-       The balance command supports output destination and output  format  se-
-       lection.
+       The  balance  command  supports  output  destination  and output format
+       selection.
 
    balancesheet
        balancesheet, bs
        This command displays a simple balance sheet, showing historical ending
-       balances of asset and liability accounts  (ignoring  any  report  begin
-       date).   It  assumes that these accounts are under a top-level asset or
+       balances  of  asset  and  liability accounts (ignoring any report begin
+       date).  It assumes that these accounts are under a top-level  asset  or
        liability account (case insensitive, plural forms also allowed).
 
-       Note this report shows all account balances with normal  positive  sign
+       Note  this  report shows all account balances with normal positive sign
        (like conventional financial statements, unlike balance/print/register)
        (experimental).
 
@@ -1850,20 +1851,20 @@ COMMANDS
                                  0
 
        With a reporting interval, multiple columns will be shown, one for each
-       report  period.  As with multicolumn balance reports, you can alter the
-       report mode  with  --change/--cumulative/--historical.   Normally  bal-
-       ancesheet  shows historical ending balances, which is what you need for
-       a balance sheet; note this means it ignores  report  begin  dates  (and
-       -T/--row-total,  since  summing  end  balances  generally does not make
-       sense).  Instead of absolute values percentages can be  displayed  with
+       report period.  As with multicolumn balance reports, you can alter  the
+       report  mode  with  --change/--cumulative/--historical.   Normally bal-
+       ancesheet shows historical ending balances, which is what you need  for
+       a  balance  sheet;  note  this means it ignores report begin dates (and
+       -T/--row-total, since summing end  balances  generally  does  not  make
+       sense).   Instead  of absolute values percentages can be displayed with
        -%.
 
-       This  command also supports output destination and output format selec-
+       This command also supports output destination and output format  selec-
        tion.
 
    balancesheetequity
        balancesheetequity, bse
-       Just like balancesheet, but also reports Equity (which  it  assumes  is
+       Just  like  balancesheet,  but also reports Equity (which it assumes is
        under a top-level equity account).
 
        Example:
@@ -1894,10 +1895,10 @@ COMMANDS
 
    cashflow
        cashflow, cf
-       This  command  displays a simple cashflow statement, showing changes in
-       "cash" accounts.  It assumes that these accounts are under a  top-level
-       asset  account (case insensitive, plural forms also allowed) and do not
-       contain receivable or A/R in their name.  Note this  report  shows  all
+       This command displays a simple cashflow statement, showing  changes  in
+       "cash"  accounts.  It assumes that these accounts are under a top-level
+       asset account (case insensitive, plural forms also allowed) and do  not
+       contain  receivable  or  A/R in their name.  Note this report shows all
        account balances with normal positive sign (like conventional financial
        statements, unlike balance/print/register) (experimental).
 
@@ -1918,83 +1919,83 @@ COMMANDS
                                $-1
 
        With a reporting interval, multiple columns will be shown, one for each
-       report  period.   Normally cashflow shows changes in assets per period,
-       though as with multicolumn balance reports you  can  alter  the  report
+       report period.  Normally cashflow shows changes in assets  per  period,
+       though  as  with  multicolumn  balance reports you can alter the report
        mode with --change/--cumulative/--historical.  Instead of absolute val-
        ues percentages can be displayed with -%.
 
-       This command also supports output destination and output format  selec-
+       This  command also supports output destination and output format selec-
        tion.
 
    check-dates
        check-dates
-       Check  that  transactions are sorted by increasing date.  With --date2,
-       checks secondary dates instead.  With  --strict,  dates  must  also  be
-       unique.   With  a  query, only matched transactions' dates are checked.
+       Check that transactions are sorted by increasing date.   With  --date2,
+       checks  secondary  dates  instead.   With  --strict, dates must also be
+       unique.  With a query, only matched transactions'  dates  are  checked.
        Reads the default journal file, or another specified with -f.
 
    check-dupes
        check-dupes
-       Reports account names having the same leaf but different prefixes.   In
-       other  words,  two  or  more  leaves  that are categorized differently.
+       Reports  account names having the same leaf but different prefixes.  In
+       other words, two or  more  leaves  that  are  categorized  differently.
        Reads the default journal file, or another specified as an argument.
 
        An example: http://stefanorodighiero.net/software/hledger-dupes.html
 
    close
        close, equity
-       Prints a "closing  balances"  transaction  and  an  "opening  balances"
+       Prints  a  "closing  balances"  transaction  and  an "opening balances"
        transaction that bring account balances to and from zero, respectively.
        Useful for bringing asset/liability balances forward into a new journal
-       file,  or for closing out revenues/expenses to retained earnings at the
+       file, or for closing out revenues/expenses to retained earnings at  the
        end of a period.
 
-       The closing transaction  transfers  balances  to  "equity:closing  bal-
-       ances",  and  the  opening  transaction  transfers  balances  from "eq-
-       uity:opening balances", or you can customise these with the  --close-to
-       and  --open-from  options.   You  can  choose  to print just one of the
+       The  closing  transaction  transfers  balances  to "equity:closing bal-
+       ances",  and  the   opening   transaction   transfers   balances   from
+       "equity:opening balances", or you can customise these with the --close-
+       to and --open-from options.  You can choose to print just  one  of  the
        transactions by using the --opening or --closing flag.
 
        If you split your journal files by time (eg yearly), you will typically
-       run  this command at the end of the year, and save the closing transac-
-       tion as last entry of the old file, and the opening transaction as  the
-       first  entry  of the new file.  This makes the files self contained, so
-       that correct balances are reported no matter which of them are  loaded.
-       Ie,  if you load just one file, the balances are initialised correctly;
-       or if you load several files, the  redundant  closing/opening  transac-
-       tions  cancel  each other out.  (They will show up in print or register
-       reports; you can  exclude  them  with  a  query  like  not:desc:'(open-
+       run this command at the end of the year, and save the closing  transac-
+       tion  as last entry of the old file, and the opening transaction as the
+       first entry of the new file.  This makes the files self  contained,  so
+       that  correct balances are reported no matter which of them are loaded.
+       Ie, if you load just one file, the balances are initialised  correctly;
+       or  if  you  load several files, the redundant closing/opening transac-
+       tions cancel each other out.  (They will show up in print  or  register
+       reports;  you  can  exclude  them  with  a  query like not:desc:'(open-
        ing|closing) balances'.)
 
        If you're running a business, you might also use this command to "close
-       the books" at the end of  an  accounting  period,  transferring  income
-       statement  account  balances  to  retained  earnings.  (You may want to
+       the  books"  at  the  end  of an accounting period, transferring income
+       statement account balances to retained  earnings.   (You  may  want  to
        change the equity account name to something like "equity:retained earn-
        ings".)
 
-       By  default,  the  closing transaction is dated yesterday, the balances
-       are calculated as of end of yesterday, and the opening  transaction  is
-       dated  today.  To close on some other date, use: hledger close -e OPEN-
-       INGDATE.  Eg, to close/open on the 2018/2019  boundary,  use  -e  2019.
+       By default, the closing transaction is dated  yesterday,  the  balances
+       are  calculated  as of end of yesterday, and the opening transaction is
+       dated today.  To close on some other date, use: hledger close -e  OPEN-
+       INGDATE.   Eg,  to  close/open  on the 2018/2019 boundary, use -e 2019.
        You can also use -p or date:PERIOD (any starting date is ignored).
 
-       Both  transactions  will  include balance assertions for the closed/re-
-       opened accounts.  You probably shouldn't use status or realness filters
-       (like  -C or -R or status:) with this command, or the generated balance
-       assertions will depend on these flags.  Likewise, if you run this  com-
-       mand  with  --auto, the balance assertions will probably always require
-       --auto.
+       Both   transactions   will   include   balance   assertions   for   the
+       closed/reopened  accounts.   You probably shouldn't use status or real-
+       ness filters (like -C or -R or status:) with this command, or the  gen-
+       erated balance assertions will depend on these flags.  Likewise, if you
+       run this command with --auto,  the  balance  assertions  will  probably
+       always require --auto.
 
-       When account balances have cost information (transaction  prices),  the
-       closing/opening  transactions  will  preserve it, so that eg balance -B
+       When  account  balances have cost information (transaction prices), the
+       closing/opening transactions will preserve it, so that  eg  balance  -B
        reports will not be affected.
 
        Examples:
 
-       Carrying asset/liability balances into a new file for  2019,  all  from
+       Carrying  asset/liability  balances  into a new file for 2019, all from
        command line:
 
-       Warning:  we  use  >> here to append; be careful not to type a single >
+       Warning: we use >> here to append; be careful not to type  a  single  >
        which would wipe your journal!
 
               $ hledger close -f 2018.journal -e 2019 assets liabilities --opening >>2019.journal
@@ -2043,18 +2044,18 @@ COMMANDS
 
    diff
        diff
-       Compares  a  particular  account's transactions in two input files.  It
+       Compares a particular account's transactions in two  input  files.   It
        shows any transactions to this account which are in one file but not in
        the other.
 
        More precisely, for each posting affecting this account in either file,
-       it looks for a corresponding posting in the other file which posts  the
-       same  amount  to  the  same  account (ignoring date, description, etc.)
+       it  looks for a corresponding posting in the other file which posts the
+       same amount to the same  account  (ignoring  date,  description,  etc.)
        Since postings not transactions are compared, this also works when mul-
        tiple bank transactions have been combined into a single journal entry.
 
        This is useful eg if you have downloaded an account's transactions from
-       your bank (eg as CSV data).  When hledger and your bank disagree  about
+       your  bank (eg as CSV data).  When hledger and your bank disagree about
        the account balance, you can compare the bank data with your journal to
        find out the cause.
 
@@ -2072,20 +2073,20 @@ COMMANDS
 
    files
        files
-       List all files included in the journal.  With a  REGEX  argument,  only
+       List  all  files  included in the journal.  With a REGEX argument, only
        file names matching the regular expression (case sensitive) are shown.
 
    help
        help
        Show any of the hledger manuals.
 
-       The  help  command  displays any of the main hledger manuals, in one of
-       several ways.  Run it with no argument to list the manuals, or  provide
+       The help command displays any of the main hledger manuals,  in  one  of
+       several  ways.  Run it with no argument to list the manuals, or provide
        a full or partial manual name to select one.
 
-       hledger  manuals  are  available in several formats.  hledger help will
-       use the first of these  display  methods  that  it  finds:  info,  man,
-       $PAGER,  less,  stdout (or when non-interactive, just stdout).  You can
+       hledger manuals are available in several formats.   hledger  help  will
+       use  the  first  of  these  display  methods  that it finds: info, man,
+       $PAGER, less, stdout (or when non-interactive, just stdout).   You  can
        force a particular viewer with the --info, --man, --pager, --cat flags.
 
        Examples:
@@ -2112,9 +2113,9 @@ COMMANDS
 
    import
        import
-       Read new transactions added to each FILE since last run, and  add  them
-       to  the  main journal file.  Or with --dry-run, just print the transac-
-       tions that would be added.  Or with --catchup, just  mark  all  of  the
+       Read  new  transactions added to each FILE since last run, and add them
+       to the main journal file.  Or with --dry-run, just print  the  transac-
+       tions  that  would  be  added.  Or with --catchup, just mark all of the
        FILEs' transactions as imported, without actually importing any.
 
        The input files are specified as arguments - no need to write -f before
@@ -2125,36 +2126,36 @@ COMMANDS
        ing transactions are always added to the input files in increasing date
        order, and by saving .latest.FILE state files.
 
-       The  --dry-run output is in journal format, so you can filter it, eg to
+       The --dry-run output is in journal format, so you can filter it, eg  to
        see only uncategorised transactions:
 
               $ hledger import --dry ... | hledger -f- print unknown --ignore-assertions
 
    Importing balance assignments
-       Entries added by import will have their posting amounts  made  explicit
-       (like  hledger  print  -x).  This means that any balance assignments in
-       imported files must be evaluated; but, imported files don't get to  see
-       the  main file's account balances.  As a result, importing entries with
+       Entries  added  by import will have their posting amounts made explicit
+       (like hledger print -x).  This means that any  balance  assignments  in
+       imported  files must be evaluated; but, imported files don't get to see
+       the main file's account balances.  As a result, importing entries  with
        balance assignments (eg from an institution that provides only balances
-       and  not  posting  amounts)  will  probably  generate incorrect posting
+       and not posting  amounts)  will  probably  generate  incorrect  posting
        amounts.  To avoid this problem, use print instead of import:
 
               $ hledger print IMPORTFILE [--new] >> $LEDGER_FILE
 
-       (If you think import should leave amounts  implicit  like  print  does,
+       (If  you  think  import  should leave amounts implicit like print does,
        please test it and send a pull request.)
 
    incomestatement
        incomestatement, is
-       This  command  displays a simple income statement, showing revenues and
-       expenses during a period.  It assumes that these accounts are  under  a
-       top-level  revenue or income or expense account (case insensitive, plu-
-       ral forms also allowed).  Note this report shows all  account  balances
-       with  normal positive sign (like conventional financial statements, un-
-       like balance/print/register) (experimental).
+       This command displays a simple income statement, showing  revenues  and
+       expenses  during  a period.  It assumes that these accounts are under a
+       top-level revenue or income or expense account (case insensitive,  plu-
+       ral  forms  also allowed).  Note this report shows all account balances
+       with normal positive  sign  (like  conventional  financial  statements,
+       unlike balance/print/register) (experimental).
 
-       This command displays a simple income statement.  It currently  assumes
-       that  you have top-level accounts named income (or revenue) and expense
+       This  command displays a simple income statement.  It currently assumes
+       that you have top-level accounts named income (or revenue) and  expense
        (plural forms also allowed.)
 
               $ hledger incomestatement
@@ -2179,12 +2180,12 @@ COMMANDS
                                  0
 
        With a reporting interval, multiple columns will be shown, one for each
-       report  period.   Normally  incomestatement shows revenues/expenses per
-       period, though as with multicolumn balance reports you  can  alter  the
-       report  mode with --change/--cumulative/--historical.  Instead of abso-
+       report period.  Normally incomestatement  shows  revenues/expenses  per
+       period,  though  as  with multicolumn balance reports you can alter the
+       report mode with --change/--cumulative/--historical.  Instead of  abso-
        lute values percentages can be displayed with -%.
 
-       This command also supports output destination and output format  selec-
+       This  command also supports output destination and output format selec-
        tion.
 
    notes
@@ -2212,23 +2213,23 @@ COMMANDS
 
    prices
        prices
-       Print  market  price  directives  from the journal.  With --costs, also
-       print synthetic market prices based on transaction prices.  With  --in-
-       verted-costs,  also  print  inverse prices based on transaction prices.
-       Prices (and postings providing prices) can  be  filtered  by  a  query.
-       Price amounts are always displayed with their full precision.
+       Print market price directives from the  journal.   With  --costs,  also
+       print  synthetic  market  prices  based  on  transaction  prices.  With
+       --inverted-costs,  also  print  inverse  prices  based  on  transaction
+       prices.   Prices  (and  postings providing prices) can be filtered by a
+       query.  Price amounts are always displayed with their full precision.
 
    print
        print, txns, p
        Show transaction journal entries, sorted by date.
 
        The print command displays full journal entries (transactions) from the
-       journal file in date order, tidily formatted.  With  --date2,  transac-
+       journal  file  in date order, tidily formatted.  With --date2, transac-
        tions are sorted by secondary date instead.
 
        print's output is always a valid hledger journal.
-       It  preserves all transaction information, but it does not preserve di-
-       rectives or inter-transaction comments
+       It preserves all transaction information,  but  it  does  not  preserve
+       directives or inter-transaction comments
 
               $ hledger print
               2008/01/01 income
@@ -2253,39 +2254,39 @@ COMMANDS
                   assets:bank:checking           $-1
 
        Normally, the journal entry's explicit or implicit amount style is pre-
-       served.   Ie when an amount is omitted in the journal, it will be omit-
-       ted in the output.  You can use the  -x/--explicit  flag  to  make  all
+       served.  Ie when an amount is omitted in the journal, it will be  omit-
+       ted  in  the  output.   You  can use the -x/--explicit flag to make all
        amounts explicit, which can be useful for troubleshooting or for making
        your journal more readable and robust against data entry errors.  Note,
-       -x  will  cause postings with a multi-commodity amount (these can arise
-       when a multi-commodity transaction has  an  implicit  amount)  will  be
-       split  into  multiple single-commodity postings, for valid journal out-
+       -x will cause postings with a multi-commodity amount (these  can  arise
+       when  a  multi-commodity  transaction  has  an implicit amount) will be
+       split into multiple single-commodity postings, for valid  journal  out-
        put.
 
-       With -B/--cost, amounts with transaction prices are converted  to  cost
+       With  -B/--cost,  amounts with transaction prices are converted to cost
        using that price.  This can be used for troubleshooting.
 
-       With  -m/--match and a STR argument, print will show at most one trans-
-       action: the one one whose description is most similar to  STR,  and  is
-       most  recent.  STR should contain at least two characters.  If there is
+       With -m/--match and a STR argument, print will show at most one  trans-
+       action:  the  one  one whose description is most similar to STR, and is
+       most recent.  STR should contain at least two characters.  If there  is
        no similar-enough match, no transaction will be shown.
 
        With --new, for each FILE being read, hledger reads (and writes) a spe-
-       cial  state  file  (.latest.FILE in the same directory), containing the
-       latest transaction date(s) that were seen  last  time  FILE  was  read.
-       When  this  file  is found, only transactions with newer dates (and new
-       transactions on the latest date) are printed.  This is useful  for  ig-
-       noring  already-seen  entries  in  import  data, such as downloaded CSV
+       cial state file (.latest.FILE in the same  directory),  containing  the
+       latest  transaction  date(s)  that  were  seen last time FILE was read.
+       When this file is found, only transactions with newer  dates  (and  new
+       transactions  on  the  latest  date)  are  printed.  This is useful for
+       ignoring already-seen entries in import data, such  as  downloaded  CSV
        files.  Eg:
 
               $ hledger -f bank1.csv print --new
               # shows transactions added since last print --new on this file
 
-       This assumes that transactions added to FILE always have  same  or  in-
-       creasing  dates,  and  that transactions on the same day do not get re-
-       ordered.  See also the import command.
+       This  assumes  that  transactions  added  to  FILE  always have same or
+       increasing dates, and that transactions on the  same  day  do  not  get
+       reordered.  See also the import command.
 
-       This command also supports output destination and output format  selec-
+       This  command also supports output destination and output format selec-
        tion.  Here's an example of print's CSV output:
 
               $ hledger print -Ocsv
@@ -2302,20 +2303,20 @@ COMMANDS
               "5","2008/12/31","","*","","pay off","","liabilities:debts","1","$","","1","",""
               "5","2008/12/31","","*","","pay off","","assets:bank:checking","-1","$","1","","",""
 
-       o There  is  one  CSV record per posting, with the parent transaction's
+       o There is one CSV record per posting, with  the  parent  transaction's
          fields repeated.
 
        o The "txnidx" (transaction index) field shows which postings belong to
-         the  same transaction.  (This number might change if transactions are
-         reordered within the file, files are parsed/included in  a  different
+         the same transaction.  (This number might change if transactions  are
+         reordered  within  the file, files are parsed/included in a different
          order, etc.)
 
-       o The  amount  is  separated into "commodity" (the symbol) and "amount"
+       o The amount is separated into "commodity" (the  symbol)  and  "amount"
          (numeric quantity) fields.
 
        o The numeric amount is repeated in either the "credit" or "debit" col-
-         umn,  for convenience.  (Those names are not accurate in the account-
-         ing sense; it just puts negative amounts under  credit  and  zero  or
+         umn, for convenience.  (Those names are not accurate in the  account-
+         ing  sense;  it  just  puts negative amounts under credit and zero or
          greater amounts under debit.)
 
    print-unique
@@ -2339,7 +2340,7 @@ COMMANDS
        Show postings and their running total.
 
        The register command displays postings in date order, one per line, and
-       their running total.  This is typically used with a query  selecting  a
+       their  running  total.  This is typically used with a query selecting a
        particular account, to see that account's activity:
 
               $ hledger register checking
@@ -2350,8 +2351,8 @@ COMMANDS
 
        With --date2, it shows and sorts by secondary date instead.
 
-       The  --historical/-H  flag  adds the balance from any undisplayed prior
-       postings to the running total.  This is useful when  you  want  to  see
+       The --historical/-H flag adds the balance from  any  undisplayed  prior
+       postings  to  the  running  total.  This is useful when you want to see
        only recent activity, with a historically accurate running balance:
 
               $ hledger register checking -b 2008/6 --historical
@@ -2361,30 +2362,30 @@ COMMANDS
 
        The --depth option limits the amount of sub-account detail displayed.
 
-       The  --average/-A flag shows the running average posting amount instead
+       The --average/-A flag shows the running average posting amount  instead
        of the running total (so, the final number displayed is the average for
-       the  whole  report period).  This flag implies --empty (see below).  It
-       is affected by --historical.  It works best when showing just  one  ac-
-       count and one commodity.
+       the whole report period).  This flag implies --empty (see  below).   It
+       is  affected  by  --historical.   It  works  best when showing just one
+       account and one commodity.
 
-       The  --related/-r  flag shows the other postings in the transactions of
+       The --related/-r flag shows the other postings in the  transactions  of
        the postings which would normally be shown.
 
-       The --invert flag negates all amounts.  For example, it can be used  on
+       The  --invert flag negates all amounts.  For example, it can be used on
        an income account where amounts are normally displayed as negative num-
-       bers.  It's also useful to show postings on the  checking  account  to-
-       gether with the related account:
+       bers.   It's  also  useful  to  show  postings  on the checking account
+       together with the related account:
 
               $ hledger register --related --invert assets:checking
 
-       With a reporting interval, register shows summary postings, one per in-
-       terval, aggregating the postings to each account:
+       With a reporting interval, register shows  summary  postings,  one  per
+       interval, aggregating the postings to each account:
 
               $ hledger register --monthly income
               2008/01                 income:salary                          $-1          $-1
               2008/06                 income:gifts                           $-1          $-2
 
-       Periods with no activity, and summary postings with a zero amount,  are
+       Periods  with no activity, and summary postings with a zero amount, are
        not shown by default; use the --empty/-E flag to see them:
 
               $ hledger register --monthly income -E
@@ -2401,28 +2402,28 @@ COMMANDS
               2008/11                                                          0          $-2
               2008/12                                                          0          $-2
 
-       Often,  you'll want to see just one line per interval.  The --depth op-
-       tion helps with this, causing subaccounts to be aggregated:
+       Often, you'll want to see just one  line  per  interval.   The  --depth
+       option helps with this, causing subaccounts to be aggregated:
 
               $ hledger register --monthly assets --depth 1h
               2008/01                 assets                                  $1           $1
               2008/06                 assets                                 $-1            0
               2008/12                 assets                                 $-1          $-1
 
-       Note when using report intervals, if you specify start/end dates  these
-       will  be adjusted outward if necessary to contain a whole number of in-
-       tervals.  This ensures that the  first  and  last  intervals  are  full
+       Note  when using report intervals, if you specify start/end dates these
+       will be adjusted outward if necessary to  contain  a  whole  number  of
+       intervals.   This  ensures  that  the first and last intervals are full
        length and comparable to the others in the report.
 
    Custom register output
-       register  uses  the  full terminal width by default, except on windows.
-       You can override this by setting the COLUMNS environment variable  (not
+       register uses the full terminal width by default,  except  on  windows.
+       You  can override this by setting the COLUMNS environment variable (not
        a bash shell variable) or by using the --width/-w option.
 
-       The  description  and  account columns normally share the space equally
-       (about half of (width - 40) each).  You can adjust this by adding a de-
-       scription width as part of --width's argument, comma-separated: --width
-       W,D .  Here's a diagram (won't display correctly in --help):
+       The description and account columns normally share  the  space  equally
+       (about  half  of  (width  - 40) each).  You can adjust this by adding a
+       description width  as  part  of  --width's  argument,  comma-separated:
+       --width W,D .  Here's a diagram (won't display correctly in --help):
 
               <--------------------------------- width (W) ---------------------------------->
               date (10)  description (D)       account (W-41-D)     amount (12)   balance (12)
@@ -2437,27 +2438,27 @@ COMMANDS
               $ hledger reg -w 100,40           # set overall width 100, description width 40
               $ hledger reg -w $COLUMNS,40      # use terminal width, & description width 40
 
-       This command also supports output destination and output format  selec-
+       This  command also supports output destination and output format selec-
        tion.
 
    register-match
        register-match
        Print the one posting whose transaction description is closest to DESC,
-       in the style of the register command.  If there  are  multiple  equally
-       good  matches,  it  shows the most recent.  Query options (options, not
-       arguments) can be used to restrict the search space.  Helps  ledger-au-
-       tosync detect already-seen transactions when importing.
+       in  the  style  of the register command.  If there are multiple equally
+       good matches, it shows the most recent.  Query  options  (options,  not
+       arguments)  can  be  used  to restrict the search space.  Helps ledger-
+       autosync detect already-seen transactions when importing.
 
    rewrite
        rewrite
        Print all transactions, rewriting the postings of matched transactions.
-       For now the only rewrite available is adding new postings,  like  print
+       For  now  the only rewrite available is adding new postings, like print
        --auto.
 
        This is a start at a generic rewriter of transaction entries.  It reads
-       the default journal and prints the transactions, like print,  but  adds
+       the  default  journal and prints the transactions, like print, but adds
        one or more specified postings to any transactions matching QUERY.  The
-       posting amounts can be fixed, or a multiplier of the existing  transac-
+       posting  amounts can be fixed, or a multiplier of the existing transac-
        tion's first posting amount.
 
        Examples:
@@ -2473,7 +2474,7 @@ COMMANDS
                 (reserve:grocery)  *0.25  ; reserve 25% for grocery
                 (reserve:)  *0.25  ; reserve 25% for grocery
 
-       Note  the  single  quotes to protect the dollar sign from bash, and the
+       Note the single quotes to protect the dollar sign from  bash,  and  the
        two spaces between account and amount.
 
        More:
@@ -2483,16 +2484,16 @@ COMMANDS
               $ hledger rewrite -- expenses:gifts --add-posting '(budget:gifts)  *-1"'
               $ hledger rewrite -- ^income        --add-posting '(budget:foreign currency)  *0.25 JPY; diversify'
 
-       Argument for --add-posting option is a  usual  posting  of  transaction
-       with  an  exception  for amount specification.  More precisely, you can
+       Argument  for  --add-posting  option  is a usual posting of transaction
+       with an exception for amount specification.  More  precisely,  you  can
        use '*' (star symbol) before the amount to indicate that that this is a
-       factor  for  an  amount of original matched posting.  If the amount in-
-       cludes a commodity name, the new posting amount will be in the new com-
-       modity;  otherwise,  it will be in the matched posting amount's commod-
-       ity.
+       factor for an amount  of  original  matched  posting.   If  the  amount
+       includes  a  commodity  name, the new posting amount will be in the new
+       commodity; otherwise, it will be in the matched posting  amount's  com-
+       modity.
 
    Re-write rules in a file
-       During the run this tool will execute  so  called  "Automated  Transac-
+       During  the  run  this  tool will execute so called "Automated Transac-
        tions" found in any journal it process.  I.e instead of specifying this
        operations in command line you can put them in a journal file.
 
@@ -2507,7 +2508,7 @@ COMMANDS
                   budget:gifts  *-1
                   assets:budget  *1
 
-       Note that '=' (equality symbol) that is used instead of date in  trans-
+       Note  that '=' (equality symbol) that is used instead of date in trans-
        actions you usually write.  It indicates the query by which you want to
        match the posting to add new ones.
 
@@ -2520,12 +2521,12 @@ COMMANDS
                                                               --add-posting 'assets:budget  *1'       \
                 > rewritten-tidy-output.journal
 
-       It is important to understand that relative order of  such  entries  in
-       journal  is important.  You can re-use result of previously added post-
+       It  is  important  to understand that relative order of such entries in
+       journal is important.  You can re-use result of previously added  post-
        ings.
 
    Diff output format
-       To use this tool for batch modification of your journal files  you  may
+       To  use  this tool for batch modification of your journal files you may
        find useful output in form of unified diff.
 
               $ hledger rewrite -- --diff -f examples/sample.journal '^income' --add-posting '(liabilities:tax)  *.33'
@@ -2549,10 +2550,10 @@ COMMANDS
 
        If you'll pass this through patch tool you'll get transactions contain-
        ing the posting that matches your query be updated.  Note that multiple
-       files  might  be  update according to list of input files specified via
+       files might be update according to list of input  files  specified  via
        --file options and include directives inside of these files.
 
-       Be careful.  Whole transaction being re-formatted in a style of  output
+       Be  careful.  Whole transaction being re-formatted in a style of output
        from hledger print.
 
        See also:
@@ -2560,48 +2561,48 @@ COMMANDS
        https://github.com/simonmichael/hledger/issues/99
 
    rewrite vs. print --auto
-       This  command  predates  print --auto, and currently does much the same
+       This command predates print --auto, and currently does  much  the  same
        thing, but with these differences:
 
-       o with multiple files, rewrite lets rules in any file affect all  other
-         files.   print  --auto  uses standard directive scoping; rules affect
+       o with  multiple files, rewrite lets rules in any file affect all other
+         files.  print --auto uses standard directive  scoping;  rules  affect
          only child files.
 
-       o rewrite's query limits which transactions can be rewritten;  all  are
+       o rewrite's  query  limits which transactions can be rewritten; all are
          printed.  print --auto's query limits which transactions are printed.
 
-       o rewrite  applies  rules  specified on command line or in the journal.
+       o rewrite applies rules specified on command line or  in  the  journal.
          print --auto applies rules specified in the journal.
 
    roi
        roi
-       Shows the time-weighted (TWR) and money-weighted (IRR) rate  of  return
+       Shows  the  time-weighted (TWR) and money-weighted (IRR) rate of return
        on your investments.
 
-       This  command  assumes  that  you have account(s) that hold nothing but
+       This command assumes that you have account(s)  that  hold  nothing  but
        your investments and whenever you record current appraisal/valuation of
        these investments you offset unrealized profit and loss into account(s)
        that, again, hold nothing but unrealized profit and loss.
 
-       Any transactions affecting balance of  investment  account(s)  and  not
-       originating  from  unrealized profit and loss account(s) are assumed to
+       Any  transactions  affecting  balance  of investment account(s) and not
+       originating from unrealized profit and loss account(s) are  assumed  to
        be your investments or withdrawals.
 
-       At a minimum, you need to supply a query (which could be  just  an  ac-
-       count name) to select your investments with --inv, and another query to
-       identify your profit and loss transactions with --pnl.
+       At  a  minimum,  you  need  to  supply  a query (which could be just an
+       account name) to select your investments with --inv, and another  query
+       to identify your profit and loss transactions with --pnl.
 
-       It will compute and display the internalized rate of return  (IRR)  and
-       time-weighted  rate  of  return (TWR) for your investments for the time
-       period requested.  Both rates of return are annualized before  display,
+       It  will  compute and display the internalized rate of return (IRR) and
+       time-weighted rate of return (TWR) for your investments  for  the  time
+       period  requested.  Both rates of return are annualized before display,
        regardless of the length of reporting interval.
 
    stats
        stats
        Show some journal statistics.
 
-       The  stats  command displays summary information for the whole journal,
-       or a matched part of it.  With a reporting interval, it shows a  report
+       The stats command displays summary information for the  whole  journal,
+       or  a matched part of it.  With a reporting interval, it shows a report
        for each report period.
 
        Example:
@@ -2619,28 +2620,28 @@ COMMANDS
               Commodities              : 1 ($)
               Market prices            : 12 ($)
 
-       This  command also supports output destination and output format selec-
+       This command also supports output destination and output format  selec-
        tion.
 
    tags
        tags
-       List all the tag names used in the journal.  With a TAGREGEX  argument,
-       only  tag  names matching the regular expression (case insensitive) are
-       shown.  With QUERY arguments, only transactions matching the query  are
-       considered.  With --values flag, the tags' unique values are listed in-
-       stead.
+       List  all the tag names used in the journal.  With a TAGREGEX argument,
+       only tag names matching the regular expression (case  insensitive)  are
+       shown.   With QUERY arguments, only transactions matching the query are
+       considered.  With --values flag, the tags'  unique  values  are  listed
+       instead.
 
    test
        test
        Run built-in unit tests.
 
-       This command runs the unit tests built in to hledger  and  hledger-lib,
-       printing  the results on stdout.  If any test fails, the exit code will
+       This  command  runs the unit tests built in to hledger and hledger-lib,
+       printing the results on stdout.  If any test fails, the exit code  will
        be non-zero.
 
-       This is mainly used by hledger developers, but you can also use  it  to
-       sanity-check  the  installed  hledger executable on your platform.  All
-       tests are expected to pass - if you ever see a failure,  please  report
+       This  is  mainly used by hledger developers, but you can also use it to
+       sanity-check the installed hledger executable on  your  platform.   All
+       tests  are  expected to pass - if you ever see a failure, please report
        as a bug!
 
        This command also accepts tasty test runner options, written after a --
@@ -2649,32 +2650,32 @@ COMMANDS
 
               $ hledger test -- -pData.Amount --color=never
 
-       For  help  on these, see https://github.com/feuerbach/tasty#options (--
+       For help on these, see  https://github.com/feuerbach/tasty#options  (--
        --help currently doesn't show them).
 
 ADD-ON COMMANDS
-       hledger also searches for external add-on commands,  and  will  include
+       hledger  also  searches  for external add-on commands, and will include
        these in the commands list.  These are programs or scripts in your PATH
-       whose name starts with hledger- and ends with a recognised file  exten-
+       whose  name starts with hledger- and ends with a recognised file exten-
        sion (currently: no extension, bat,com,exe, hs,lhs,pl,py,rb,rkt,sh).
 
-       Add-ons  can  be  invoked like any hledger command, but there are a few
+       Add-ons can be invoked like any hledger command, but there  are  a  few
        things to be aware of.  Eg if the hledger-web add-on is installed,
 
-       o hledger -h web shows hledger's  help,  while  hledger  web  -h  shows
+       o hledger  -h  web  shows  hledger's  help,  while hledger web -h shows
          hledger-web's help.
 
-       o Flags  specific  to  the add-on must have a preceding -- to hide them
-         from hledger.  So hledger web --serve --port 9000 will  be  rejected;
+       o Flags specific to the add-on must have a preceding --  to  hide  them
+         from  hledger.   So hledger web --serve --port 9000 will be rejected;
          you must use hledger web -- --serve --port 9000.
 
        o You can always run add-ons directly if preferred: hledger-web --serve
          --port 9000.
 
-       Add-ons are a relatively easy way to add local features  or  experiment
-       with  new  ideas.   They  can  be  written in any language, but haskell
-       scripts have a big advantage:  they  can  use  the  same  hledger  (and
-       haskell)  library functions that built-in commands do, for command-line
+       Add-ons  are  a relatively easy way to add local features or experiment
+       with new ideas.  They can be  written  in  any  language,  but  haskell
+       scripts  have  a  big  advantage:  they  can  use the same hledger (and
+       haskell) library functions that built-in commands do, for  command-line
        options, journal parsing, reporting, etc.
 
        Here are some hledger add-ons available:
@@ -2689,7 +2690,7 @@ ADD-ON COMMANDS
        hledger-web provides a simple web interface.
 
    Third party add-ons
-       These are maintained separately, and usually updated  shortly  after  a
+       These  are  maintained  separately, and usually updated shortly after a
        hledger release.
 
    iadd
@@ -2701,35 +2702,35 @@ ADD-ON COMMANDS
        ing to various schemes.
 
    Experimental add-ons
-       These  are  available  in source form in the hledger repo's bin/ direc-
-       tory.  They may be less mature and documented than  built-in  commands.
+       These are available in source form in the hledger  repo's  bin/  direc-
+       tory.   They  may be less mature and documented than built-in commands.
        Reading and tweaking these is a good way to start making your own!
 
    autosync
        hledger-autosync is a symbolic link for easily running ledger-autosync,
-       if installed.  ledger-autosync does  deduplicating  conversion  of  OFX
-       data  and some CSV formats, and can also download the data if your bank
+       if  installed.   ledger-autosync  does  deduplicating conversion of OFX
+       data and some CSV formats, and can also download the data if your  bank
        offers OFX Direct Connect.
 
    chart
        hledger-chart.hs is an old very basic pie chart generator.
 
 ENVIRONMENT
-       COLUMNS The screen width used by the register  command.   Default:  the
+       COLUMNS  The  screen  width used by the register command.  Default: the
        full terminal width.
 
        LEDGER_FILE The journal file path when not specified with -f.  Default:
-       ~/.hledger.journal (on  windows,  perhaps  C:/Users/USER/.hledger.jour-
+       ~/.hledger.journal  (on  windows,  perhaps C:/Users/USER/.hledger.jour-
        nal).
 
 FILES
-       Reads  data from one or more files in hledger journal, timeclock, time-
-       dot,  or  CSV  format  specified   with   -f,   or   $LEDGER_FILE,   or
-       $HOME/.hledger.journal           (on          windows,          perhaps
+       Reads data from one or more files in hledger journal, timeclock,  time-
+       dot,   or   CSV   format   specified   with  -f,  or  $LEDGER_FILE,  or
+       $HOME/.hledger.journal          (on          windows,           perhaps
        C:/Users/USER/.hledger.journal).
 
 LIMITATIONS
-       The need to precede addon command options with  --  when  invoked  from
+       The  need  to  precede  addon command options with -- when invoked from
        hledger is awkward.
 
        When input data contains non-ascii characters, a suitable system locale
@@ -2745,33 +2746,33 @@ LIMITATIONS
        In a Cygwin/MSYS/Mintty window, the tab key is not supported in hledger
        add.
 
-       Not all of Ledger's journal file syntax is supported.  See file  format
+       Not  all of Ledger's journal file syntax is supported.  See file format
        differences.
 
-       On  large  data  files,  hledger  is  slower  and uses more memory than
+       On large data files, hledger  is  slower  and  uses  more  memory  than
        Ledger.
 
 TROUBLESHOOTING
-       Here are some issues you might encounter when you run hledger (and  re-
-       member  you  can  also seek help from the IRC channel, mail list or bug
+       Here  are  some  issues  you  might encounter when you run hledger (and
+       remember you can also seek help from the IRC channel, mail list or  bug
        tracker):
 
        Successfully installed, but "No command 'hledger' found"
        stack and cabal install binaries into a special directory, which should
-       be  added  to your PATH environment variable.  Eg on unix-like systems,
+       be added to your PATH environment variable.  Eg on  unix-like  systems,
        that is ~/.local/bin and ~/.cabal/bin respectively.
 
        I set a custom LEDGER_FILE, but hledger is still using the default file
-       LEDGER_FILE should be a real environment variable,  not  just  a  shell
-       variable.   The command env | grep LEDGER_FILE should show it.  You may
+       LEDGER_FILE  should  be  a  real environment variable, not just a shell
+       variable.  The command env | grep LEDGER_FILE should show it.  You  may
        need to use export.  Here's an explanation.
 
-       "Illegal byte sequence" or "Invalid or  incomplete  multibyte  or  wide
+       "Illegal  byte  sequence"  or  "Invalid or incomplete multibyte or wide
        character" errors
        In order to handle non-ascii letters and symbols (like ), hledger needs
        an appropriate locale.  This is usually configured system-wide; you can
        also configure it temporarily.  The locale may need to be one that sup-
-       ports UTF-8, if you built hledger with GHC < 7.2 (or  possibly  always,
+       ports  UTF-8,  if you built hledger with GHC < 7.2 (or possibly always,
        I'm not sure yet).
 
        Here's  an  example  of  setting  the  locale  temporarily,  on  ubuntu
@@ -2790,7 +2791,7 @@ TROUBLESHOOTING
               $ echo "export LANG=en_US.UTF-8" >>~/.bash_profile
               $ bash --login
 
-       If we preferred to use eg fr_FR.utf8, we might  have  to  install  that
+       If  we  preferred  to  use eg fr_FR.utf8, we might have to install that
        first:
 
               $ apt-get install language-pack-fr
@@ -2811,7 +2812,7 @@ TROUBLESHOOTING
 
 
 REPORTING BUGS
-       Report bugs at http://bugs.hledger.org (or on the #hledger IRC  channel
+       Report  bugs at http://bugs.hledger.org (or on the #hledger IRC channel
        or hledger mail list)
 
 
@@ -2825,7 +2826,7 @@ COPYRIGHT
 
 
 SEE ALSO
-       hledger(1),      hledger-ui(1),     hledger-web(1),     hledger-api(1),
+       hledger(1),     hledger-ui(1),     hledger-web(1),      hledger-api(1),
        hledger_csv(5), hledger_journal(5), hledger_timeclock(5), hledger_time-
        dot(5), ledger(1)
 


### PR DESCRIPTION
Two small pieces in this PR:

1. Update to latest output of 'Shake manuals ; stack build', starting from a clean checkout. This was run to ensure environment was working, and was thought to be a prerequisite for any docs work.
2. Update the two files in doc/mockups that had yyyy/mm/dd formatting to use ISO yyyy-mm-dd formatting.