### PR TITLE
lib: Speed up space parsing

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -781,7 +781,7 @@ smartdate = do
 smartdateonly :: TextParser m SmartDate
 smartdateonly = do
   d <- smartdate
-  skipMany spacenonewline
+  skipNonNewlineSpaces
   eof
   return d
 
@@ -907,7 +907,7 @@ lastthisnextthing = do
        ,"this"
        ,"next"
       ]
-  skipMany spacenonewline  -- make the space optional for easier scripting
+  skipNonNewlineSpaces  -- make the space optional for easier scripting
   p <- choice $ map string' [
         "day"
        ,"week"
@@ -972,7 +972,7 @@ lastthisnextthing = do
 -- Right (DayOfMonth 2,DateSpan 2009-01-01..)
 periodexprp :: Day -> TextParser m (Interval, DateSpan)
 periodexprp rdate = do
-  skipMany spacenonewline
+  skipNonNewlineSpaces
   choice $ map try [
                     intervalanddateperiodexprp rdate,
                     (,) NoInterval <$> periodexprdatespanp rdate
@@ -983,7 +983,7 @@ intervalanddateperiodexprp :: Day -> TextParser m (Interval, DateSpan)
 intervalanddateperiodexprp rdate = do
   i <- reportingintervalp
   s <- option def . try $ do
-      skipMany spacenonewline
+      skipNonNewlineSpaces
       periodexprdatespanp rdate
   return (i,s)
 
@@ -1002,47 +1002,47 @@ reportingintervalp = choice' [
                        do string' "bimonthly"
                           return $ Months 2,
                        do string' "every"
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           n <- nth
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           string' "day"
                           of_ "week"
                           return $ DayOfWeek n,
                        do string' "every"
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           DayOfWeek <$> weekday,
                        do string' "every"
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           n <- nth
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           string' "day"
                           optOf_ "month"
                           return $ DayOfMonth n,
                        do string' "every"
                           let mnth = choice' [month, mon] >>= \(_,m,_) -> return (read m)
                           d_o_y <- runPermutation $
-                            DayOfYear <$> toPermutation (try (skipMany spacenonewline *> mnth))
-                                      <*> toPermutation (try (skipMany spacenonewline *> nth))
+                            DayOfYear <$> toPermutation (try (skipNonNewlineSpaces *> mnth))
+                                      <*> toPermutation (try (skipNonNewlineSpaces *> nth))
                           optOf_ "year"
                           return d_o_y,
                        do string' "every"
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           ("",m,d) <- md
                           optOf_ "year"
                           return $ DayOfYear (read m) (read d),
                        do string' "every"
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           n <- nth
-                          skipMany spacenonewline
+                          skipNonNewlineSpaces
                           wd <- weekday
                           optOf_ "month"
                           return $ WeekdayOfMonth n wd
                     ]
     where
       of_ period = do
-        skipMany spacenonewline
+        skipNonNewlineSpaces
         string' "of"
-        skipMany spacenonewline
+        skipNonNewlineSpaces
         string' period
 
       optOf_ period = optional $ try $ of_ period
@@ -1058,13 +1058,13 @@ reportingintervalp = choice' [
           do string' compact'
              return $ intcons 1,
           do string' "every"
-             skipMany spacenonewline
+             skipNonNewlineSpaces
              string' singular'
              return $ intcons 1,
           do string' "every"
-             skipMany spacenonewline
+             skipNonNewlineSpaces
              n <- read <$> some digitChar
-             skipMany spacenonewline
+             skipNonNewlineSpaces
              string' plural'
              return $ intcons n
           ]
