### PR TITLE
more org support in timedot; drop format auto-detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,6 +330,13 @@ ghcid-test-%: $(call def-help,ghcid-test-TESTPATTERN, start ghcid autobuilding a
 ghcid-doctest: $(call def-help,ghcid-doctest, start ghcid autobuilding and running hledger-lib doctests)
 	ghcid -c 'cd hledger-lib; $(STACK) ghci hledger-lib:test:doctest' --test ':main' --reload hledger-lib
 
+GHCIDRESTART=--restart Makefile --restart Makefile.local
+GHCIDRELOAD=--reload t.j --reload t.timedot
+GHCIDCMD=:main -f t.j bal date:today -S
+
+ghcid-watch watch: $(call def-help,ghcid-watch, start ghcid autobuilding and running a custom GHCI command with reload/restart on certain files - customise this)
+	ghcid -c 'make ghci' --test '$(GHCIDCMD)' $(GHCIDRELOAD) $(GHCIDRESTART)
+
 # keep synced with Shake.hs header
 SHAKEDEPS= \
 	--package base-prelude \

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -1003,13 +1003,14 @@ multilinecommentp = startComment *> anyLine `skipManyTill` endComment
 
 {-# INLINABLE multilinecommentp #-}
 
+-- | A blank or comment line in journal format: a line that's empty or
+-- containing only whitespace or whose first non-whitespace character
+-- is semicolon, hash, or star.
 emptyorcommentlinep :: TextParser m ()
 emptyorcommentlinep = do
   skipMany spacenonewline
   skiplinecommentp <|> void newline
   where
-    -- A line (file-level) comment can start with a semicolon, hash, or star
-    -- (allowing org nodes).
     skiplinecommentp :: TextParser m ()
     skiplinecommentp = do
       satisfy $ \c -> c == ';' || c == '#' || c == '*'

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -50,7 +50,7 @@ import qualified "base-compat-batteries" Control.Monad.Fail.Compat as Fail (fail
 import Control.Exception          (IOException, handle, throw)
 import Control.Monad              (liftM, unless, when)
 import Control.Monad.Except       (ExceptT, throwError)
-import Control.Monad.IO.Class     (liftIO)
+import Control.Monad.IO.Class     (MonadIO, liftIO)
 import Control.Monad.State.Strict (StateT, get, modify', evalStateT)
 import Control.Monad.Trans.Class  (lift)
 import Data.Char                  (toLower, isDigit, isSpace, ord)
@@ -95,12 +95,12 @@ type CsvValue  = String
 
 -- ** reader
 
-reader :: Reader
+reader :: MonadIO m => Reader m
 reader = Reader
   {rFormat     = "csv"
   ,rExtensions = ["csv","tsv","ssv"]
-  ,rParser     = parse
-  ,rExperimental = False
+  ,rReadFn     = parse
+  ,rParser    = error' "sorry, CSV files can't be included yet"
   }
 
 -- | Parse and post-process a "Journal" from CSV data, or give an error.

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -78,12 +78,12 @@ import           Hledger.Utils
 
 -- ** reader
 
-reader :: Reader
+reader :: MonadIO m => Reader m
 reader = Reader
   {rFormat     = "timeclock"
   ,rExtensions = ["timeclock"]
-  ,rParser     = parse
-  ,rExperimental = False
+  ,rReadFn     = parse
+  ,rParser    = timeclockfilep
   }
 
 -- | Parse and post-process a "Journal" from timeclock.el's timeclock

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -63,12 +63,12 @@ import Hledger.Utils
 
 -- ** reader
 
-reader :: Reader
+reader :: MonadIO m => Reader m
 reader = Reader
   {rFormat     = "timedot"
   ,rExtensions = ["timedot"]
-  ,rParser     = parse
-  ,rExperimental = False
+  ,rReadFn     = parse
+  ,rParser    = timedotp
   }
 
 -- | Parse and post-process a "Journal" from the timedot format, or give an error.

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -87,21 +87,26 @@ timedotfilep :: JournalParser m ParsedJournal
 timedotfilep = do many timedotfileitemp
                   eof
                   get
-    where
-      timedotfileitemp :: JournalParser m ()
-      timedotfileitemp = do
-        traceparse "timedotfileitemp"
-        choice [
-          void $ lift emptyorcommentlinep
-         ,timedotdayp >>= \ts -> modify' (addTransactions ts)
-         ] <?> "timedot day entry, or default year or comment line or blank line"
+
+timedotfileitemp :: JournalParser m ()
+timedotfileitemp = do
+  traceparse "timedotfileitemp"
+  choice [
+    try $ void $ lift emptyorcommentlinep'
+   ,try timedotdayp >>= \ts -> modify' (addTransactions ts)
+   ,lift $ skipSome anySingle >> eolof  -- an initial line not beginning with a date, ignore
+   ] <?> "timedot day entry, or default year or comment line or blank line"
 
 addTransactions :: [Transaction] -> Journal -> Journal
 addTransactions ts j = foldl' (flip ($)) j (map addTransaction ts)
 
+emptyorcommentlinep' = optional orgheadingprefixp >> emptyorcommentlinep
+
+orgheadingprefixp = skipSome (char '*') >> skipSome spacenonewline
+
 -- | Parse timedot day entries to zero or more time transactions for that day.
 -- @
--- 2/1
+-- 2020/2/1 optional day description
 -- fos.haskell  .... ..
 -- biz.research .
 -- inc.client1  .... .... .... .... .... ....
@@ -109,8 +114,9 @@ addTransactions ts j = foldl' (flip ($)) j (map addTransaction ts)
 timedotdayp :: JournalParser m [Transaction]
 timedotdayp = do
   traceparse " timedotdayp"
+  lift $ optional orgheadingprefixp
   d <- datep <* lift eolof
-  es <- catMaybes <$> many (const Nothing <$> try (lift emptyorcommentlinep) <|>
+  es <- catMaybes <$> many (const Nothing <$> try (lift emptyorcommentlinep') <|>
                             Just <$> (notFollowedBy datep >> timedotentryp))
   return $ map (\t -> t{tdate=d}) es -- <$> many timedotentryp
 
@@ -122,7 +128,7 @@ timedotentryp :: JournalParser m Transaction
 timedotentryp = do
   traceparse "  timedotentryp"
   pos <- genericSourcePos <$> getSourcePos
-  lift (skipMany spacenonewline)
+  lift $ optional $ choice [orgheadingprefixp, skipSome spacenonewline]
   a <- modifiedaccountnamep
   lift (skipMany spacenonewline)
   hours <-

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -51,14 +51,14 @@ import Control.Monad.Except (ExceptT)
 import Control.Monad.State.Strict
 import Data.Char (isSpace)
 import Data.List (foldl')
-import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Time (Day)
 import Text.Megaparsec hiding (parse)
 import Text.Megaparsec.Char
 
 import Hledger.Data
-import Hledger.Read.Common
+import Hledger.Read.Common hiding (emptyorcommentlinep)
 import Hledger.Utils
 
 -- ** reader
@@ -73,37 +73,56 @@ reader = Reader
 
 -- | Parse and post-process a "Journal" from the timedot format, or give an error.
 parse :: InputOpts -> FilePath -> Text -> ExceptT String IO Journal
-parse = parseAndFinaliseJournal' timedotfilep
+parse = parseAndFinaliseJournal' timedotp
 
 -- ** utilities
 
-traceparse :: Monad m => a -> m a
-traceparse = return
--- traceparse :: String -> JournalParser m ()
--- traceparse = lift.traceParse
+traceparse :: String -> TextParser m ()
+traceparse = const $ return ()
+-- traceparse = traceParse  -- for debugging
 
 -- ** parsers
+{-
+Rough grammar for timedot format:
 
-timedotfilep :: JournalParser m ParsedJournal
-timedotfilep = do many timedotfileitemp
-                  eof
-                  get
+timedot:           preamble day*
+preamble:          (emptyline | commentline | orgheading)*
+orgheading:        orgheadingprefix restofline
+day:               dateline entry* (emptyline | commentline)*
+dateline:          orgheadingprefix? date description?
+orgheadingprefix:  star+ space+
+description:       restofline  ; till semicolon?
+entry:          orgheadingprefix? space* singlespaced (doublespace quantity?)?
+doublespace:       space space+
+quantity:          (dot (dot | space)* | number | number unit)
 
-timedotfileitemp :: JournalParser m ()
-timedotfileitemp = do
-  traceparse "timedotfileitemp"
-  choice [
-    try $ void $ lift emptyorcommentlinep'
-   ,try timedotdayp >>= \ts -> modify' (addTransactions ts)
-   ,lift $ skipSome anySingle >> eolof  -- an initial line not beginning with a date, ignore
-   ] <?> "timedot day entry, or default year or comment line or blank line"
+Date lines and item lines can begin with an org heading prefix, which is ignored.
+Org headings before the first date line are ignored, regardless of content.
+-}
 
-addTransactions :: [Transaction] -> Journal -> Journal
-addTransactions ts j = foldl' (flip ($)) j (map addTransaction ts)
+timedotfilep = timedotp -- XXX rename export above
 
-emptyorcommentlinep' = optional orgheadingprefixp >> emptyorcommentlinep
+timedotp :: JournalParser m ParsedJournal
+timedotp = preamblep >> many dayp >> eof >> get
 
-orgheadingprefixp = skipSome (char '*') >> skipSome spacenonewline
+preamblep :: JournalParser m ()
+preamblep = do
+  lift $ traceparse "preamblep"
+  void $ many $ notFollowedBy datelinep >> (lift $ emptyorcommentlinep "#;*")
+
+-- | XXX new comment line parser, move to Hledger.Read.Common.emptyorcommentlinep
+-- Parse empty lines, all-blank lines, and lines beginning with any of the provided
+-- comment-beginning characters.
+emptyorcommentlinep :: [Char] -> TextParser m ()
+emptyorcommentlinep cs =
+  label ("empty line or comment line beginning with "++cs) $ do
+    traceparse "emptyorcommentlinep" -- XXX possible to combine label and traceparse ?
+    skipMany spacenonewline
+    void newline <|> void commentp
+    where
+      commentp = do
+        choice (map (some.char) cs)
+        takeWhileP Nothing (/='\n') <* newline
 
 -- | Parse timedot day entries to zero or more time transactions for that day.
 -- @
@@ -112,30 +131,50 @@ orgheadingprefixp = skipSome (char '*') >> skipSome spacenonewline
 -- biz.research .
 -- inc.client1  .... .... .... .... .... ....
 -- @
-timedotdayp :: JournalParser m [Transaction]
-timedotdayp = do
-  traceparse " timedotdayp"
+dayp :: JournalParser m ()
+dayp = label "timedot day entry" $ do
+  lift $ traceparse "dayp"
+  (d,desc) <- datelinep
+  ts <- many entryp
+  let ts' = map (\t -> t{tdate=d, tdescription=desc}) ts
+  modify' $ addTransactions ts'
+  void $ many $
+    (lift $ emptyorcommentlinep "#;") <|> orgnondatelinep
+  where
+    addTransactions :: [Transaction] -> Journal -> Journal
+    addTransactions ts j = foldl' (flip ($)) j (map addTransaction ts)
+
+datelinep :: JournalParser m (Day,Text)
+datelinep = do
+  lift $ traceparse "datelinep"
   lift $ optional orgheadingprefixp
   d <- datep
-  daydesc <- strip <$> lift restofline
-  es <- catMaybes <$> many (const Nothing <$> try (lift emptyorcommentlinep') <|>
-                            Just <$> (notFollowedBy datep >> timedotentryp))
-  return $ map (\t -> t{tdate=d, tdescription=T.pack daydesc}) es -- <$> many timedotentryp
+  desc <- strip <$> lift restofline
+  return (d, T.pack desc)
+
+orgnondatelinep :: JournalParser m ()
+orgnondatelinep = do
+  lift $ traceparse "orgnondatelinep"
+  notFollowedBy datelinep
+  lift orgheadingprefixp
+  void $ lift restofline
+
+orgheadingprefixp = skipSome (char '*') >> skipSome spacenonewline
 
 -- | Parse a single timedot entry to one (dateless) transaction.
 -- @
 -- fos.haskell  .... ..
 -- @
-timedotentryp :: JournalParser m Transaction
-timedotentryp = do
-  traceparse "  timedotentryp"
+entryp :: JournalParser m Transaction
+entryp = do
+  lift $ traceparse "  entryp"
   pos <- genericSourcePos <$> getSourcePos
   lift $ optional $ choice [orgheadingprefixp, skipSome spacenonewline]
   a <- modifiedaccountnamep
   lift (skipMany spacenonewline)
   hours <-
     try (lift followingcommentp >> return 0)
-    <|> (timedotdurationp <*
+    <|> (durationp <*
          (try (lift followingcommentp) <|> (newline >> return "")))
   let t = nulltransaction{
         tsourcepos = pos,
@@ -150,8 +189,8 @@ timedotentryp = do
         }
   return t
 
-timedotdurationp :: JournalParser m Quantity
-timedotdurationp = try timedotnumericp <|> timedotdotsp
+durationp :: JournalParser m Quantity
+durationp = try numericquantityp <|> dotquantityp
 
 -- | Parse a duration of seconds, minutes, hours, days, weeks, months or years,
 -- written as a decimal number followed by s, m, h, d, w, mo or y, assuming h
@@ -162,8 +201,8 @@ timedotdurationp = try timedotnumericp <|> timedotdotsp
 -- 1.5h
 -- 90m
 -- @
-timedotnumericp :: JournalParser m Quantity
-timedotnumericp = do
+numericquantityp :: JournalParser m Quantity
+numericquantityp = do
   (q, _, _, _) <- lift $ numberp Nothing
   msymbol <- optional $ choice $ map (string . fst) timeUnits
   lift (skipMany spacenonewline)
@@ -191,7 +230,7 @@ timeUnits =
 -- @
 -- .... ..
 -- @
-timedotdotsp :: JournalParser m Quantity
-timedotdotsp = do
+dotquantityp :: JournalParser m Quantity
+dotquantityp = do
   dots <- filter (not.isSpace) <$> many (oneOf (". " :: [Char]))
   return $ (/4) $ fromIntegral $ length dots

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -53,6 +53,7 @@ import Data.Char (isSpace)
 import Data.List (foldl')
 import Data.Maybe
 import Data.Text (Text)
+import qualified Data.Text as T
 import Text.Megaparsec hiding (parse)
 import Text.Megaparsec.Char
 
@@ -115,10 +116,11 @@ timedotdayp :: JournalParser m [Transaction]
 timedotdayp = do
   traceparse " timedotdayp"
   lift $ optional orgheadingprefixp
-  d <- datep <* lift eolof
+  d <- datep
+  daydesc <- strip <$> lift restofline
   es <- catMaybes <$> many (const Nothing <$> try (lift emptyorcommentlinep') <|>
                             Just <$> (notFollowedBy datep >> timedotentryp))
-  return $ map (\t -> t{tdate=d}) es -- <$> many timedotentryp
+  return $ map (\t -> t{tdate=d, tdescription=T.pack daydesc}) es -- <$> many timedotentryp
 
 -- | Parse a single timedot entry to one (dateless) transaction.
 -- @

--- a/hledger-lib/Hledger/Utils/Debug.hs
+++ b/hledger-lib/Hledger/Utils/Debug.hs
@@ -204,8 +204,8 @@ dbg9With = ptraceAtWith 9
 dbgExit :: Show a => String -> a -> a
 dbgExit msg = const (unsafePerformIO exitFailure) . dbg0 msg
 
--- | Like ptraceAt, but convenient to insert in an IO monad (plus
--- convenience aliases).
+-- | Like ptraceAt, but convenient to insert in an IO monad and
+-- enforces monadic sequencing (plus convenience aliases).
 -- XXX These have a bug; they should use
 -- traceIO, not trace, otherwise GHC can occasionally over-optimise
 -- (cf lpaste a few days ago where it killed/blocked a child thread).

--- a/hledger-lib/hledger_timedot.m4.md
+++ b/hledger-lib/hledger_timedot.m4.md
@@ -33,7 +33,7 @@ Each timelog item generates a hledger transaction.
 
 Quantities can be written as:
 
-- time dots: a sequence of dots (.) representing quarter hours.
+- dots: a sequence of dots (.) representing quarter hours.
   Spaces may optionally be used for grouping.
   Eg: .... ..
 
@@ -56,10 +56,13 @@ right in the time log, if needed:
   items taking no time, which will not appear in balance reports by
   default. (Add -E to see them.)
 
-- Org headline prefixes (stars followed by at least one space, at the
-  start of a line) are ignored, so a timedot file can also be an org
-  outline. Emacs org mode users can use these to add structure and
-  control which parts of the file are visible.
+- Org mode headlines (lines beginning with one or more `*` followed by
+  a space) can be used as date lines or timelog items (the stars are
+  ignored). Also all org headlines before the first date line are
+  ignored. This means org users can manage their timelog as an org
+  outline (eg using org-mode/orgstruct-mode in Emacs), for
+  organisation, faster navigation, controlling visibility etc.
+
 
 Examples:
 
@@ -90,17 +93,19 @@ biz:research  1
 ```
 
 ```timedot
-** 2020-02-29
-*** DONE
+* 2020 Work Diary
+** Q1
+*** 2020-02-29
+**** DONE
 0700 yoga
-*** UNPLANNED
-*** BEGUN
+**** UNPLANNED
+**** BEGUN
 hom:chores
  cleaning  ...
  water plants
   outdoor - one full watering can
   indoor - light watering
-*** TODO
+**** TODO
 adm:planning: trip
 *** LATER
 

--- a/hledger-lib/hledger_timedot.m4.md
+++ b/hledger-lib/hledger_timedot.m4.md
@@ -22,15 +22,16 @@ so it could be used to represent dated quantities other than time.
 In the docs below we'll assume it's time.
 
 A timedot file contains a series of day entries.
-A day entry begins with a date, and is followed by category/quantity pairs, one per line.
-Dates are hledger-style [simple dates](journal.html#simple-dates) (see hledger_journal(5)).
-Categories are hledger-style account names, optionally indented.
-As in a hledger journal, there must be at least two spaces between the category (account name) and the quantity.
+A day entry begins with a non-indented hledger-style [simple date](journal.html#simple-dates) (see hledger_journal(5)).
+
+This is followed by optionally-indented timelog items for that day, one per line.
+Each timelog item is a note, usually a hledger:style:account:name representing a time category,
+followed by two or more spaces, and a quantity.
 
 Quantities can be written as:
 
-- a sequence of dots (.) representing quarter hours.
-  Spaces may optionally be used for grouping and readability.
+- time dots: a sequence of dots (.) representing quarter hours.
+  Spaces may optionally be used for grouping.
   Eg: .... ..
 
 - an integral or decimal number, representing hours.
@@ -43,8 +44,21 @@ Quantities can be written as:
   The following equivalencies are assumed, currently:
   1m = 60s, 1h = 60m, 1d = 24h, 1w = 7d, 1mo = 30d, 1y=365d.
 
-Blank lines and lines beginning with #, ; or * are ignored.
-An example:
+There is some flexibility allowing notes and todo lists to be kept
+right in the time log, if needed:
+
+- Blank lines and lines beginning with `#` or `;` are ignored.
+
+- Lines not ending with a double-space and quantity are parsed as
+  items taking no time, which will not appear in balance reports by
+  default. (Add -E to see them.)
+
+- Org headline prefixes (stars followed by at least one space, at the
+  start of a line) are ignored, so a timedot file can also be an org
+  outline. Emacs org mode users can use these to add structure and
+  control which parts of the file are visible.
+
+Examples:
 
 ```timedot
 # on this day, 6h was spent on client work, 1.5h on haskell FOSS work, etc.
@@ -58,13 +72,35 @@ inc:client1   .... ....
 biz:research  .
 ```
 
-Or with numbers:
-
 ```timedot
 2016/2/3
 inc:client1   4
 fos:hledger   3
 biz:research  1
+```
+
+```timedot
+* Time log
+** 2020-01-01
+*** adm:time  .
+*** adm:finance  .
+```
+
+```timedot
+** 2020-02-29
+*** DONE
+0700 yoga
+*** UNPLANNED
+*** BEGUN
+hom:chores
+ cleaning  ...
+ water plants
+  outdoor - one full watering can
+  indoor - light watering
+*** TODO
+adm:planning: trip
+*** LATER
+
 ```
 
 Reporting:

--- a/hledger-lib/hledger_timedot.m4.md
+++ b/hledger-lib/hledger_timedot.m4.md
@@ -22,11 +22,14 @@ so it could be used to represent dated quantities other than time.
 In the docs below we'll assume it's time.
 
 A timedot file contains a series of day entries.
-A day entry begins with a non-indented hledger-style [simple date](journal.html#simple-dates) (see hledger_journal(5)).
+A day entry begins with a non-indented hledger-style
+[simple date](journal.html#simple-dates) (Y-M-D, Y/M/D, Y.M.D..)
+Any additional text on the same line is used as a transaction description for this day.
 
 This is followed by optionally-indented timelog items for that day, one per line.
 Each timelog item is a note, usually a hledger:style:account:name representing a time category,
 followed by two or more spaces, and a quantity.
+Each timelog item generates a hledger transaction.
 
 Quantities can be written as:
 

--- a/tests/journal/parse-errors.test
+++ b/tests/journal/parse-errors.test
@@ -22,15 +22,12 @@ expecting date separator or digit
 2018/1/1
   a  1
 
-# 2. When read from stdin, this example actually passes because hledger tries all readers.
-# If they all failed, it would show the error from the first (journal reader).
-# But in this case the timedot reader can parse it.
+# 2. When read from stdin with no reader prefix, the journal reader is used,
+# and fails here. (Before 1.17, all readers were tried and the timedot reader
+# would succeed.)
 $ hledger -f - print
->
-2018-01-01 *
-    (a)            1.00
-
->=
+>2 /could not balance/
+>=1
 
 # 3. So in these tests we must sometimes force the desired format, like so.
 # Now we see the error from the journal reader.

--- a/tests/timeclock.test
+++ b/tests/timeclock.test
@@ -1,4 +1,5 @@
-# 1. a timeclock session is parsed as a similarly-named transaction with one virtual posting
+# 1. a timeclock session is parsed as a similarly-named transaction with one virtual posting.
+# Note since 1.17 we need to specify stdin's format explicitly.
 <
 i 2009/1/1 08:00:00
 o 2009/1/1 09:00:00 stuff on checkout record  is ignored
@@ -7,7 +8,7 @@ i 2009/1/2 08:00:00 account name
 o 2009/1/2 09:00:00
 i 2009/1/3 08:00:00 some:account name  and a description
 o 2009/1/3 09:00:00
-$ hledger -f - print
+$ hledger -f timeclock:- print
 >
 2009-01-01 * 08:00-09:00
     ()           1.00h
@@ -24,14 +25,14 @@ $ hledger -f - print
 # For a missing clock-out, now is implied
 <
 i 2020/1/1 08:00
-$ hledger -f - balance
+$ hledger -f timeclock:- balance
 > /./
 >= 0
 
 # For a log not starting with clock-out, print error
 <
 o 2020/1/1 08:00
-$ hledger -f - balance
+$ hledger -f timeclock:- balance
 >2 /line 1: expected timeclock code i/
 >= !0
 
@@ -39,7 +40,7 @@ $ hledger -f - balance
 <
 o 2020/1/1 08:00
 o 2020/1/1 09:00
-$ hledger -f - balance
+$ hledger -f timeclock:- balance
 >2 /line 1: expected timeclock code i/
 >= !0
 
@@ -47,13 +48,13 @@ $ hledger -f - balance
 <
 i 2020/1/1 08:00
 i 2020/1/1 09:00
-$ hledger -f - balance
+$ hledger -f timeclock:- balance
 >2 /line 2: expected timeclock code o/
 >= !0
 
 ## TODO
 ## multi-day sessions get a new transaction for each day
-#hledger -f- print
+#hledger -ftimeclock:- print
 #<<<
 #i 2017/04/20 09:00:00 A
 #o 2017/04/20 17:00:00
@@ -67,7 +68,7 @@ $ hledger -f - balance
 #
 ## unclosed sessions are automatically closed at report time
 ## TODO this output looks wrong
-#hledger -f- print
+#hledger -ftimeclock:- print
 #<<<
 #i 2017/04/20 09:00:00 A
 #o 2017/04/20 17:00:00

--- a/tests/timedot.test
+++ b/tests/timedot.test
@@ -16,3 +16,14 @@ $ hledger -f- print
 
 >=0
 
+# 2. Org mode headline prefixes are ignored.
+<
+* 2020-01-01
+** a:aa  1
+
+$ hledger -f- print
+2020-01-01 *
+    (a:aa)            1.00
+
+>=0
+

--- a/tests/timedot.test
+++ b/tests/timedot.test
@@ -1,3 +1,5 @@
+# Note since 1.17 we need to specify stdin's format explicitly.
+
 # 1. basic timedot entry
 <
 # comment
@@ -7,7 +9,7 @@
  a:aa  1
  b:bb  2
 
-$ hledger -f- print
+$ hledger -ftimedot:- print
 2020-01-01 *
     (a:aa)            1.00
 
@@ -21,7 +23,7 @@ $ hledger -f- print
 * 2020-01-01
 ** a:aa  1
 
-$ hledger -f- print
+$ hledger -ftimedot:- print
 2020-01-01 *
     (a:aa)            1.00
 


### PR DESCRIPTION
Following discussion in #hledger, here are two inter-related changes I'm considering merging, perhaps as soon as for tomorrow's 1.17 release. Though really, both of them probably need more testing than that. Here's the most disruptive one:

> For a long time hledger has auto-detected the file format when it's
not known, eg when reading from a file with unusual extension (like
.dat or .txt), or from standard input (-f-), or when using the include
directive (which currently ignores file extensions).
> 
> Auto-detecting has been done by trying all readers until one succeeds.
This could guess wrong in some cases, but it was so rare that it has
been working fine.
> 
> Recently, more conveniences have been added to timedot format,
increasing its overlap with journal format, which makes this kind of
auto-detection unreliable.
> 
> Auto-detection and auto-detection failures are (probably) still pretty
rare in practice. But when it does happen it's confusing, giving
misleading errors or false successes (eg printing timedot entries
instead of a journal error).
> 
> For predictability and to minimise confusion, hledger no longer tries
to guess; when there's no file extension or reader prefix, it assumes
journal format. To specify one of the other formats, you must use a
standard file extension (.timeclock, .timedot, .csv, .ssv, .tsv), or a
reader prefix (-f csv:foo.txt, -f timedot:-).
> 
> For now, the include directive still tries to autodetect
(journal/timeclock/timedot), and this can't be overridden; it will be
fixed later.

Please let me know what you think. And test for impact on your local scripts and command line UX, if possible. This could add some inconvenience.