### PR TITLE
csv: Increase maximum number of postings in CSV reader from 9 to 99.

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -457,7 +457,7 @@ journalfieldnamep = do
   lift (dbgparse 2 "trying journalfieldnamep")
   T.unpack <$> choiceInState (map (lift . string . T.pack) journalfieldnames)
 
-maxpostings = 9
+maxpostings = 99
 
 -- Transaction fields and pseudo fields for CSV conversion.
 -- Names must precede any other name they contain, for the parser
@@ -470,7 +470,7 @@ journalfieldnames =
           ,"balance" ++ i
           ,"comment" ++ i
           ,"currency" ++ i
-          ] | x <- [1..maxpostings], let i = show x]
+          ] | x <- [maxpostings, (maxpostings-1)..1], let i = show x]
   ++
   ["amount-in"
   ,"amount-out"

--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -414,7 +414,7 @@ For more about the transaction parts they refer to, see the manual for hledger's
 
 #### account
 
-`accountN`, where N is 1 to 9, causes a [posting](journal.html#postings) to be generated, 
+`accountN`, where N is 1 to 99, causes a [posting](journal.html#postings) to be generated, 
 with that account name.
 
 Most often there are two postings, so you'll want to set `account1` and `account2`.
@@ -430,7 +430,7 @@ a default account name will be chosen (like "expenses:unknown" or "income:unknow
 If the CSV uses separate fields for inflows and outflows, you can
 use `amountN-in` and `amountN-out` instead.
 By assigning to `amount1`, `amount2`, ... etc. you can generate anywhere
-from 0 to 9 postings.
+from 0 to 99 postings.
 
 There is also an older, unnumbered form of these names, suitable for
 2-posting transactions, which sets both posting 1's and (negated) posting 2's amount:


### PR DESCRIPTION
The ordering of journalfieldnames is changed in order to comply with the requirement stated in the comment:
"Names must precede any other name they contain, for the parser".
If left unchanged, "account1" would precede "account11", "account12", and so on, which would break the parsing.
With the new ordering, "account11" precedes "account1".
