### PR TITLE
cli: changes to "hledger print -O csv" output

### DIFF
--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -148,7 +148,9 @@ transactionToCSV t =
 postingToCSV :: Posting -> CSV
 postingToCSV p =
   map (\(a@(Amount {aquantity=q,acommodity=c})) ->
-    let a_ = a{acommodity=""} in
+    -- commodity goes into separate column, so we suppress it, along with digit group
+    -- separators and prices
+    let a_ = a{acommodity="",astyle=(astyle a){asdigitgroups=Nothing},aprice=Nothing} in
     let amount = showAmount a_ in
     let commodity = T.unpack c in
     let credit = if q < 0 then showAmount $ negate a_ else "" in


### PR DESCRIPTION
Couple of changes to csv output of "hledger print":

1. digit group separators suppressed in amounts
2. prices suppressed in amounts
3. added posting idx

Result of (1) + (2) is that amount are now properly numeric (and thus CSV output could be used in number-munching applications like python or R)

Effect of (3) is nice to have if your transactions are always built is predictable way, as it allows you to choose/filter for first/second/last posting, etc