### PR TITLE
cli: Replace use of fromIntegral in anon with unsafeCoerce. Much safer!

### DIFF
--- a/hledger/Hledger/Cli/Anon.hs
+++ b/hledger/Hledger/Cli/Anon.hs
@@ -5,6 +5,7 @@ Instances for anonymizing sensitive data in various types.
 Note that there is no clear way to anonymize numbers.
 
 -}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Hledger.Cli.Anon
     ( Anon(..)
@@ -14,9 +15,11 @@ where
 
 import Control.Arrow (first)
 import Data.Hashable (hash)
-import Data.Word (Word32)
-import Numeric (showHex)
 import qualified Data.Text as T
+import Data.Text.Lazy (toStrict)
+import Data.Text.Lazy.Builder (toLazyText)
+import Data.Text.Lazy.Builder.Int (hexadecimal)
+import Unsafe.Coerce (unsafeCoerce)
 
 import Hledger.Data
 
@@ -26,16 +29,16 @@ class Anon a where
 
 instance Anon Journal where
     -- Apply the anonymisation transformation on a journal after finalisation
-    anon j = j { jtxns = map anon . jtxns $ j
+    anon j = j { jtxns = map anon $ jtxns j
                , jparseparentaccounts = map anonAccount $ jparseparentaccounts j
                , jparsealiases = []  -- already applied
                , jdeclaredaccounts = map (first anon) $ jdeclaredaccounts j
                }
 
 instance Anon Posting where
-    anon p = p { paccount = anonAccount . paccount $ p
-               , pcomment = T.empty
-               , ptransaction = fmap anon . ptransaction $ p  -- Note that this will be overridden
+    anon p = p { paccount = anonAccount $ paccount p
+               , pcomment = ""
+               , ptransaction = anon <$> ptransaction p  -- Note that this will be overridden
                , poriginal = anon <$> poriginal p
                }
 
@@ -48,6 +51,7 @@ instance Anon Transaction where
 
 -- | Anonymize account name preserving hierarchy
 anonAccount :: AccountName -> AccountName
-anonAccount = T.intercalate (T.pack ":") . map anon . T.splitOn (T.pack ":")
+anonAccount = T.intercalate ":" . map anon . T.split (==acctsepchar)
 
-instance Anon T.Text where anon = T.pack . flip showHex "" . (fromIntegral :: Int -> Word32) . hash
+instance Anon T.Text where
+  anon = toStrict . toLazyText . hexadecimal . (unsafeCoerce :: Int -> Word) . hash


### PR DESCRIPTION
But seriously, I think this is fine, since we're restricting to `unsafeCoerce :: Int -> Word` and the output is a random anonymised hex string. Also fixes a theoretical anonymisation bug, where the anonymisation function on a 64-bit system is periodic of order `2^32`. I don't know, I guess a determined actor could de-anonymise your account names?

If you're uncomfortable with `unsafeCoerce`, but still want to fix the security bug, changing the type of `fromIntegral` to `Int -> Word` should give identical results to this (in slightly more steps).

BTW: Is there a reason this module is in hledger instead of hledger-lib? It seems like it more naturally lives there.

Edit: Actually, perhaps the reason you chose `Word32` is to keep the size of the output to 8 hex characters, and avoid swamping the screen, in which case this may be counterproductive.

Edit 2: In fact, it looks like there's a rewrite rule which changes `fromIntegral :: Int -> Word` into something more or less equivalent to this, so I think there's no value to this PR in either case. I'll leave it open to preserve this one-sided discussion about this particular use of `fromIntegral`, feel free to close when you've seen it.