### PR TITLE
implement parsing of "q1" and "2020q1"

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -1082,8 +1082,8 @@ periodexprdatespanp rdate = choice $ map try [
                            ]
 
 -- |
--- -- >>> parsewith (doubledatespan (parsedate "2018/01/01") <* eof) "20180101-201804"
--- Right DateSpan 2018-01-01..2018-04-01
+-- >>> parsewith (doubledatespanp (parsedate "2018/01/01") <* eof) "20180101-201804"
+-- Right DateSpan 2018Q1
 doubledatespanp :: Day -> TextParser m DateSpan
 doubledatespanp rdate = do
   optional (string' "from" >> skipNonNewlineSpaces)


### PR DESCRIPTION
Unfortunately I was not able to run the tests.
Nevertheless, I added some doctest examples.
