### PR TITLE
lib: disallow tabs in simplecommoditysymbolp (fixes #1301)

### DIFF
--- a/hledger-lib/Hledger/Data/Commodity.hs
+++ b/hledger-lib/Hledger/Data/Commodity.hs
@@ -26,12 +26,10 @@ import Hledger.Utils
 
 
 -- characters that may not be used in a non-quoted commodity symbol
-nonsimplecommoditychars = "0123456789-+.@*;\n \"{}=" :: String
-
 isNonsimpleCommodityChar :: Char -> Bool
 isNonsimpleCommodityChar c = isDigit c || c `textElem` otherChars
  where
-   otherChars = "-+.@*;\n \"{}=" :: T.Text
+   otherChars = "-+.@*;\t\n \"{}=" :: T.Text
    textElem = T.any . (==)
 
 quoteCommoditySymbolIfNeeded s | T.any (isNonsimpleCommodityChar) s = "\"" <> s <> "\""

--- a/tests/journal/amounts-and-commodities.test
+++ b/tests/journal/amounts-and-commodities.test
@@ -151,6 +151,21 @@ $ hledger -f- print
 $ hledger -f- print
 > //    # any stdout, no stderr, 0 exit code
 
+# 12. After commodity on the right, don't parse tab
+<
+2020-07-21
+	a    	-1600 EUR
+	a		1600 EUR	
+	
+; import Stock value at 2020-07-22
+2020-07-21 
+	a 	-1 EUR  
+	a 	 1 EUR	
+$ hledger -f- bal a
+--------------------
+                   0
+>=
+
 # 12. Example of surprising decimal mark parsing behaviour.
 # Without a commodity declaration, these amounts are parsed as 10 and 10000.
 # <


### PR DESCRIPTION
Does what it says on the tin :)

We already disallow `\n` and space, so adding `\t` there seems logical. I threw in a test for a good measure