### PR TITLE
;web: maintain query when choosing a different 'inacct' account on the sidebar

### DIFF
--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -49,6 +49,7 @@ module Hledger.Query (
   matchesCommodity,
   matchesPriceDirective,
   words'',
+  prefixes,
   -- * tests
   tests_Query
 )

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -122,7 +122,7 @@ instance Yesod App where
         -- flip the default for items with zero amounts, show them by default
         ropts' = ropts { empty_ = not (empty_ ropts) }
         accounts =
-          balanceReportAsHtml (JournalR, RegisterR) here hideEmptyAccts j qopts $
+          balanceReportAsHtml (JournalR, RegisterR) here hideEmptyAccts j q qopts $
           balanceReport ropts' m j
 
         topShowmd = if showSidebar then "col-md-4" else "col-any-0" :: Text

--- a/hledger-web/Hledger/Web/Handler/JournalR.hs
+++ b/hledger-web/Hledger/Web/Handler/JournalR.hs
@@ -13,19 +13,20 @@ import Hledger.Web.Import
 import Hledger.Web.WebOptions
 import Hledger.Web.Widget.AddForm (addModal)
 import Hledger.Web.Widget.Common
-            (accountQuery, mixedAmountAsHtml, transactionFragment)
+            (accountQuery, mixedAmountAsHtml,
+             transactionFragment, replaceInacct)
 
 -- | The formatted journal view, with sidebar.
 getJournalR :: Handler Html
 getJournalR = do
   checkServerSideUiEnabled
-  VD{caps, j, m, opts, qopts, today} <- getViewData
+  VD{caps, j, m, opts, q, qopts, today} <- getViewData
   when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
   let title = case inAccount qopts of
         Nothing -> "General Journal"
         Just (a, inclsubs) -> "Transactions in " <> a <> if inclsubs then "" else " (excluding subaccounts)"
       title' = title <> if m /= Any then ", filtered" else ""
-      acctlink a = (RegisterR, [("q", accountQuery a)])
+      acctlink a = (RegisterR, [("q", replaceInacct q $ accountQuery a)])
       (_, items) = transactionsReport (reportopts_ $ cliopts_ opts) j m
       transactionFrag = transactionFragment j
 

--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -18,13 +18,14 @@ import Hledger.Web.Import
 import Hledger.Web.WebOptions
 import Hledger.Web.Widget.AddForm (addModal)
 import Hledger.Web.Widget.Common
-             (accountQuery, mixedAmountAsHtml, transactionFragment)
+             (accountQuery, mixedAmountAsHtml,
+              transactionFragment, removeInacct, replaceInacct)
 
 -- | The main journal/account register view, with accounts sidebar.
 getRegisterR :: Handler Html
 getRegisterR = do
   checkServerSideUiEnabled
-  VD{caps, j, m, opts, qopts, today} <- getViewData
+  VD{caps, j, m, opts, q, qopts, today} <- getViewData
   when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
 
   let (a,inclsubs) = fromMaybe ("all accounts",True) $ inAccount qopts
@@ -34,7 +35,7 @@ getRegisterR = do
 
   let ropts = reportopts_ (cliopts_ opts)
       acctQuery = fromMaybe Any (inAccountQuery qopts)
-      acctlink acc = (RegisterR, [("q", accountQuery acc)])
+      acctlink acc = (RegisterR, [("q", replaceInacct q $ accountQuery acc)])
       otherTransAccounts =
           map (\(acct,(name,comma)) -> (acct, (T.pack name, T.pack comma))) .
           undecorateLinks . elideRightDecorated 40 . decorateLinks .

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -15,6 +15,8 @@ module Hledger.Web.Widget.Common
   , writeJournalTextIfValidAndChanged
   , journalFile404
   , transactionFragment
+  , removeInacct
+  , replaceInacct
   ) where
 
 import Data.Default (def)

--- a/hledger-web/templates/balance-report.hamlet
+++ b/hledger-web/templates/balance-report.hamlet
@@ -11,11 +11,11 @@ $forall (acct, adisplay, aindent, abal) <- items
     <td .acct :isZeroMixedAmount abal:.empty>
       <div .ff-wrapper>
         \#{indent aindent}
-        <a.acct-name href="@?{(registerR, [("q", accountQuery acct)])}"
+        <a.acct-name href="@?{(registerR, [("q", replaceInacct q $ accountQuery acct)])}"
            title="Show transactions affecting this account and subaccounts">
           #{adisplay}
         $if hasSubAccounts acct
-          <a href="@?{(registerR, [("q", accountOnlyQuery acct)])}" .only.hidden-sm.hidden-xs
+          <a href="@?{(registerR, [("q", replaceInacct q $ accountOnlyQuery acct)])}" .only.hidden-sm.hidden-xs
              title="Show transactions affecting this account but not subaccounts">only
     <td>
       ^{mixedAmountAsHtml abal}

--- a/hledger-web/templates/register.hamlet
+++ b/hledger-web/templates/register.hamlet
@@ -21,7 +21,7 @@
       $forall (torig, tacct, split, _acct, amt, bal) <- items
         <tr ##{tindex torig} title="#{showTransaction torig}" style="vertical-align:top;">
           <td .date>
-            <a href="@{JournalR}##{transactionFrag torig}">
+            <a href="@?{(JournalR, [("q", T.unwords $ removeInacct q)])}##{transactionFrag torig}">
               #{show (tdate tacct)}
           <td>
             #{textElideRight 30 (tdescription tacct)}


### PR DESCRIPTION
This is an experimental feature
that I proposed already last year in googlegroups.
I am annoyed that date restrictions get lost
when I traverse through the accounts on the left sidebar.
Thus I added the non-inacct parts of part to the account links.
I could also add these to the links in the journal and the register.
It works only if the query was already sent to the server.
I hope I got the quotation right.
I had to export Query.prefixes.
Alternatively I could move replaceInacct to the Query module.