### PR TITLE
ui: fix regression in 'F' (fixes #1255)

### DIFF
--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -14,6 +14,7 @@ import Brick.Widgets.Edit
 import Data.List
 import Data.Text.Zipper (gotoEOL)
 import Data.Time.Calendar (Day)
+import Data.Maybe (fromMaybe)
 
 import Hledger
 import Hledger.Cli.CliOptions
@@ -172,7 +173,7 @@ toggleForecast d ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportopts
     forecast' =
       case forecast_ ropts of
         Just _  -> Nothing
-        Nothing -> forecastPeriodFromRawOpts d $ rawopts_ copts
+        Nothing -> Just $ fromMaybe nulldatespan $ forecastPeriodFromRawOpts d $ rawopts_ copts
 
 -- | Toggle between showing all and showing only real (non-virtual) items.
 toggleReal :: UIState -> UIState


### PR DESCRIPTION
Does what it says on the tin.
Tested with this journal:
```
~ monthly from 2020-05-01   forecast
   a   1
   b

2020-06-10 Past
    a    10
    b


2020-10-06 Future 
    a    1000
    b
```

Pressing `F` causes the future transaction to appear