### PR TITLE
Replace some uses of fromIntegral with safer calls

### DIFF
--- a/bin/hledger-smooth.hs
+++ b/bin/hledger-smooth.hs
@@ -105,7 +105,7 @@ splitPosting acct dates p@Posting{paccount,pamount}
         [d]        -> (d, [])
         []         -> error' "splitPosting ran out of dates, should not happen (maybe sort your transactions by date)"
     days = initSafe [start..end]
-    amt  = (fromIntegral $ length days) `divideMixedAmount` pamount
+    amt  = (genericLength days) `divideMixedAmount` pamount
     -- give one of the postings an exact balancing amount to ensure the transaction is balanced
     -- lastamt = pamount - ptrace (amt `multiplyMixedAmount` (fromIntegral $ length days))
     lastamt = missingmixedamt

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -411,8 +411,8 @@ showamountquantity :: Amount -> String
 showamountquantity Amount{aquantity=q, astyle=AmountStyle{asprecision=p, asdecimalpoint=mdec, asdigitgroups=mgrps}} =
     punctuatenumber (fromMaybe '.' mdec) mgrps qstr
     where
-      -- isint n = fromIntegral (round n) == n
-      qstr -- p == maxprecision && isint q = printf "%d" (round q::Integer)
+      -- isint n = round n == n
+      qstr  -- p == maxprecision && isint q = printf "%d" (round q::Integer)
         | p == maxprecisionwithpoint = show q
         | p == maxprecision          = chopdotzero $ show q
         | otherwise                  = show $ roundTo p q

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -261,7 +261,7 @@ multiplyAmountAndPrice n a@Amount{aquantity=q,aprice=p} = a{aquantity=q*n, apric
 isNegativeAmount :: Amount -> Bool
 isNegativeAmount Amount{aquantity=q} = q < 0
 
--- | Round an Amount to its specified display precision. If that is
+-- | Round an Amount's Quantity to its specified display precision. If that is
 -- NaturalPrecision, this does nothing.
 amountRoundedQuantity :: Amount -> Quantity
 amountRoundedQuantity Amount{aquantity=q, astyle=AmountStyle{asprecision=p}} = case p of

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -435,7 +435,7 @@ applyDigitGroupStyle (Just (DigitGroups c gs)) s = addseps (repeatLast gs) s
   where
     addseps [] s = s
     addseps (g:gs) s
-      | genericLength s <= toInteger g = s
+      | toInteger (length s) <= toInteger g = s
       | otherwise     = let (part,rest) = genericSplitAt g s
                         in part ++ c : addseps gs rest
     repeatLast [] = []
@@ -602,7 +602,7 @@ multiplyMixedAmountAndPrice n = mapMixedAmount (multiplyAmountAndPrice n)
 -- | Calculate the average of some mixed amounts.
 averageMixedAmounts :: [MixedAmount] -> MixedAmount
 averageMixedAmounts [] = 0
-averageMixedAmounts as = genericLength as `divideMixedAmount` sum as
+averageMixedAmounts as = fromIntegral (length as) `divideMixedAmount` sum as
 
 -- | Is this mixed amount negative, if we can tell that unambiguously?
 -- Ie when normalised, are all individual commodity amounts negative ?

--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -560,8 +560,8 @@ nthdayofyearcontaining m md date
   | not (validDay   md) = error' $ "nthdayofyearcontaining: invalid day "  ++show md
   | mmddOfSameYear <= date = mmddOfSameYear
   | otherwise = mmddOfPrevYear
-  where mmddOfSameYear = addDays (fromIntegral md-1) $ applyN (m-1) nextmonth s
-        mmddOfPrevYear = addDays (fromIntegral md-1) $ applyN (m-1) nextmonth $ prevyear s
+  where mmddOfSameYear = addDays (toInteger md-1) $ applyN (m-1) nextmonth s
+        mmddOfPrevYear = addDays (toInteger md-1) $ applyN (m-1) nextmonth $ prevyear s
         s = startofyear date
 
 -- | For given date d find month-long interval that starts on nth day of month
@@ -612,8 +612,8 @@ nthdayofmonthcontaining md date
 nthdayofweekcontaining :: WeekDay -> Day -> Day
 nthdayofweekcontaining n d | nthOfSameWeek <= d = nthOfSameWeek
                            | otherwise = nthOfPrevWeek
-    where nthOfSameWeek = addDays (fromIntegral n-1) s
-          nthOfPrevWeek = addDays (fromIntegral n-1) $ prevweek s
+    where nthOfSameWeek = addDays (toInteger n-1) s
+          nthOfPrevWeek = addDays (toInteger n-1) $ prevweek s
           s = startofweek d
 
 -- | For given date d find month-long interval that starts on nth weekday of month
@@ -647,9 +647,9 @@ advancetonthweekday n wd s =
   maybe err (addWeeks (n-1)) $ firstMatch (>=s) $ iterate (addWeeks 1) $ firstweekday s
   where
     err = error' "advancetonthweekday: should not happen"
-    addWeeks k = addDays (7 * fromIntegral k)
+    addWeeks k = addDays (7 * toInteger k)
     firstMatch p = headMay . dropWhile (not . p)
-    firstweekday = addDays (fromIntegral wd-1) . startofweek
+    firstweekday = addDays (toInteger wd-1) . startofweek
 
 ----------------------------------------------------------------------
 -- parsing

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -716,7 +716,7 @@ journalBalanceTransactions assrt j' =
     runST $ do
       -- We'll update a mutable array of transactions as we balance them,
       -- not strictly necessary but avoids a sort at the end I think.
-      balancedtxns <- newListArray (1, genericLength ts) ts
+      balancedtxns <- newListArray (1, toInteger $ length ts) ts
 
       -- Infer missing posting amounts, check transactions are balanced,
       -- and check balance assertions. This is done in two passes:

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1495,26 +1495,26 @@ tests_Journal = tests "Journal" [
       --
       test "1091a" $ do
         commodityStylesFromAmounts [
-           nullamt{aquantity=1000, astyle=AmountStyle L False 3 (Just ',') Nothing}
-          ,nullamt{aquantity=1000, astyle=AmountStyle L False 2 (Just '.') (Just (DigitGroups ',' [3]))}
+           nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 3) (Just ',') Nothing}
+          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 2) (Just '.') (Just (DigitGroups ',' [3]))}
           ]
          @?=
           -- The commodity style should have period as decimal mark
           -- and comma as digit group mark.
           Right (M.fromList [
-            ("", AmountStyle L False 3 (Just '.') (Just (DigitGroups ',' [3])))
+            ("", AmountStyle L False (Precision 3) (Just '.') (Just (DigitGroups ',' [3])))
           ])
         -- same journal, entries in reverse order
       ,test "1091b" $ do
         commodityStylesFromAmounts [
-           nullamt{aquantity=1000, astyle=AmountStyle L False 2 (Just '.') (Just (DigitGroups ',' [3]))}
-          ,nullamt{aquantity=1000, astyle=AmountStyle L False 3 (Just ',') Nothing}
+           nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 2) (Just '.') (Just (DigitGroups ',' [3]))}
+          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 3) (Just ',') Nothing}
           ]
          @?=
           -- The commodity style should have period as decimal mark
           -- and comma as digit group mark.
           Right (M.fromList [
-            ("", AmountStyle L False 3 (Just '.') (Just (DigitGroups ',' [3])))
+            ("", AmountStyle L False (Precision 3) (Just '.') (Just (DigitGroups ',' [3])))
           ])
 
      ]

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -89,6 +89,7 @@ instance ToJSON Decimal where
 
 instance ToJSON Amount
 instance ToJSON AmountStyle
