### PR TITLE
simpler, more flexible generation of postings from csv

### DIFF
--- a/hledger-lib/hledger_csv.5
+++ b/hledger-lib/hledger_csv.5
@@ -494,6 +494,9 @@ with that account name.
 .PP
 Most often there are two postings, so you\[aq]ll want to set
 \f[C]account1\f[R] and \f[C]account2\f[R].
+Typically \f[C]account1\f[R] is associated with the CSV file, and is set
+once with a top-level assignment, while \f[C]account2\f[R] is set based
+on each transaction\[aq]s description, and in conditional blocks.
 .PP
 If a posting\[aq]s account name is left unset but its amount is set (see
 below), a default account name will be chosen (like
@@ -501,38 +504,30 @@ below), a default account name will be chosen (like
 .SS amount
 .PP
 \f[C]amountN\f[R] sets posting N\[aq]s amount.
+If the CSV uses separate fields for debit and credit amounts, you can
+use \f[C]amountN-in\f[R] and \f[C]amountN-out\f[R] instead.
 .PP
-Or if the CSV has debits and credits in two separate fields, use
-\f[C]amountN-in\f[R] and \f[C]amountN-out\f[R] instead.
-.PP
-Some aliases and special behaviour exist to support older CSV rules
-(before hledger 1.17):
-.IP \[bu] 2
-if \f[C]amount1\f[R] is the only posting amount assigned, then a second
-posting with the balancing amount will be generated automatically.
-(Unless the account name is parenthesised indicating an unbalanced
-posting.)
-.IP \[bu] 2
-\f[C]amount\f[R] is an alias for \f[C]amount1\f[R]
-.IP \[bu] 2
-\f[C]amount-in\f[R]/\f[C]amount-out\f[R] are aliases for
-\f[C]amount1-in\f[R]/\f[C]amount1-out\f[R]
-.PP
-This can occasionally get in the way.
-For example, currently it\[aq]s possible to generate a transaction with
-a blank amount1, but not one with a blank amount2.
+Also, for compatibility with hledger <1.17: \f[C]amount\f[R] or
+\f[C]amount-in\f[R]/\f[C]amount-out\f[R] with no number sets the amount
+for postings 1 and 2.
+For posting 2 the amount is negated, and converted to cost if
+there\[aq]s a transaction price.
 .SS currency
 .PP
 If the CSV has the currency symbol in a separate field (ie, not part of
 the amount field), you can use \f[C]currencyN\f[R] to prepend it to
 posting N\[aq]s amount.
-Or, \f[C]currency\f[R] affects all postings.
+Or, \f[C]currency\f[R] with no number affects all postings.
 .SS balance
 .PP
 \f[C]balanceN\f[R] sets a balance assertion amount (or if the posting
-amount is left empty, a balance assignment).
-You may need to adjust this with the \f[C]balance-type\f[R] rule (see
-below).
+amount is left empty, a balance assignment) on posting N.
+.PP
+Also, for compatibility with hledger <1.17: \f[C]balance\f[R] with no
+number is equivalent to \f[C]balance1\f[R].
+.PP
+You can adjust the type of assertion/assignment with the
+\f[C]balance-type\f[R] rule (see below).
 .SS comment
 .PP
 Finally, \f[C]commentN\f[R] sets a comment on the Nth posting.

--- a/hledger-lib/hledger_csv.info
+++ b/hledger-lib/hledger_csv.info
@@ -469,7 +469,9 @@ File: hledger_csv.info,  Node: account,  Next: amount,  Up: Posting field names
 that account name.
 
    Most often there are two postings, so you'll want to set 'account1'
