### PR TITLE
cli: print -O sql

### DIFF
--- a/hledger/Hledger/Cli/Commands/Print.md
+++ b/hledger/Hledger/Cli/Commands/Print.md
@@ -75,7 +75,7 @@ This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options
 The output formats supported are
-`txt`, `csv`, and (experimental) `json`.
+`txt`, `csv`, and (experimental) `json` and `sql`.
 
 Here's an example of print's CSV output:
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -774,7 +774,7 @@ $ hledger print -o -        # write to stdout (the default)
 
 Some commands (print, register, the balance commands) offer a choice of output format. 
 In addition to the usual plain text format (`txt`), there are
-CSV (`csv`), HTML (`html`) and JSON (`json`).
+CSV (`csv`), HTML (`html`), JSON (`json`) and SQL (`sql`).
 This is controlled by the `-O/--output-format` option:
 ```shell
 $ hledger print -O csv
@@ -818,6 +818,19 @@ Some notes about JSON output:
   We hope this approach will not cause problems in practice; if you
   find otherwise, please let us know. 
   (Cf [#1195](https://github.com/simonmichael/hledger/issues/1195))
+
+Notes about SQL output:
+
+- SQL output is also marked experimental, and much like JSON could use
+real-world feedback.
+
+- SQL output is expected to work with sqlite, MySQL and PostgreSQL
+
+- SQL output is structured with the expectations that statements will
+  be executed in the empty database. If you already have tables created
+  via SQL output of hledger, you would probably want to either clear tables
+  of existing data (via `delete` or `truncate` SQL statements) or drop
+  tables completely as otherwise your postings will be duped.
 
 ## Regular expressions
 


### PR DESCRIPTION
This adds support for `-O sql` to `hledger print` + some minimal docs.

`hledger print -O sql` will output commands to create `postings` table with structure mimicking the CSV output:

```
$ cat /tmp/1.journal
2020-06-10 Past
    a    10
    b

2020-10-06 Future 
    a    1000
    b


$ hledger print -O sql -f /tmp/1.journal
create table if not exists postings(postidx serial,txnidx int,date1 date,date2 date,status text,code text,description text,comment text,account text,amount numeric,commodity text,credit numeric,debit numeric,posting_status text,posting_comment text);
insert into postings(txnidx,date1,date2,status,code,description,comment,account,amount,commodity,credit,debit,posting_status,posting_comment) values
('1','2020-06-10',NULL,NULL,NULL,'Past',NULL,'a','10',NULL,NULL,'10',NULL,NULL)
,('1','2020-06-10',NULL,NULL,NULL,'Past',NULL,'b','-10',NULL,'10',NULL,NULL,NULL)
,('2','2020-10-06',NULL,NULL,NULL,'Future',NULL,'a','1000',NULL,NULL,'1000',NULL,NULL)
,('2','2020-10-06',NULL,NULL,NULL,'Future',NULL,'b','-1000',NULL,'1000',NULL,NULL,NULL)
;
$ 
```

I've tested it on real-life journal of 50K postings and got it imported into sqlite3, MySQL and postgresql.


Usage:
```
$ hledger print -O sql -f /tmp/1.journal | sqlite3 /tmp/1.db
$ sqlite3 /tmp/1.db
SQLite version 3.22.0 2018-01-22 18:45:57
Enter ".help" for usage hints.
sqlite> select * from postings;
|1|2020-06-10||||Past||a|10|||10||
|1|2020-06-10||||Past||b|-10||10|||
|2|2020-10-06||||Future||a|1000|||1000||
|2|2020-10-06||||Future||b|-1000||1000|||
sqlite> select account, sum(amount) from postings group by 1;
a|1010
b|-1010
sqlite> 
```