### PR TITLE
;doc: update shell output in hledger*/*.m4.md to use ISO date formatting

### DIFF
--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -72,7 +72,7 @@ date-format  %d/%m/%Y
 ```
 ```shell
 $ hledger print -f basic.csv
-2019/11/12 Foo
+2019-11-12 Foo
     expenses:unknown           10.23
     income:unknown            -10.23
 
@@ -119,11 +119,11 @@ account1  assets:bank:boi:checking
 ```
 ```shell
 $ hledger -f bankofireland-checking.csv print
-2012/12/07 LODGMENT       529898
+2012-12-07 LODGMENT       529898
     assets:bank:boi:checking         EUR10.0 = EUR131.2
     income:unknown                  EUR-10.0
 
-2012/12/07 PAYMENT
+2012-12-07 PAYMENT
     assets:bank:boi:checking         EUR-5.0 = EUR126.0
     expenses:unknown                  EUR5.0
 
@@ -184,11 +184,11 @@ if ,\$[1-9][.0-9]+(,[^,]*){1}$
 ```
 ```shell
 $ hledger -f amazon-orders.csv print
-2012/07/29 (16000000000000DGLNJPI1P9B8DKPVHL) To Foo.  ; status:Completed
+2012-07-29 (16000000000000DGLNJPI1P9B8DKPVHL) To Foo.  ; status:Completed
     assets:amazon
     expenses:misc          $20.00
 
-2012/07/30 (17LA58JSKRD4HDGLNJPI1P9B8DKPVHL) To Adapteva, Inc.  ; status:Completed
+2012-07-30 (17LA58JSKRD4HDGLNJPI1P9B8DKPVHL) To Adapteva, Inc.  ; status:Completed
     assets:amazon
     expenses:misc          $25.00
     expenses:fees           $1.00
@@ -326,32 +326,32 @@ if Google
 
 ```shell
 $ hledger -f paypal-custom.csv  print
-2019/10/01 (60P57143A8206782E) Calm Radio MONTHLY - $1 for the first 2 Months: Me - Order 99309. Item total: $1.00 USD first 2 months, then $6.99 / Month  ; itemid:, fromemail:simon@joyful.com, toemail:memberships@calmradio.com, time:03:46:20, type:Subscription Payment, status:Completed
+2019-10-01 (60P57143A8206782E) Calm Radio MONTHLY - $1 for the first 2 Months: Me - Order 99309. Item total: $1.00 USD first 2 months, then $6.99 / Month  ; itemid:, fromemail:simon@joyful.com, toemail:memberships@calmradio.com, time:03:46:20, type:Subscription Payment, status:Completed
     assets:online:paypal          $-6.99 = $-6.99
     expenses:online:apps           $6.99
 
-2019/10/01 (0TU1544T080463733) Bank Deposit to PP Account for 60P57143A8206782E  ; itemid:, fromemail:, toemail:simon@joyful.com, time:03:46:20, type:Bank Deposit to PP Account, status:Pending
+2019-10-01 (0TU1544T080463733) Bank Deposit to PP Account for 60P57143A8206782E  ; itemid:, fromemail:, toemail:simon@joyful.com, time:03:46:20, type:Bank Deposit to PP Account, status:Pending
     assets:online:paypal               $6.99 = $0.00
     assets:bank:wf:pchecking          $-6.99
 
-2019/10/01 (2722394R5F586712G) Patreon Patreon* Membership  ; itemid:, fromemail:simon@joyful.com, toemail:support@patreon.com, time:08:57:01, type:PreApproved Payment Bill User Payment, status:Completed
+2019-10-01 (2722394R5F586712G) Patreon Patreon* Membership  ; itemid:, fromemail:simon@joyful.com, toemail:support@patreon.com, time:08:57:01, type:PreApproved Payment Bill User Payment, status:Completed
     assets:online:paypal          $-7.00 = $-7.00
     expenses:dues                  $7.00
 
-2019/10/01 (71854087RG994194F) Bank Deposit to PP Account for 2722394R5F586712G Patreon* Membership  ; itemid:, fromemail:, toemail:simon@joyful.com, time:08:57:01, type:Bank Deposit to PP Account, status:Pending
+2019-10-01 (71854087RG994194F) Bank Deposit to PP Account for 2722394R5F586712G Patreon* Membership  ; itemid:, fromemail:, toemail:simon@joyful.com, time:08:57:01, type:Bank Deposit to PP Account, status:Pending
     assets:online:paypal               $7.00 = $0.00
     assets:bank:wf:pchecking          $-7.00
 
-2019/10/19 (K9U43044RY432050M) Wikimedia Foundation, Inc. Monthly donation to the Wikimedia Foundation  ; itemid:, fromemail:simon@joyful.com, toemail:tle@wikimedia.org, time:03:02:12, type:Subscription Payment, status:Completed
+2019-10-19 (K9U43044RY432050M) Wikimedia Foundation, Inc. Monthly donation to the Wikimedia Foundation  ; itemid:, fromemail:simon@joyful.com, toemail:tle@wikimedia.org, time:03:02:12, type:Subscription Payment, status:Completed
     assets:online:paypal             $-2.00 = $-2.00
     expenses:dues                     $2.00
     expenses:banking:paypal      ; business:
 
-2019/10/19 (3XJ107139A851061F) Bank Deposit to PP Account for K9U43044RY432050M  ; itemid:, fromemail:, toemail:simon@joyful.com, time:03:02:12, type:Bank Deposit to PP Account, status:Pending
+2019-10-19 (3XJ107139A851061F) Bank Deposit to PP Account for K9U43044RY432050M  ; itemid:, fromemail:, toemail:simon@joyful.com, time:03:02:12, type:Bank Deposit to PP Account, status:Pending
     assets:online:paypal               $2.00 = $0.00
     assets:bank:wf:pchecking          $-2.00
 
-2019/10/22 (6L8L1662YP1334033) Noble Benefactor Joyful Systems  ; itemid:, fromemail:noble@bene.fac.tor, toemail:simon@joyful.com, time:05:07:06, type:Subscription Payment, status:Completed
+2019-10-22 (6L8L1662YP1334033) Noble Benefactor Joyful Systems  ; itemid:, fromemail:noble@bene.fac.tor, toemail:simon@joyful.com, time:05:07:06, type:Subscription Payment, status:Completed
     assets:online:paypal                       $9.41 = $9.41
     revenues:foss donations:darcshub         $-10.00  ; business:
     expenses:banking:paypal                    $0.59  ; business:

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -137,12 +137,12 @@ primary date if unspecified.
 
 ```shell
 $ hledger register checking
-2010/02/23 movie ticket         assets:checking                $-10         $-10
+2010-02-23 movie ticket         assets:checking                $-10         $-10
 ```
 
 ```shell
 $ hledger register checking --date2
-2010/02/19 movie ticket         assets:checking                $-10         $-10
+2010-02-19 movie ticket         assets:checking                $-10         $-10
 ```
 
 Secondary dates require some effort; you must use them consistently in
@@ -168,12 +168,12 @@ be reported on 6/1 for easy bank reconciliation:
 
 ```shell
 $ hledger -f t.j register food
-2015/05/30                      expenses:food                  $10           $10
+2015-05-30                      expenses:food                  $10           $10
 ```
 
 ```shell
 $ hledger -f t.j register checking
-2015/06/01                      assets:checking               $-10          $-10
+2015-06-01                      assets:checking               $-10          $-10
 ```
 
 DATE should be a [simple date](#simple-dates); if the year is not
@@ -567,7 +567,7 @@ will cause the calculated amount to have that price attached:
 ```
 ```
 $ hledger print --explicit
-2019/01/01
+2019-01-01
     (a)         $1 @ €2 = $1 @ €2
 ```
 
@@ -1389,12 +1389,12 @@ Some examples:
 ```
 ```shell
 $ hledger print --auto
-2017/12/01
+2017-12-01
     expenses:food              $10
     assets:checking
     (liabilities:charity)      $-1
 
-2017/12/14
+2017-12-14
     expenses:gifts             $20
     assets:checking
     assets:checking:gifts     -$20

--- a/hledger-lib/hledger_timeclock.m4.md
+++ b/hledger-lib/hledger_timeclock.m4.md
@@ -39,13 +39,13 @@ the above time log, `hledger print` generates these journal entries:
 
 ``` shell
 $ hledger -f t.timeclock print
-2015/03/30 * optional description after two spaces
+2015-03-30 * optional description after two spaces
     (some:account name)         0.33h
 
-2015/03/31 * 22:21-23:59
+2015-03-31 * 22:21-23:59
     (another account)         1.64h
 
-2015/04/01 * 00:00-02:00
+2015-04-01 * 00:00-02:00
     (another account)         2.01h
 
 ```

--- a/hledger-lib/hledger_timedot.m4.md
+++ b/hledger-lib/hledger_timedot.m4.md
@@ -76,17 +76,17 @@ Reporting:
 
 ```shell
 $ hledger -f t.timedot print date:2016/2/2
-2016/02/02 *
+2016-02-02 *
     (inc:client1)          2.00
 
-2016/02/02 *
+2016-02-02 *
     (biz:research)          0.25
 ```
 ```shell
 $ hledger -f t.timedot bal --daily --tree
-Balance changes in 2016/02/01-2016/02/03:
+Balance changes in 2016-02-01-2016-02-03:
 
-            ||  2016/02/01d  2016/02/02d  2016/02/03d 
+            ||  2016-02-01d  2016-02-02d  2016-02-03d 
 ============++========================================
  biz        ||         0.25         0.25         1.00 
    research ||         0.25         0.25         1.00 

--- a/hledger/hledger_examples.m4.md
+++ b/hledger/hledger_examples.m4.md
@@ -20,11 +20,11 @@ Some basic reports:
 
 ```shell
 $ hledger print
-2015/09/30 gift received
+2015-09-30 gift received
     assets:cash            $20
     income:gifts          $-20
 
-2015/10/16 farmers market
+2015-10-16 farmers market
     expenses:food           $10
     assets:cash            $-10
 ```
@@ -50,8 +50,8 @@ $ hledger balance
 
 ```shell
 $ hledger register cash
-2015/09/30 gift received   assets:cash               $20           $20
-2015/10/16 farmers market  assets:cash              $-10           $10
+2015-09-30 gift received   assets:cash               $20           $20
+2015-10-16 farmers market  assets:cash              $-10           $10
 ```
 
 More commands:

--- a/hledger/hledger_options.m4.md
+++ b/hledger/hledger_options.m4.md
@@ -606,13 +606,13 @@ P 2000-04-01 A  4 B
 Show the cost of each posting:
 ```shell
 $ hledger -f- print --value=cost
-2000/01/01
+2000-01-01
     (a)             5 B
 
-2000/02/01
+2000-02-01
     (a)             6 B
 
-2000/03/01
+2000-03-01
     (a)             7 B
 
 ```
@@ -631,13 +631,13 @@ $ hledger -f- print --value=end date:2000/01-2000/03
 With no report period specified, that shows the value as of the last day of the journal (2000-03-01):
 ```shell
 $ hledger -f- print --value=end
-2000/01/01
+2000-01-01
     (a)             3 B
 
-2000/02/01
+2000-02-01
     (a)             3 B
 
-2000/03/01
+2000-03-01
     (a)             3 B
 
 ```
@@ -659,13 +659,13 @@ $ hledger -f- print --value=now
 Show the value on 2000/01/15:
 ```shell
 $ hledger -f- print --value=2000-01-15
-2000/01/01
+2000-01-01
     (a)             1 B
 
-2000/02/01
+2000-02-01
     (a)             1 B
 
-2000/03/01
+2000-03-01
     (a)             1 B
 
 ```
@@ -681,7 +681,7 @@ P 2000-01-01 A 2B
 ```
 ```
 $ hledger print -x -X A
-2000/01/01
+2000-01-01
     a               0
     b               0
 
@@ -700,7 +700,7 @@ commodity 0.00A
 ```
 ```
 $ hledger print -X A
-2000/01/01
+2000-01-01
     a           0.50A
     b          -0.50A
 


### PR DESCRIPTION
Note that this PR does not change the bodies of these files to use yyyy-mm-dd formatting; some yyyy/mm/dd remain there, subject to discussion.