### PR TITLE
lib: condition tables in csv rules + tests

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -569,7 +569,7 @@ conditionaltablep = do
   lift $ dbgparse 8 "trying conditionaltablep"
   start <- getOffset
   string "if" 
-  sep <- lift $ satisfy (not.isAlphaNum)
+  sep <- lift $ satisfy (\c -> not (isAlphaNum c || isSpace c))
   fields <- journalfieldnamep `sepBy1` (char sep)
   newline
   body <- flip manyTill (lift eolof) $ do

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -333,15 +333,17 @@ defrules = CsvRules' {
 -- | Create CsvRules from the content parsed out of the rules file
 mkrules :: CsvRulesParsed -> CsvRules
 mkrules rules =
-  let conditionalblocks = reverse $ rconditionalblocks rules in
+  let conditionalblocks = reverse $ rconditionalblocks rules
+      maybeMemo = if length conditionalblocks >= 15 then memo else id
+  in
     CsvRules' {
     rdirectives=reverse $ rdirectives rules,
     rcsvfieldindexes=rcsvfieldindexes rules,
     rassignments=reverse $ rassignments rules,
     rconditionalblocks=conditionalblocks,
-    rblocksassigning = memo (\f -> filter (any ((==f).fst) . cbAssignments) conditionalblocks)
+    rblocksassigning = maybeMemo (\f -> filter (any ((==f).fst) . cbAssignments) conditionalblocks)
     }
