### PR TITLE
balcmds: elide amounts with 3 or more commodities, unless --no-elide

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -121,8 +121,10 @@ module Hledger.Data.Amount (
   showMixedAmountDebug,
   showMixedAmountWithoutPrice,
   showMixedAmountOneLineWithoutPrice,
+  showMixedAmountElided,
   cshowMixedAmountWithoutPrice,
   cshowMixedAmountOneLineWithoutPrice,
+  cshowMixedAmountElided,
   showMixedAmountWithZeroCommodity,
   showMixedAmountWithPrecision,
   setMixedAmountPrecision,
@@ -735,6 +737,39 @@ cshowMixedAmountOneLineWithoutPrice m = intercalate ", " $ map cshowAmountWithou
     where
       (Mixed as) = normaliseMixedAmountSquashPricesForDisplay $ stripPrices m
       stripPrices (Mixed as) = Mixed $ map stripprice as where stripprice a = a{aprice=Nothing}
+
+-- | Like showMixedAmountOneLineWithoutPrice, but show at most two commodities,
+-- with a elision indicator if there are more.
+showMixedAmountElided :: MixedAmount -> String
+showMixedAmountElided m = intercalate ", " $ take 2 astrs ++ elisionstr
+  where
+    astrs = map showAmountWithoutPrice as
+      where
+        (Mixed as) = normaliseMixedAmountSquashPricesForDisplay $ stripPrices m
+          where
+            stripPrices (Mixed as) = Mixed $ map stripprice as
+              where
+                stripprice a = a{aprice=Nothing}
+    elisionstr | n > 2     = [show (n - 2) ++ " more.."]
+               | otherwise = []
+      where
+        n = length astrs
+
+-- | Colour version.
+cshowMixedAmountElided :: MixedAmount -> String
+cshowMixedAmountElided m = intercalate ", " $ take 2 astrs ++ elisionstr
+  where
+    astrs = map cshowAmountWithoutPrice as
+      where
+        (Mixed as) = normaliseMixedAmountSquashPricesForDisplay $ stripPrices m
+          where
+            stripPrices (Mixed as) = Mixed $ map stripprice as
+              where
+                stripprice a = a{aprice=Nothing}
+    elisionstr | n > 2     = [show (n - 2) ++ " more.."]
+               | otherwise = []
+      where
+        n = length astrs
 
 -- | Canonicalise a mixed amount's display styles using the provided commodity style map.
 canonicaliseMixedAmount :: M.Map CommoditySymbol AmountStyle -> MixedAmount -> MixedAmount

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -263,7 +263,7 @@ budgetReportAsText ropts@ReportOpts{..} budgetr =
     budgetwidth = maximum' $ map snd amountsAndGoals
     amountsAndGoals = map (\(a,g) -> (amountLength a, amountLength g))
                     . concatMap prrAmounts $ prRows budgetr
-      where amountLength = maybe 0 (length . showMixedAmountOneLineWithoutPrice)
+      where amountLength = maybe 0 (length . showMixedAmountOneLineWithoutPrice False)
     -- XXX lay out actual, percentage and/or goal in the single table cell for now, should probably use separate cells
     showcell :: BudgetCell -> String
     showcell (mactual, mbudget) = actualstr ++ " " ++ budgetstr
@@ -296,12 +296,10 @@ budgetReportAsText ropts@ReportOpts{..} budgetr =
                Nothing
       where
         maybecost = if valuationTypeIsCost ropts then mixedAmountCost else id
-    showamt :: MixedAmount -> String
-    showamt | color_    = cshowMixedAmountOneLineWithoutPrice
-            | otherwise = showMixedAmountOneLineWithoutPrice
+    showamt = showMixedAmountOneLineWithoutPrice color_
 
-    -- don't show the budget amount in color, it messes up alignment
-    showbudgetamt = showMixedAmountOneLineWithoutPrice
+    -- don't show the budget amount in color, it messes up alignment (XXX)
+    showbudgetamt = showMixedAmountOneLineWithoutPrice False
 
     maybetranspose | transpose_ = \(Table rh ch vals) -> Table ch rh (transpose vals)
                    | otherwise  = id

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -108,7 +108,7 @@ asInit d reset ui@UIState{
       AccountsScreenItem{asItemIndentLevel        = indent
                         ,asItemAccountName        = fullacct
                         ,asItemDisplayAccountName = replaceHiddenAccountsNameWith "All" $ if tree_ ropts' then shortacct else fullacct
-                        ,asItemRenderedAmounts    = map showAmountWithoutPrice amts -- like showMixedAmountOneLineWithoutPrice
+                        ,asItemRenderedAmounts    = map (showAmountWithoutPrice False) amts
                         }
       where
         Mixed amts = normaliseMixedAmountSquashPricesForDisplay $ stripPrices bal

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -95,8 +95,8 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportopts_=ropts
                                                      [s] -> s
                                                      ss  -> intercalate ", " ss
                                                      -- _   -> "<split>"  -- should do this if accounts field width < 30
-                            ,rsItemChangeAmount  = showMixedAmountOneLineWithoutPrice False change
-                            ,rsItemBalanceAmount = showMixedAmountOneLineWithoutPrice False bal
+                            ,rsItemChangeAmount  = showMixedAmountElided False change
+                            ,rsItemBalanceAmount = showMixedAmountElided False bal
                             ,rsItemTransaction   = t
                             }
     -- blank items are added to allow more control of scroll position; we won't allow movement over these

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -95,8 +95,8 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportopts_=ropts
                                                      [s] -> s
                                                      ss  -> intercalate ", " ss
                                                      -- _   -> "<split>"  -- should do this if accounts field width < 30
-                            ,rsItemChangeAmount  = showMixedAmountOneLineWithoutPrice change
-                            ,rsItemBalanceAmount = showMixedAmountOneLineWithoutPrice bal
+                            ,rsItemChangeAmount  = showMixedAmountOneLineWithoutPrice False change
+                            ,rsItemBalanceAmount = showMixedAmountOneLineWithoutPrice False bal
                             ,rsItemTransaction   = t
                             }
     -- blank items are added to allow more control of scroll position; we won't allow movement over these

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -102,7 +102,7 @@ accountOnlyQuery = ("inacctonly:" <>) . quoteIfSpaced
 
 mixedAmountAsHtml :: MixedAmount -> HtmlUrl a
 mixedAmountAsHtml b _ =
