### PR TITLE
csv: Add support for & operators in conditional blocks

### DIFF
--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -564,8 +564,8 @@ CSVFIELD is a percent sign followed by the field's name or column number, like `
 
 A single matcher can be written on the same line as the "if";
 or multiple matchers can be written on the following lines, non-indented.
-Multiple matchers are OR'd (any one of them can match), unless one includes 
-an `&` symbol, in which case it is combined with the previous matcher.
+Multiple matchers are OR'd (any one of them can match), unless one begins with
+an `&` symbol, in which case it is AND'ed with the previous matcher.
 
 ```rules
 if

--- a/hledger-lib/hledger_csv.m4.md
+++ b/hledger-lib/hledger_csv.m4.md
@@ -564,7 +564,15 @@ CSVFIELD is a percent sign followed by the field's name or column number, like `
 
 A single matcher can be written on the same line as the "if";
 or multiple matchers can be written on the following lines, non-indented.
-Multiple matchers are OR'd (any one of them can match).
+Multiple matchers are OR'd (any one of them can match), unless one includes 
+an `&` symbol, in which case it is combined with the previous matcher.
+
+```rules
+if
+MATCHER
+& MATCHER
+ RULE
+```
 
 After the patterns there should be one or more rules to apply, all
 indented by at least one space. Three kinds of rule are allowed in

--- a/tests/csv.test
+++ b/tests/csv.test
@@ -882,6 +882,30 @@ start of conditional block found, but no assignment rules afterward
 )
 >=1
 
+# 44. handle conditions with & operator
+<
+10/2009/09,Flubber Co,50
+10/2009/09,Blubber Co,50
+
+RULES
+fields date, description, amount
+date-format %d/%Y/%m
+currency $
+account1 assets:myacct
+if Flubber
+& %amount 50
+  account2 acct
+$  ./csvtest.sh
+2009-09-10 Flubber Co
+    assets:myacct             $50
+    acct                     $-50
+
+2009-09-10 Blubber Co
+    assets:myacct              $50
+    income:unknown            $-50
+
+>=0
+
 
 ## . 
 #<


### PR DESCRIPTION
This adds support for the `&` operator in conditional blocks for CSV rule files. A more general alternative would be nested if statements, but that seems to be a bit more involved from what I can tell.

No prior Haskell experience, so any feedback is much appreciated.