### PR TITLE
web: Add IPv6 support

### DIFF
--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -16,7 +16,7 @@ import qualified Data.Text as T
 import Network.Socket
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp (runSettings, runSettingsSocket, defaultSettings, setHost, setPort)
-import Network.Wai.Handler.Launch (runHostPortUrl)
+import Network.Wai.Handler.Launch (runHostPortFullUrl)
 import Prelude hiding (putStrLn)
 import System.Directory (removeFile)
 import System.Exit (exitSuccess, exitFailure)
@@ -106,5 +106,5 @@ web opts j = do
       putStrLn "Opening web browser..."
       hFlush stdout
       -- exits after 2m of inactivity (hardcoded)
-      Network.Wai.Handler.Launch.runHostPortUrl h p "" app
+      Network.Wai.Handler.Launch.runHostPortFullUrl h p u app
 

--- a/hledger-web/Hledger/Web/Settings.hs
+++ b/hledger-web/Hledger/Web/Settings.hs
@@ -45,7 +45,10 @@ defport = 5000
 
 defbaseurl :: String -> Int -> String
 defbaseurl host port =
-  "http://" ++ host ++ if port /= 80 then ":" ++ show port else ""
+  if ':' `elem` host then
+    "http://[" ++ host ++ "]" ++ if port /= 80 then ":" ++ show port else ""
+  else
+    "http://" ++ host ++ if port /= 80 then ":" ++ show port else ""
 
 -- Static setting below. Changing these requires a recompile
 

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -158,11 +158,7 @@ rawOptsToWebOpts rawopts =
     stripTrailingSlash = reverse . dropWhile (== '/') . reverse -- yesod don't like it
 
 checkWebOpts :: WebOpts -> WebOpts
-checkWebOpts wopts = do
-  let h = host_ wopts
-  if any (`notElem` (".0123456789" :: String)) h
-    then usageError $ "--host requires an IP address, not " ++ show h
-    else wopts
+checkWebOpts = id
 
 getHledgerWebOpts :: IO WebOpts
 getHledgerWebOpts = do

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.32.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cbf332de4147396a82198ccf5173db10b775ed99f9830e89aea475bfd4da5a7f
+-- hash: 0376acf91d14e3868fa58b399419538104d2187ad41552aa62bd24ca675274b3
 
 name:           hledger-web
 version:        1.16.99
@@ -188,7 +188,7 @@ library
     , wai
     , wai-cors
     , wai-extra
-    , wai-handler-launch >=1.3
+    , wai-handler-launch >=3.0.3
     , warp
     , yaml
     , yesod >=1.4 && <1.7

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -131,7 +131,7 @@ library:
   - utf8-string
   - wai
   - wai-extra
-  - wai-handler-launch >=1.3
+  - wai-handler-launch >=3.0.3
   - wai-cors
   - warp
   - yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,3 +18,4 @@ extra-deps:
 # for hledger:
 # for hledger-ui:
 # for hledger-web:
+- wai-handler-launch-3.0.3


### PR DESCRIPTION
# Motivation

This PR closes #1145. It allows `hledger-web` to be reachable over IPv6, e.g. by calling it like
```
hledger-web --host ::1
```

# Changes

 - Modify the `--host` validation in `hledger-web/Hledger/Web/WebOptions.hs` to allow IPv6 addresses
 - Modifies the default base URL to surround the host in `[` and `]` if an IPv6 address is used (required for proper IPv6-URLs in the browser)

# Problems

 - `Network.Wai.Handler.Launch.runHostPortUrl` uses the hardcoded host `127.0.0.1` to launch the browser. **Until there is a solution for https://github.com/yesodweb/wai-handlers/issues/1, this PR should probably not be merged, as the server is not reachable over the URL that is opened**
   - This problem is not relevant if `--serve` is used.
 - Not tested with [IPv4-mapped addresses](https://en.wikipedia.org/wiki/IPv6#IPv4-mapped_IPv6_addresses)