-  
+
 --- *** rules parsers
 
 {-

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -410,14 +410,14 @@ DIGIT: 0-9
 rulesp :: CsvRulesParser CsvRules
 rulesp = do
   _ <- many $ choice
-    [blankorcommentlinep                                                  <?> "blank or comment line"
-    ,(directivep        >>= modify' . addDirective)                       <?> "directive"
-    ,(fieldnamelistp    >>= modify' . setIndexesAndAssignmentsFromList)   <?> "field name list"
-    ,(fieldassignmentp  >>= modify' . addAssignment)                      <?> "field assignment"
-    -- conditionaltablep backtracks because it shares "if" prefix with conditionalblockp and the
-    -- reverse is there to ensure that conditions are added in the order they listed in the file
-    ,try (conditionaltablep >>= modify' . addConditionalBlocks . reverse) <?> "conditional table"
-    ,(conditionalblockp >>= modify' . addConditionalBlock)                <?> "conditional block"
+    [blankorcommentlinep                                                <?> "blank or comment line"
+    ,(directivep        >>= modify' . addDirective)                     <?> "directive"
+    ,(fieldnamelistp    >>= modify' . setIndexesAndAssignmentsFromList) <?> "field name list"
+    ,(fieldassignmentp  >>= modify' . addAssignment)                    <?> "field assignment"
+    -- conditionalblockp backtracks because it shares "if" prefix with conditionaltablep.
+    ,try (conditionalblockp >>= modify' . addConditionalBlock)          <?> "conditional block"
+    -- 'reverse' is there to ensure that conditions are added in the order they listed in the file
+    ,(conditionaltablep >>= modify' . addConditionalBlocks . reverse)   <?> "conditional table"
     ]
   eof
   r <- get
@@ -1141,7 +1141,7 @@ getEffectiveAssignment rules record f = lastMay $ map snd $ assignments
         -- all top level field assignments
         toplevelassignments    = rassignments rules
         -- all field assignments in conditional blocks assigning to field f and active for the current csv record
-        conditionalassignments = concatMap cbAssignments $ filter isBlockActive $ rblocksassigning rules f
+        conditionalassignments = concatMap cbAssignments $ filter isBlockActive $ (rblocksassigning rules) f
           where
             -- does this conditional block match the current csv record ?
             isBlockActive :: ConditionalBlock -> Bool

--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -520,7 +520,7 @@ separator TAB
 
 See also: [File Extension](#file-extension).
 
-## `if`
+## `if` block
 
 ```rules
 if MATCHER
@@ -590,6 +590,57 @@ banking thru software
  comment  XXX deductible ? check it
 ```
 
+## `if` table
+
+```rules
+if,CSVFIELDNAME1,CSVFIELDNAME2,...,CSVFIELDNAMEn
+MATCHER1,VALUE11,VALUE12,...,VALUE1n
+MATCHER2,VALUE21,VALUE22,...,VALUE2n
+MATCHER3,VALUE31,VALUE32,...,VALUE3n
+<empty line>
+```
+
+Conditional tables ("if tables") are a different syntax to specify
+field assignments that will be applied only to CSV records which match certain patterns.
+
+MATCHER could be either field or record matcher, as described above. When MATCHER matches,
+values from that row would be assigned to the CSV fields named on the `if` line, in the same order.
+
+Therefore `if` table is exactly equivalent to a sequence of of `if` blocks:
+```rules
+if MATCHER1
+  CSVFIELDNAME1 VALUE11
+  CSVFIELDNAME2 VALUE12
+  ...
+  CSVFIELDNAMEn VALUE1n
+
+if MATCHER2
+  CSVFIELDNAME1 VALUE21
+  CSVFIELDNAME2 VALUE22
+  ...
+  CSVFIELDNAMEn VALUE2n
+
+if MATCHER3
+  CSVFIELDNAME1 VALUE31
+  CSVFIELDNAME2 VALUE32
+  ...
+  CSVFIELDNAMEn VALUE3n
+```
+
+Each line starting with MATCHER should contain enough (possibly empty) values for all the listed fields.
+
+Rules would be checked and applied in the order they are listed in the table and, like with `if` blocks, later rules (in the same or another table) or `if` blocks could override the effect of any rule.
+
+Instead of ',' you can use a variety of other non-alphanumeric characters as a separator. First character after `if` is taken to be the separator for the rest of the table. It is the responsibility of the user to ensure that separator does not occur inside MATCHERs and values - there is no way to escape separator.
+
+
+Example:
+```rules
+if,account2,comment
+atm transaction fee,expenses:business:banking,deductible? check it
+%description groceries,expenses:groceries,
+2020/01/12.*Plumbing LLC,expenses:house:upkeep,emergency plumbing call-out
+```
 
 ## `end`
 

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -833,6 +833,31 @@ expecting end of input, field assignment, or newline
 )
 >=1
 
+# 42. Rules override each other in the order listed in the file
+<
+10/2009/09,Flubber Co,50
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if Flubber
+  account2 foo
+  comment bar
+
+if 10/2009/09.*Flubber
+  account2 acct
+  comment cmt
+
+$  ./csvtest.sh
+2009-09-10 Flubber Co  ; cmt
+    assets:myacct             $50
+    acct                     $-50
+
+>=0
+
+
 ## . 
 #<
 #$  ./csvtest.sh

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -857,6 +857,31 @@ $  ./csvtest.sh
 
 >=0
 
+# 43. Attempt to use space as a separator in the tabular rules
+<
+10/2009/09,Flubber Co,50
+10/2009/09,Blubber Co,150
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if account2 comment
+%amount 150 acct2 
+%description Flubber acct 
+$  ./csvtest.sh
+>2
+hledger: user error (input.rules:5:1:
+  |
+5 | if account2 comment
+  | ^
+start of conditional block found, but no assignment rules afterward
+(assignment rules in a conditional block should be indented)
+
+)
+>=1
+
 
 ## . 
 #<

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -665,6 +665,174 @@ $  ./csvtest.sh
 
 >=0
 
+# 35. tabular rules assigning multiple fields
+<
+10/2009/09,Flubber Co,50
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if,account2,comment
+Flubber,acct,cmt
+$  ./csvtest.sh
+2009-09-10 Flubber Co  ; cmt
+    assets:myacct             $50
+    acct                     $-50
+
+>=0
+
+# 36. tabular rules assigning multiple fields followed by regular rules
+<
+10/2009/09,Flubber Co,50
+10/2009/09,Blubber Co,150
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if,account2,comment
+Flubber,acct,cmt
+
+if
+Blubber
+  account2   acct2
+  comment     cmt2
+$  ./csvtest.sh
+2009-09-10 Flubber Co  ; cmt
+    assets:myacct             $50
+    acct                     $-50
+
+2009-09-10 Blubber Co  ; cmt2
+    assets:myacct            $150
+    acct2                   $-150
+
+>=0
+
+# 37. tabular rules with empty values
+<
+10/2009/09,Flubber Co,50
+10/2009/09,Blubber Co,150
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if,account2,comment
+Flubber,acct,
+Blubber,acct2,
+$  ./csvtest.sh
+2009-09-10 Flubber Co
+    assets:myacct             $50
+    acct                     $-50
+
+2009-09-10 Blubber Co
+    assets:myacct            $150
+    acct2                   $-150
+
+>=0
+
+# 38. tabular rules with field matchers and '|' separator
+<
+10/2009/09,Flubber Co,50
+10/2009/09,Blubber Co,150
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if|account2|comment
+%description Flubber|acct|
+%amount 150|acct2|cmt2
+$  ./csvtest.sh
+2009-09-10 Flubber Co
+    assets:myacct             $50
+    acct                     $-50
+
+2009-09-10 Blubber Co  ; cmt2
+    assets:myacct            $150
+    acct2                   $-150
+
+>=0
+
+# 39. Insfficient number of values in tabular rules error
+<
+10/2009/09,Flubber Co,50
+10/2009/09,Blubber Co,150
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if|account2|comment
+%amount 150|acct2
+%description Flubber|acct|
+$  ./csvtest.sh
+>2
+hledger: user error (input.rules:6:1:
+  |
+6 | %amount 150|acct2
+  | ^
+line of conditional table should have 2 values, but this one has only 1
+
+)
+>=1
+
+# 40. unindented condition block error
+<
+10/2009/09,Flubber Co,50
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if Flubber
+account2 acct
+comment cmt
+$  ./csvtest.sh
+>2
+hledger: user error (input.rules:5:1:
+  |
+5 | if Flubber
+  | ^
+start of conditional block found, but no assignment rules afterward
+(assignment rules in a conditional block should be indented)
+
+)
+>=1
+
+# 41. Assignment to custom field (#1264) + spaces after the if (#1120)
+<
+10/2009/09,Flubber Co,50
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if Flubber
+  myaccount2 acct
+  comment cmt
+
+
+account2 %myaccount2
+$  ./csvtest.sh
+>2
+hledger: user error (input.rules:6:3:
+  |
+6 |   myaccount2 acct
+  |   ^^^^^^^^^^^^
+unexpected "myaccount2 a"
+expecting end of input, field assignment, or newline
+)
+>=1
+
 ## . 
 #<
 #$  ./csvtest.sh

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -829,7 +829,7 @@ hledger: user error (input.rules:6:3:
 6 |   myaccount2 acct
   |   ^^^^^^^^^^^^
 unexpected "myaccount2 a"
-expecting end of input, field assignment, or newline
+expecting conditional block
 )
 >=1
 

--- a/tests/csvtest.sh
+++ b/tests/csvtest.sh
@@ -12,4 +12,6 @@ BEGIN{output=CSV}
 
 trap "rm -f t.$$.csv t.$$.csv.rules" EXIT ERR
 
-hledger -f csv:t.$$.csv --rules-file t.$$.csv.rules print "$@"
+# Remove variable file name from error messages
+:; ( hledger -f csv:t.$$.csv --rules-file t.$$.csv.rules print "$@" ) \
+       2> >( sed -re "s/t.*.csv/input/" >&2 )


### PR DESCRIPTION
This closes #1252  and fixes seemingly long-standing issue in csv rules parser where excessive backtracking prevented proper error reporting. 

I've also found out that `blocksAssigning` occupy 50-60% of the run time, and memorized it. This yields ~50% speedup on my files.

I've added tests to illustrate error messages + a bunch of test cases for #1252  + docs