-and 'account2'.
+and 'account2'.  Typically 'account1' is associated with the CSV file,
+and is set once with a top-level assignment, while 'account2' is set
+based on each transaction's description, and in conditional blocks.
 
    If a posting's account name is left unset but its amount is set (see
 below), a default account name will be chosen (like "expenses:unknown"
@@ -481,24 +483,14 @@ File: hledger_csv.info,  Node: amount,  Next: currency,  Prev: account,  Up: Pos
 2.2.2.2 amount
 ..............
 
-'amountN' sets posting N's amount.
+'amountN' sets posting N's amount.  If the CSV uses separate fields for
+debit and credit amounts, you can use 'amountN-in' and 'amountN-out'
+instead.
 
-   Or if the CSV has debits and credits in two separate fields, use
-'amountN-in' and 'amountN-out' instead.
-
-   Some aliases and special behaviour exist to support older CSV rules
-(before hledger 1.17):
-
-   * if 'amount1' is the only posting amount assigned, then a second
-     posting with the balancing amount will be generated automatically.
-     (Unless the account name is parenthesised indicating an unbalanced
-     posting.)
-   * 'amount' is an alias for 'amount1'
-   * 'amount-in'/'amount-out' are aliases for 'amount1-in'/'amount1-out'
-
-   This can occasionally get in the way.  For example, currently it's
-possible to generate a transaction with a blank amount1, but not one
-with a blank amount2.
+   Also, for compatibility with hledger <1.17: 'amount' or
+'amount-in'/'amount-out' with no number sets the amount for postings 1
+and 2.  For posting 2 the amount is negated, and converted to cost if
+there's a transaction price.
 
 
 File: hledger_csv.info,  Node: currency,  Next: balance,  Prev: amount,  Up: Posting field names
@@ -508,7 +500,7 @@ File: hledger_csv.info,  Node: currency,  Next: balance,  Prev: amount,  Up: Pos
 
 If the CSV has the currency symbol in a separate field (ie, not part of
 the amount field), you can use 'currencyN' to prepend it to posting N's
-amount.  Or, 'currency' affects all postings.
+amount.  Or, 'currency' with no number affects all postings.
 
 
 File: hledger_csv.info,  Node: balance,  Next: comment,  Prev: currency,  Up: Posting field names
@@ -517,7 +509,12 @@ File: hledger_csv.info,  Node: balance,  Next: comment,  Prev: currency,  Up: Po
 ...............
 
 'balanceN' sets a balance assertion amount (or if the posting amount is
-left empty, a balance assignment).  You may need to adjust this with the
+left empty, a balance assignment) on posting N.
+
+   Also, for compatibility with hledger <1.17: 'balance' with no number
+is equivalent to 'balance1'.
+
+   You can adjust the type of assertion/assignment with the
 'balance-type' rule (see below).
 
 
@@ -1044,52 +1041,52 @@ Node: Posting field names16638
 Ref: #posting-field-names16790
 Node: account16860
 Ref: #account16976
-Node: amount17320
-Ref: #amount17451
-Node: currency18195
-Ref: #currency18330
-Node: balance18521
-Ref: #balance18655
-Node: comment18834
-Ref: #comment18951
-Node: field assignment19114
-Ref: #field-assignment19257
-Node: separator20075
-Ref: #separator20204
-Node: if20615
-Ref: #if20717
-Node: end22636
-Ref: #end22742
-Node: date-format22966
-Ref: #date-format23098
-Node: newest-first23847
-Ref: #newest-first23985
-Node: include24668
-Ref: #include24797
-Node: balance-type25241
-Ref: #balance-type25361
-Node: TIPS26061
-Ref: #tips26143
-Node: Rapid feedback26399
-Ref: #rapid-feedback26516
-Node: Valid CSV26976
-Ref: #valid-csv27106
-Node: File Extension27298
-Ref: #file-extension27450
-Node: Reading multiple CSV files27860
-Ref: #reading-multiple-csv-files28045
-Node: Valid transactions28286
-Ref: #valid-transactions28464
-Node: Deduplicating importing29092
-Ref: #deduplicating-importing29271
-Node: Setting amounts30304
-Ref: #setting-amounts30473
-Node: Setting currency/commodity31459
-Ref: #setting-currencycommodity31651
-Node: Referencing other fields32454
-Ref: #referencing-other-fields32654
-Node: How CSV rules are evaluated33551
-Ref: #how-csv-rules-are-evaluated33724
+Node: amount17512
+Ref: #amount17643
+Node: currency18024
+Ref: #currency18159
+Node: balance18365
+Ref: #balance18499
+Node: comment18816
+Ref: #comment18933
+Node: field assignment19096
+Ref: #field-assignment19239
+Node: separator20057
+Ref: #separator20186
+Node: if20597
+Ref: #if20699
+Node: end22618
+Ref: #end22724
+Node: date-format22948
+Ref: #date-format23080
+Node: newest-first23829
+Ref: #newest-first23967
+Node: include24650
+Ref: #include24779
+Node: balance-type25223
+Ref: #balance-type25343
+Node: TIPS26043
+Ref: #tips26125
+Node: Rapid feedback26381
+Ref: #rapid-feedback26498
+Node: Valid CSV26958
+Ref: #valid-csv27088
+Node: File Extension27280
+Ref: #file-extension27432
+Node: Reading multiple CSV files27842
+Ref: #reading-multiple-csv-files28027
+Node: Valid transactions28268
+Ref: #valid-transactions28446
+Node: Deduplicating importing29074
+Ref: #deduplicating-importing29253
+Node: Setting amounts30286
+Ref: #setting-amounts30455
+Node: Setting currency/commodity31441
+Ref: #setting-currencycommodity31633
+Node: Referencing other fields32436
+Ref: #referencing-other-fields32636
+Node: How CSV rules are evaluated33533
+Ref: #how-csv-rules-are-evaluated33706
 
 End Tag Table
 

