### PR TITLE
aregister: an account transaction register like the ones in ui/web

### DIFF
--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -91,16 +91,23 @@ accountTransactionsReport ropts j reportq thisacctq = (label, items)
                reportq
 
     -- get all transactions
-    ts1 = jtxns j
+    ts1 =
+      -- ptraceAtWith 5 (("ts1:\n"++).pshowTransactions) $
+      jtxns j
 
     -- apply any cur:SYM filters in reportq'
     symq  = filterQuery queryIsSym reportq'
-    ts2 = (if queryIsNull symq then id else map (filterTransactionAmounts symq)) ts1
+    ts2 =
+      ptraceAtWith 5 (("ts2:\n"++).pshowTransactions) $
+      (if queryIsNull symq then id else map (filterTransactionAmounts symq)) ts1
 
     -- keep just the transactions affecting this account (via possibly realness or status-filtered postings)
     realq = filterQuery queryIsReal reportq'
     statusq = filterQuery queryIsStatus reportq'
-    ts3 = filter (matchesTransaction thisacctq . filterTransactionPostings (And [realq, statusq])) ts2
+    ts3 =
+      traceAt 3 ("thisacctq: "++show thisacctq) $
+      ptraceAtWith 5 (("ts3:\n"++).pshowTransactions) $
+      filter (matchesTransaction thisacctq . filterTransactionPostings (And [realq, statusq])) ts2
 
     -- maybe convert these transactions to cost or value
     prices = journalPriceOracle (infer_value_ ropts) j
@@ -114,19 +121,23 @@ accountTransactionsReport ropts j reportq thisacctq = (label, items)
     tval = case value_ ropts of
              Just v  -> \t -> transactionApplyValuation prices styles periodlast mreportlast today multiperiod t v
              Nothing -> id
-    ts4 = map tval ts3 
+    ts4 =
+      ptraceAtWith 5 (("ts4:\n"++).pshowTransactions) $
+      map tval ts3 
 
     -- sort by the transaction's register date, for accurate starting balance
     -- these are not yet filtered by tdate, we want to search them all for priorps