+instance ToJSON AmountPrecision
 instance ToJSON Side
 instance ToJSON DigitGroupStyle
 instance ToJSON MixedAmount
@@ -158,6 +159,7 @@ instance FromJSON Status
 instance FromJSON GenericSourcePos
 instance FromJSON Amount
 instance FromJSON AmountStyle
+instance FromJSON AmountPrecision
 instance FromJSON Side
 instance FromJSON DigitGroupStyle
 instance FromJSON MixedAmount

--- a/hledger-lib/Hledger/Data/Period.hs
+++ b/hledger-lib/Hledger/Data/Period.hs
@@ -295,7 +295,7 @@ periodShrink today (YearPeriod y)
 periodShrink today _ = YearPeriod y
   where (y,_,_) = toGregorian today
 
-mondayBefore d = addDays (fromIntegral (1 - wd)) d
+mondayBefore d = addDays (1 - toInteger wd) d
   where
     (_,_,wd) = toWeekDate d
 

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -45,6 +45,7 @@ import Data.Text (Text)
 -- import qualified Data.Text as T
 import Data.Time.Calendar
 import Data.Time.LocalTime
+import Data.Word (Word8)
 import System.Time (ClockTime(..))
 import Text.Printf
 
@@ -192,7 +193,7 @@ instance NFData AmountPrice
 data AmountStyle = AmountStyle {
       ascommodityside   :: Side,                 -- ^ does the symbol appear on the left or the right ?
       ascommodityspaced :: Bool,                 -- ^ space between symbol and quantity ?
-      asprecision       :: !Int,                 -- ^ number of digits displayed after the decimal point
+      asprecision       :: !Word8,               -- ^ number of digits displayed after the decimal point
       asdecimalpoint    :: Maybe Char,           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
       asdigitgroups     :: Maybe DigitGroupStyle -- ^ style for displaying digit groups, if any
 } deriving (Eq,Ord,Read,Typeable,Data,Generic)
