### PR TITLE
Bugfix in timeclock format parsing

### DIFF
--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -99,7 +99,7 @@ timeclockfilep = do many timeclockitemp
       timeclockitemp = choice [
                             void (lift emptyorcommentlinep)
                           , timeclockentryp >>= \e -> modify' (\j -> j{jparsetimeclockentries = e : jparsetimeclockentries j})
-                          ] <?> "timeclock entry, or default year or historical price directive"
+                          ] <?> "timeclock entry, comment line, or empty line"
 
 -- | Parse a timeclock entry.
 timeclockentryp :: JournalParser m TimeclockEntry

--- a/tests/timeclock.test
+++ b/tests/timeclock.test
@@ -1,6 +1,5 @@
 # 1. a timeclock session is parsed as a similarly-named transaction with one virtual posting
-hledger -f - print
-<<<
+<
 i 2009/1/1 08:00:00
 o 2009/1/1 09:00:00 stuff on checkout record  is ignored
 
@@ -8,7 +7,8 @@ i 2009/1/2 08:00:00 account name
 o 2009/1/2 09:00:00
 i 2009/1/3 08:00:00 some:account name  and a description
 o 2009/1/3 09:00:00
->>>
+$ hledger -f - print
+>
 2009-01-01 * 08:00-09:00
     ()           1.00h
 
@@ -18,11 +18,41 @@ o 2009/1/3 09:00:00
 2009-01-03 * and a description
     (some:account name)           1.00h
 
->>>2
->>>= 0
+>2
+>= 0
+
+# For a missing clock-out, now is implied
+<
+i 2020/1/1 08:00
+$ hledger -f - balance
+> /./
+>= 0
+
+# For a log not starting with clock-out, print error
+<
+o 2020/1/1 08:00
+$ hledger -f - balance
+>2 /line 1: expected timeclock code i/
+>= !0
+
+# For a different log starting not with clock-out, print error
+<
+o 2020/1/1 08:00
+o 2020/1/1 09:00
+$ hledger -f - balance
+>2 /line 1: expected timeclock code i/
+>= !0
+
+# For two consecutive clock-in, print error
+<
+i 2020/1/1 08:00
+i 2020/1/1 09:00
+$ hledger -f - balance
+>2 /line 2: expected timeclock code o/
+>= !0
 
 ## TODO
-## 2. multi-day sessions get a new transaction for each day
+## multi-day sessions get a new transaction for each day
 #hledger -f- print
 #<<<
 #i 2017/04/20 09:00:00 A
@@ -35,7 +65,7 @@ o 2009/1/3 09:00:00
 #>>>2
 #>>>=
 #
-## 3. unclosed sessions are automatically closed at report time
+## unclosed sessions are automatically closed at report time
 ## TODO this output looks wrong
 #hledger -f- print
 #<<<
@@ -70,7 +100,6 @@ o 2009/1/3 09:00:00
 #>>>2
 #>>>=
 
-# 4. 
 
 # ledger timeclock example from #ledger
 # ==== consulting.timeclock


### PR DESCRIPTION
This should close #1169

Handle cases in timeclock format where a `i` line comes after an `i` line or an `o` line comes after an `o` line. See the shelltests which I added for details.