### PR TITLE
`-split-sections` everywhere

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,11 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
-resolver: lts-16.3
+resolver: lts-16.9
+
+# Provides a very nice reduction in final binary size.
+ghc-options:
+  $everything: -split-sections
 
 packages:
 - hledger-lib


### PR DESCRIPTION
This PR enables `-split-sections` for the stack build of `hledger` and its dependencies. This reduces the size of the `hledger` binary on my machine from 27mb to 13mb.

How are the official releases made? Should this setting be activated elsewhere?