### PR TITLE
json: use a simpler, more consumable number representation

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -806,14 +806,16 @@ Some notes about JSON output:
   instead of FOO's full details. This should never happen in hledger's
   JSON output; if you see otherwise, please report as a bug.
 
-- Quantities are represented in hledger as Decimal values storing up
-  to 255 significant digits, eg for repeating decimals. This is too
-  many digits and too much hassle for most JSON users, so in JSON we
-  show simple Numbers with up to 10 decimal places. The number of
-  significant digits is still unbounded, but that part is under your
-  control. We hope this approach will not cause problems in practice;
-  if you find otherwise, please let us know. (Cf
-  [#1195](https://github.com/simonmichael/hledger/issues/1195))
+- hledger represents quantities as Decimal values storing up to 255
+  significant digits, eg for repeating decimals. Such numbers can
+  arise in practice (from automatically-calculated transaction
+  prices), and would break most JSON consumers. So in JSON, we show
+  quantities as simple Numbers with at most 10 decimal places. We
+  don't limit the number of integer digits, but that part is under
+  your control.
+  We hope this approach will not cause problems in practice; if you
+  find otherwise, please let us know. 
+  (Cf [#1195](https://github.com/simonmichael/hledger/issues/1195))
 
 ## Regular expressions
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -801,11 +801,19 @@ Some notes about JSON output:
 - The JSON output from hledger commands is essentially the same as the
   JSON served by [hledger-web's JSON API](hledger-web.html#json-api),
   but pretty printed, using line breaks and indentation.
-
-- Our pretty printer has the ability to elide data in certain cases -
+  Our pretty printer has the ability to elide data in certain cases -
   rendering non-strings as if they were strings, or displaying "FOO.."
   instead of FOO's full details. This should never happen in hledger's
   JSON output; if you see otherwise, please report as a bug.
+
+- Quantities are represented in hledger as Decimal values storing up
+  to 255 significant digits, eg for repeating decimals. This is too
+  many digits and too much hassle for most JSON users, so in JSON we
+  show simple Numbers with up to 10 decimal places. The number of
+  significant digits is still unbounded, but that part is under your
+  control. We hope this approach will not cause problems in practice;
+  if you find otherwise, please let us know. (Cf
+  [#1195](https://github.com/simonmichael/hledger/issues/1195))
 
 ## Regular expressions
 


### PR DESCRIPTION
A proposed fix for #1195:

> Amounts in JSON are now rendered as simple Numbers with up to 10
decimal places, instead of Decimal objects which would in some cases
have 255 digits, too many for most JSON parsers to handle.
A provisional fix, see the comment in Json.hs for more detail.