### PR TITLE
lib: Fix interaction of --drop, --tree, and boring parent ellision.

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -139,14 +139,15 @@ instance ToJSON DisplayName where
     toEncoding = toEncoding . displayFull
 
 -- | Construct a flat display name, where the full name is also displayed at
--- depth 0
+-- depth 1
 flatDisplayName :: AccountName -> DisplayName
-flatDisplayName a = DisplayName a a 0
+flatDisplayName a = DisplayName a a 1
 
 -- | Construct a tree display name, where only the leaf is displayed at its
 -- given depth
 treeDisplayName :: AccountName -> DisplayName
 treeDisplayName a = DisplayName a (accountLeafName a) (accountNameLevel a)
+
 -- | Get the full, canonical, name of a PeriodicReportRow tagged by a
 -- DisplayName.
 prrFullName :: PeriodicReportRow DisplayName a -> AccountName

--- a/tests/balance/drop.test
+++ b/tests/balance/drop.test
@@ -1,0 +1,43 @@
+# 1. Drop works in flat mode
+<
+2018/1/1
+  (b:j)  1
+
+2018/1/1
+  (b:j:q)  1
+
+2018/1/1
+  (c)    1
+
+2018/1/1
+  (b:i:p)  1
+
+2018/1/1
+  (a:k)  1
+
+$ hledger -f - balance --flat --no-total --drop 1
+                   1  k
+                   1  i:p
+                   1  j
+                   1  j:q
+                   1  ...
+>=
+
+## 2. Drop works in tree mode with no boring parent ellision
+$ hledger -f - balance --tree --no-elide --no-total --drop 1
+                   1  k
+                   1  i
+                   1    p
+                   2  j
+                   1    q
+                   1  ...
+>=
+
+## 3. Drop works in tree mode with boring parent ellision
+$ hledger -f - balance --tree --no-total --drop 1
+                   1  k
+                   1  i:p
+                   2  j
+                   1    q
+                   1  ...
+>=


### PR DESCRIPTION
When using --drop with --tree and boring parent ellision, previously all parents were mistakenly considered boring. Fix this, and add some tests so this doesn't happen again.