### PR TITLE
cli: No longer force --no-total in compound balance reports when using --percent.

### DIFF
--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -101,10 +101,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportopts_=r
             _            -> Nothing
       balancetype = fromMaybe cbctype mBalanceTypeOverride
       -- Set balance type in the report options.
-      ropts' = ropts{
-        balancetype_=balancetype,
-        no_total_=if percent_ && length cbcqueries > 1 then True else no_total_
-      }
+      ropts' = ropts{balancetype_=balancetype}
 
       title =
         cbctitle

--- a/tests/incomestatement.test
+++ b/tests/incomestatement.test
@@ -285,7 +285,7 @@ Income Statement 2008-01-31..2008-12-31 (Historical Ending Balances)
 >>>= 0
 
 # 8. Percentage test
-hledger -f sample.journal incomestatement -p 'quarterly 2008' -T --average -%
+hledger -f sample.journal incomestatement -p 'quarterly 2008' -T --average -% --no-total
 >>>
 Income Statement 2008
 


### PR DESCRIPTION
Partly addresses #1309. I'm not sure what the original rationale for this was, but it seems like something the user should be able to control themselves. The fact that the behaviour of `--no-total` in compound balance reports has changed recently may also be justification for removing this.