### PR TITLE
Use multiBalanceReport for balanceReport

### DIFF
--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -72,9 +72,9 @@ budgetReport ropts' assrt reportspan d j =
     actualj = dbg1With (("actualj"++).show.jtxns)  $ budgetRollUp budgetedaccts showunbudgeted j
     budgetj = dbg1With (("budgetj"++).show.jtxns)  $ budgetJournal assrt ropts reportspan j
     actualreport@(PeriodicReport actualspans _ _) =
-        dbg1 "actualreport" $ multiBalanceReport d ropts actualj
+        dbg1 "actualreport" $ multiBalanceReport d ropts{empty_=True} actualj
     budgetgoalreport@(PeriodicReport _ budgetgoalitems budgetgoaltotals) =
-        dbg1 "budgetgoalreport" $ multiBalanceReport d (ropts{empty_=True}) budgetj
+        dbg1 "budgetgoalreport" $ multiBalanceReport d ropts{empty_=True} budgetj
     budgetgoalreport'
       -- If no interval is specified:
       -- budgetgoalreport's span might be shorter actualreport's due to periodic txns;

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -47,8 +47,8 @@ type BudgetAverage = Average
 
 -- | A budget report tracks expected and actual changes per account and subperiod.
 type BudgetCell = (Maybe Change, Maybe BudgetGoal)
-type BudgetReport = PeriodicReport AccountName BudgetCell
-type BudgetReportRow = PeriodicReportRow AccountName BudgetCell
+type BudgetReport    = PeriodicReport    DisplayName BudgetCell
+type BudgetReportRow = PeriodicReportRow DisplayName BudgetCell
 
 -- | Calculate budget goals from all periodic transactions,
 -- actual balance changes from the regular transactions,
@@ -99,9 +99,9 @@ sortBudgetReport ropts j (PeriodicReport ps rows trow) = PeriodicReport ps sorte
     sortTreeBURByActualAmount :: [BudgetReportRow] -> [BudgetReportRow]
     sortTreeBURByActualAmount rows = sortedrows
       where
-        anamesandrows = [(prrName r, r) | r <- rows]
+        anamesandrows = [(prrFullName r, r) | r <- rows]
         anames = map fst anamesandrows
-        atotals = [(a, tot) | PeriodicReportRow a _ _ (tot,_) _ <- rows]
+        atotals = [(displayFull a, tot) | PeriodicReportRow a _ (tot,_) _ <- rows]
         accounttree = accountTree "root" anames
         accounttreewithbals = mapAccounts setibalance accounttree
           where
@@ -124,8 +124,8 @@ sortBudgetReport ropts j (PeriodicReport ps rows trow) = PeriodicReport ps sorte
     -- <unbudgeted> remains at the top.
     sortByAccountDeclaration rows = sortedrows
       where