@@ -1086,17 +1086,17 @@ periodexprdatespanp rdate = choice $ map try [
 -- Right DateSpan 2018-01-01..2018-04-01
 doubledatespanp :: Day -> TextParser m DateSpan
 doubledatespanp rdate = do
-  optional (string' "from" >> skipMany spacenonewline)
+  optional (string' "from" >> skipNonNewlineSpaces)
   b <- smartdate
-  skipMany spacenonewline
-  optional (choice [string' "to", string "..", string' "-"] >> skipMany spacenonewline)
+  skipNonNewlineSpaces
+  optional (choice [string' "to", string "..", string' "-"] >> skipNonNewlineSpaces)
   DateSpan (Just $ fixSmartDate rdate b) . Just . fixSmartDate rdate <$> smartdate
 
 fromdatespanp :: Day -> TextParser m DateSpan
 fromdatespanp rdate = do
   b <- choice [
     do
-      string' "from" >> skipMany spacenonewline
+      string' "from" >> skipNonNewlineSpaces
       smartdate
     ,
     do
@@ -1108,12 +1108,12 @@ fromdatespanp rdate = do
 
 todatespanp :: Day -> TextParser m DateSpan
 todatespanp rdate = do
-  choice [string' "to", string' "until", string "..", string' "-"] >> skipMany spacenonewline
+  choice [string' "to", string' "until", string "..", string' "-"] >> skipNonNewlineSpaces
   DateSpan Nothing . Just . fixSmartDate rdate <$> smartdate
 
 justdatespanp :: Day -> TextParser m DateSpan
 justdatespanp rdate = do
-  optional (string' "in" >> skipMany spacenonewline)
+  optional (string' "in" >> skipNonNewlineSpaces)
   spanFromSmartDate rdate <$> smartdate
 
 -- | Make a datespan from two valid date strings parseable by parsedate

--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -196,7 +196,7 @@ words'' :: [T.Text] -> T.Text -> [T.Text]
 words'' prefixes = fromparse . parsewith maybeprefixedquotedphrases -- XXX
     where
       maybeprefixedquotedphrases :: SimpleTextParser [T.Text]
-      maybeprefixedquotedphrases = choice' [prefixedQuotedPattern, singleQuotedPattern, doubleQuotedPattern, pattern] `sepBy` skipSome spacenonewline
+      maybeprefixedquotedphrases = choice' [prefixedQuotedPattern, singleQuotedPattern, doubleQuotedPattern, pattern] `sepBy` skipNonNewlineSpaces1
       prefixedQuotedPattern :: SimpleTextParser T.Text
       prefixedQuotedPattern = do
         not' <- fromMaybe "" `fmap` (optional $ string "not:")

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -247,7 +247,7 @@ directivep = (do
 includedirectivep :: MonadIO m => ErroringJournalParser m ()
 includedirectivep = do
   string "include"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   prefixedglob <- T.unpack <$> takeWhileP Nothing (/= '\n') -- don't consume newline yet
   parentoff <- getOffset
   parentpos <- getSourcePos
@@ -331,7 +331,7 @@ accountdirectivep = do
   off <- getOffset -- XXX figure out a more precise position later
 
   string "account"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
 
   -- the account name, possibly modified by preceding alias or apply account directives
   acct <- modifiedaccountnamep
@@ -339,7 +339,7 @@ accountdirectivep = do
   -- maybe an account type code (ALERX) after two or more spaces
   -- XXX added in 1.11, deprecated in 1.13, remove in 1.14
   mtypecode :: Maybe Char <- lift $ optional $ try $ do
-    skipSome spacenonewline -- at least one more space in addition to the one consumed by modifiedaccountp
+    skipNonNewlineSpaces1 -- at least one more space in addition to the one consumed by modifiedaccountp
     choice $ map char "ALERX"
 
   -- maybe a comment, on this and/or following lines
@@ -400,7 +400,7 @@ addAccountDeclaration (a,cmt,tags) =
                j{jdeclaredaccounts = d:decls})
 
 indentedlinep :: JournalParser m String
-indentedlinep = lift (skipSome spacenonewline) >> (rstrip <$> lift restofline)
+indentedlinep = lift skipNonNewlineSpaces1 >> (rstrip <$> lift restofline)
 
 -- | Parse a one-line or multi-line commodity directive.
 --
@@ -419,11 +419,11 @@ commoditydirectiveonelinep :: JournalParser m ()
 commoditydirectiveonelinep = do
   (off, Amount{acommodity,astyle}) <- try $ do
     string "commodity"
-    lift (skipSome spacenonewline)
+    lift skipNonNewlineSpaces1
     off <- getOffset
     amount <- amountp
     pure $ (off, amount)
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   _ <- lift followingcommentp
   let comm = Commodity{csymbol=acommodity, cformat=Just $ dbg6 "style from commodity directive" astyle}
   if asdecimalpoint astyle == Nothing
@@ -447,21 +447,21 @@ pleaseincludedecimalpoint = chomp $ unlines [
 commoditydirectivemultilinep :: JournalParser m ()
 commoditydirectivemultilinep = do
   string "commodity"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   sym <- lift commoditysymbolp
   _ <- lift followingcommentp
   mformat <- lastMay <$> many (indented $ formatdirectivep sym)
   let comm = Commodity{csymbol=sym, cformat=mformat}
   modify' (\j -> j{jcommodities=M.insert sym comm $ jcommodities j})
   where
-    indented = (lift (skipSome spacenonewline) >>)
+    indented = (lift skipNonNewlineSpaces1 >>)
 
 -- | Parse a format (sub)directive, throwing a parse error if its
 -- symbol does not match the one given.
 formatdirectivep :: CommoditySymbol -> JournalParser m AmountStyle
 formatdirectivep expectedsym = do
   string "format"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   off <- getOffset
   Amount{acommodity,astyle} <- amountp
   _ <- lift followingcommentp
@@ -477,7 +477,7 @@ keywordp :: String -> JournalParser m ()
 keywordp = (() <$) . string . fromString
 
 spacesp :: JournalParser m ()
-spacesp = () <$ lift (skipSome spacenonewline)
+spacesp = () <$ lift skipNonNewlineSpaces1
 
 -- | Backtracking parser similar to string, but allows varying amount of space between words
 keywordsp :: String -> JournalParser m ()
@@ -486,7 +486,7 @@ keywordsp = try . sequence_ . intersperse spacesp . map keywordp . words
 applyaccountdirectivep :: JournalParser m ()
 applyaccountdirectivep = do
   keywordsp "apply account" <?> "apply account directive"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   parent <- lift accountnamep
   newline
   pushParentAccount parent
@@ -499,7 +499,7 @@ endapplyaccountdirectivep = do
 aliasdirectivep :: JournalParser m ()
 aliasdirectivep = do
   string "alias"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   alias <- lift accountaliasp
   addAccountAlias alias
 
@@ -511,7 +511,7 @@ basicaliasp = do
   -- dbgparse 0 "basicaliasp"
   old <- rstrip <$> (some $ noneOf ("=" :: [Char]))
   char '='
-  skipMany spacenonewline
+  skipNonNewlineSpaces
   new <- rstrip <$> anySingle `manyTill` eolof  -- eol in journal, eof in command lines, normally
   return $ BasicAlias (T.pack old) (T.pack new)
 
@@ -521,9 +521,9 @@ regexaliasp = do
   char '/'
   re <- some $ noneOf ("/\n\r" :: [Char]) -- paranoid: don't try to read past line end
   char '/'
-  skipMany spacenonewline
+  skipNonNewlineSpaces
   char '='
-  skipMany spacenonewline
+  skipNonNewlineSpaces
   repl <- anySingle `manyTill` eolof
   return $ RegexAlias re repl
 
@@ -535,7 +535,7 @@ endaliasesdirectivep = do
 tagdirectivep :: JournalParser m ()
 tagdirectivep = do
   string "tag" <?> "tag directive"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   _ <- lift $ some nonspace
   lift restofline
   return ()
@@ -549,7 +549,7 @@ endtagdirectivep = do
 defaultyeardirectivep :: JournalParser m ()
 defaultyeardirectivep = do
   char 'Y' <?> "default year"
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   y <- some digitChar
   let y' = read y
   failIfInvalidYear y
@@ -558,7 +558,7 @@ defaultyeardirectivep = do
 defaultcommoditydirectivep :: JournalParser m ()
 defaultcommoditydirectivep = do
   char 'D' <?> "default commodity"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   off <- getOffset
   Amount{acommodity,astyle} <- amountp
   lift restofline
@@ -569,11 +569,11 @@ defaultcommoditydirectivep = do
 marketpricedirectivep :: JournalParser m PriceDirective
 marketpricedirectivep = do
   char 'P' <?> "market price"
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   date <- try (do {LocalTime d _ <- datetimep; return d}) <|> datep -- a time is ignored
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   symbol <- lift commoditysymbolp
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   price <- amountp
   lift restofline
   return $ PriceDirective date symbol price
@@ -581,7 +581,7 @@ marketpricedirectivep = do
 ignoredpricecommoditydirectivep :: JournalParser m ()
 ignoredpricecommoditydirectivep = do
   char 'N' <?> "ignored-price commodity"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   lift commoditysymbolp
   lift restofline
   return ()
@@ -589,11 +589,11 @@ ignoredpricecommoditydirectivep = do
 commodityconversiondirectivep :: JournalParser m ()
 commodityconversiondirectivep = do
   char 'C' <?> "commodity conversion"
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   amountp
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   char '='
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   amountp
   lift restofline
   return ()
@@ -604,7 +604,7 @@ commodityconversiondirectivep = do
 transactionmodifierp :: JournalParser m TransactionModifier
 transactionmodifierp = do
   char '=' <?> "modifier transaction"
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   querytxt <- lift $ T.strip <$> descriptionp
   (_comment, _tags) <- lift transactioncommentp   -- TODO apply these to modified txns ?
   postings <- postingsp Nothing
@@ -624,7 +624,7 @@ periodictransactionp = do
 
   -- first line
   char '~' <?> "periodic transaction"
-  lift $ skipMany spacenonewline
+  lift $ skipNonNewlineSpaces
   -- a period expression
   off <- getOffset
 
@@ -704,7 +704,7 @@ postingsp mTransactionYear = many (postingp mTransactionYear) <?> "postings"
 
 -- linebeginningwithspaces :: JournalParser m String
 -- linebeginningwithspaces = do
---   sp <- lift (skipSome spacenonewline)
+--   sp <- lift skipNonNewlineSpaces1
 --   c <- nonspace
 --   cs <- lift restofline
 --   return $ sp ++ (c:cs) ++ "\n"
@@ -713,17 +713,17 @@ postingp :: Maybe Year -> JournalParser m Posting
 postingp mTransactionYear = do
   -- lift $ dbgparse 0 "postingp"
   (status, account) <- try $ do
-    lift (skipSome spacenonewline)
+    lift skipNonNewlineSpaces1
     status <- lift statusp
-    lift (skipMany spacenonewline)
+    lift skipNonNewlineSpaces
     account <- modifiedaccountnamep
     return (status, account)
   let (ptype, account') = (accountNamePostingType account, textUnbracket account)
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   amount <- option missingmixedamt $ Mixed . (:[]) <$> amountp
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   massertion <- optional balanceassertionp
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   (comment,tags,mdate,mdate2) <- lift $ postingcommentp mTransactionYear
   return posting
    { pdate=mdate

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -121,10 +121,10 @@ timeclockentryp :: JournalParser m TimeclockEntry
 timeclockentryp = do
   sourcepos <- genericSourcePos <$> lift getSourcePos
   code <- oneOf ("bhioO" :: [Char])
-  lift (skipSome spacenonewline)
+  lift skipNonNewlineSpaces1
   datetime <- datetimep
-  account <- fromMaybe "" <$> optional (lift (skipSome spacenonewline) >> modifiedaccountnamep)
-  description <- T.pack . fromMaybe "" <$> lift (optional (skipSome spacenonewline >> restofline))
+  account <- fromMaybe "" <$> optional (lift skipNonNewlineSpaces1 >> modifiedaccountnamep)
+  description <- T.pack . fromMaybe "" <$> lift (optional (skipNonNewlineSpaces1 >> restofline))
   return $ TimeclockEntry sourcepos (read [code]) datetime account description
 
 

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -159,7 +159,7 @@ commentlinesp = do
 
 orgheadingprefixp = do
   -- traceparse "orgheadingprefixp"
-  skipSome (char '*') >> skipSome spacenonewline
+  skipSome (char '*') >> skipNonNewlineSpaces1
 
 -- | Parse a single timedot entry to one (dateless) transaction.
 -- @
@@ -170,9 +170,9 @@ entryp = do
   lift $ traceparse "entryp"
   pos <- genericSourcePos <$> getSourcePos
   notFollowedBy datelinep
-  lift $ optional $ choice [orgheadingprefixp, skipSome spacenonewline]
+  lift $ optional $ choice [orgheadingprefixp, skipNonNewlineSpaces1]
   a <- modifiedaccountnamep
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   hours <-
     try (lift followingcommentp >> return 0)
     <|> (durationp <*
@@ -211,7 +211,7 @@ numericquantityp = do
   -- lift $ traceparse "numericquantityp"
   (q, _, _, _) <- lift $ numberp Nothing
   msymbol <- optional $ choice $ map (string . fst) timeUnits
-  lift (skipMany spacenonewline)
+  lift skipNonNewlineSpaces
   let q' =
         case msymbol of
           Nothing  -> q
@@ -249,7 +249,7 @@ emptyorcommentlinep :: [Char] -> TextParser m ()
 emptyorcommentlinep cs =
   label ("empty line or comment line beginning with "++cs) $ do
     traceparse "emptyorcommentlinep" -- XXX possible to combine label and traceparse ?
-    skipMany spacenonewline
+    skipNonNewlineSpaces
     void newline <|> void commentp
     traceparse' "emptyorcommentlinep"
     where

--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -145,7 +145,7 @@ words' :: String -> [String]
 words' "" = []
 words' s  = map stripquotes $ fromparse $ parsewithString p s
     where
-      p = do ss <- (singleQuotedPattern <|> doubleQuotedPattern <|> pattern) `sepBy` skipSome spacenonewline
+      p = do ss <- (singleQuotedPattern <|> doubleQuotedPattern <|> pattern) `sepBy` skipNonNewlineSpaces1
              -- eof
              return ss
       pattern = many (noneOf whitespacechars)

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -279,7 +279,7 @@ dateAndCodeWizard PrevInput{..} EntryState{..} = do
             dateandcodep = do
                 d <- smartdate
                 c <- optional codep
-                skipMany spacenonewline
+                skipNonNewlineSpaces
                 eof
                 return (d, fromMaybe "" c)
       -- defday = fixSmartDate today $ fromparse $ (parse smartdate "" . lowercase) defdate
@@ -356,7 +356,7 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
       amountandcommentp :: JournalParser Identity (Amount, Text)
       amountandcommentp = do
         a <- amountp
-        lift (skipMany spacenonewline)
+        lift skipNonNewlineSpaces
         c <- T.pack <$> fromMaybe "" `fmap` optional (char ';' >> many anySingle)
         -- eof
         return (a,c)


### PR DESCRIPTION
This replaces all uses of `skipMany spacenonewline` with `takeWhileP isNonNewlineSpace`, and similarly for `skipSome` and `takeWhile1P`.

Profiling suggested this would give some performance improvements. Evidence for actually getting this improvement is mixed:
- quickbench is showing no significant difference in run time.
- running `hledger balance assets +RTS -P` on my system suggests a roughly 8% decrease in total time and total memeory allocation.

In any case, I think this change probably gives improvements, and is unlikely to cause any harm.