### PR TITLE
Use some text library functions, avoid reversing twice.

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -361,7 +361,7 @@ commentAddTag c (t,v)
   | T.null c' = tag
   | otherwise = c' `commentJoin` tag
   where
-    c'  = textchomp c
+    c'  = T.stripEnd c
     tag = t <> ": " <> v
 
 -- | Add a tag on its own line to a comment, preserving any prior content.

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -302,11 +302,10 @@ commentSpace = ("  "++)
 -- appropriately bracketed/parenthesised for the given posting type.
 showAccountName :: Maybe Int -> PostingType -> AccountName -> String
 showAccountName w = fmt
-    where
-      fmt RegularPosting = take w' . T.unpack
-      fmt VirtualPosting = parenthesise . reverse . take (w'-2) . reverse . T.unpack
-      fmt BalancedVirtualPosting = bracket . reverse . take (w'-2) . reverse . T.unpack
-      w' = fromMaybe 999999 w
+  where
+    fmt RegularPosting = maybe id take w . T.unpack
+    fmt VirtualPosting = parenthesise . maybe id (takeEnd . subtract 2) w . T.unpack
+    fmt BalancedVirtualPosting = bracket . maybe id (takeEnd . subtract 2) w . T.unpack
 
 parenthesise :: String -> String
 parenthesise s = "("++s++")"

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -121,7 +121,7 @@ transactionNote = snd . payeeAndNoteFromDescription . tdescription
 payeeAndNoteFromDescription :: Text -> (Text,Text)
 payeeAndNoteFromDescription t
   | T.null n = (t, t)
-  | otherwise = (textstrip p, textstrip $ T.drop 1 n)
+  | otherwise = (T.strip p, T.strip $ T.drop 1 n)
   where
     (p, n) = T.span (/= '|') t
 

--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -1,6 +1,7 @@
 -- | String formatting helpers, starting to get a bit out of control.
 
 module Hledger.Utils.String (
+ takeEnd,
  -- * misc
  lowercase,
  uppercase,
@@ -57,6 +58,14 @@ import Text.Printf (printf)
 import Hledger.Utils.Parse
 import Hledger.Utils.Regex
 
+
+-- | Take elements from the end of a list.
+takeEnd n l = go (drop n l) l
+  where
+    go (_:xs) (_:ys) = go xs ys
+    go []     r      = r
+    go _      []     = []
+
 lowercase, uppercase :: String -> String
 lowercase = map toLower
 uppercase = map toUpper
@@ -86,7 +95,7 @@ stripbrackets = dropWhile (`elem` "([") . reverse . dropWhile (`elem` "])") . re
 
 elideLeft :: Int -> String -> String
 elideLeft width s =
-    if length s > width then ".." ++ reverse (take (width - 2) $ reverse s) else s
+    if length s > width then ".." ++ takeEnd (width - 2) s else s
 
 elideRight :: Int -> String -> String
 elideRight width s =

--- a/hledger-lib/Hledger/Utils/Text.hs
+++ b/hledger-lib/Hledger/Utils/Text.hs
@@ -27,10 +27,6 @@ module Hledger.Utils.Text
  -- isSingleQuoted,
  -- isDoubleQuoted,
  -- -- * single-line layout
-  textstrip,
-  textlstrip,
-  textrstrip,
-  textchomp,
  -- elideLeft,
   textElideRight,
  -- formatString,
@@ -77,22 +73,6 @@ import Hledger.Utils.Test
 -- lowercase, uppercase :: String -> String
 -- lowercase = map toLower
 -- uppercase = map toUpper
-
--- | Remove leading and trailing whitespace.
-textstrip :: Text -> Text
-textstrip = textlstrip . textrstrip
-
--- | Remove leading whitespace.
-textlstrip :: Text -> Text
-textlstrip = T.dropWhile (`elem` (" \t" :: String)) :: Text -> Text -- XXX isSpace ?
-
--- | Remove trailing whitespace.
-textrstrip = T.reverse . textlstrip . T.reverse
-textrstrip :: Text -> Text
-
--- | Remove trailing newlines/carriage returns (and other whitespace).
-textchomp :: Text -> Text
-textchomp = T.stripEnd
 
 -- stripbrackets :: String -> String
 -- stripbrackets = dropWhile (`elem` "([") . reverse . dropWhile (`elem` "])") . reverse :: String -> String


### PR DESCRIPTION
Remove some instances of `reverse . take n . reverse`, and use some text library functions.

Note that the text library stripping functions have slightly different behaviour, as they will remove all whitespace characters instead of just spaces and tabs, but none of the tests seem to fail.