### PR TITLE
lib: test for issue with sign checking code + fix

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -610,6 +610,7 @@ isNegativeMixedAmount m =
     []  -> Just False
     [a] -> Just $ isNegativeAmount a
     as | all isNegativeAmount as -> Just True
+    as | not (any isNegativeAmount as) -> Just False
     _ -> Nothing  -- multiple amounts with different signs
 
 -- | Does this mixed amount appear to be zero when rendered with its

--- a/tests/journal/parse-errors.test
+++ b/tests/journal/parse-errors.test
@@ -131,3 +131,27 @@ real postings all have the same sign
     b              1B
 
 >=1
+
+# 12. Typical "hledger equity --close" transaction does not trigger sign error.
+<
+2019-01-01 opening balances
+    assets:a1         $3
+    assets:a2         £10
+    equity:opening/closing balances
+
+2019-12-31 closing balances
+    assets:a1         $-3 = $0.00
+    assets:a2         £-10 = £0.00
+    equity:opening/closing balances
+$ hledger -f- print
+2019-01-01 opening balances
+    assets:a1                                    $3
+    assets:a2                                   £10
+    equity:opening/closing balances
+
+2019-12-31 closing balances
+    assets:a1                                   $-3 = $0
+    assets:a2                                  £-10 = £0
+    equity:opening/closing balances
+
+>=0


### PR DESCRIPTION
The issue is that `isNegativeMixedAmount` does not return `Just False` for _positive_ mixed amount, so new sign-checking code ignores any such mixed amount completely and falsely thinks that all remaining amounts are of the same sign.