-  for_ (lines (showMixedAmountWithoutPrice b)) $ \t -> do
+  for_ (lines (showMixedAmountWithoutPrice False b)) $ \t -> do
     H.span ! A.class_ c $ toHtml t
     H.br
   where

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -629,12 +629,16 @@ balanceReportAsTable opts@ReportOpts{average_, row_total_, balancetype_}
 
 -- | Given a table representing a multi-column balance report (for example,
 -- made using 'balanceReportAsTable'), render it in a format suitable for
--- console output.
+-- console output. Amounts with more than two commodities will be elided
+-- unless --no-elide is used.
 balanceReportTableAsText :: ReportOpts -> Table String String MixedAmount -> String
-balanceReportTableAsText ropts = tableAsText ropts showamt
+balanceReportTableAsText ropts@ReportOpts{..} = tableAsText ropts showamt
   where
-    showamt | color_ ropts = cshowMixedAmountOneLineWithoutPrice
-            | otherwise    =  showMixedAmountOneLineWithoutPrice
+    showamt
+      | no_elide_ && color_ = cshowMixedAmountOneLineWithoutPrice
+      | no_elide_           =  showMixedAmountOneLineWithoutPrice
+      | color_              = cshowMixedAmountElided
+      | otherwise           =  showMixedAmountElided
 
 
 tests_Balance = tests "Balance" [

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -315,6 +315,17 @@ supported.
 The `--transpose` flag can be used to exchange the rows and columns of
 a multicolumn report.
      
+When showing multicommodity amounts, multicolumn balance reports will
+elide any amounts which have more than two commodities, since
+otherwise columns could get very wide. The `--no-elide` flag disables
+this. Hiding totals with the `-N/--no-total` flag can also help reduce
+the width of multicommodity reports. 
+
+When the report is still too wide, a good workaround is to pipe it
+into `less -RS` (-R for colour, -S to chop long lines). 
+Eg: `hledger bal -D | less -RS`.
+
+
 ### Budget report
 
 With `--budget`, extra columns are displayed showing budget goals for each account and period, if any.

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -86,8 +86,8 @@ postingsReportItemAsCsvRecord (_, _, _, p, b) = [idx,date,code,desc,acct,amt,bal
                              BalancedVirtualPosting -> (\s -> "["++s++"]")
                              VirtualPosting -> (\s -> "("++s++")")
                              _ -> id
-    amt = showMixedAmountOneLineWithoutPrice $ pamount p
-    bal = showMixedAmountOneLineWithoutPrice b
+    amt = showMixedAmountOneLineWithoutPrice False $ pamount p
+    bal = showMixedAmountOneLineWithoutPrice False b
 
 -- | Render a register report as plain text suitable for console output.
 postingsReportAsText :: CliOpts -> PostingsReport -> String
@@ -179,8 +179,7 @@ postingsReportItemAsText opts preferredamtwidth preferredbalwidth (mdate, mendda
               BalancedVirtualPosting -> (\s -> "["++s++"]", acctwidth-2)
               VirtualPosting         -> (\s -> "("++s++")", acctwidth-2)
               _                      -> (id,acctwidth)
-      showamt | color_ (reportopts_ opts) = cshowMixedAmountWithoutPrice
-              | otherwise                 = showMixedAmountWithoutPrice
+      showamt = showMixedAmountWithoutPrice (color_ $ reportopts_ opts)
       amt = showamt $ pamount p
       bal = showamt b
       -- alternate behaviour, show null amounts as 0 instead of blank

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -262,7 +262,7 @@ compoundBalanceReportAsCsv ropts (CompoundPeriodicReport title colspans subrepor
       | no_total_ ropts || length subreports == 1 = id
       | otherwise = (++
           ["Net:" :
-           map showMixedAmountOneLineWithoutPrice (
+           map (showMixedAmountOneLineWithoutPrice False) (
              coltotals
              ++ (if row_total_ ropts then [grandtotal] else [])
              ++ (if average_ ropts   then [grandavg]   else [])
@@ -309,9 +309,9 @@ compoundBalanceReportAsHtml ropts cbr =
                   in
                     [tr_ $ mconcat $
                          th_ [class_ "", style_ "text-align:left"] "Net:"
-                       : [th_ [class_ "amount coltotal", defstyle] (toHtml $ showMixedAmountOneLineWithoutPrice a) | a <- coltotals]
-                      ++ (if row_total_ ropts then [th_ [class_ "amount coltotal", defstyle] $ toHtml $ showMixedAmountOneLineWithoutPrice $ grandtotal] else [])
-                      ++ (if average_ ropts   then [th_ [class_ "amount colaverage", defstyle] $ toHtml $ showMixedAmountOneLineWithoutPrice $ grandavg] else [])
+                       : [th_ [class_ "amount coltotal", defstyle] (toHtml $ showMixedAmountOneLineWithoutPrice False a) | a <- coltotals]
+                      ++ (if row_total_ ropts then [th_ [class_ "amount coltotal", defstyle] $ toHtml $ showMixedAmountOneLineWithoutPrice False grandtotal] else [])
+                      ++ (if average_ ropts   then [th_ [class_ "amount colaverage", defstyle] $ toHtml $ showMixedAmountOneLineWithoutPrice False grandavg] else [])
                     ]
 
   in do

--- a/tests/balance/multicommodity.test
+++ b/tests/balance/multicommodity.test
@@ -1,0 +1,26 @@
+# 1. In tabular balance reports, amounts with more than two commodities are elided.
+<
+2020-01-01
+  (a)  1A
+  (a)  1B
+  (a)  1C
+  (a)  1D
+
+$ hledger -f- bal -Y
+Balance changes in 2020:
+
+   ||             2020 
+===++==================
+ a || 1A, 1B, 2 more.. 
+---++------------------
+   || 1A, 1B, 2 more.. 
+
+# 2. Unless --no-elide is used.
+$ hledger -f- bal -Y --no-elide
+Balance changes in 2020:
+
+   ||           2020 
+===++================
+ a || 1A, 1B, 1C, 1D 
+---++----------------
+   || 1A, 1B, 1C, 1D 


### PR DESCRIPTION
Multicolumn balance reports showing many commodities tend to become
unreadably wide, especially in tree mode. Now by default we show at
most two commodities, and a count of the rest if there are more than
two. This should help keep reports somewhat readable by default.