### PR TITLE
lib: also infer market prices from transactions, like Ledger

### DIFF
--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -471,8 +471,8 @@ data Journal = Journal {
   ,jdeclaredaccounttypes  :: M.Map AccountType [AccountName]        -- ^ Accounts whose type has been declared in account directives (usually 5 top-level accounts)
   ,jcommodities           :: M.Map CommoditySymbol Commodity        -- ^ commodities and formats declared by commodity directives
   ,jinferredcommodities   :: M.Map CommoditySymbol AmountStyle      -- ^ commodities and formats inferred from journal amounts  TODO misnamed - jusedstyles
-  ,jpricedirectives       :: [PriceDirective]                       -- ^ All market price declarations (P directives), in parse order (after journal finalisation).
-                                                                    --   These will be converted to a Prices db for looking up prices by date.
+  ,jpricedirectives       :: [PriceDirective]                       -- ^ Declarations of market prices by P directives, in parse order (after journal finalisation)
+  ,jtransactionimpliedmarketprices :: [MarketPrice]                 -- ^ Market prices implied by transactions, in parse order (after journal finalisation)
   ,jtxnmodifiers          :: [TransactionModifier]
   ,jperiodictxns          :: [PeriodicTransaction]
   ,jtxns                  :: [Transaction]

--- a/hledger-lib/hledger_journal.m4.md
+++ b/hledger-lib/hledger_journal.m4.md
@@ -989,7 +989,7 @@ D $1,000.00
   b
 ```
 
-### Market prices
+### Declaring market prices
 
 The `P` directive declares a market price, which is
 an exchange rate between two commodities on a certain date.
@@ -1016,8 +1016,8 @@ P 2009/1/1 € $1.35
 P 2010/1/1 € $1.40
 ```
 
-The [`-V/--value`](hledger.html#v-market-value) flag can be used to convert reported amounts
-to another commodity using these prices.
+The `-V`, `-X` and `--value` flags use these market prices to show amount values
+in another commodity. See [Valuation](hledger.html#valuation).
 
 ### Declaring accounts
 

--- a/tests/journal/valuation.test
+++ b/tests/journal/valuation.test
@@ -76,9 +76,9 @@ $ hledger -f- bal -N -V -e 3000/2
 
 D 1000.00 H                ; declare a default commodity named H
 
-P 2015/08/14 EEEE  41.66   ; default commodity H is used for these market prices
-P 2015/08/14 FFFF  74.62
-P 2015/08/14 GGGG  32.39
+P 2015/08/15 EEEE  41.66   ; default commodity H is used for these market prices
+P 2015/08/15 FFFF  74.62
+P 2015/08/15 GGGG  32.39
 
 2015/08/15
     a  2.4120 EEEE @@ 100  ; default commodity H is used for these transaction prices

--- a/tests/journal/valuation2.test
+++ b/tests/journal/valuation2.test
@@ -221,3 +221,32 @@ P 2002/01/01 A  2 B
 # was inclusive.
 $ hledger -f- bal -N -V -e 2002-01-01
                  1 B  a
+
+# Test market prices inferred from transactions, as in Ledger.
+
+<
+2020-01-01
+  (assets:stock)   1 TSLA @ $500
+
+2020-03-01
+  (assets:stock)   1 TSLA @ $500
+
+P 2020-03-01 TSLA  $600
+
+2020-05-01
+  (assets:stock)   1 TSLA @ $800
+
+# 22. Market price is inferred from a transaction price,
+# -V works without a P directive.
+$ hledger -f- bal -N -V -e 2020-01-02
+                $500  assets:stock
+
+# 23. A P-declared market price has precedence over a transaction price 
+# on the same date.
+$ hledger -f- bal -N -V -e 2020-03-02
+               $1200  assets:stock
+
+# 24. A transaction-implied market price has precedence 
+# over an older P-declared market price.
+$ hledger -f- bal -N -V -e 2020-05-02
+               $2400  assets:stock


### PR DESCRIPTION
WIP for #1239, untested and may not work yet. Draft docs:
```hs
-- When the valuation commodity is specified, this looks for an
-- exchange rate (market price) calculated in any of the following
-- ways, in order of preference:
--
-- 1. a declared market price (DMP) - a P directive giving the
--    exchange rate from source commodity to valuation commodity
--
-- 2. a transaction-implied market price (TMP) - a market price
--    equivalent to the transaction price used in the latest
--    transaction from source commodity to valuation commodity
--    (on or before the valuation date)
--
-- 3. a reverse declared market price (RDMP) - calculated by inverting
--    a DMP
--
-- 4. a reverse transaction-implied market price (RTMP) - calculated
--    by inverting a TMP
--
-- 5. an indirect market price (IMP) - calculated by combining the
--    shortest chain of market prices (any of the above types) leading
--    from source commodity to valuation commodity.
```
Any testing/problem reports welcome.