@@ -214,7 +215,7 @@ instance Show AmountStyle where
 -- point), and the size of each group, starting with the one nearest
 -- the decimal point. The last group size is assumed to repeat. Eg,
 -- comma between thousands is DigitGroups ',' [3].
-data DigitGroupStyle = DigitGroups Char [Int]
+data DigitGroupStyle = DigitGroups Char [Word8]
   deriving (Eq,Ord,Read,Show,Typeable,Data,Generic)
 
 instance NFData DigitGroupStyle

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -193,7 +193,7 @@ instance NFData AmountPrice
 data AmountStyle = AmountStyle {
       ascommodityside   :: Side,                 -- ^ does the symbol appear on the left or the right ?
       ascommodityspaced :: Bool,                 -- ^ space between symbol and quantity ?
-      asprecision       :: !Word8,               -- ^ number of digits displayed after the decimal point
+      asprecision       :: !AmountPrecision,     -- ^ number of digits displayed after the decimal point
       asdecimalpoint    :: Maybe Char,           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
       asdigitgroups     :: Maybe DigitGroupStyle -- ^ style for displaying digit groups, if any
 } deriving (Eq,Ord,Read,Typeable,Data,Generic)
@@ -208,6 +208,10 @@ instance Show AmountStyle where
     (show asprecision)
     (show asdecimalpoint)
     (show asdigitgroups)
+
+data AmountPrecision = Precision !Word8 | NaturalPrecision deriving (Eq,Ord,Read,Show,Typeable,Data,Generic)
+
+instance NFData AmountPrecision
 
 -- | A style for displaying digit groups in the integer part of a
 -- floating point number. It consists of the character used to

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -241,14 +241,13 @@ runErroringJournalParser p t =
 rejp = runErroringJournalParser
 
 genericSourcePos :: SourcePos -> GenericSourcePos