-    ts5 = sortBy (comparing (transactionRegisterDate reportq' thisacctq)) ts4
+    ts5 =
+      ptraceAtWith 5 (("ts5:\n"++).pshowTransactions) $
+      sortBy (comparing (transactionRegisterDate reportq' thisacctq)) ts4
 
     (startbal,label)
       | balancetype_ ropts == HistoricalBalance = (sumPostings priorps, balancelabel)
       | otherwise                               = (nullmixedamt,        totallabel)
       where
-        priorps = dbg1 "priorps" $
+        priorps = dbg5 "priorps" $
                   filter (matchesPosting
-                          (dbg1 "priorq" $
+                          (dbg5 "priorq" $
                            And [thisacctq, tostartdateq, datelessreportq]))
                          $ transactionsPostings ts5
         tostartdateq =
@@ -146,6 +157,9 @@ accountTransactionsReport ropts j reportq thisacctq = (label, items)
             accountTransactionsReportItems reportq' thisacctq startbal negate $
             (if filtertxns then filter (reportq' `matchesTransaction`) else id) $
             ts5
+
+pshowTransactions :: [Transaction] -> String
+pshowTransactions = pshow . map (\t -> unwords [show $ tdate t, T.unpack $ tdescription t])
 
 -- | Generate transactions report items from a list of transactions,
 -- using the provided user-specified report query, a query specifying

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -136,10 +136,11 @@ accountTransactionsReport ropts j reportq thisacctq = (label, items)
         mstartdate = queryStartDate (date2_ ropts) reportq'
         datelessreportq = filterQuery (not . queryIsDateOrDate2) reportq'
 
-    -- now should we include only transactions dated inside report period ?
-    -- or all transactions with any posting inside the report period ? an option ?
-    -- filtering might apply some other query terms here too. I think we should.
-    filtertxns = True
+    -- accountTransactionsReportItem will keep transactions of any date which have any posting inside the report period.
+    -- Should we also require that transaction date is inside the report period ?
+    -- Should we be filtering by reportq here to apply other query terms (?)
+    -- Make it an option for now.
+    filtertxns = txn_dates_ ropts
 
     items = reverse $
             accountTransactionsReportItems reportq' thisacctq startbal negate $

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -85,6 +85,7 @@ instance Default AccountListMode where def = ALFlat
 -- or query arguments, but not all. Some are used only by certain
 -- commands, as noted below.
 data ReportOpts = ReportOpts {
+     -- for most reports:
      today_          :: Maybe Day  -- ^ The current date. A late addition to ReportOpts.
                                    -- Optional, but when set it may affect some reports:
                                    -- Reports use it when picking a -V valuation date.
@@ -105,9 +106,11 @@ data ReportOpts = ReportOpts {
                                --   and quoted if needed (see 'quoteIfNeeded')
     --
     ,average_        :: Bool
-    -- register command only
+    -- for posting reports (register)
     ,related_        :: Bool
-    -- balance-type commands only
+    -- for account transactions reports (aregister)
+    ,txn_dates_      :: Bool
+    -- for balance reports (bal, bs, cf, is)
     ,balancetype_    :: BalanceType
     ,accountlistmode_ :: AccountListMode
     ,drop_           :: Int
@@ -163,6 +166,7 @@ defreportopts = ReportOpts
     def
     def
     def
+    def
 
 rawOptsToReportOpts :: RawOpts -> IO ReportOpts
 rawOptsToReportOpts rawopts = checkReportOpts <$> do
@@ -186,6 +190,7 @@ rawOptsToReportOpts rawopts = checkReportOpts <$> do
     ,query_       = unwords . map quoteIfNeeded $ listofstringopt "args" rawopts' -- doesn't handle an arg like "" right
     ,average_     = boolopt "average" rawopts'
     ,related_     = boolopt "related" rawopts'
+    ,txn_dates_   = boolopt "txn-dates" rawopts'
     ,balancetype_ = balancetypeopt rawopts'
     ,accountlistmode_ = accountlistmodeopt rawopts'
     ,drop_        = posintopt "drop" rawopts'

--- a/hledger-lib/hledger_csv.5
+++ b/hledger-lib/hledger_csv.5
@@ -635,6 +635,7 @@ Conditional blocks (\[dq]if blocks\[dq]) are a block of rules that are
 applied only to CSV records which match certain patterns.
 They are often used for customising account names based on transaction
 descriptions.
+.SS Matching the whole record
 .PP
 Each MATCHER can be a record matcher, which looks like this:
 .IP
@@ -659,6 +660,7 @@ field containing a comma will appear like two fields).
 Eg, if the original record is
 \f[C]2020-01-01; \[dq]Acme, Inc.\[dq];  1,000\f[R], the REGEX will
 actually see \f[C]2020-01-01,Acme, Inc.,  1,000\f[R]).
+.SS Matching individual fields
 .PP
 Or, MATCHER can be a field matcher, like this:
 .IP
@@ -671,6 +673,7 @@ Or, MATCHER can be a field matcher, like this:
 which matches just the content of a particular CSV field.
 CSVFIELD is a percent sign followed by the field\[aq]s name or column
 number, like \f[C]%date\f[R] or \f[C]%1\f[R].
+.SS Combining matchers
 .PP
 A single matcher can be written on the same line as the \[dq]if\[dq]; or
 multiple matchers can be written on the following lines, non-indented.
@@ -686,6 +689,7 @@ MATCHER
  RULE
 \f[R]
 .fi
+.SS Rules applied on successful match
 .PP
 After the patterns there should be one or more rules to apply, all
 indented by at least one space.

--- a/hledger-lib/hledger_csv.info
+++ b/hledger-lib/hledger_csv.info
@@ -615,7 +615,20 @@ applied only to CSV records which match certain patterns.  They are
 often used for customising account names based on transaction
 descriptions.
 
-   Each MATCHER can be a record matcher, which looks like this:
+* Menu:
+
+* Matching the whole record::
+* Matching individual fields::
+* Combining matchers::
+* Rules applied on successful match::
+
+
+File: hledger_csv.info,  Node: Matching the whole record,  Next: Matching individual fields,  Up: if block
+
+2.5.1 Matching the whole record
+-------------------------------
+
+Each MATCHER can be a record matcher, which looks like this:
 
 REGEX
 
@@ -632,7 +645,13 @@ that a field containing a comma will appear like two fields).  Eg, if
 the original record is '2020-01-01; "Acme, Inc."; 1,000', the REGEX will
 actually see '2020-01-01,Acme, Inc., 1,000').
 
-   Or, MATCHER can be a field matcher, like this:
+
+File: hledger_csv.info,  Node: Matching individual fields,  Next: Combining matchers,  Prev: Matching the whole record,  Up: if block
+
+2.5.2 Matching individual fields
+--------------------------------
+
+Or, MATCHER can be a field matcher, like this:
 
 %CSVFIELD REGEX
 
@@ -640,7 +659,13 @@ actually see '2020-01-01,Acme, Inc., 1,000').
 is a percent sign followed by the field's name or column number, like
 '%date' or '%1'.
 
-   A single matcher can be written on the same line as the "if"; or
+
+File: hledger_csv.info,  Node: Combining matchers,  Next: Rules applied on successful match,  Prev: Matching individual fields,  Up: if block
+
+2.5.3 Combining matchers
+------------------------
+
+A single matcher can be written on the same line as the "if"; or
 multiple matchers can be written on the following lines, non-indented.
 Multiple matchers are OR'd (any one of them can match), unless one
 begins with an '&' symbol, in which case it is AND'ed with the previous
@@ -651,7 +676,13 @@ MATCHER
 & MATCHER
  RULE
 
-   After the patterns there should be one or more rules to apply, all
+
+File: hledger_csv.info,  Node: Rules applied on successful match,  Prev: Combining matchers,  Up: if block
+
+2.5.4 Rules applied on successful match
+---------------------------------------
+
+After the patterns there should be one or more rules to apply, all
 indented by at least one space.  Three kinds of rule are allowed in
 conditional blocks:
 
@@ -1148,40 +1179,48 @@ Node: separator21340
 Ref: #separator21475
 Node: if block21886
 Ref: #if-block22011
-Node: if table24287
-Ref: #if-table24406
-Node: end26144
-Ref: #end26256
-Node: date-format26480
-Ref: #date-format26612
-Node: newest-first27361
-Ref: #newest-first27499
-Node: include28182
-Ref: #include28313
-Node: balance-type28757
-Ref: #balance-type28877
-Node: TIPS29577
-Ref: #tips29659
-Node: Rapid feedback29915
-Ref: #rapid-feedback30032
-Node: Valid CSV30492
-Ref: #valid-csv30622
-Node: File Extension30814
-Ref: #file-extension30966
-Node: Reading multiple CSV files31376
-Ref: #reading-multiple-csv-files31561
-Node: Valid transactions31802
-Ref: #valid-transactions31980
-Node: Deduplicating importing32608
-Ref: #deduplicating-importing32787
-Node: Setting amounts33820
-Ref: #setting-amounts33989
-Node: Setting currency/commodity34976
-Ref: #setting-currencycommodity35168
-Node: Referencing other fields35971
-Ref: #referencing-other-fields36171
-Node: How CSV rules are evaluated37068
-Ref: #how-csv-rules-are-evaluated37241
+Node: Matching the whole record22412
+Ref: #matching-the-whole-record22587
+Node: Matching individual fields23391
+Ref: #matching-individual-fields23595
+Node: Combining matchers23819
+Ref: #combining-matchers24015
+Node: Rules applied on successful match24328
+Ref: #rules-applied-on-successful-match24519
+Node: if table25173
+Ref: #if-table25292
+Node: end27030
+Ref: #end27142
+Node: date-format27366
+Ref: #date-format27498
+Node: newest-first28247
+Ref: #newest-first28385
+Node: include29068
+Ref: #include29199
+Node: balance-type29643
+Ref: #balance-type29763
+Node: TIPS30463
+Ref: #tips30545
+Node: Rapid feedback30801
+Ref: #rapid-feedback30918
+Node: Valid CSV31378
+Ref: #valid-csv31508
+Node: File Extension31700
+Ref: #file-extension31852
+Node: Reading multiple CSV files32262
+Ref: #reading-multiple-csv-files32447
+Node: Valid transactions32688
+Ref: #valid-transactions32866
+Node: Deduplicating importing33494
+Ref: #deduplicating-importing33673
+Node: Setting amounts34706
+Ref: #setting-amounts34875
+Node: Setting currency/commodity35862
+Ref: #setting-currencycommodity36054
+Node: Referencing other fields36857
+Ref: #referencing-other-fields37057
+Node: How CSV rules are evaluated37954
+Ref: #how-csv-rules-are-evaluated38127
 
 End Tag Table
 

--- a/hledger-lib/hledger_csv.txt
+++ b/hledger-lib/hledger_csv.txt
@@ -479,6 +479,7 @@ CSV RULES
        only to CSV records which match certain patterns.  They are often  used
        for customising account names based on transaction descriptions.
 
+   Matching the whole record
        Each MATCHER can be a record matcher, which looks like this:
 
               REGEX
@@ -496,6 +497,7 @@ CSV RULES
        original record is 2020-01-01; "Acme, Inc.";  1,000, the REGEX will ac-
        tually see 2020-01-01,Acme, Inc.,  1,000).
 
+   Matching individual fields
        Or, MATCHER can be a field matcher, like this:
 
               %CSVFIELD REGEX
@@ -504,6 +506,7 @@ CSV RULES
        a  percent  sign  followed  by  the field's name or column number, like
        %date or %1.
 
+   Combining matchers
        A single matcher can be written on the same line as the "if"; or multi-
        ple matchers can be written on the following lines, non-indented.  Mul-
        tiple matchers are OR'd (any one of them can match), unless one  begins
@@ -514,6 +517,7 @@ CSV RULES
               & MATCHER
                RULE
 
+   Rules applied on successful match
        After  the patterns there should be one or more rules to apply, all in-
        dented by at least one space.  Three kinds of rule are allowed in  con-
        ditional blocks:

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -20,6 +20,7 @@ module Hledger.Cli.Commands (
   ,module Hledger.Cli.Commands.Accounts
   ,module Hledger.Cli.Commands.Activity
   ,module Hledger.Cli.Commands.Add
+  ,module Hledger.Cli.Commands.Aregister
   ,module Hledger.Cli.Commands.Balance
   ,module Hledger.Cli.Commands.Balancesheet
   ,module Hledger.Cli.Commands.Balancesheetequity
@@ -66,6 +67,7 @@ import Hledger.Cli.Version
 import Hledger.Cli.Commands.Accounts
 import Hledger.Cli.Commands.Activity
 import Hledger.Cli.Commands.Add
+import Hledger.Cli.Commands.Aregister
 import Hledger.Cli.Commands.Balance
 import Hledger.Cli.Commands.Balancesheet
 import Hledger.Cli.Commands.Balancesheetequity
@@ -102,6 +104,7 @@ builtinCommands = [
    (accountsmode           , accounts)
   ,(activitymode           , activity)
   ,(addmode                , add)
+  ,(aregistermode          , aregister)
   ,(balancemode            , balance)
   ,(balancesheetequitymode , balancesheetequity)
   ,(balancesheetmode       , balancesheet)
@@ -172,6 +175,7 @@ commandsList = unlines [
   ," rewrite                  generate automated postings/diffs (old, use --auto)"
   ,""
   ,"Financial reports:"
+  ," aregister (areg)         show transactions in a particular account"
   ," balancesheet (bs)        show assets, liabilities and net worth"
   ," balancesheetequity (bse) show assets, liabilities and equity"
   ," cashflow (cf)            show changes in liquid assets"
@@ -291,6 +295,7 @@ tests_Hledger_Cli = tests "Hledger.Cli" [
 tests_Commands = tests "Commands" [
    tests_Balance
   ,tests_Register
+  ,tests_Aregister
 
   -- some more tests easiest to define here:
 

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -134,13 +134,21 @@ accountTransactionsReportItemAsCsvRecord
 -- | Render a register report as plain text suitable for console output.
 accountTransactionsReportAsText :: CliOpts -> Query -> Query -> AccountTransactionsReport -> String
 accountTransactionsReportAsText opts reportq thisacctq (_balancelabel,items) =
-  unlines $ map (accountTransactionsReportItemAsText opts reportq thisacctq amtwidth balwidth) items
+  unlines $ title :
+    map (accountTransactionsReportItemAsText opts reportq thisacctq amtwidth balwidth) items
   where
     amtwidth = maximumStrict $ 12 : map (strWidth . showamt . itemamt) items
     balwidth = maximumStrict $ 12 : map (strWidth . showamt . itembal) items
     showamt = showMixedAmountOneLineWithoutPrice False
     itemamt (_,_,_,_,a,_) = a
     itembal (_,_,_,_,_,a) = a
+    -- show a title indicating which account was picked, which can be confusing otherwise
+    title = maybe "" (("Transactions in "++).(++" and subaccounts:")) macct
+      where
+        -- XXX temporary hack ? recover the account name from the query
+        macct = case filterQuery queryIsAcct thisacctq of
+                  Acct r -> Just $ init $ init $ init $ init $ init $ tail r  -- Acct "^JS:expenses(:|$)"
+                  _      -> Nothing  -- shouldn't happen
 
 -- | Render one account register report line item as plain text. Layout is like so:
 -- @

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -73,7 +73,7 @@ aregister opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
   d <- getCurrentDay
   -- the first argument specifies the account, any remaining arguments are a filter query
   let args' = listofstringopt "args" rawopts
-  when (null args') $ error' "please provide an account name or pattern"
+  when (null args') $ error' "aregister needs an account, please provide an account name or pattern"
   let
     (apat:queryargs) = args'
     acct = headDef (error' $ show apat++" did not match any account") $

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -1,0 +1,229 @@
+{-|
+
+The @aregister@ command lists a single account's transactions,
+like the account register in hledger-ui and hledger-web,
+and unlike the register command which lists postings across multiple accounts.
+
+-}
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Hledger.Cli.Commands.Aregister (
+  aregistermode
+ ,aregister
+ -- ,showPostingWithBalanceForVty
+ ,tests_Aregister
+) where
+
+import Control.Monad (when)
+import Data.Aeson (toJSON)
+import Data.Aeson.Text (encodeToLazyText)
+import Data.List
+import Data.Maybe
+-- import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Data.Time (addDays)
+import Safe (headDef)
+import System.Console.CmdArgs.Explicit
+import Hledger.Read.CsvReader (CSV, CsvRecord, printCSV)
+
+import Hledger
+import Hledger.Cli.CliOptions
+import Hledger.Cli.Utils
+
+aregistermode = hledgerCommandMode
+  $(embedFileRelative "Hledger/Cli/Commands/Aregister.txt")
+  ([
+   flagNone ["txn-dates"] (setboolopt "txn-dates") 
+     "filter strictly by transaction date, not posting date. Warning: this can show a wrong running balance."
+  --  flagNone ["cumulative"] (setboolopt "change")
+  --    "show running total from report start date (default)"
+  -- ,flagNone ["historical","H"] (setboolopt "historical")
+  --    "show historical running total/balance (includes postings before report start date)\n "
+  -- ,flagNone ["average","A"] (setboolopt "average")
+  --    "show running average of posting amounts instead of total (implies --empty)"
+  -- ,flagNone ["related","r"] (setboolopt "related") "show postings' siblings instead"
+  -- ,flagNone ["invert"] (setboolopt "invert") "display all amounts with reversed sign"
+  ,flagReq  ["width","w"] (\s opts -> Right $ setopt "width" s opts) "N"
+     ("set output width (default: " ++
+#ifdef mingw32_HOST_OS
+      show defaultWidth
+#else
+      "terminal width"
+#endif
+      ++ " or $COLUMNS). -wN,M sets description width as well."
+     )
+  ,outputFormatFlag ["txt","csv","json"]
+  ,outputFileFlag
+  ])
+  [generalflagsgroup1]
+  hiddenflags
+  ([], Just $ argsFlag "ACCTPAT [QUERY]")
+
+-- based on Hledger.UI.RegisterScreen:
+
+-- | Print an account register report for a specified account.
+aregister :: CliOpts -> Journal -> IO ()
+aregister opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
+  d <- getCurrentDay
+  -- the first argument specifies the account, any remaining arguments are a filter query
+  let args' = listofstringopt "args" rawopts
+  when (null args') $ error' "please provide an account name or pattern"
+  let
+    (apat:queryargs) = args'
+    acct = headDef (error' $ show apat++" did not match any account") $
+           filter (regexMatches apat . T.unpack) $ journalAccountNames j
+    -- gather report options
+    inclusive = True  -- tree_ ropts
+    thisacctq = Acct $ (if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex) acct
+    ropts' = ropts{
+       query_=unwords $ map quoteIfNeeded $ queryargs
+       -- remove a depth limit for reportq, as in RegisterScreen, I forget why XXX
+      ,depth_=Nothing
+       -- always show historical balance
+      ,balancetype_= HistoricalBalance
+      }
+    reportq = And [queryFromOpts d ropts', excludeforecastq (isJust $ forecast_ ropts)]
+      where
+        -- As in RegisterScreen, why ? XXX
+        -- Except in forecast mode, exclude future/forecast transactions.
+        excludeforecastq True = Any
+        excludeforecastq False =  -- not:date:tomorrow- not:tag:generated-transaction
+          And [
+             Not (Date $ DateSpan (Just $ addDays 1 d) Nothing)
+            ,Not (Tag "generated-transaction" Nothing)
+          ]
+    -- run the report
+    -- TODO: need to also pass the queries so we can choose which date to render - move them into the report ?
+    (balancelabel,items) = accountTransactionsReport ropts' j reportq thisacctq
+    items' = (if empty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $
+             reverse items
+    -- select renderer
+    render | fmt=="json" = (++"\n") . T.unpack . TL.toStrict . encodeToLazyText . toJSON
+           | fmt=="csv"  = (++"\n") . printCSV . accountTransactionsReportAsCsv reportq thisacctq
+           | fmt=="txt"  = accountTransactionsReportAsText opts reportq thisacctq
+           | otherwise   = const $ error' $ unsupportedOutputFormatError fmt
+      where
+        fmt = outputFormatFromOpts opts
+
+  writeOutput opts $ render (balancelabel,items')
+
+accountTransactionsReportAsCsv :: Query -> Query -> AccountTransactionsReport -> CSV
+accountTransactionsReportAsCsv reportq thisacctq (_,is) =
+  ["txnidx","date","code","description","account","amount","total"]
+  : map (accountTransactionsReportItemAsCsvRecord reportq thisacctq) is
+
+accountTransactionsReportItemAsCsvRecord :: Query -> Query -> AccountTransactionsReportItem -> CsvRecord
+accountTransactionsReportItemAsCsvRecord
+  reportq thisacctq
+  (t@Transaction{tindex,tcode,tdescription}, _, _issplit, otheracctsstr, change, balance)
+  = [idx,date,code,desc,otheracctsstr,amt,bal]
+  where
+    idx  = show tindex
+    date = showDate $ transactionRegisterDate reportq thisacctq t
+    code = T.unpack tcode
+    desc = T.unpack tdescription
+    amt  = showMixedAmountOneLineWithoutPrice False change
+    bal  = showMixedAmountOneLineWithoutPrice False balance
+
+-- | Render a register report as plain text suitable for console output.
+accountTransactionsReportAsText :: CliOpts -> Query -> Query -> AccountTransactionsReport -> String
+accountTransactionsReportAsText opts reportq thisacctq (_balancelabel,items) =
+  unlines $ map (accountTransactionsReportItemAsText opts reportq thisacctq amtwidth balwidth) items
+  where
+    amtwidth = maximumStrict $ 12 : map (strWidth . showamt . itemamt) items
+    balwidth = maximumStrict $ 12 : map (strWidth . showamt . itembal) items
+    showamt = showMixedAmountOneLineWithoutPrice False
+    itemamt (_,_,_,_,a,_) = a
+    itembal (_,_,_,_,_,a) = a
+
+-- | Render one account register report line item as plain text. Layout is like so:
+-- @
+-- <---------------- width (specified, terminal width, or 80) -------------------->
+-- date (10)  description           other accounts       change (12)   balance (12)
+-- DDDDDDDDDD dddddddddddddddddddd  aaaaaaaaaaaaaaaaaaa  AAAAAAAAAAAA  AAAAAAAAAAAA
+-- @
+-- If description's width is specified, account will use the remaining space.
+-- Otherwise, description and account divide up the space equally.
+--
+-- Returns a string which can be multi-line, eg if the running balance
+-- has multiple commodities.
+--
+accountTransactionsReportItemAsText :: CliOpts -> Query -> Query -> Int -> Int -> AccountTransactionsReportItem -> String
+accountTransactionsReportItemAsText
+  copts@CliOpts{reportopts_=ReportOpts{color_}} reportq thisacctq preferredamtwidth preferredbalwidth
+  (t@Transaction{tdescription}, _, _issplit, otheracctsstr, change, balance)
+    -- Transaction -- the transaction, unmodified
+    -- Transaction -- the transaction, as seen from the current account
+    -- Bool        -- is this a split (more than one posting to other accounts) ?
+    -- String      -- a display string describing the other account(s), if any
+    -- MixedAmount -- the amount posted to the current account(s) (or total amount posted)
+    -- MixedAmount -- the register's running total or the current account(s)'s historical balance, after this transaction
+
+  = intercalate "\n" $
+    concat [fitString (Just datewidth) (Just datewidth) True True date
+           ," "
+           ,fitString (Just descwidth) (Just descwidth) True True desc
+           ,"  "
+           ,fitString (Just acctwidth) (Just acctwidth) True True accts
+           ,"  "
+           ,fitString (Just amtwidth) (Just amtwidth) True False amtfirstline
+           ,"  "
+           ,fitString (Just balwidth) (Just balwidth) True False balfirstline
+           ]
+    :
+    [concat [spacer
+            ,fitString (Just amtwidth) (Just amtwidth) True False a
+            ,"  "
+            ,fitString (Just balwidth) (Just balwidth) True False b
+            ]
+     | (a,b) <- zip amtrest balrest
+     ]
+    where
+      -- calculate widths
+      (totalwidth,mdescwidth) = registerWidthsFromOpts copts
+      (datewidth, date) = (10, showDate $ transactionRegisterDate reportq thisacctq t)
+      (amtwidth, balwidth)
+        | shortfall <= 0 = (preferredamtwidth, preferredbalwidth)
+        | otherwise      = (adjustedamtwidth, adjustedbalwidth)
+        where
+          mincolwidth = 2 -- columns always show at least an ellipsis
+          maxamtswidth = max 0 (totalwidth - (datewidth + 1 + mincolwidth + 2 + mincolwidth + 2 + 2))
+          shortfall = (preferredamtwidth + preferredbalwidth) - maxamtswidth
+          amtwidthproportion = fromIntegral preferredamtwidth / fromIntegral (preferredamtwidth + preferredbalwidth)
+          adjustedamtwidth = round $ amtwidthproportion * fromIntegral maxamtswidth
+          adjustedbalwidth = maxamtswidth - adjustedamtwidth
+
+      remaining = totalwidth - (datewidth + 1 + 2 + amtwidth + 2 + balwidth)
+      (descwidth, acctwidth) = (w, remaining - 2 - w)
+        where
+          w = fromMaybe ((remaining - 2) `div` 2) mdescwidth
+
+      -- gather content
+      desc = T.unpack tdescription
+      accts = -- T.unpack $ elideAccountName acctwidth $ T.pack
+              otheracctsstr
+      showamt = -- showMixedAmountWithoutPrice color_
+                showMixedAmountOneLineWithoutPrice color_
+      amt = showamt change
+      bal = showamt balance
+      -- alternate behaviour, show null amounts as 0 instead of blank
+      -- amt = if null amt' then "0" else amt'
+      -- bal = if null bal' then "0" else bal'
+      (amtlines, ballines) = (lines amt, lines bal)
+      (amtlen, ballen) = (length amtlines, length ballines)
+      numlines = max 1 (max amtlen ballen)
+      (amtfirstline:amtrest) = take numlines $ amtlines ++ repeat "" -- posting amount is top-aligned
+      (balfirstline:balrest) = take numlines $ replicate (numlines - ballen) "" ++ ballines -- balance amount is bottom-aligned
+      spacer = replicate (totalwidth - (amtwidth + 2 + balwidth)) ' '
+
+-- tests
+
+tests_Aregister = tests "Aregister" [
+
+ ]

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -115,7 +115,7 @@ aregister opts@CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
 
 accountTransactionsReportAsCsv :: Query -> Query -> AccountTransactionsReport -> CSV
 accountTransactionsReportAsCsv reportq thisacctq (_,is) =
-  ["txnidx","date","code","description","account","amount","total"]
+  ["txnidx","date","code","description","otheraccounts","change","balance"]
   : map (accountTransactionsReportItemAsCsvRecord reportq thisacctq) is
 
 accountTransactionsReportItemAsCsvRecord :: Query -> Query -> AccountTransactionsReportItem -> CsvRecord

--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -14,11 +14,12 @@ Each line shows:
 - the account's historical running balance (including balance from
   transactions before the report start date).
 
-This is different from `register`, which shows individual postings.
 With `aregister`, each line represents a whole transaction - as in
-hledger-ui, hledger-web, and your bank statement. You might prefer
-`aregister` for reconciling with real-world asset/liability accounts,
-and `register` for reviewing detailed revenues/expenses.
+hledger-ui, hledger-web, and your bank statement. By contrast, the
+`register` command shows individual postings, across all accounts.
+You might prefer `aregister` for reconciling with real-world
+asset/liability accounts, and `register` for reviewing detailed
+revenues/expenses.
 
 An account must be specified as the first argument, which should be
 the full account name or an account pattern (regular expression).

--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -1,0 +1,66 @@
+aregister, areg\
+Show transactions affecting a particular account, and the account's
+running balance.
+
+_FLAGS
+
+`aregister` shows the transactions affecting a particular account
+(and its subaccounts), from the point of view of that account. 
+Each line shows:
+
+- the transaction's (or posting's, see below) date
+- the names of the other account(s) involved
+- the net change to this account's balance
+- the account's historical running balance (including balance from
+  transactions before the report start date).
+
+This is different from `register`, which shows individual postings.
+With `aregister`, each line represents a whole transaction - as in
+hledger-ui, hledger-web, and your bank statement. You might prefer
+`aregister` for reconciling with real-world asset/liability accounts,
+and `register` for reviewing detailed revenues/expenses.
+
+An account must be specified as the first argument, which should be
+the full account name or an account pattern (regular expression).
+aregister will show transactions in this account (the first one
+matched) and any of its subaccounts.
+
+Any additional arguments form a query which will filter the
+transactions shown.
+
+Transactions making a net change of zero are not shown by default;
+add the `-E/--empty` flag to show them.
+
+## aregister and custom posting dates
+
+Transactions whose date is outside the report period can still be
+shown, if they have a posting to this account dated inside the report
+period. (And in this case it's the posting date that is shown.) 
+This ensures that `aregister` can show an accurate historical running
+balance, matching the one shown by `register -H` with the same
+arguments.
+
+To filter strictly by transaction date instead, add the `--txn-dates`
+flag. If you use this flag and some of your postings have custom
+dates, it's probably best to assume the running balance is wrong.
+
+### Output format
+
+This command also supports the
+[output destination](hledger.html#output-destination) and
+[output format](hledger.html#output-format) options
+The output formats supported are `txt`, `csv`, and `json`.
+
+Examples:
+
+Show all transactions and historical running balance in the first
+account whose name contains "checking":
+```shell
+$ hledger areg checking
+```
+
+Show transactions and historical running balance in all asset accounts
+during july:
+```shell
+$ hledger areg assets date:jul
+```

--- a/hledger/Hledger/Cli/Commands/Aregister.txt
+++ b/hledger/Hledger/Cli/Commands/Aregister.txt
@@ -1,0 +1,60 @@
+aregister, areg
+Show transactions affecting a particular account, and the account's
+running balance.
+
+_FLAGS
+
+aregister shows the transactions affecting a particular account (and its
+subaccounts), from the point of view of that account. Each line shows:
+
+-   the transaction's (or posting's, see below) date
+-   the names of the other account(s) involved
+-   the net change to this account's balance
+-   the account's historical running balance (including balance from
+    transactions before the report start date).
+
+This is different from register, which shows individual postings. With
+aregister, each line represents a whole transaction - as in hledger-ui,
+hledger-web, and your bank statement. You might prefer aregister for
+reconciling with real-world asset/liability accounts, and register for
+reviewing detailed revenues/expenses.
+
+An account must be specified as the first argument, which should be the
+full account name or an account pattern (regular expression). aregister
+will show transactions in this account (the first one matched) and any
+of its subaccounts.
+
+Any additional arguments form a query which will filter the transactions
+shown.
+
+Transactions making a net change of zero are not shown by default; add
+the -E/--empty flag to show them.
+
+aregister and custom posting dates
+
+Transactions whose date is outside the report period can still be shown,
+if they have a posting to this account dated inside the report period.
+(And in this case it's the posting date that is shown.) This ensures
+that aregister can show an accurate historical running balance, matching
+the one shown by register -H with the same arguments.
+
+To filter strictly by transaction date instead, add the --txn-dates
+flag. If you use this flag and some of your postings have custom dates,
+it's probably best to assume the running balance is wrong.
+
+Output format
+
+This command also supports the output destination and output format
+options The output formats supported are txt, csv, and json.
+
+Examples:
+
+Show all transactions and historical running balance in the first
+account whose name contains "checking":
+
+$ hledger areg checking
+
+Show transactions and historical running balance in all asset accounts
+during july:
+
+$ hledger areg assets date:jul

--- a/hledger/Hledger/Cli/Commands/Balance.txt
+++ b/hledger/Hledger/Cli/Commands/Balance.txt
@@ -292,10 +292,6 @@ Balance changes in 2008:
 
 (Average is rounded to the dollar here since all journal amounts are)
 
-A limitation of multicolumn balance reports: eliding of boring parent
-accounts in tree mode, as in the classic balance report, is not yet
-supported.
-
 The --transpose flag can be used to exchange the rows and columns of a
 multicolumn report.
 

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -2510,6 +2510,84 @@ Date [2015/05/22]: <CTRL-D> $
 .PP
 On Microsoft Windows, the add command makes sure that no part of the
 file path ends with a period, as that would cause problems (#1056).
+.SS aregister
+.PP
+aregister, areg
+.PD 0
+.P
+.PD
+Show transactions affecting a particular account, and the account\[aq]s
+running balance.
+.PP
+\f[C]aregister\f[R] shows the transactions affecting a particular
+account (and its subaccounts), from the point of view of that account.
+Each line shows:
+.IP \[bu] 2
+the transaction\[aq]s (or posting\[aq]s, see below) date
+.IP \[bu] 2
+the names of the other account(s) involved
+.IP \[bu] 2
+the net change to this account\[aq]s balance
+.IP \[bu] 2
+the account\[aq]s historical running balance (including balance from
+transactions before the report start date).
+.PP
+This is different from \f[C]register\f[R], which shows individual
+postings.
+With \f[C]aregister\f[R], each line represents a whole transaction - as
+in hledger-ui, hledger-web, and your bank statement.
+You might prefer \f[C]aregister\f[R] for reconciling with real-world
+asset/liability accounts, and \f[C]register\f[R] for reviewing detailed
+revenues/expenses.
+.PP
+An account must be specified as the first argument, which should be the
+full account name or an account pattern (regular expression).
+aregister will show transactions in this account (the first one matched)
+and any of its subaccounts.
+.PP
+Any additional arguments form a query which will filter the transactions
+shown.
+.PP
+Transactions making a net change of zero are not shown by default; add
+the \f[C]-E/--empty\f[R] flag to show them.
+.SS aregister and custom posting dates
+.PP
+Transactions whose date is outside the report period can still be shown,
+if they have a posting to this account dated inside the report period.
+(And in this case it\[aq]s the posting date that is shown.) This ensures
+that \f[C]aregister\f[R] can show an accurate historical running
+balance, matching the one shown by \f[C]register -H\f[R] with the same
+arguments.
+.PP
+To filter strictly by transaction date instead, add the
+\f[C]--txn-dates\f[R] flag.
+If you use this flag and some of your postings have custom dates,
+it\[aq]s probably best to assume the running balance is wrong.
+.SS Output format
+.PP
+This command also supports the output destination and output format
+options The output formats supported are \f[C]txt\f[R], \f[C]csv\f[R],
+and \f[C]json\f[R].
+.PP
+Examples:
+.PP
+Show all transactions and historical running balance in the first
+account whose name contains \[dq]checking\[dq]:
+.IP
+.nf
+\f[C]
+$ hledger areg checking
+\f[R]
+.fi
+.PP
+Show transactions and historical running balance in all asset accounts
+during july:
+.IP
+.nf
+\f[C]
+$ hledger areg assets date:jul
+\f[R]
+.fi
 .SS balance
 .PP
 balance, bal, b
@@ -2875,10 +2953,6 @@ Balance changes in 2008:
 (Average is rounded to the dollar here since all journal amounts are)
 \f[R]
 .fi
-.PP
-A limitation of multicolumn balance reports: eliding of boring parent
-accounts in tree mode, as in the classic balance report, is not yet
-supported.
 .PP
 The \f[C]--transpose\f[R] flag can be used to exchange the rows and
 columns of a multicolumn report.

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bf35436858458ba596817d0df9607254f9cc89ef56e8e33c50592da42d6ab9a6
+-- hash: c1625e78b08f4636b95a4c4913115d62e4603dbfbd9d715188f442a33ae2016d
 
 name:           hledger
 version:        1.18.99
@@ -61,6 +61,7 @@ extra-source-files:
     Hledger/Cli/Commands/Accounts.txt
     Hledger/Cli/Commands/Activity.txt
     Hledger/Cli/Commands/Add.txt
+    Hledger/Cli/Commands/Aregister.txt
     Hledger/Cli/Commands/Balance.txt
     Hledger/Cli/Commands/Balancesheet.txt
     Hledger/Cli/Commands/Balancesheetequity.txt
@@ -116,6 +117,7 @@ library
       Hledger.Cli.Commands.Accounts
       Hledger.Cli.Commands.Activity
       Hledger.Cli.Commands.Add
+      Hledger.Cli.Commands.Aregister
       Hledger.Cli.Commands.Balance
       Hledger.Cli.Commands.Balancesheet
       Hledger.Cli.Commands.Balancesheetequity

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -1896,6 +1896,8 @@ detailed command help.
 * accounts::
 * activity::
 * add::
+* aregister::
+* aregister and custom posting dates::
 * balance::
 * balancesheet::
 * balancesheetequity::
@@ -1977,7 +1979,7 @@ $ hledger activity --quarterly
 2008-10-01 **
 
 
-File: hledger.info,  Node: add,  Next: balance,  Prev: activity,  Up: COMMANDS
+File: hledger.info,  Node: add,  Next: aregister,  Prev: activity,  Up: COMMANDS
 
 3.3 add
 =======
@@ -2048,9 +2050,84 @@ Date [2015/05/22]: <CTRL-D> $
 file path ends with a period, as that would cause problems (#1056).
 
 
-File: hledger.info,  Node: balance,  Next: balancesheet,  Prev: add,  Up: COMMANDS
+File: hledger.info,  Node: aregister,  Next: aregister and custom posting dates,  Prev: add,  Up: COMMANDS
 
-3.4 balance
+3.4 aregister
+=============
+
+aregister, areg
+Show transactions affecting a particular account, and the account's
+running balance.
+
+   'aregister' shows the transactions affecting a particular account
+(and its subaccounts), from the point of view of that account.  Each
+line shows:
+
+   * the transaction's (or posting's, see below) date
+   * the names of the other account(s) involved
+   * the net change to this account's balance
+   * the account's historical running balance (including balance from
+     transactions before the report start date).
+
+   This is different from 'register', which shows individual postings.
+With 'aregister', each line represents a whole transaction - as in
+hledger-ui, hledger-web, and your bank statement.  You might prefer
+'aregister' for reconciling with real-world asset/liability accounts,
+and 'register' for reviewing detailed revenues/expenses.
+
+   An account must be specified as the first argument, which should be
+the full account name or an account pattern (regular expression).
+aregister will show transactions in this account (the first one matched)
+and any of its subaccounts.
+
+   Any additional arguments form a query which will filter the
+transactions shown.
+
+   Transactions making a net change of zero are not shown by default;
+add the '-E/--empty' flag to show them.
+
+
+File: hledger.info,  Node: aregister and custom posting dates,  Next: balance,  Prev: aregister,  Up: COMMANDS
+
+3.5 aregister and custom posting dates
+======================================
+
+Transactions whose date is outside the report period can still be shown,
+if they have a posting to this account dated inside the report period.
+(And in this case it's the posting date that is shown.)  This ensures
+that 'aregister' can show an accurate historical running balance,
+matching the one shown by 'register -H' with the same arguments.
+
+   To filter strictly by transaction date instead, add the '--txn-dates'
+flag.  If you use this flag and some of your postings have custom dates,
+it's probably best to assume the running balance is wrong.
+
+* Menu:
+
+* Output format::
+
+3.5.1 Output format
+-------------------
+
+This command also supports the output destination and output format
+options The output formats supported are 'txt', 'csv', and 'json'.
+
+   Examples:
+
+   Show all transactions and historical running balance in the first
+account whose name contains "checking":
+
+$ hledger areg checking
+
+   Show transactions and historical running balance in all asset
+accounts during july:
+
+$ hledger areg assets date:jul
+
+
+File: hledger.info,  Node: balance,  Next: balancesheet,  Prev: aregister and custom posting dates,  Up: COMMANDS
+
+3.6 balance
 ===========
 
 balance, bal, b
@@ -2093,7 +2170,7 @@ is used to ensure this (more below).
 
 File: hledger.info,  Node: Classic balance report,  Next: Customising the classic balance report,  Up: balance
 
-3.4.1 Classic balance report
+3.6.1 Classic balance report
 ----------------------------
 
 This is the original balance report, as found in Ledger.  It usually
@@ -2141,7 +2218,7 @@ $ hledger balance -p 2008/6 expenses --no-total
 
 File: hledger.info,  Node: Customising the classic balance report,  Next: Colour support,  Prev: Classic balance report,  Up: balance
 
-3.4.2 Customising the classic balance report
+3.6.2 Customising the classic balance report
 --------------------------------------------
 
 You can customise the layout of classic balance reports with '--format
@@ -2203,7 +2280,7 @@ may be needed to get pleasing results.
 
 File: hledger.info,  Node: Colour support,  Next: Flat mode,  Prev: Customising the classic balance report,  Up: balance
 
-3.4.3 Colour support
+3.6.3 Colour support
 --------------------
 
 The balance command shows negative amounts in red, if:
@@ -2214,7 +2291,7 @@ The balance command shows negative amounts in red, if:
 
 File: hledger.info,  Node: Flat mode,  Next: Depth limited balance reports,  Prev: Colour support,  Up: balance
 
-3.4.4 Flat mode
+3.6.4 Flat mode
 ---------------
 
 To see a flat list instead of the default hierarchical display, use
@@ -2230,7 +2307,7 @@ $ hledger balance -p 2008/6 expenses -N --flat --drop 1
 
 File: hledger.info,  Node: Depth limited balance reports,  Next: Percentages,  Prev: Flat mode,  Up: balance
 
-3.4.5 Depth limited balance reports
+3.6.5 Depth limited balance reports
 -----------------------------------
 
 With '--depth N' or 'depth:N' or just '-N', balance reports show
@@ -2249,7 +2326,7 @@ show inclusive balances at the depth limit.
 
 File: hledger.info,  Node: Percentages,  Next: Multicolumn balance report,  Prev: Depth limited balance reports,  Up: balance
 
-3.4.6 Percentages
+3.6.6 Percentages
 -----------------
 
 With '-%' or '--percent', balance reports show each account's value
@@ -2281,7 +2358,7 @@ to use '-V' or '-B' to coerce the report into using a single commodity.
 
 File: hledger.info,  Node: Multicolumn balance report,  Next: Budget report,  Prev: Percentages,  Up: balance
 
-3.4.7 Multicolumn balance report
+3.6.7 Multicolumn balance report
 --------------------------------
 
 Multicolumn or tabular balance reports are a very useful hledger
@@ -2386,10 +2463,6 @@ Balance changes in 2008:
 
 (Average is rounded to the dollar here since all journal amounts are)
 
-   A limitation of multicolumn balance reports: eliding of boring parent
-accounts in tree mode, as in the classic balance report, is not yet
-supported.
-
    The '--transpose' flag can be used to exchange the rows and columns
 of a multicolumn report.
 
@@ -2406,7 +2479,7 @@ bal -D | less -RS'.
 
 File: hledger.info,  Node: Budget report,  Next: ,  Prev: Multicolumn balance report,  Up: balance
 
-3.4.8 Budget report
+3.6.8 Budget report
 -------------------
 
 With '--budget', extra columns are displayed showing budget goals for
@@ -2529,7 +2602,7 @@ Budget performance in 2017/11/01-2017/12/31:
 
 File: hledger.info,  Node: Nested budgets,  Up: Budget report
 
-3.4.8.1 Nested budgets
+3.6.8.1 Nested budgets
 ......................
 
 You can add budgets to any account in your account hierarchy.  If you
@@ -2614,7 +2687,7 @@ Budget performance in 2019/01:
 ----------------------------------------++-------------------------------
                                         ||        0 [                 0] 
 
-3.4.9 Output format
+3.6.9 Output format
 -------------------
 
 This command also supports the output destination and output format
@@ -2624,7 +2697,7 @@ non-budget reports only) 'html', and (experimental) 'json'.
 
 File: hledger.info,  Node: balancesheet,  Next: balancesheetequity,  Prev: balance,  Up: COMMANDS
 
-3.5 balancesheet
+3.7 balancesheet
 ================
 
 balancesheet, bs
@@ -2674,7 +2747,7 @@ options The output formats supported are 'txt', 'csv', 'html', and
 
 File: hledger.info,  Node: balancesheetequity,  Next: cashflow,  Prev: balancesheet,  Up: COMMANDS
 
-3.6 balancesheetequity
+3.8 balancesheetequity
 ======================
 
 balancesheetequity, bse
@@ -2714,7 +2787,7 @@ options The output formats supported are 'txt', 'csv', 'html', and
 
 File: hledger.info,  Node: cashflow,  Next: check-dates,  Prev: balancesheetequity,  Up: COMMANDS
 
-3.7 cashflow
+3.9 cashflow
 ============
 
 cashflow, cf
@@ -2754,8 +2827,8 @@ options The output formats supported are 'txt', 'csv', 'html', and
 
 File: hledger.info,  Node: check-dates,  Next: check-dupes,  Prev: cashflow,  Up: COMMANDS
 
-3.8 check-dates
-===============
+3.10 check-dates
+================
 
 check-dates
 Check that transactions are sorted by increasing date.  With -date2,
@@ -2766,8 +2839,8 @@ Reads the default journal file, or another specified with -f.
 
 File: hledger.info,  Node: check-dupes,  Next: close,  Prev: check-dates,  Up: COMMANDS
 
-3.9 check-dupes
-===============
+3.11 check-dupes
+================
 
 check-dupes
 Reports account names having the same leaf but different prefixes.  In
@@ -2779,7 +2852,7 @@ the default journal file, or another specified as an argument.
 
 File: hledger.info,  Node: close,  Next: codes,  Prev: check-dupes,  Up: COMMANDS
 
-3.10 close
+3.12 close
 ==========
 
 close, equity
@@ -2819,7 +2892,7 @@ you have many foreign currency or investment transactions.
 
 File: hledger.info,  Node: close usage,  Up: close
 
-3.10.1 close usage
+3.12.1 close usage
 ------------------
 
 If you split your journal files by time (eg yearly), you will typically
@@ -2890,7 +2963,7 @@ breaking balance assertions:
 
 File: hledger.info,  Node: codes,  Next: commodities,  Prev: close,  Up: COMMANDS
 
-3.11 codes
+3.13 codes
 ==========
 
 codes
@@ -2936,7 +3009,7 @@ $ hledger codes -E
 
 File: hledger.info,  Node: commodities,  Next: descriptions,  Prev: codes,  Up: COMMANDS
 
-3.12 commodities
+3.14 commodities
 ================
 
 commodities
@@ -2945,7 +3018,7 @@ List all commodity/currency symbols used or declared in the journal.
 
 File: hledger.info,  Node: descriptions,  Next: diff,  Prev: commodities,  Up: COMMANDS
 
-3.13 descriptions
+3.15 descriptions
 =================
 
 descriptions
@@ -2965,7 +3038,7 @@ Person A
 
 File: hledger.info,  Node: diff,  Next: files,  Prev: descriptions,  Up: COMMANDS
 
-3.14 diff
+3.16 diff
 =========
 
 diff
@@ -3000,7 +3073,7 @@ These transactions are in the second file only:
 
 File: hledger.info,  Node: files,  Next: help,  Prev: diff,  Up: COMMANDS
 
-3.15 files
+3.17 files
 ==========
 
 files
@@ -3010,7 +3083,7 @@ file names matching the regular expression (case sensitive) are shown.
 
 File: hledger.info,  Node: help,  Next: import,  Prev: files,  Up: COMMANDS
 
-3.16 help
+3.18 help
 =========
 
 help
@@ -3050,7 +3123,7 @@ DESCRIPTION
 
 File: hledger.info,  Node: import,  Next: incomestatement,  Prev: help,  Up: COMMANDS
 
-3.17 import
+3.19 import
 ===========
 
 import
@@ -3079,7 +3152,7 @@ $ hledger import --dry ... | hledger -f- print unknown --ignore-assertions
 
 File: hledger.info,  Node: Importing balance assignments,  Up: import
 
-3.17.1 Importing balance assignments
+3.19.1 Importing balance assignments
 ------------------------------------
 
 Entries added by import will have their posting amounts made explicit
@@ -3098,7 +3171,7 @@ please test it and send a pull request.)
 
 File: hledger.info,  Node: incomestatement,  Next: notes,  Prev: import,  Up: COMMANDS
 
-3.18 incomestatement
+3.20 incomestatement
 ====================
 
 incomestatement, is
@@ -3147,7 +3220,7 @@ options The output formats supported are 'txt', 'csv', 'html', and
 
 File: hledger.info,  Node: notes,  Next: payees,  Prev: incomestatement,  Up: COMMANDS
 
-3.19 notes
+3.21 notes
 ==========
 
 notes
@@ -3167,7 +3240,7 @@ Snacks
 
 File: hledger.info,  Node: payees,  Next: prices,  Prev: notes,  Up: COMMANDS
 
-3.20 payees
+3.22 payees
 ===========
 
 payees
@@ -3189,7 +3262,7 @@ Person A
 
 File: hledger.info,  Node: prices,  Next: print,  Prev: payees,  Up: COMMANDS
 
-3.21 prices
+3.23 prices
 ===========
 
 prices
@@ -3202,7 +3275,7 @@ Price amounts are always displayed with their full precision.
 
 File: hledger.info,  Node: print,  Next: print-unique,  Prev: prices,  Up: COMMANDS
 
-3.22 print
+3.24 print
 ==========
 
 print, txns, p
@@ -3311,7 +3384,7 @@ $ hledger print -Ocsv
 
 File: hledger.info,  Node: print-unique,  Next: register,  Prev: print,  Up: COMMANDS
 
-3.23 print-unique
+3.25 print-unique
 =================
 
 print-unique
@@ -3332,7 +3405,7 @@ $ LEDGER_FILE=unique.journal hledger print-unique
 
 File: hledger.info,  Node: register,  Next: register-match,  Prev: print-unique,  Up: COMMANDS
 
-3.24 register
+3.26 register
 =============
 
 register, reg, r
@@ -3422,7 +3495,7 @@ length and comparable to the others in the report.
 
 File: hledger.info,  Node: Custom register output,  Up: register
 
-3.24.1 Custom register output
+3.26.1 Custom register output
 -----------------------------
 
 register uses the full terminal width by default, except on windows.
@@ -3454,7 +3527,7 @@ options The output formats supported are 'txt', 'csv', and
 
 File: hledger.info,  Node: register-match,  Next: rewrite,  Prev: register,  Up: COMMANDS
 
-3.25 register-match
+3.27 register-match
 ===================
 
 register-match
@@ -3467,7 +3540,7 @@ ledger-autosync detect already-seen transactions when importing.
 
 File: hledger.info,  Node: rewrite,  Next: roi,  Prev: register-match,  Up: COMMANDS
 
-3.26 rewrite
+3.28 rewrite
 ============
 
 rewrite
@@ -3519,7 +3592,7 @@ commodity.
 
 File: hledger.info,  Node: Re-write rules in a file,  Up: rewrite
 
-3.26.1 Re-write rules in a file
+3.28.1 Re-write rules in a file
 -------------------------------
 
 During the run this tool will execute so called "Automated Transactions"
@@ -3562,7 +3635,7 @@ postings.
 
 File: hledger.info,  Node: Diff output format,  Next: rewrite vs print --auto,  Up: Re-write rules in a file
 
-3.26.1.1 Diff output format
+3.28.1.1 Diff output format
 ...........................
 
 To use this tool for batch modification of your journal files you may
@@ -3603,7 +3676,7 @@ output from 'hledger print'.
 
 File: hledger.info,  Node: rewrite vs print --auto,  Prev: Diff output format,  Up: Re-write rules in a file
 
-3.26.1.2 rewrite vs. print -auto
+3.28.1.2 rewrite vs. print -auto
 ................................
 
 This command predates print -auto, and currently does much the same
@@ -3623,7 +3696,7 @@ thing, but with these differences:
 
 File: hledger.info,  Node: roi,  Next: stats,  Prev: rewrite,  Up: COMMANDS
 
-3.27 roi
+3.29 roi
 ========
 
 roi
@@ -3651,7 +3724,7 @@ regardless of the length of reporting interval.
 
 File: hledger.info,  Node: stats,  Next: tags,  Prev: roi,  Up: COMMANDS
 
-3.28 stats
+3.30 stats
 ==========
 
 stats
@@ -3682,7 +3755,7 @@ selection.
 
 File: hledger.info,  Node: tags,  Next: test,  Prev: stats,  Up: COMMANDS
 
-3.29 tags
+3.31 tags
 =========
 
 tags
@@ -3695,7 +3768,7 @@ instead.
 
 File: hledger.info,  Node: test,  Next: Add-on commands,  Prev: tags,  Up: COMMANDS
 
-3.30 test
+3.32 test
 =========
 
 test
@@ -3722,7 +3795,7 @@ $ hledger test -- -pData.Amount --color=never
 
 File: hledger.info,  Node: Add-on commands,  Prev: test,  Up: COMMANDS
 
-3.31 Add-on commands
+3.33 Add-on commands
 ====================
 
 hledger also searches for external add-on commands, and will include
@@ -3763,7 +3836,7 @@ interfaces.  These are maintained and released along with hledger:
 
 File: hledger.info,  Node: ui,  Next: web,  Up: Add-on commands
 
-3.31.1 ui
+3.33.1 ui
 ---------
 
 hledger-ui provides an efficient terminal interface.
@@ -3771,7 +3844,7 @@ hledger-ui provides an efficient terminal interface.
 
 File: hledger.info,  Node: web,  Next: iadd,  Prev: ui,  Up: Add-on commands
 
-3.31.2 web
+3.33.2 web
 ----------
 
 hledger-web provides a simple web interface.
@@ -3781,7 +3854,7 @@ hledger-web provides a simple web interface.
 
 File: hledger.info,  Node: iadd,  Next: interest,  Prev: web,  Up: Add-on commands
 
-3.31.3 iadd
+3.33.3 iadd
 -----------
 
 hledger-iadd is a more interactive, terminal UI replacement for the add
@@ -3790,7 +3863,7 @@ command.
 
 File: hledger.info,  Node: interest,  Prev: iadd,  Up: Add-on commands
 
-3.31.4 interest
+3.33.4 interest
 ---------------
 
 hledger-interest generates interest transactions for an account
@@ -4027,115 +4100,120 @@ Node: Effect of valuation on reports58740
 Ref: #effect-of-valuation-on-reports58928
 Node: COMMANDS64449
 Ref: #commands64557
-Node: accounts65651
-Ref: #accounts65749
-Node: activity66448
-Ref: #activity66558
-Node: add66941
-Ref: #add67040
-Node: balance69833
-Ref: #balance69944
-Node: Classic balance report71402
-Ref: #classic-balance-report71575
-Node: Customising the classic balance report73009
-Ref: #customising-the-classic-balance-report73237
-Node: Colour support75313
-Ref: #colour-support75480
-Node: Flat mode75653
-Ref: #flat-mode75801
-Node: Depth limited balance reports76214
-Ref: #depth-limited-balance-reports76399
-Node: Percentages76855
-Ref: #percentages77021
-Node: Multicolumn balance report78158
-Ref: #multicolumn-balance-report78338
-Node: Budget report84076
-Ref: #budget-report84219
-Node: Nested budgets89485
-Ref: #nested-budgets89597
-Ref: #output-format-193078
-Node: balancesheet93275
-Ref: #balancesheet93411
-Node: balancesheetequity94877
-Ref: #balancesheetequity95026
-Node: cashflow95749
-Ref: #cashflow95877
-Node: check-dates97056
-Ref: #check-dates97183
-Node: check-dupes97462
-Ref: #check-dupes97586
-Node: close97879
-Ref: #close97987
-Node: close usage99509
-Ref: #close-usage99602
-Node: codes102415
-Ref: #codes102523
-Node: commodities103235
-Ref: #commodities103362
-Node: descriptions103444
-Ref: #descriptions103572
-Node: diff103876
-Ref: #diff103982
-Node: files105029
-Ref: #files105129
-Node: help105276
-Ref: #help105376
-Node: import106457
-Ref: #import106571
-Node: Importing balance assignments107464
-Ref: #importing-balance-assignments107612
-Node: incomestatement108261
-Ref: #incomestatement108394
-Node: notes109881
-Ref: #notes109994
-Node: payees110362
-Ref: #payees110468
-Node: prices110888
-Ref: #prices110994
-Node: print111335
-Ref: #print111445
-Node: print-unique116241
-Ref: #print-unique116367
-Node: register116652
-Ref: #register116779
-Node: Custom register output120951
-Ref: #custom-register-output121080
-Node: register-match122417
-Ref: #register-match122551
-Node: rewrite122902
-Ref: #rewrite123017
-Node: Re-write rules in a file124872
-Ref: #re-write-rules-in-a-file125006
-Node: Diff output format126216
-Ref: #diff-output-format126385
-Node: rewrite vs print --auto127477
-Ref: #rewrite-vs.-print---auto127656
-Node: roi128212
-Ref: #roi128310
-Node: stats129322
-Ref: #stats129421
-Node: tags130209
-Ref: #tags130307
-Node: test130601
-Ref: #test130709
-Node: Add-on commands131456
-Ref: #add-on-commands131573
-Node: ui132916
-Ref: #ui133004
-Node: web133058
-Ref: #web133161
-Node: iadd133277
-Ref: #iadd133388
-Node: interest133470
-Ref: #interest133577
-Node: ENVIRONMENT133817
-Ref: #environment133929
-Node: FILES134758
-Ref: #files-1134861
-Node: LIMITATIONS135074
-Ref: #limitations135193
-Node: TROUBLESHOOTING135935
-Ref: #troubleshooting136048
+Node: accounts65704
+Ref: #accounts65802
+Node: activity66501
+Ref: #activity66611
+Node: add66994
+Ref: #add67095
+Node: aregister69888
+Ref: #aregister70027
+Node: aregister and custom posting dates71316
+Ref: #aregister-and-custom-posting-dates71509
+Ref: #output-format-172130
+Node: balance72535
+Ref: #balance72677
+Node: Classic balance report74135
+Ref: #classic-balance-report74308
+Node: Customising the classic balance report75742
+Ref: #customising-the-classic-balance-report75970
+Node: Colour support78046
+Ref: #colour-support78213
+Node: Flat mode78386
+Ref: #flat-mode78534
+Node: Depth limited balance reports78947
+Ref: #depth-limited-balance-reports79132
+Node: Percentages79588
+Ref: #percentages79754
+Node: Multicolumn balance report80891
+Ref: #multicolumn-balance-report81071
+Node: Budget report86656
+Ref: #budget-report86799
+Node: Nested budgets92065
+Ref: #nested-budgets92177
+Ref: #output-format-295658
+Node: balancesheet95855
+Ref: #balancesheet95991
+Node: balancesheetequity97457
+Ref: #balancesheetequity97606
+Node: cashflow98329
+Ref: #cashflow98457
+Node: check-dates99636
+Ref: #check-dates99765
+Node: check-dupes100044
+Ref: #check-dupes100170
+Node: close100463
+Ref: #close100571
+Node: close usage102093
+Ref: #close-usage102186
+Node: codes104999
+Ref: #codes105107
+Node: commodities105819
+Ref: #commodities105946
+Node: descriptions106028
+Ref: #descriptions106156
+Node: diff106460
+Ref: #diff106566
+Node: files107613
+Ref: #files107713
+Node: help107860
+Ref: #help107960
+Node: import109041
+Ref: #import109155
+Node: Importing balance assignments110048
+Ref: #importing-balance-assignments110196
+Node: incomestatement110845
+Ref: #incomestatement110978
+Node: notes112465
+Ref: #notes112578
+Node: payees112946
+Ref: #payees113052
+Node: prices113472
+Ref: #prices113578
+Node: print113919
+Ref: #print114029
+Node: print-unique118825
+Ref: #print-unique118951
+Node: register119236
+Ref: #register119363
+Node: Custom register output123535
+Ref: #custom-register-output123664
+Node: register-match125001
+Ref: #register-match125135
+Node: rewrite125486
+Ref: #rewrite125601
+Node: Re-write rules in a file127456
+Ref: #re-write-rules-in-a-file127590
+Node: Diff output format128800
+Ref: #diff-output-format128969
+Node: rewrite vs print --auto130061
+Ref: #rewrite-vs.-print---auto130240
+Node: roi130796
+Ref: #roi130894
+Node: stats131906
+Ref: #stats132005
+Node: tags132793
+Ref: #tags132891
+Node: test133185
+Ref: #test133293
+Node: Add-on commands134040
+Ref: #add-on-commands134157
+Node: ui135500
+Ref: #ui135588
+Node: web135642
+Ref: #web135745
+Node: iadd135861
+Ref: #iadd135972
+Node: interest136054
+Ref: #interest136161
+Node: ENVIRONMENT136401
+Ref: #environment136513
+Node: FILES137342
+Ref: #files-1137445
+Node: LIMITATIONS137658
+Ref: #limitations137777
+Node: TROUBLESHOOTING138519
+Ref: #troubleshooting138632
 
 End Tag Table
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -1553,6 +1553,10 @@ _include_(Hledger/Cli/Commands/Activity.md)
 
 _include_(Hledger/Cli/Commands/Add.md)
 
+## aregister
+
+_include_(Hledger/Cli/Commands/Aregister.md)
+
 ## balance
 
 _include_({{Hledger/Cli/Commands/Balance.md}})

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -1739,6 +1739,68 @@ COMMANDS
        On Microsoft Windows, the add command makes sure that no  part  of  the
        file path ends with a period, as that would cause problems (#1056).
 
+   aregister
+       aregister, areg
+       Show  transactions  affecting  a  particular account, and the account's
+       running balance.
+
+       aregister shows the transactions affecting a  particular  account  (and
+       its  subaccounts),  from  the point of view of that account.  Each line
+       shows:
+
+       o the transaction's (or posting's, see below) date
+
+       o the names of the other account(s) involved
+
+       o the net change to this account's balance
+
+       o the account's historical  running  balance  (including  balance  from
+         transactions before the report start date).
+
+       This is different from register, which shows individual postings.  With
+       aregister, each line represents a whole transaction - as in hledger-ui,
+       hledger-web,  and  your bank statement.  You might prefer aregister for
+       reconciling with real-world asset/liability accounts, and register  for
+       reviewing detailed revenues/expenses.
+
+       An account must be specified as the first argument, which should be the
+       full account name or an account pattern (regular expression).   aregis-
+       ter  will show transactions in this account (the first one matched) and
+       any of its subaccounts.
+
+       Any additional arguments form a query which will  filter  the  transac-
+       tions shown.
+
+       Transactions  making a net change of zero are not shown by default; add
+       the -E/--empty flag to show them.
+
+   aregister and custom posting dates
+       Transactions whose date is outside  the  report  period  can  still  be
+       shown,  if  they have a posting to this account dated inside the report
+       period.  (And in this case it's the posting date that is  shown.)  This
+       ensures that aregister can show an accurate historical running balance,
+       matching the one shown by register -H with the same arguments.
+
+       To filter strictly by transaction date  instead,  add  the  --txn-dates
+       flag.   If  you  use  this  flag  and some of your postings have custom
+       dates, it's probably best to assume the running balance is wrong.
+
+   Output format
+       This command also supports the output destination and output format op-
+       tions The output formats supported are txt, csv, and json.
+
+       Examples:
+
+       Show  all  transactions and historical running balance in the first ac-
+       count whose name contains "checking":
+
+              $ hledger areg checking
+
+       Show transactions and historical running balance in all asset  accounts
+       during july:
+
+              $ hledger areg assets date:jul
+
    balance
        balance, bal, b
        Show accounts and their balances.
@@ -2033,10 +2095,6 @@ COMMANDS
                           ||     $-1      $1       0       0        0        0
 
               (Average is rounded to the dollar here since all journal amounts are)
-
-       A  limitation  of multicolumn balance reports: eliding of boring parent
-       accounts in tree mode, as in the classic balance  report,  is  not  yet
-       supported.
 
        The  --transpose flag can be used to exchange the rows and columns of a
        multicolumn report.

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -55,6 +55,7 @@ extra-source-files:
 - Hledger/Cli/Commands/Accounts.txt
 - Hledger/Cli/Commands/Activity.txt
 - Hledger/Cli/Commands/Add.txt
+- Hledger/Cli/Commands/Aregister.txt
 - Hledger/Cli/Commands/Balance.txt
 - Hledger/Cli/Commands/Balancesheet.txt
 - Hledger/Cli/Commands/Balancesheetequity.txt
@@ -163,6 +164,7 @@ library:
   - Hledger.Cli.Commands.Accounts
   - Hledger.Cli.Commands.Activity
   - Hledger.Cli.Commands.Add
+  - Hledger.Cli.Commands.Aregister
   - Hledger.Cli.Commands.Balance
   - Hledger.Cli.Commands.Balancesheet
   - Hledger.Cli.Commands.Balancesheetequity


### PR DESCRIPTION
> aregister, areg\
> Show transactions affecting a particular account, and the account's
> running balance.
> 
> _FLAGS
> 
> `aregister` shows the transactions affecting a particular account
> (and its subaccounts), from the point of view of that account. 
> Each line shows:
> 
> - the transaction's (or posting's, see below) date
> - the names of the other account(s) involved
> - the net change to this account's balance
> - the account's historical running balance (including balance from
>   transactions before the report start date).
> 
> This is different from `register`, which shows individual postings.
> With `aregister`, each line represents a whole transaction - as in
> hledger-ui, hledger-web, and your bank statement. You might prefer
> `aregister` for reconciling with real-world asset/liability accounts,
> and `register` for reviewing detailed revenues/expenses.
> 
> An account must be specified as the first argument, which should be
> the full account name or an account pattern (regular expression).
> aregister will show transactions in this account (the first one
> matched) and any of its subaccounts.
> 
> Any additional arguments form a query which will filter the
> transactions shown.
> 
> Transactions making a net change of zero are not shown by default;
> add the `-E/--empty` flag to show them.
> 
> ## aregister and custom posting dates
> 
> Transactions whose date is outside the report period can still be
> shown, if they have a posting to this account dated inside the report
> period. (And in this case it's the posting date that is shown.) 
> This ensures that `aregister` can show an accurate historical running
> balance, matching the one shown by `register -H` with the same
> arguments.
> 
> To filter strictly by transaction date instead, add the `--txn-dates`
> flag. If you use this flag and some of your postings have custom
> dates, it's probably best to assume the running balance is wrong.
> 
> ### Output format
> 
> This command also supports the
> [output destination](hledger.html#output-destination) and
> [output format](hledger.html#output-format) options
> The output formats supported are `txt`, `csv`, and `json`.
> 
> Examples:
> 
> Show all transactions and historical running balance in the first
> account whose name contains "checking":
> ```shell
> $ hledger areg checking
> ```
> 
> Show transactions and historical running balance in all asset accounts
> during july:
> ```shell
> $ hledger areg assets date:jul
> ```
