### PR TITLE
web: avoid using sessions (partly fixes #1081)

### DIFF
--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -99,9 +99,7 @@ type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
 instance Yesod App where
   approot = ApprootMaster $ appRoot . settings
 
-  makeSessionBackend _ =
-    let sessionexpirysecs = 120
-    in  Just <$> defaultClientSessionBackend sessionexpirysecs ".hledger-web_client_session_key.aes"
+  makeSessionBackend _ = return Nothing
 
   -- defaultLayout :: WidgetFor site () -> HandlerFor site Html
   defaultLayout widget = do


### PR DESCRIPTION
do not use ~/.hledger-web_client_session_key.aes anymore (as seen in https://github.com/simonmichael/hledger/issues/1081#issuecomment-530955978)