### PR TITLE
lib: multiBalanceReport derives query from ReportOpts

### DIFF
--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -61,7 +61,6 @@ budgetReport ropts' assrt reportspan d j =
     -- and that reports with and without --empty make sense when compared side by side
     ropts = ropts' { accountlistmode_ = ALTree }
     showunbudgeted = empty_ ropts
-    q = queryFromOpts d ropts
     budgetedaccts =
       dbg2 "budgetedacctsinperiod" $
       nub $
@@ -73,9 +72,9 @@ budgetReport ropts' assrt reportspan d j =
     actualj = dbg1With (("actualj"++).show.jtxns)  $ budgetRollUp budgetedaccts showunbudgeted j
     budgetj = dbg1With (("budgetj"++).show.jtxns)  $ budgetJournal assrt ropts reportspan j
     actualreport@(PeriodicReport actualspans _ _) =
-        dbg1 "actualreport" $ multiBalanceReport ropts q actualj
+        dbg1 "actualreport" $ multiBalanceReport d ropts actualj
     budgetgoalreport@(PeriodicReport _ budgetgoalitems budgetgoaltotals) =
-        dbg1 "budgetgoalreport" $ multiBalanceReport (ropts{empty_=True}) q budgetj
+        dbg1 "budgetgoalreport" $ multiBalanceReport d (ropts{empty_=True}) budgetj
     budgetgoalreport'
       -- If no interval is specified:
       -- budgetgoalreport's span might be shorter actualreport's due to periodic txns;

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -326,7 +326,7 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts@ReportOpts{..}} j = do
 
       else
         if multiperiod then do  -- multi period balance report
-          let report = multiBalanceReport ropts (queryFromOpts d ropts) j
+          let report = multiBalanceReport d ropts j
               render = case fmt of
                 "txt"  -> multiBalanceReportAsText ropts
                 "csv"  -> (++"\n") . printCSV . multiBalanceReportAsCsv ropts


### PR DESCRIPTION
All call sites of multiBalanceReport do `multiBalanceReport opts (queryFromOpts d opts)`.

I think it is best to move derivation of query inside `multiBalanceReport` to reduce the "gotcha" factor, as passing a query that is "wider" than period requested in opts (like `Any`) effectively renders period selection in opts null and void -- I discovered that a painful way while playing with multiBalanceReport in ghci