--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -418,6 +418,8 @@ For more about the transaction parts they refer to, see the manual for hledger's
 with that account name.
 
 Most often there are two postings, so you'll want to set `account1` and `account2`.
+Typically `account1` is associated with the CSV file, and is set once with a top-level assignment,
+while `account2` is set based on each transaction's description, and in conditional blocks.
 
 If a posting's account name is left unset but its amount is set (see below),
 a default account name will be chosen (like "expenses:unknown" or "income:unknown").
@@ -425,31 +427,31 @@ a default account name will be chosen (like "expenses:unknown" or "income:unknow
 #### amount
 
 `amountN` sets posting N's amount. 
+If the CSV uses separate fields for debit and credit amounts, you can
+use `amountN-in` and `amountN-out` instead.
 
-Or if the CSV has debits and credits in two separate fields, use `amountN-in` and `amountN-out` instead.
-
-Some aliases and special behaviour exist to support older CSV rules (before hledger 1.17):
-
-- if `amount1` is the only posting amount assigned, then a second posting 
-  with the balancing amount will be generated automatically.
-  (Unless the account name is parenthesised indicating an [unbalanced posting](journal.html#virtual-postings).)
-- `amount` is an alias for `amount1`
-- `amount-in`/`amount-out` are aliases for `amount1-in`/`amount1-out`
-
-This can occasionally get in the way. For example, currently it's possible to generate
-a transaction with a blank amount1, but not one with a blank amount2.
+Also, for compatibility with hledger <1.17:
+`amount` or `amount-in`/`amount-out` with no number sets the amount
+for postings 1 and 2. For posting 2 the amount is negated, and
+converted to cost if there's a [transaction price](journal.html#transaction-prices).
 
 #### currency
 
 If the CSV has the currency symbol in a separate field (ie, not part
 of the amount field), you can use `currencyN` to prepend it to posting
-N's amount. Or, `currency` affects all postings.
+N's amount. Or, `currency` with no number affects all postings.
 
 #### balance
 
 `balanceN` sets a [balance assertion](journal.html#balance-assertions) amount
-(or if the posting amount is left empty, a [balance assignment](journal.html#balance-assignments)).
-You may need to adjust this with the [`balance-type` rule](#balance-type) (see below).
+(or if the posting amount is left empty, a [balance assignment](journal.html#balance-assignments))
+on posting N.
+
+Also, for compatibility with hledger <1.17:
+`balance` with no number is equivalent to `balance1`.
+
+You can adjust the type of assertion/assignment with the
+[`balance-type` rule](#balance-type) (see below).
 
 #### comment
 

--- a/hledger-lib/hledger_csv.txt
+++ b/hledger-lib/hledger_csv.txt
@@ -381,42 +381,38 @@ CSV RULES
        that account name.
 
        Most  often  there are two postings, so you'll want to set account1 and
-       account2.
+       account2.  Typically account1 is associated with the CSV file,  and  is
+       set  once  with  a top-level assignment, while account2 is set based on
+       each transaction's description, and in conditional blocks.
 
        If a posting's account name is left unset but its amount  is  set  (see
        below),  a default account name will be chosen (like "expenses:unknown"
        or "income:unknown").
 
    amount
-       amountN sets posting N's amount.
+       amountN sets posting N's amount.  If the CSV uses separate  fields  for
+       debit  and  credit  amounts, you can use amountN-in and amountN-out in-
+       stead.
 
-       Or if the CSV has debits  and  credits  in  two  separate  fields,  use
-       amountN-in and amountN-out instead.
-
-       Some  aliases  and  special  behaviour exist to support older CSV rules
-       (before hledger 1.17):
-
-       o if amount1 is the only posting amount assigned, then a second posting
-         with  the  balancing amount will be generated automatically.  (Unless
-         the account name is parenthesised indicating an unbalanced posting.)
-
-       o amount is an alias for amount1
-
-       o amount-in/amount-out are aliases for amount1-in/amount1-out
-
-       This can occasionally get in the way.  For example, currently it's pos-
-       sible  to generate a transaction with a blank amount1, but not one with
-       a blank amount2.
+       Also, for compatibility with hledger <1.17: amount or amount-in/amount-
+       out with no number sets the amount for postings 1 and 2.  For posting 2
+       the amount is negated, and converted to cost if there's  a  transaction
+       price.
 
    currency
        If the CSV has the currency symbol in a separate field (ie, not part of
-       the  amount  field), you can use currencyN to prepend it to posting N's
-       amount.  Or, currency affects all postings.
+       the amount field), you can use currencyN to prepend it to  posting  N's
+       amount.  Or, currency with no number affects all postings.
 
    balance
-       balanceN sets a balance assertion amount (or if the posting  amount  is
-       left  empty,  a  balance assignment).  You may need to adjust this with
-       the balance-type rule (see below).
+       balanceN  sets  a balance assertion amount (or if the posting amount is
+       left empty, a balance assignment) on posting N.
+
+       Also, for compatibility with hledger <1.17: balance with no  number  is
+       equivalent to balance1.
+
+       You  can  adjust the type of assertion/assignment with the balance-type
+       rule (see below).
 
    comment
        Finally, commentN sets a comment on the Nth posting.  Comments can also

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -219,9 +219,9 @@ account4 the:remainder
 
 $  ./csvtest.sh
 2009-09-10 Flubber Co
-    assets:myacct            $50.000 = $321.000
-    expenses:unknown     = $123.000
-    expenses:tax              $0.234  ; VAT
+    assets:myacct          $50.000 = $321.000
+    income:unknown        $-50.000 = $123.000
+    expenses:tax            $0.234  ; VAT
     the:remainder
 
 >=0
@@ -240,9 +240,9 @@ account4 the:remainder
 
 $  ./csvtest.sh
 2009-09-10 Flubber Co
-    assets:myacct                $50 = $321
-    expenses:unknown     = $123
-    expenses:tax              £0.234  ; VAT
+    assets:myacct              $50 = $321
+    income:unknown            $-50 = $123
+    expenses:tax            £0.234  ; VAT
     the:remainder
 
 >=0
@@ -472,7 +472,7 @@ $  ./csvtest.sh
 
 2018-12-22 (10101010101) Someone for Joyful Systems
     sm:assets:online:paypal           $7.77 = $88.66
-    sm:expenses:unknown              $-7.77
+    sm:expenses:unknown
 
 >=0
 
@@ -613,15 +613,16 @@ $  ./csvtest.sh
 
 >=0
 
-# 31. Currently can't generate a transaction with amount on the first posting only. XXX
+# 31. Can generate a transaction with amount on the first posting only.
 <
 2020-01-01, 1
 RULES
 fields date, amount1
+account2 b
 $  ./csvtest.sh
 2020-01-01
     expenses:unknown               1
-    income:unknown                -1
+    b
 
 >=0
 
@@ -630,23 +631,24 @@ $  ./csvtest.sh
 2020-01-01, 1
 RULES
 fields date, amount2
-account1 asset
+account1 a
 $  ./csvtest.sh
 2020-01-01
-    asset
+    a
     expenses:unknown               1
 
 >=0
 
-# 33. If account1 is unset, the above doesn't work. Also amount2 appears to become amount1 ? XXX
+# 33. The old amount rules convert amount1 to cost in posting 2:
 <
 2020-01-01, 1
 RULES
-fields date, amount2
+fields date, amt
+amount  %amt @@ 1 EUR
 $  ./csvtest.sh
 2020-01-01
-    expenses:unknown               1
-    income:unknown                -1
+    expenses:unknown      1 @@ 1 EUR
+    income:unknown            -1 EUR
 
 >=0
 


### PR DESCRIPTION
A rewrite and simplification of the posting-generating code. The
"special handling for pre 1.17 rules" should now be less noticeable.
amount1/amount2 no longer force a second posting or explicit amounts
on both postings. (Only amount/amount-in/amount-out do that.)
Error messages and handling of corner cases may be more robust, also.

@adept, does it sound ok ? This scheme seems like one we would have considered, but I think maybe we didn't, perhaps because the old code really didn't allow it.