-genericSourcePos p = GenericSourcePos (sourceName p) (fromIntegral . unPos $ sourceLine p) (fromIntegral . unPos $ sourceColumn p)
+genericSourcePos p = GenericSourcePos (sourceName p) (unPos $ sourceLine p) (unPos $ sourceColumn p)
 
 -- | Construct a generic start & end line parse position from start and end megaparsec SourcePos's.
 journalSourcePos :: SourcePos -> SourcePos -> GenericSourcePos
-journalSourcePos p p' = JournalSourcePos (sourceName p) (fromIntegral . unPos $ sourceLine p, fromIntegral $ line')
-    where line'
-            | (unPos $ sourceColumn p') == 1 = unPos (sourceLine p') - 1
-            | otherwise = unPos $ sourceLine p' -- might be at end of file withat last new-line
+journalSourcePos p p' = JournalSourcePos (sourceName p) (unPos $ sourceLine p, line')
+    where line' | (unPos $ sourceColumn p') == 1 = unPos (sourceLine p') - 1
+                | otherwise = unPos $ sourceLine p' -- might be at end of file withat last new-line
 
 -- | Given a parser to ParsedJournal, input options, file path and
 -- content: run the parser on the content, and finalise the result to

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -855,7 +855,7 @@ fromRawNumber raw mExp = do
     toQuantity e preDecimalGrp postDecimalGrp
       | precision < 0   = Right (Decimal 0 (digitGrpNum * 10^(-precision)), 0)
       | precision < 256 = Right (Decimal precision8 digitGrpNum, precision8)
-      | otherwise = Left "invalid number: numbers with more than 255 decimal digits are now allowed at this time"
+      | otherwise = Left "invalid number: numbers with more than 255 decimal digits are not allowed at this time"
       where
         digitGrpNum = digitGroupNumber $ preDecimalGrp <> postDecimalGrp
         precision   = toInteger (digitGroupLength postDecimalGrp) - e

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -1024,7 +1024,7 @@ data DigitGrp = DigitGrp {
 instance Show DigitGrp where
   show (DigitGrp len num) = "\"" ++ padding ++ numStr ++ "\""
     where numStr = show num
-          padding = genericReplicate (toInteger len - genericLength numStr) '0'
+          padding = genericReplicate (toInteger len - toInteger (length numStr)) '0'
 
 instance Sem.Semigroup DigitGrp where
   DigitGrp l1 n1 <> DigitGrp l2 n2 = DigitGrp (l1 + l2) (n1 * 10^l2 + n2)

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -779,7 +779,7 @@ tests_JournalReader = tests "JournalReader" [
      bad "2011/1/1 00:00:60"
      bad "2011/1/1 3:5:7"
      -- timezone is parsed but ignored
-     let t = LocalTime (fromGregorian 2018 1 1) (TimeOfDay 0 0 (fromIntegral 0))
+     let t = LocalTime (fromGregorian 2018 1 1) (TimeOfDay 0 0 0)
      assertParseEq datetimep "2018/1/1 00:00-0800" t
      assertParseEq datetimep "2018/1/1 00:00+1234" t
 

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -182,7 +182,7 @@ entryp = do
         tstatus    = Cleared,
         tpostings  = [
           nullposting{paccount=a
-                     ,pamount=Mixed [setAmountPrecision 2 $ num hours]  -- don't assume hours; do set precision to 2
+                     ,pamount=Mixed [setAmountPrecision (Precision 2) $ num hours]  -- don't assume hours; do set precision to 2
                      ,ptype=VirtualPosting
                      ,ptransaction=Just t
                      }

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -240,7 +240,7 @@ dotquantityp :: JournalParser m Quantity
 dotquantityp = do
   -- lift $ traceparse "dotquantityp"
   dots <- filter (not.isSpace) <$> many (oneOf (". " :: [Char]))
-  return $ (/4) $ fromIntegral $ length dots
+  return $ fromIntegral (length dots) / 4
 
 -- | XXX new comment line parser, move to Hledger.Read.Common.emptyorcommentlinep
 -- Parse empty lines, all-blank lines, and lines beginning with any of the provided

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -605,7 +605,7 @@ tableAsText (ReportOpts{pretty_tables_ = pretty}) showcell =
 tests_MultiBalanceReport = tests "MultiBalanceReport" [
 
   let
-    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}, aismultiplier=False}
+    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = Precision 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}, aismultiplier=False}
     (opts,journal) `gives` r = do
       let (eitems, etotal) = r
           (PeriodicReport _ aitems atotal) = multiBalanceReport nulldate opts journal

--- a/hledger-lib/Hledger/Utils/Text.hs
+++ b/hledger-lib/Hledger/Utils/Text.hs
@@ -404,9 +404,9 @@ textWidth s = maximum $ map (T.foldr (\a b -> charWidth a + b) 0) $ T.lines s
 
 -- | Read a decimal number from a Text. Assumes the input consists only of digit
 -- characters.
-readDecimal :: Integral a => Text -> a
+readDecimal :: Text -> Integer
 readDecimal = foldl' step 0 . T.unpack
-  where step a c = a * 10 + fromIntegral (digitToInt c)
+  where step a c = a * 10 + toInteger (digitToInt c)
 
 
 tests_Text = tests "Text" [

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -360,7 +360,7 @@ rsHandle ui@UIState{
               let
                 ts = map rsItemTransaction $ V.toList $ nonblanks
                 numberedts = zip [1..] ts
-                i = fromIntegral $ maybe 0 (+1) $ elemIndex t ts -- XXX
+                i = maybe 0 (toInteger . (+1)) $ elemIndex t ts -- XXX
               in
                 continue $ screenEnter d transactionScreen{tsTransaction=(i,t)
                                                           ,tsTransactions=numberedts

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -371,7 +371,7 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
                   -- 4 maximum precision entered so far in this transaction ?
                   -- 5 3 or 4, whichever would show the most decimal places ?
                   -- I think 1 or 4, whichever would show the most decimal places
-                  maxprecisionwithpoint
+                  NaturalPrecision
   --
   -- let -- (amt,comment) = (strip a, strip $ dropWhile (==';') b) where (a,b) = break (==';') amtcmt
       -- a           = fromparse $ runParser (amountp <|> return missingamt) (jparsestate esJournal) "" amt

--- a/hledger/Hledger/Cli/Commands/Prices.hs
+++ b/hledger/Hledger/Cli/Commands/Prices.hs
@@ -50,7 +50,9 @@ divideAmount' n a = a' where
     a' = (n `divideAmount` a) { astyle = style' }
     style' = (astyle a) { asprecision = precision' }
     extPrecision = (1+) . floor . logBase 10 $ (realToFrac n :: Double)
-    precision' = extPrecision + asprecision (astyle a)
+    precision' = case asprecision (astyle a) of
+                      NaturalPrecision -> NaturalPrecision
+                      Precision p      -> Precision $ extPrecision + p
 
 -- XXX
 


### PR DESCRIPTION
Partly addressing #1325, a lot of uses of `fromIntegral` come from the fact that `Decimal` uses a `Word8` to store the precision, while `Amount` uses an `Int`. If we use `Word8` for `aprecision`, we save 7 uses of `fromIntegral`.

Issues this raises:
- There are two magic precision values `maxprecision` and `maxprecisionwithpoint`. With a domain of `Word8` rather than `Int`, this is a much larger target for accidentally hitting.
- People might try to input large (i.e. >255) precision values and get wraparound effects. This was also true before, before it only happened when you actually called `roundTo`. Now it appears a bit earlier.

 Another 19 instances are eliminated by replacing `fromIntegral . length` with `genericLength`, replacing `fromIntegral` with `toInteger` when appropriate, or just omitting it entirely (it was occasionally converting from `Int` to `Int`, a glorified identity).