### PR TITLE
tests: Remove commented test behaviour in 373, better distinguish tree and flat mode in 219.

### DIFF
--- a/tests/balance/219.test
+++ b/tests/balance/219.test
@@ -1,6 +1,6 @@
 # issue 219, --tree and --flat flags should override each other cleanly
 # 1. multiple flags ending with --flat, equivalent to --flat
-hledger -f balance-multicol.journal bal -MEH --no-total date:2013/1 --tree --flat
+hledger -f balance-multicol.journal bal -MH --no-elide --no-total date:2013/1 --tree --flat
 >>>
 Ending balances (historical) in 2013-01:
 
@@ -10,7 +10,7 @@ Ending balances (historical) in 2013-01:
 >>>= 0
 
 # 2. multiple flags ending with --tree, equivalent to --tree
-hledger -f balance-multicol.journal bal -MEH --no-total date:2013/1 --flat --tree
+hledger -f balance-multicol.journal bal -MH --no-elide --no-total date:2013/1 --flat --tree
 >>>
 Ending balances (historical) in 2013-01:
 

--- a/tests/balance/373-layout.test
+++ b/tests/balance/373-layout.test
@@ -16,12 +16,6 @@
   1                                         -1
 
 # 1. simple balance report in tree mode with zero/boring parents
-# TODO should be like
-#$ ledger bal
-#                   1  1:2:3
-#                   1    4:5
-#--------------------
-#                   0
 $ hledger -f - bal --tree
                    0  1:2
                    1    3
@@ -31,12 +25,6 @@ $ hledger -f - bal --tree
                    0
 
 # 2. simple balance report in flat mode
-# TODO should be like
-#$ ledger bal --flat
-#                   1  1:2:3
-#                   1  1:2:3:4:5
-#--------------------
-#                   0
 $ hledger -f - bal --flat
                   -1  1:2
                    1  1:2:3
@@ -58,8 +46,8 @@ Balance changes in 2015:
 -----------++------
            ||    0 
 
-# 4. tabular balance report in tree mode, showing zero accounts
-$ hledger -f - bal -Y --tree -E
+# 4. tabular balance report in tree mode, showing boring parents
+$ hledger -f - bal -Y --tree --no-elide
 Balance changes in 2015:
 
            || 2015 
@@ -74,16 +62,6 @@ Balance changes in 2015:
 
 # 5. tabular balance report in tree mode, hiding zero accounts
 # Undisplayed parent accounts should be mentioned in the displayed account names as necessary
-# TODO: should be like
-# Balance changes in 2015:
-#
-#            || 2015 
-# ===========++======
-#  1:2:3     ||    1 
-#  1:2:3:4:5 ||    1 
-# -----------++------
-#            ||      
-#
 $ hledger -f - bal -Y --tree
 Balance changes in 2015:
 


### PR DESCRIPTION
In my opinion, the commented test behaviour is incorrect, and the current behaviour is correct. The commented behaviour mostly involves eliding accounts that have zero inclusive balance, *even though* those accounts have non-zero exclusive balance. I think eliding those accounts creates confusion.

For example, in the following, why is the total given as 0?
```
$ hledger bal --tree
                   1  1:2:3
                   1    4:5
--------------------
                   0
```
It's because `1:2` has an exclusive balance of -1, which cancels with the exclusive balance of `1:2:3`. Similarly, there's an exclusive balance of -1 in `1:2:3:4`.
The current behaviour shows those amounts
```
$ hledger bal --tree
                   0  1:2
                   1    3
                   0      4
                   1        5
--------------------
                   0
```
This may be more verbose, but is much clearer.