-        (unbudgetedrow,rows') = partition ((=="<unbudgeted>") . prrName) rows
-        anamesandrows = [(prrName r, r) | r <- rows']
+        (unbudgetedrow,rows') = partition ((==unbudgetedAccountName) . prrFullName) rows
+        anamesandrows = [(prrFullName r, r) | r <- rows']
         anames = map fst anamesandrows
         sortedanames = sortAccountNamesByDeclaration j (tree_ ropts) anames
         sortedrows = unbudgetedrow ++ sortAccountItemsLike sortedanames anamesandrows
@@ -189,17 +189,17 @@ budgetRollUp budgetedaccts showunbudgeted j = j { jtxns = remapTxn <$> jtxns j }
 --
 combineBudgetAndActual :: MultiBalanceReport -> MultiBalanceReport -> BudgetReport
 combineBudgetAndActual
-      (PeriodicReport budgetperiods budgetrows (PeriodicReportRow _ _ budgettots budgetgrandtot budgetgrandavg))
-      (PeriodicReport actualperiods actualrows (PeriodicReportRow _ _ actualtots actualgrandtot actualgrandavg)) =
+      (PeriodicReport budgetperiods budgetrows (PeriodicReportRow _ budgettots budgetgrandtot budgetgrandavg))
+      (PeriodicReport actualperiods actualrows (PeriodicReportRow _ actualtots actualgrandtot actualgrandavg)) =
     PeriodicReport periods rows totalrow
   where
     periods = nubSort . filter (/= nulldatespan) $ budgetperiods ++ actualperiods
 
     -- first, combine any corresponding budget goals with actual changes
     rows1 =
-      [ PeriodicReportRow acct treeindent amtandgoals totamtandgoal avgamtandgoal
-      | PeriodicReportRow acct treeindent actualamts actualtot actualavg <- actualrows
-      , let mbudgetgoals       = Map.lookup acct budgetGoalsByAcct :: Maybe ([BudgetGoal], BudgetTotal, BudgetAverage)
+      [ PeriodicReportRow acct amtandgoals totamtandgoal avgamtandgoal
+      | PeriodicReportRow acct actualamts actualtot actualavg <- actualrows
+      , let mbudgetgoals       = Map.lookup (displayFull acct) budgetGoalsByAcct :: Maybe ([BudgetGoal], BudgetTotal, BudgetAverage)
       , let budgetmamts        = maybe (replicate (length periods) Nothing) (map Just . first3) mbudgetgoals :: [Maybe BudgetGoal]
       , let mbudgettot         = second3 <$> mbudgetgoals :: Maybe BudgetTotal
       , let mbudgetavg         = third3 <$> mbudgetgoals  :: Maybe BudgetAverage
@@ -211,14 +211,14 @@ combineBudgetAndActual
       ]
       where
         budgetGoalsByAcct :: Map AccountName ([BudgetGoal], BudgetTotal, BudgetAverage) =
-          Map.fromList [ (acct, (amts, tot, avg))
-                         | PeriodicReportRow acct _ amts tot avg <- budgetrows ]
+          Map.fromList [ (displayFull acct, (amts, tot, avg))
+                         | PeriodicReportRow acct amts tot avg <- budgetrows ]
 
     -- next, make rows for budget goals with no actual changes
     rows2 =
-      [ PeriodicReportRow acct treeindent amtandgoals totamtandgoal avgamtandgoal
-      | PeriodicReportRow acct treeindent budgetgoals budgettot budgetavg <- budgetrows
-      , acct `notElem` map prrName rows1
+      [ PeriodicReportRow acct amtandgoals totamtandgoal avgamtandgoal
+      | PeriodicReportRow acct budgetgoals budgettot budgetavg <- budgetrows
+      , displayFull acct `notElem` map prrFullName rows1
       , let acctBudgetByPeriod = Map.fromList $ zip budgetperiods budgetgoals :: Map DateSpan BudgetGoal
       , let amtandgoals        = [ (Nothing, Map.lookup p acctBudgetByPeriod) | p <- periods ] :: [BudgetCell]
       , let totamtandgoal      = (Nothing, Just budgettot)
@@ -230,10 +230,10 @@ combineBudgetAndActual
     -- TODO: respect --sort-amount
     -- TODO: add --sort-budget to sort by budget goal amount
     rows :: [BudgetReportRow] =
-      sortOn prrName $ rows1 ++ rows2
+      sortOn prrFullName $ rows1 ++ rows2
 
     -- TODO: grand total & average shows 0% when there are no actual amounts, inconsistent with other cells
-    totalrow = PeriodicReportRow () 0
+    totalrow = PeriodicReportRow ()
         [ (Map.lookup p totActualByPeriod, Map.lookup p totBudgetByPeriod) | p <- periods ]
         ( Just actualgrandtot, Just budgetgrandtot )
         ( Just actualgrandavg, Just budgetgrandavg )
@@ -311,7 +311,7 @@ budgetReportAsText ropts@ReportOpts{..} budgetr =
 budgetReportAsTable :: ReportOpts -> BudgetReport -> Table String String (Maybe MixedAmount, Maybe MixedAmount)
 budgetReportAsTable
   ropts
-  (PeriodicReport periods rows (PeriodicReportRow _ _ coltots grandtot grandavg)) =
+  (PeriodicReport periods rows (PeriodicReportRow _ coltots grandtot grandavg)) =
     addtotalrow $
     Table
       (T.Group NoLine $ map Header accts)
@@ -322,10 +322,13 @@ budgetReportAsTable
                   ++ ["  Total" | row_total_ ropts]
                   ++ ["Average" | average_ ropts]
     accts = map renderacct rows
-    renderacct (PeriodicReportRow a i _ _ _)
-      | tree_ ropts = replicate ((i-1)*2) ' ' ++ T.unpack (accountLeafName a)
-      | otherwise   = T.unpack $ maybeAccountNameDrop ropts a
-    rowvals (PeriodicReportRow _ _ as rowtot rowavg) =
+    -- FIXME. Have to check explicitly for which to render here, since
+    -- budgetReport sets accountlistmode to ALTree. Find a principled way to do
+    -- this.
+    renderacct row
+      | tree_ ropts = replicate ((prrDepth row - 1)*2) ' ' ++ T.unpack (prrDisplayName row)
+      | otherwise   = T.unpack . maybeAccountNameDrop ropts $ prrFullName row
+    rowvals (PeriodicReportRow _ as rowtot rowavg) =
         as ++ [rowtot | row_total_ ropts] ++ [rowavg | average_ ropts]
     addtotalrow
       | no_total_ ropts = id

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -37,7 +37,6 @@ import Hledger.Utils
 --import Hledger.Read (mamountp')
 import Hledger.Reports.ReportOptions
 import Hledger.Reports.ReportTypes
-import Hledger.Reports.BalanceReport (sortAccountItemsLike)
 import Hledger.Reports.MultiBalanceReport
 
 

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -18,6 +18,8 @@ module Hledger.Reports.MultiBalanceReport (
   balanceReportFromMultiBalanceReport,
   tableAsText,
 
+  sortAccountItemsLike,
+
   -- -- * Tests
   tests_MultiBalanceReport
 )
@@ -480,12 +482,11 @@ balanceReportFromMultiBalanceReport ropts q j = (rows', total)
     PeriodicReport _ rows (PeriodicReportRow _ totals _ _) =
         multiBalanceReportWith ropts' q j (journalPriceOracle (infer_value_ ropts) j)
     rows' = [( displayFull a
-             , leafName a
+             , displayName a
              , if tree_ ropts' then displayDepth a - 1 else 0  -- BalanceReport uses 0-based account depths
              , headDef nullmixedamt amts     -- 0 columns is illegal, should not happen, return zeroes if it does
              ) | PeriodicReportRow a amts _ _ <- rows]
     total = headDef nullmixedamt totals
-    leafName = if flat_ ropts' then displayFull else displayName  -- BalanceReport expects full account name here with --flat
     ropts' = setDefaultAccountListMode ALTree ropts
 
 

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -348,7 +348,7 @@ displayedAccounts ropts q valuedaccts =
     displayedName name
         | depth == 0  = DisplayName "..." "..." 0
         | tree_ ropts = treeDisplayName name
-        | otherwise   = flatDisplayName name
+        | otherwise   = DisplayName name (accountNameDrop (drop_ ropts) name) 0
       where
         elided = accountNameFromComponents . reverse . map accountLeafName $
             name : takeWhile (not . isDisplayed) parents

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -32,6 +32,9 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe
 import Data.Ord
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup ((<>))
+#endif
 import Data.Time.Calendar
 import Safe
 import Text.Tabular as T

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -344,7 +344,7 @@ displayedAccounts ropts q valuedaccts
     | otherwise  = HM.mapWithKey (\a _ -> displayedName a) displayedAccts
   where
     -- Accounts which are to be displayed
-    displayedAccts = HM.filterWithKey keep (valuedaccts <> allParents)
+    displayedAccts = HM.filterWithKey keep valuedaccts
       where
         keep name amts = isInteresting name amts || isInterestingParent name
 
@@ -380,10 +380,6 @@ displayedAccounts ropts q valuedaccts
         | flat_ ropts                     = const False
         | empty_ ropts || no_elide_ ropts = const True
         | otherwise                       = (`HM.member` interestingParents)
-
-    allParents
-        | tree_ ropts = HM.fromList [(a,[]) | a <- expandAccountNames $ HM.keys interestingAccounts]
-        | otherwise   = mempty
 
     isZeroRow balance = all (mixedAmountLooksZero . balance)
     keepEmpty = empty_ ropts || depth == 0

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.33.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c30491f8c77b1d38a1992455cc9c340cbcb17e95ec5c07085f9987b289747ba1
+-- hash: dd7c200231996bc96dfb65f042843355e9f7db7002d68c953ada6e89cedd5cc5
 
 name:           hledger-lib
 version:        1.18.99
@@ -149,6 +149,7 @@ library
     , timeit
     , transformers >=0.2
     , uglymemo
+    , unordered-containers >=0.2
     , utf8-string >=0.3.5
   default-language: Haskell2010
 
@@ -202,6 +203,7 @@ test-suite doctest
     , timeit
     , transformers >=0.2
     , uglymemo
+    , unordered-containers >=0.2
     , utf8-string >=0.3.5
   if (impl(ghc < 8.2))
     buildable: False
@@ -257,6 +259,7 @@ test-suite unittest
     , timeit
     , transformers >=0.2
     , uglymemo
+    , unordered-containers >=0.2
     , utf8-string >=0.3.5
   buildable: True
   default-language: Haskell2010

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -82,6 +82,7 @@ dependencies:
 - time >=1.5
 - timeit
 - transformers >=0.2
+- unordered-containers >=0.2
 - uglymemo
 - utf8-string >=0.3.5
 - extra >=1.6.3

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -314,9 +314,9 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts@ReportOpts{..}} j = do
 
       if budget then do  -- single or multi period budget report
         reportspan <- reportSpan j ropts
-        let budgetreport     = dbg1 "budgetreport"     $ budgetReport ropts assrt reportspan d j
+        let budgetreport = dbg4 "budgetreport" $ budgetReport ropts assrt reportspan d j
               where
-                assrt          = not $ ignore_assertions_ $ inputopts_ opts
+                assrt = not $ ignore_assertions_ $ inputopts_ opts
             render = case fmt of
               "txt"  -> budgetReportAsText ropts
               "json" -> (++"\n") . TL.unpack . toJsonText
@@ -335,13 +335,7 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts@ReportOpts{..}} j = do
           writeOutput opts $ render report
 
         else do  -- single period simple balance report
-          let report
-                | balancetype_ `elem` [HistoricalBalance, CumulativeChange]
-                  = let ropts' | flat_ ropts = ropts
-                               | otherwise   = ropts{accountlistmode_=ALTree}
-                    in balanceReportFromMultiBalanceReport ropts' (queryFromOpts d ropts) j
-                          -- for historical balances we must use balanceReportFromMultiBalanceReport (also forces --no-elide)
-                | otherwise = balanceReport ropts (queryFromOpts d ropts) j -- simple Ledger-style balance report
+          let report = balanceReport ropts (queryFromOpts d ropts) j -- simple Ledger-style balance report
               render = case fmt of
                 "txt"  -> balanceReportAsText
                 "csv"  -> \ropts r -> (++ "\n") $ printCSV $ balanceReportAsCsv ropts r

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -355,7 +355,7 @@ balance opts@CliOpts{rawopts_=rawopts,reportopts_=ropts@ReportOpts{..}} j = do
 balanceReportAsCsv :: ReportOpts -> BalanceReport -> CSV
 balanceReportAsCsv opts (items, total) =
   ["account","balance"] :
-  [[T.unpack (maybeAccountNameDrop opts a), showMixedAmountOneLineWithoutPrice b] | (a, _, _, b) <- items]
+  [[T.unpack a, showMixedAmountOneLineWithoutPrice b] | (a, _, _, b) <- items]
   ++
   if no_total_ opts
   then []
@@ -404,7 +404,7 @@ This implementation turned out to be a bit convoluted but implements the followi
 balanceReportItemAsText :: ReportOpts -> StringFormat -> BalanceReportItem -> [String]
 balanceReportItemAsText opts fmt (_, accountName, depth, amt) =
   renderBalanceReportItem opts fmt (
-    maybeAccountNameDrop opts accountName,
+    accountName,
     depth,
     normaliseMixedAmountSquashPricesForDisplay amt
     )

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -203,7 +203,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportopts_=r
           -- "2008/01/01-2008/12/31", not "2008").
           titledatestr
             | balancetype == HistoricalBalance = showEndDates enddates
-            | otherwise                        = showDateSpan requestedspan 
+            | otherwise                        = showDateSpan requestedspan
             where
               enddates = map (addDays (-1)) $ catMaybes $ map spanEnd colspans  -- these spans will always have a definite end date
               requestedspan = queryDateSpan date2_ userq `spanDefaultsFrom` journalDateSpan date2_ j
@@ -271,12 +271,12 @@ compoundBalanceSubreport ropts@ReportOpts{..} userq j priceoracle subreportqfn s
           where
             nonzeroaccounts =
               dbg5 "nonzeroaccounts" $
-              mapMaybe (\(PeriodicReportRow act _ amts _ _) ->
-                            if not (all mixedAmountLooksZero amts) then Just act else Nothing) rows
+              mapMaybe (\(PeriodicReportRow act amts _ _) ->
+                            if not (all mixedAmountLooksZero amts) then Just (displayFull act) else Nothing) rows
             rows' = filter (not . emptyRow) rows
               where
-                emptyRow (PeriodicReportRow act _ amts _ _) =
-                  all mixedAmountLooksZero amts && not (any (act `isAccountNamePrefixOf`) nonzeroaccounts)
+                emptyRow (PeriodicReportRow act amts _ _) =
+                  all mixedAmountLooksZero amts && not (any (displayFull act `isAccountNamePrefixOf`) nonzeroaccounts)
 
 -- | Render a compound balance report as plain text suitable for console output.
 {- Eg:

--- a/tests/balance/373-layout.test
+++ b/tests/balance/373-layout.test
@@ -87,12 +87,14 @@ Balance changes in 2015:
 $ hledger -f - bal -Y --tree
 Balance changes in 2015:
 
-           || 2015 
-===========++======
-     3     ||    1 
-         5 ||    1 
------------++------
-           ||      
+         || 2015 
+=========++======
+ 1:2     ||    0 
+   3     ||    1 
+     4   ||    0 
+       5 ||    1 
+---------++------
+         ||    0 
 
 # 6. TODO: after 5, test account code sorting
 # account 1:2:3      100

--- a/tests/balance/sorting.test
+++ b/tests/balance/sorting.test
@@ -32,7 +32,7 @@ Balance changes in 2018:
 >=
 
 # 2. Tree mode. Missing parent accounts are added (b).
-$ hledger -f- bal -NY --tree
+$ hledger -f- bal -NY --tree --no-elide
 Balance changes in 2018:
 
      || 2018 
@@ -90,7 +90,7 @@ Balance changes in 2018:
 
 # 4. With account directives, tree mode.
 # Missing parent accounts are added (b).
-$ hledger -f- bal -NY --tree
+$ hledger -f- bal -NY --tree --no-elide
 Balance changes in 2018:
 
      || 2018 
@@ -141,7 +141,7 @@ Balance changes in 2018:
 2018/1/1
   (a:k)  1
 
-$ hledger -f- bal -NY --sort-amount --tree
+$ hledger -f- bal -NY --sort-amount --tree --no-elide
 Balance changes in 2018:
 
      || 2018 


### PR DESCRIPTION
This PR aims to accomplish two major goals:

-  Get boring parent ellision working for `multiBalanceReport`
-  Remove the special `BalanceReport` code, and just use `multiBalanceReport`

I believe it does both, with the following additional benefits:

- A refactor of `multiBalanceReportWith`, to make the structure easier to follow, and with a clearer division of responsibilities
- All decisions for how an account name is to be displayed are now made in `multiBalanceReport`, rather than scattered around the code base
- Some miscellaneous improvements in account name rendering, including `--drop` now working with `MultiBalanceReport`s, and addressing some of #373 