### PR TITLE
Make a wrapper around compiled Regex, for more total functions.

### DIFF
--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -14,7 +14,7 @@ import Data.List.Extra (groupSort, groupOn)
 import Data.Maybe (fromMaybe)
 import Data.Ord (Down(..))
 import qualified Data.Map as M
-import Data.Text (pack,unpack)
+import qualified Data.Text as T
 import Safe (headMay, lookupJustDef)
 import Text.Printf
 
@@ -28,11 +28,12 @@ import Hledger.Utils
 -- deriving instance Show Account
 instance Show Account where
     show Account{..} = printf "Account %s (boring:%s, postings:%d, ebalance:%s, ibalance:%s)"
-                       (pack $ regexReplace ":" "_" $ unpack aname)  -- hide : so pretty-show doesn't break line
+                       (T.map colonToUnderscore aname)  -- hide : so pretty-show doesn't break line
                        (if aboring then "y" else "n" :: String)
                        anumpostings
                        (showMixedAmount aebalance)
                        (showMixedAmount aibalance)
+      where colonToUnderscore x = if x == ':' then '_' else x
 
 instance Eq Account where
   (==) a b = aname a == aname b -- quick equality test for speed

--- a/hledger-lib/Hledger/Data/AccountName.hs
+++ b/hledger-lib/Hledger/Data/AccountName.hs
@@ -39,14 +39,14 @@ module Hledger.Data.AccountName (
 )
 where
 
-import Data.List
 import Data.List.Extra (nubSort)
+import qualified Data.List.NonEmpty as NE
 #if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
+import Data.Semigroup ((<>))
 #endif
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Tree
+import Data.Tree (Tree(..))
 
 import Hledger.Data.Types
 import Hledger.Utils
@@ -115,7 +115,7 @@ expandAccountNames as = nubSort $ concatMap expandAccountName as
 
 -- | "a:b:c" -> ["a","a:b","a:b:c"]
 expandAccountName :: AccountName -> [AccountName]
-expandAccountName = map accountNameFromComponents . tail . inits . accountNameComponents
+expandAccountName = map accountNameFromComponents . NE.tail . NE.inits . accountNameComponents
 
 -- | ["a:b:c","d:e"] -> ["a","d"]
 topAccountNames :: [AccountName] -> [AccountName]
@@ -209,8 +209,10 @@ clipOrEllipsifyAccountName n        = clipAccountName n
 -- >>> putStr $ escapeName "First?!#$*?$(*) !@^#*? %)*!@#"
 -- First\?!#\$\*\?\$\(\*\) !@\^#\*\? %\)\*!@#
 escapeName :: AccountName -> String
-escapeName = replaceAllBy (toRegex' "[[?+|()*\\\\^$]") ("\\" <>)  -- PARTIAL: should not happen
-           . T.unpack
+escapeName = T.unpack . T.concatMap escapeChar
+  where
+    escapeChar c = if c `elem` escapedChars then T.snoc "\\" c else T.singleton c
+    escapedChars = ['[', '?', '+', '|', '(', ')', '*', '$', '^', '\\']
 
 -- | Convert an account name to a regular expression matching it and its subaccounts.
 accountNameToAccountRegex :: AccountName -> Regexp

--- a/hledger-lib/Hledger/Data/Ledger.hs
+++ b/hledger-lib/Hledger/Data/Ledger.hs
@@ -17,7 +17,6 @@ module Hledger.Data.Ledger (
   ,ledgerRootAccount
   ,ledgerTopAccounts
   ,ledgerLeafAccounts
-  ,ledgerAccountsMatching
   ,ledgerPostings
   ,ledgerDateSpan
   ,ledgerCommodities
@@ -26,8 +25,6 @@ module Hledger.Data.Ledger (
 where
 
 import qualified Data.Map as M
--- import Data.Text (Text)
-import qualified Data.Text as T
 import Safe (headDef)
 import Text.Printf
 
@@ -89,10 +86,6 @@ ledgerTopAccounts = asubs . head . laccounts
 -- | List a ledger's bottom-level (subaccount-less) accounts, in tree order.
 ledgerLeafAccounts :: Ledger -> [Account]
 ledgerLeafAccounts = filter (null.asubs) . laccounts
-
--- | Accounts in ledger whose name matches the pattern, in tree order.
-ledgerAccountsMatching :: [String] -> Ledger -> [Account]
-ledgerAccountsMatching pats = filter (matchpats pats . T.unpack . aname) . laccounts -- XXX pack
 
 -- | List a ledger's postings, in the order parsed.
 ledgerPostings :: Ledger -> [Posting]

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -315,7 +315,7 @@ aliasReplace (BasicAlias old new) a
       Right $ new <> T.drop (T.length old) a
   | otherwise = Right a
 aliasReplace (RegexAlias re repl) a =
-  fmap T.pack $ regexReplaceCIMemo_ re repl $ T.unpack a -- XXX
+  fmap T.pack $ regexReplaceMemo_ re repl $ T.unpack a -- XXX
 
 -- | Apply a specified valuation to this posting's amount, using the
 -- provided price oracle, commodity styles, reference dates, and

--- a/hledger-lib/Hledger/Data/RawOptions.hs
+++ b/hledger-lib/Hledger/Data/RawOptions.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 {-|
 
 hledger's cmdargs modes parse command-line arguments to an
@@ -28,17 +26,16 @@ module Hledger.Data.RawOptions (
 )
 where
 
-import Data.Maybe
-import Data.Data
-import Data.Default
-import Safe
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Default (Default(..))
+import Safe (headMay, lastMay, readDef)
 
 import Hledger.Utils
 
 
 -- | The result of running cmdargs: an association list of option names to string values.
 newtype RawOpts = RawOpts { unRawOpts :: [(String,String)] }
-    deriving (Show, Data, Typeable)
+  deriving (Show)
 
 instance Default RawOpts where def = RawOpts []
 
@@ -61,6 +58,7 @@ boolopt = inRawOpts
 -- for which the given predicate returns a Just value.
 -- Useful for exclusive choice flags like --daily|--weekly|--quarterly...
 --
+-- >>> import Safe (readMay)
 -- >>> choiceopt Just (RawOpts [("a",""), ("b",""), ("c","")])
 -- Just "c"
 -- >>> choiceopt (const Nothing) (RawOpts [("a","")])

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -28,7 +28,6 @@ module Hledger.Data.Types
 where
 
 import GHC.Generics (Generic)
-import Control.DeepSeq (NFData)
 import Data.Decimal
 import Data.Default
 import Data.Functor (($>))
@@ -78,8 +77,6 @@ data WhichDate = PrimaryDate | SecondaryDate deriving (Eq,Show)
 data DateSpan = DateSpan (Maybe Day) (Maybe Day) deriving (Eq,Ord,Generic)
 
 instance Default DateSpan where def = DateSpan Nothing Nothing
-
-instance NFData DateSpan
 
 -- synonyms for various date-related scalars
 type Year = Integer
@@ -135,8 +132,6 @@ data Interval =
 
 instance Default Interval where def = NoInterval
 
-instance NFData Interval
-
 type AccountName = Text
 
 data AccountType =
@@ -147,8 +142,6 @@ data AccountType =
   | Expense
   | Cash  -- ^ a subtype of Asset - liquid assets to show in cashflow report
   deriving (Show,Eq,Ord,Generic)
-
-instance NFData AccountType
 
 -- not worth the trouble, letters defined in accountdirectivep for now
 --instance Read AccountType
@@ -164,11 +157,7 @@ data AccountAlias = BasicAlias AccountName AccountName
                   | RegexAlias Regexp Replacement
   deriving (Eq, Read, Show, Ord, Generic)
 
--- instance NFData AccountAlias
-
 data Side = L | R deriving (Eq,Show,Read,Ord,Generic)
-
-instance NFData Side
 
 -- | The basic numeric type used in amounts.
 type Quantity = Decimal
@@ -184,8 +173,6 @@ instance ToMarkup Quantity
 data AmountPrice = UnitPrice Amount | TotalPrice Amount
   deriving (Eq,Ord,Generic,Show)
 
-instance NFData AmountPrice
-
 -- | Display style for an amount.
 data AmountStyle = AmountStyle {
       ascommodityside   :: Side,                 -- ^ does the symbol appear on the left or the right ?
@@ -194,8 +181,6 @@ data AmountStyle = AmountStyle {
       asdecimalpoint    :: Maybe Char,           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
       asdigitgroups     :: Maybe DigitGroupStyle -- ^ style for displaying digit groups, if any
 } deriving (Eq,Ord,Read,Generic)
-
-instance NFData AmountStyle
 
 instance Show AmountStyle where
   show AmountStyle{..} =
@@ -208,8 +193,6 @@ instance Show AmountStyle where
 
 data AmountPrecision = Precision !Word8 | NaturalPrecision deriving (Eq,Ord,Read,Show,Generic)
 
-instance NFData AmountPrecision
-
 -- | A style for displaying digit groups in the integer part of a
 -- floating point number. It consists of the character used to
 -- separate groups (comma or period, whichever is not used as decimal
@@ -219,16 +202,12 @@ instance NFData AmountPrecision
 data DigitGroupStyle = DigitGroups Char [Word8]
   deriving (Eq,Ord,Read,Show,Generic)
 
-instance NFData DigitGroupStyle
-
 type CommoditySymbol = Text
 
 data Commodity = Commodity {
   csymbol :: CommoditySymbol,
   cformat :: Maybe AmountStyle
   } deriving (Show,Eq,Generic) --,Ord)
-
-instance NFData Commodity
 
 data Amount = Amount {
       acommodity  :: CommoditySymbol,   -- commodity symbol, or special value "AUTO"
@@ -239,16 +218,10 @@ data Amount = Amount {
       aprice      :: Maybe AmountPrice  -- ^ the (fixed, transaction-specific) price for this amount, if any
     } deriving (Eq,Ord,Generic,Show)
 
-instance NFData Amount
-
 newtype MixedAmount = Mixed [Amount] deriving (Eq,Ord,Generic,Show)
-
-instance NFData MixedAmount
 
 data PostingType = RegularPosting | VirtualPosting | BalancedVirtualPosting
                    deriving (Eq,Show,Generic)
-
-instance NFData PostingType
 
 type TagName = Text
 type TagValue = Text
@@ -259,8 +232,6 @@ type DateTag = (TagName, Day)
 -- (nothing, !, or *). What these mean is ultimately user defined.
 data Status = Unmarked | Pending | Cleared
   deriving (Eq,Ord,Bounded,Enum,Generic)
-
-instance NFData Status
 
 instance Show Status where -- custom show.. bad idea.. don't do it..
   show Unmarked = ""
@@ -311,8 +282,6 @@ data BalanceAssertion = BalanceAssertion {
       baposition  :: GenericSourcePos    -- ^ the assertion's file position, for error reporting
     } deriving (Eq,Generic,Show)
 
-instance NFData BalanceAssertion
-
 data Posting = Posting {
       pdate             :: Maybe Day,         -- ^ this posting's date, if different from the transaction's
       pdate2            :: Maybe Day,         -- ^ this posting's secondary date, if different from the transaction's
@@ -331,8 +300,6 @@ data Posting = Posting {
                                                     --   changed by a pivot or budget report), this references the original
                                                     --   untransformed posting (which will have Nothing in this field).
     } deriving (Generic)
-
-instance NFData Posting
 
 -- The equality test for postings ignores the parent transaction's
 -- identity, to avoid recurring ad infinitum.
@@ -362,8 +329,6 @@ data GenericSourcePos = GenericSourcePos FilePath Int Int    -- ^ file path, 1-b
                       | JournalSourcePos FilePath (Int, Int) -- ^ file path, inclusive range of 1-based line numbers (first, last).
   deriving (Eq, Read, Show, Ord, Generic)
 
-instance NFData GenericSourcePos
-
 --{-# ANN Transaction "HLint: ignore" #-}
 --    Ambiguous type variable ‘p0’ arising from an annotation
 --    prevents the constraint ‘(Data p0)’ from being solved.
@@ -382,8 +347,6 @@ data Transaction = Transaction {
       tpostings                :: [Posting]  -- ^ this transaction's postings
     } deriving (Eq,Generic,Show)
 
-instance NFData Transaction
-
 -- | A transaction modifier rule. This has a query which matches postings
 -- in the journal, and a list of transformations to apply to those
 -- postings or their transactions. Currently there is one kind of transformation:
@@ -393,8 +356,6 @@ data TransactionModifier = TransactionModifier {
       tmquerytxt :: Text,
       tmpostingrules :: [TMPostingRule]
     } deriving (Eq,Generic,Show)
-
-instance NFData TransactionModifier
 
 nulltransactionmodifier = TransactionModifier{
   tmquerytxt = ""
@@ -433,11 +394,7 @@ nullperiodictransaction = PeriodicTransaction{
      ,ptpostings     = []
 }
 
-instance NFData PeriodicTransaction
-
 data TimeclockCode = SetBalance | SetRequiredHours | In | Out | FinalOut deriving (Eq,Ord,Generic)
-
-instance NFData TimeclockCode
 
 data TimeclockEntry = TimeclockEntry {
       tlsourcepos   :: GenericSourcePos,
@@ -446,8 +403,6 @@ data TimeclockEntry = TimeclockEntry {
       tlaccount     :: AccountName,
       tldescription :: Text
     } deriving (Eq,Ord,Generic)
-
-instance NFData TimeclockEntry
 
 -- | A market price declaration made by the journal format's P directive.
 -- It declares two things: a historical exchange rate between two commodities,
@@ -459,8 +414,6 @@ data PriceDirective = PriceDirective {
   } deriving (Eq,Ord,Generic,Show)
         -- Show instance derived in Amount.hs (XXX why ?)
 
-instance NFData PriceDirective
-
 -- | A historical market price (exchange rate) from one commodity to another.
 -- A more concise form of a PriceDirective, without the amount display info.
 data MarketPrice = MarketPrice {
@@ -470,8 +423,6 @@ data MarketPrice = MarketPrice {
   ,mprate :: Quantity           -- ^ One unit of the "from" commodity is worth this quantity of the "to" commodity.
   } deriving (Eq,Ord,Generic)
         -- Show instance derived in Amount.hs (XXX why ?)
-
-instance NFData MarketPrice
 
 -- additional valuation-related types in Valuation.hs
 
@@ -512,8 +463,6 @@ data Journal = Journal {
   } deriving (Eq, Generic)
 
 deriving instance Generic ClockTime
-instance NFData ClockTime
--- instance NFData Journal
 
 -- | A journal in the process of being parsed, not yet finalised.
 -- The data is partial, and list fields are in reverse order.
@@ -531,8 +480,6 @@ data AccountDeclarationInfo = AccountDeclarationInfo {
   ,adideclarationorder :: Int    -- ^ the order in which this account was declared,
                                  --   relative to other account declarations, during parsing (1..)
 } deriving (Eq,Show,Generic)
-
-instance NFData AccountDeclarationInfo
 
 nullaccountdeclarationinfo = AccountDeclarationInfo {
    adicomment          = ""

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -166,7 +166,7 @@ data AccountAlias = BasicAlias AccountName AccountName
                   | RegexAlias Regexp Replacement
   deriving (Eq, Read, Show, Ord, Data, Generic, Typeable)
 
-instance NFData AccountAlias
+-- instance NFData AccountAlias
 
 data Side = L | R deriving (Eq,Show,Read,Ord,Typeable,Data,Generic)
 
@@ -512,13 +512,13 @@ data Journal = Journal {
                                                                     --   any included journal files. The main file is first,
                                                                     --   followed by any included files in the order encountered.
   ,jlastreadtime          :: ClockTime                              -- ^ when this journal was last read from its file(s)
-  } deriving (Eq, Typeable, Data, Generic)
+  } deriving (Eq, Generic)
 
 deriving instance Data ClockTime
 deriving instance Typeable ClockTime
 deriving instance Generic ClockTime
 instance NFData ClockTime
-instance NFData Journal
+-- instance NFData Journal
 
 -- | A journal in the process of being parsed, not yet finalised.
 -- The data is partial, and list fields are in reverse order.

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -17,7 +17,6 @@ For more detailed documentation on each type, see the corresponding modules.
 -}
 
 -- {-# LANGUAGE DeriveAnyClass #-}  -- https://hackage.haskell.org/package/deepseq-1.4.4.0/docs/Control-DeepSeq.html#v:rnf
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -30,7 +29,6 @@ where
 
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
-import Data.Data
 import Data.Decimal
 import Data.Default
 import Data.Functor (($>))
@@ -77,7 +75,7 @@ data SmartInterval = Day | Week | Month | Quarter | Year deriving (Show)
 
 data WhichDate = PrimaryDate | SecondaryDate deriving (Eq,Show)
 
-data DateSpan = DateSpan (Maybe Day) (Maybe Day) deriving (Eq,Ord,Data,Generic,Typeable)
+data DateSpan = DateSpan (Maybe Day) (Maybe Day) deriving (Eq,Ord,Generic)
 
 instance Default DateSpan where def = DateSpan Nothing Nothing
 
@@ -105,7 +103,7 @@ data Period =
   | PeriodFrom Day
   | PeriodTo Day
   | PeriodAll
-  deriving (Eq,Ord,Show,Data,Generic,Typeable)
+  deriving (Eq,Ord,Show,Generic)
 
 instance Default Period where def = PeriodAll
 
@@ -116,7 +114,7 @@ instance Default Period where def = PeriodAll
 --   MonthLong
 --   QuarterLong
 --   YearLong
---  deriving (Eq,Ord,Show,Data,Generic,Typeable)
+--  deriving (Eq,Ord,Show,Generic)
 
 -- Ways in which a period can be divided into subperiods.
 data Interval =
@@ -133,7 +131,7 @@ data Interval =
   -- WeekOfYear Int
   -- MonthOfYear Int
   -- QuarterOfYear Int
-  deriving (Eq,Show,Ord,Data,Generic,Typeable)
+  deriving (Eq,Show,Ord,Generic)
 
 instance Default Interval where def = NoInterval
 
@@ -148,7 +146,7 @@ data AccountType =
   | Revenue
   | Expense
   | Cash  -- ^ a subtype of Asset - liquid assets to show in cashflow report
-  deriving (Show,Eq,Ord,Data,Generic)
+  deriving (Show,Eq,Ord,Generic)
 
 instance NFData AccountType
 
@@ -164,17 +162,16 @@ instance NFData AccountType
 
 data AccountAlias = BasicAlias AccountName AccountName
                   | RegexAlias Regexp Replacement
-  deriving (Eq, Read, Show, Ord, Data, Generic, Typeable)
+  deriving (Eq, Read, Show, Ord, Generic)
 
 -- instance NFData AccountAlias
 
-data Side = L | R deriving (Eq,Show,Read,Ord,Typeable,Data,Generic)
+data Side = L | R deriving (Eq,Show,Read,Ord,Generic)
 
 instance NFData Side
 
 -- | The basic numeric type used in amounts.
 type Quantity = Decimal
-deriving instance Data Quantity
 -- The following is for hledger-web, and requires blaze-markup.
 -- Doing it here avoids needing a matching flag on the hledger-web package.
 instance ToMarkup Quantity
@@ -185,7 +182,7 @@ instance ToMarkup Quantity
 -- commodity, as recorded in the journal entry eg with @ or @@.
 -- Docs call this "transaction price". The amount is always positive.
 data AmountPrice = UnitPrice Amount | TotalPrice Amount
-  deriving (Eq,Ord,Typeable,Data,Generic,Show)
+  deriving (Eq,Ord,Generic,Show)
 
 instance NFData AmountPrice
 
@@ -196,7 +193,7 @@ data AmountStyle = AmountStyle {
       asprecision       :: !AmountPrecision,     -- ^ number of digits displayed after the decimal point
       asdecimalpoint    :: Maybe Char,           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
       asdigitgroups     :: Maybe DigitGroupStyle -- ^ style for displaying digit groups, if any
-} deriving (Eq,Ord,Read,Typeable,Data,Generic)
+} deriving (Eq,Ord,Read,Generic)
 
 instance NFData AmountStyle
 
@@ -209,7 +206,7 @@ instance Show AmountStyle where
     (show asdecimalpoint)
     (show asdigitgroups)
 
-data AmountPrecision = Precision !Word8 | NaturalPrecision deriving (Eq,Ord,Read,Show,Typeable,Data,Generic)
+data AmountPrecision = Precision !Word8 | NaturalPrecision deriving (Eq,Ord,Read,Show,Generic)
 
 instance NFData AmountPrecision
 
@@ -220,7 +217,7 @@ instance NFData AmountPrecision
 -- the decimal point. The last group size is assumed to repeat. Eg,
 -- comma between thousands is DigitGroups ',' [3].
 data DigitGroupStyle = DigitGroups Char [Word8]
-  deriving (Eq,Ord,Read,Show,Typeable,Data,Generic)
+  deriving (Eq,Ord,Read,Show,Generic)
 
 instance NFData DigitGroupStyle
 
@@ -229,7 +226,7 @@ type CommoditySymbol = Text
 data Commodity = Commodity {
   csymbol :: CommoditySymbol,
   cformat :: Maybe AmountStyle
-  } deriving (Show,Eq,Data,Generic) --,Ord,Typeable,Data,Generic)
+  } deriving (Show,Eq,Generic) --,Ord)
 
 instance NFData Commodity
 
@@ -240,16 +237,16 @@ data Amount = Amount {
                                         --   in a TMPostingRule. In a regular Posting, should always be false.
       astyle      :: AmountStyle,
       aprice      :: Maybe AmountPrice  -- ^ the (fixed, transaction-specific) price for this amount, if any
-    } deriving (Eq,Ord,Typeable,Data,Generic,Show)
+    } deriving (Eq,Ord,Generic,Show)
 
 instance NFData Amount
 
-newtype MixedAmount = Mixed [Amount] deriving (Eq,Ord,Typeable,Data,Generic,Show)
+newtype MixedAmount = Mixed [Amount] deriving (Eq,Ord,Generic,Show)
 
 instance NFData MixedAmount
 
 data PostingType = RegularPosting | VirtualPosting | BalancedVirtualPosting
-                   deriving (Eq,Show,Typeable,Data,Generic)
+                   deriving (Eq,Show,Generic)
 
 instance NFData PostingType
 
@@ -261,7 +258,7 @@ type DateTag = (TagName, Day)
 -- | The status of a transaction or posting, recorded with a status mark
 -- (nothing, !, or *). What these mean is ultimately user defined.
 data Status = Unmarked | Pending | Cleared
-  deriving (Eq,Ord,Bounded,Enum,Typeable,Data,Generic)
+  deriving (Eq,Ord,Bounded,Enum,Generic)
 
 instance NFData Status
 
@@ -312,7 +309,7 @@ data BalanceAssertion = BalanceAssertion {
       batotal     :: Bool,               -- ^ disallow additional non-asserted commodities ?
       bainclusive :: Bool,               -- ^ include subaccounts when calculating the actual balance ?
       baposition  :: GenericSourcePos    -- ^ the assertion's file position, for error reporting
-    } deriving (Eq,Typeable,Data,Generic,Show)
+    } deriving (Eq,Generic,Show)
 
 instance NFData BalanceAssertion
 
@@ -333,7 +330,7 @@ data Posting = Posting {
                                                     --   (eg its amount or price was inferred, or the account name was
                                                     --   changed by a pivot or budget report), this references the original
                                                     --   untransformed posting (which will have Nothing in this field).
-    } deriving (Typeable,Data,Generic)
+    } deriving (Generic)
 
 instance NFData Posting
 
@@ -363,7 +360,7 @@ instance Show Posting where
 -- | The position of parse errors (eg), like parsec's SourcePos but generic.
 data GenericSourcePos = GenericSourcePos FilePath Int Int    -- ^ file path, 1-based line number and 1-based column number.
                       | JournalSourcePos FilePath (Int, Int) -- ^ file path, inclusive range of 1-based line numbers (first, last).
-  deriving (Eq, Read, Show, Ord, Data, Generic, Typeable)
+  deriving (Eq, Read, Show, Ord, Generic)
 
 instance NFData GenericSourcePos
 
@@ -383,7 +380,7 @@ data Transaction = Transaction {
       tcomment                 :: Text,      -- ^ this transaction's comment lines, as a single non-indented multi-line string
       ttags                    :: [Tag],     -- ^ tag names and values, extracted from the comment
       tpostings                :: [Posting]  -- ^ this transaction's postings
-    } deriving (Eq,Typeable,Data,Generic,Show)
+    } deriving (Eq,Generic,Show)
 
 instance NFData Transaction
 
@@ -395,7 +392,7 @@ instance NFData Transaction
 data TransactionModifier = TransactionModifier {
       tmquerytxt :: Text,
       tmpostingrules :: [TMPostingRule]
-    } deriving (Eq,Typeable,Data,Generic,Show)
+    } deriving (Eq,Generic,Show)
 
 instance NFData TransactionModifier
 
@@ -422,7 +419,7 @@ data PeriodicTransaction = PeriodicTransaction {
       ptcomment      :: Text,
       pttags         :: [Tag],
       ptpostings     :: [Posting]
-    } deriving (Eq,Typeable,Data,Generic) -- , Show in PeriodicTransaction.hs
+    } deriving (Eq,Generic) -- , Show in PeriodicTransaction.hs
 
 nullperiodictransaction = PeriodicTransaction{
       ptperiodexpr   = ""
@@ -438,7 +435,7 @@ nullperiodictransaction = PeriodicTransaction{
 
 instance NFData PeriodicTransaction
 
-data TimeclockCode = SetBalance | SetRequiredHours | In | Out | FinalOut deriving (Eq,Ord,Typeable,Data,Generic)
+data TimeclockCode = SetBalance | SetRequiredHours | In | Out | FinalOut deriving (Eq,Ord,Generic)
 
 instance NFData TimeclockCode
 
@@ -448,7 +445,7 @@ data TimeclockEntry = TimeclockEntry {
       tldatetime    :: LocalTime,
       tlaccount     :: AccountName,
       tldescription :: Text
-    } deriving (Eq,Ord,Typeable,Data,Generic)
+    } deriving (Eq,Ord,Generic)
 
 instance NFData TimeclockEntry
 
@@ -459,7 +456,7 @@ data PriceDirective = PriceDirective {
    pddate      :: Day
   ,pdcommodity :: CommoditySymbol
   ,pdamount    :: Amount
-  } deriving (Eq,Ord,Typeable,Data,Generic,Show)
+  } deriving (Eq,Ord,Generic,Show)
         -- Show instance derived in Amount.hs (XXX why ?)
 
 instance NFData PriceDirective
@@ -471,7 +468,7 @@ data MarketPrice = MarketPrice {
   ,mpfrom :: CommoditySymbol    -- ^ The commodity being converted from.
   ,mpto   :: CommoditySymbol    -- ^ The commodity being converted to.
   ,mprate :: Quantity           -- ^ One unit of the "from" commodity is worth this quantity of the "to" commodity.
-  } deriving (Eq,Ord,Typeable,Data,Generic)
+  } deriving (Eq,Ord,Generic)
         -- Show instance derived in Amount.hs (XXX why ?)
 
 instance NFData MarketPrice
@@ -514,8 +511,6 @@ data Journal = Journal {
   ,jlastreadtime          :: ClockTime                              -- ^ when this journal was last read from its file(s)
   } deriving (Eq, Generic)
 
-deriving instance Data ClockTime
-deriving instance Typeable ClockTime
 deriving instance Generic ClockTime
 instance NFData ClockTime
 -- instance NFData Journal
@@ -535,7 +530,7 @@ data AccountDeclarationInfo = AccountDeclarationInfo {
   ,aditags             :: [Tag]  -- ^ tags extracted from the account comment, if any
   ,adideclarationorder :: Int    -- ^ the order in which this account was declared,
                                  --   relative to other account declarations, during parsing (1..)
-} deriving (Eq,Show,Data,Generic)
+} deriving (Eq,Show,Generic)
 
 instance NFData AccountDeclarationInfo
 
@@ -558,14 +553,14 @@ data Account = Account {
   ,anumpostings              :: Int            -- ^ the number of postings to this account
   ,aebalance                 :: MixedAmount    -- ^ this account's balance, excluding subaccounts
   ,aibalance                 :: MixedAmount    -- ^ this account's balance, including subaccounts
-  } deriving (Typeable, Data, Generic)
+  } deriving (Generic)
 
 -- | Whether an account's balance is normally a positive number (in
 -- accounting terms, a debit balance) or a negative number (credit balance).
 -- Assets and expenses are normally positive (debit), while liabilities, equity
 -- and income are normally negative (credit).
 -- https://en.wikipedia.org/wiki/Normal_balance
-data NormalSign = NormallyPositive | NormallyNegative deriving (Show, Data, Eq)
+data NormalSign = NormallyPositive | NormallyNegative deriving (Show, Eq)
 
 -- | A Ledger has the journal it derives from, and the accounts
 -- derived from that. Accounts are accessible both list-wise and

--- a/hledger-lib/Hledger/Data/Valuation.hs
+++ b/hledger-lib/Hledger/Data/Valuation.hs
@@ -9,7 +9,7 @@ looking up historical market prices (exchange rates) between commodities.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Hledger.Data.Valuation (
    ValuationType(..)
@@ -29,7 +29,6 @@ where
 
 import Control.Applicative ((<|>))
 import Control.DeepSeq (NFData)
-import Data.Data
 import Data.Decimal (roundTo)
 import Data.Function ((&), on)
 import Data.Graph.Inductive  (Gr, Node, NodeMap, mkMapGraph, mkNode, lab, out, sp)
@@ -60,7 +59,7 @@ data ValuationType =
   | AtNow      (Maybe CommoditySymbol)  -- ^ convert to default or given valuation commodity, using current market prices
   | AtDate Day (Maybe CommoditySymbol)  -- ^ convert to default or given valuation commodity, using market prices on some date
   | AtDefault  (Maybe CommoditySymbol)  -- ^ works like AtNow in single period reports, like AtEnd in multiperiod reports
-  deriving (Show,Data,Eq) -- Typeable
+  deriving (Show,Eq)
 
 -- | A snapshot of the known exchange rates between commodity pairs at a given date,
 -- as a graph allowing fast lookup and path finding, along with some helper data.

--- a/hledger-lib/Hledger/Data/Valuation.hs
+++ b/hledger-lib/Hledger/Data/Valuation.hs
@@ -28,7 +28,6 @@ module Hledger.Data.Valuation (
 where
 
 import Control.Applicative ((<|>))
-import Control.DeepSeq (NFData)
 import Data.Decimal (roundTo)
 import Data.Function ((&), on)
 import Data.Graph.Inductive  (Gr, Node, NodeMap, mkMapGraph, mkNode, lab, out, sp)
@@ -85,8 +84,6 @@ data PriceGraph = PriceGraph {
     --   graph).
   }
   deriving (Show,Generic)
-
-instance NFData PriceGraph
 
 -- | A price oracle is a magic memoising function that efficiently
 -- looks up market prices (exchange rates) from one commodity to

--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -10,7 +10,6 @@ transactions..)  by various criteria, and a SimpleTextParser for query expressio
 {-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 
 {-# LANGUAGE CPP                #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE ViewPatterns       #-}
@@ -60,18 +59,17 @@ module Hledger.Query (
 where
 
 import Control.Applicative ((<|>), liftA2, many, optional)
-import Data.Data
-import Data.Either
-import Data.List
-import Data.Maybe
+import Data.Either (partitionEithers)
+import Data.List (partition)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Monoid ((<>))
 #endif
 import qualified Data.Text as T
-import Data.Time.Calendar
+import Data.Time.Calendar (Day, fromGregorian )
 import Safe (readDef, readMay, maximumByMay, maximumMay, minimumMay)
 import Text.Megaparsec (between, noneOf, sepBy)
-import Text.Megaparsec.Char
+import Text.Megaparsec.Char (char, string)
 
 import Hledger.Utils hiding (words')
 import Hledger.Data.Types
@@ -105,7 +103,7 @@ data Query = Any              -- ^ always match
                               --   and sometimes like a query option (for controlling display)
            | Tag Regexp (Maybe Regexp)  -- ^ match if a tag's name, and optionally its value, is matched by these respective regexps
                                         -- matching the regexp if provided, exists
-    deriving (Eq,Show,Data,Typeable)
+    deriving (Eq,Show)
 
 -- | Construct a payee tag
 payeeTag :: Maybe String -> Either RegexError Query
@@ -118,14 +116,14 @@ noteTag = liftA2 Tag (toRegexCI_ "note") . maybe (pure Nothing) (fmap Just . toR
 -- | A more expressive Ord, used for amt: queries. The Abs* variants
 -- compare with the absolute value of a number, ignoring sign.
 data OrdPlus = Lt | LtEq | Gt | GtEq | Eq | AbsLt | AbsLtEq | AbsGt | AbsGtEq | AbsEq
- deriving (Show,Eq,Data,Typeable)
+ deriving (Show,Eq)
 
 -- | A query option changes a query's/report's behaviour and output in some way.
 data QueryOpt = QueryOptInAcctOnly AccountName  -- ^ show an account register focussed on this account
               | QueryOptInAcct AccountName      -- ^ as above but include sub-accounts in the account register
            -- | QueryOptCostBasis      -- ^ show amounts converted to cost where possible
            -- | QueryOptDate2  -- ^ show secondary dates instead of primary dates
-    deriving (Show, Eq, Data, Typeable)
+    deriving (Show, Eq)
 
 -- parsing
 

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -14,7 +14,6 @@ Some of these might belong in Hledger.Read.JournalReader or Hledger.Read.
 --- ** language
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -116,32 +115,33 @@ where
 --- ** imports
 import Prelude ()
 import "base-compat-batteries" Prelude.Compat hiding (fail, readFile)
+import Control.Applicative.Permutations (runPermutation, toPermutationWithDefault)
 import qualified "base-compat-batteries" Control.Monad.Fail.Compat as Fail (fail)
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError)
 import Control.Monad.State.Strict hiding (fail)
 import Data.Bifunctor (bimap, second)
-import Data.Char
-import Data.Data
+import Data.Char (digitToInt, isDigit, isSpace)
 import Data.Decimal (DecimalRaw (Decimal), Decimal)
-import Data.Default
+import Data.Default (Default(..))
 import Data.Function ((&))
-import Data.Functor.Identity
+import Data.Functor.Identity (Identity)
 import "base-compat-batteries" Data.List.Compat
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Maybe
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe)
 import qualified Data.Map as M
 import qualified Data.Semigroup as Sem
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Time.Calendar
-import Data.Time.LocalTime
+import Data.Time.Calendar (Day, fromGregorianValid, toGregorian)
+import Data.Time.LocalTime (LocalTime(..), TimeOfDay(..))
 import Data.Word (Word8)
 import System.Time (getClockTime)
 import Text.Megaparsec
-import Text.Megaparsec.Char
+import Text.Megaparsec.Char (char, char', digitChar, newline, string)
 import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Custom
-import Control.Applicative.Permutations
+  (FinalParseError, attachSource, customErrorBundlePretty,
+  finalErrorBundlePretty, parseErrorAt, parseErrorAtRegion)
 
 import Hledger.Data
 import Hledger.Utils hiding (match)
@@ -194,7 +194,7 @@ data InputOpts = InputOpts {
     ,new_save_          :: Bool                 -- ^ save latest new transactions state for next time
     ,pivot_             :: String               -- ^ use the given field's value as the account name
     ,auto_              :: Bool                 -- ^ generate automatic postings when journal is parsed
- } deriving (Show, Data) --, Typeable)
+ } deriving (Show)
 
 instance Default InputOpts where def = definputopts
 

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -144,7 +144,7 @@ import Text.Megaparsec.Custom
 import Control.Applicative.Permutations
 
 import Hledger.Data
-import Hledger.Utils
+import Hledger.Utils hiding (match)
 
 --- ** doctest setup
 -- $setup

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -529,8 +529,8 @@ regexaliasp = do
   char '='
   skipNonNewlineSpaces
   repl <- anySingle `manyTill` eolof
-  case toRegex_ re of
-    Right _ -> return $! RegexAlias re repl
+  case toRegexCI_ re of
+    Right r -> return $! RegexAlias r repl
     Left e  -> customFailure $! parseErrorAtRegion off1 off2 e
 
 endaliasesdirectivep :: JournalParser m ()

--- a/hledger-lib/Hledger/Reports.hs
+++ b/hledger-lib/Hledger/Reports.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, DeriveDataTypeable, FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleInstances #-}
 {-|
 
 Generate several common kinds of report from a journal, as \"*Report\" -

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, DeriveDataTypeable, FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleInstances #-}
 {-|
 
 An account-centric transactions report.

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -50,7 +50,7 @@ entriesReport ropts@ReportOpts{..} q j@Journal{..} =
 
 tests_EntriesReport = tests "EntriesReport" [
   tests "entriesReport" [
-     test "not acct" $ (length $ entriesReport defreportopts (Not $ Acct "bank") samplejournal) @?= 1
+     test "not acct" $ (length $ entriesReport defreportopts (Not . Acct $ toRegex' "bank") samplejournal) @?= 1
     ,test "date" $ (length $ entriesReport defreportopts (Date $ DateSpan (Just $ fromGregorian 2008 06 01) (Just $ fromGregorian 2008 07 01)) samplejournal) @?= 3
   ]
  ]

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, DeriveDataTypeable, FlexibleInstances, ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleInstances, ScopedTypeVariables #-}
 {-|
 
 Journal entries report, used by the print command.

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -277,13 +277,13 @@ tests_PostingsReport = tests "PostingsReport" [
     (Any, samplejournal) `gives` 13
     -- register --depth just clips account names
     (Depth 2, samplejournal) `gives` 13
-    (And [Depth 1, StatusQ Cleared, Acct "expenses"], samplejournal) `gives` 2
-    (And [And [Depth 1, StatusQ Cleared], Acct "expenses"], samplejournal) `gives` 2
+    (And [Depth 1, StatusQ Cleared, Acct (toRegex' "expenses")], samplejournal) `gives` 2
+    (And [And [Depth 1, StatusQ Cleared], Acct (toRegex' "expenses")], samplejournal) `gives` 2
     -- with query and/or command-line options
     (length $ snd $ postingsReport defreportopts Any samplejournal) @?= 13
     (length $ snd $ postingsReport defreportopts{interval_=Months 1} Any samplejournal) @?= 11
     (length $ snd $ postingsReport defreportopts{interval_=Months 1, empty_=True} Any samplejournal) @?= 20
-    (length $ snd $ postingsReport defreportopts (Acct "assets:bank:checking") samplejournal) @?= 5
+    (length $ snd $ postingsReport defreportopts (Acct (toRegex' "assets:bank:checking")) samplejournal) @?= 5
 
      -- (defreportopts, And [Acct "a a", Acct "'b"], samplejournal2) `gives` 0
      -- [(Just (fromGregorian 2008 01 01,"income"),assets:bank:checking             $1,$1)

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -4,7 +4,6 @@ Postings report, used by the register command.
 
 -}
 
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -373,7 +373,7 @@ tests_PostingsReport = tests "PostingsReport" [
         j <- samplejournal
         let gives displayexpr =
                 (registerdates (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is`)
-                    where opts = defreportopts{display_=Just displayexpr}
+                    where opts = defreportopts
         "d<[2008/6/2]"  `gives` ["2008/01/01","2008/06/01"]
         "d<=[2008/6/2]" `gives` ["2008/01/01","2008/06/01","2008/06/02"]
         "d=[2008/6/2]"  `gives` ["2008/06/02"]

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -4,7 +4,6 @@ Options common to most hledger reports.
 
 -}
 
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -49,14 +48,12 @@ module Hledger.Reports.ReportOptions (
 where
 
 import Control.Applicative ((<|>))
-import Data.Data (Data)
 import Data.List.Extra (nubSort)
-import Data.Maybe
+import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Text as T
-import Data.Typeable (Typeable)
-import Data.Time.Calendar
-import Data.Default
-import Safe
+import Data.Time.Calendar (Day, addDays, fromGregorian)
+import Data.Default (Default(..))
+import Safe (lastDef, lastMay)
 
 import System.Console.ANSI (hSupportsANSIColor)
 import System.Environment (lookupEnv)
@@ -76,12 +73,12 @@ data BalanceType = PeriodChange      -- ^ The change of balance in each period.
                  | HistoricalBalance -- ^ The historical ending balance, including the effect of
                                      --   all postings before the report period. Unless altered by,
                                      --   a query, this is what you would see on a bank statement.
-  deriving (Eq,Show,Data,Typeable)
+  deriving (Eq,Show)
 
 instance Default BalanceType where def = PeriodChange
 
 -- | Should accounts be displayed: in the command's default style, hierarchically, or as a flat list ?
-data AccountListMode = ALFlat | ALTree deriving (Eq, Show, Data, Typeable)
+data AccountListMode = ALFlat | ALTree deriving (Eq, Show)
 
 instance Default AccountListMode where def = ALFlat
 
@@ -140,7 +137,7 @@ data ReportOpts = ReportOpts {
       --   TERM and existence of NO_COLOR environment variables.
     ,forecast_       :: Maybe DateSpan
     ,transpose_      :: Bool
- } deriving (Show, Data, Typeable)
+ } deriving (Show)
 
 instance Default ReportOpts where def = defreportopts
 

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -98,7 +98,6 @@ data ReportOpts = ReportOpts {
     ,value_          :: Maybe ValuationType  -- ^ What value should amounts be converted to ?
     ,infer_value_    :: Bool      -- ^ Infer market prices from transactions ?
     ,depth_          :: Maybe Int
-    ,display_        :: Maybe DisplayExp  -- XXX unused ?
     ,date2_          :: Bool
     ,empty_          :: Bool
     ,no_elide_       :: Bool
@@ -172,7 +171,6 @@ defreportopts = ReportOpts
     def
     def
     def
-    def
 
 rawOptsToReportOpts :: RawOpts -> IO ReportOpts
 rawOptsToReportOpts rawopts = checkReportOpts <$> do
@@ -189,7 +187,6 @@ rawOptsToReportOpts rawopts = checkReportOpts <$> do
     ,value_       = valuationTypeFromRawOpts rawopts'
     ,infer_value_ = boolopt "infer-value" rawopts'
     ,depth_       = maybeposintopt "depth" rawopts'
-    ,display_     = maybedisplayopt d rawopts'
     ,date2_       = boolopt "date2" rawopts'
     ,empty_       = boolopt "empty" rawopts'
     ,no_elide_    = boolopt "no-elide" rawopts'
@@ -415,15 +412,6 @@ valuationTypeIsDefaultValue ropts =
   case value_ ropts of
     Just (AtDefault _) -> True
     _                  -> False
-
-type DisplayExp = String
-
-maybedisplayopt :: Day -> RawOpts -> Maybe DisplayExp
-maybedisplayopt d rawopts =
-    maybe Nothing (Just . replaceAllBy (toRegex' "\\[.+?\\]") fixbracketeddatestr) $ maybestringopt "display" rawopts
-  where
-    fixbracketeddatestr "" = ""
-    fixbracketeddatestr s = "[" ++ fixSmartDateStr d (T.pack $ init $ tail s) ++ "]"
 
 -- | Select the Transaction date accessor based on --date2.
 transactionDateFn :: ReportOpts -> (Transaction -> Day)

--- a/hledger-lib/Hledger/Reports/TransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/TransactionsReport.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, DeriveDataTypeable, FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleInstances #-}
 {-|
 
 A transactions report. Like an EntriesReport, but with more

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable    #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -80,7 +79,6 @@ import Control.Monad (foldM)
 import Data.Aeson (ToJSON(..), Value(String))
 import Data.Array ((!), elems, indices)
 import Data.Char (isDigit)
-import Data.Data (Data(..), mkNoRepType)
 import Data.List (foldl')
 import Data.MemoUgly (memo)
 import qualified Data.Text as T
@@ -123,11 +121,6 @@ instance Read Regexp where
                                                     ("Regex",s) <- lex r,
                                                     (m,t) <- readsPrec (app_prec+1) s]) r
     where app_prec = 10
-
-instance Data Regexp where
-  toConstr _   = error' "No toConstr for Regex"
-  gunfold _ _  = error' "No gunfold for Regex"
-  dataTypeOf _ = mkNoRepType "Hledger.Utils.Regex"
 
 instance ToJSON Regexp where
   toJSON (Regexp   s _) = String . T.pack $ "Regexp "   ++ s

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -215,7 +215,6 @@ replaceRegexUnmemo_ re repl s = foldM (replaceMatch_ repl) s (reverse $ match (r
         -- The replacement text: the replacement pattern with all
         -- numeric backreferences replaced by the appropriate groups
         -- from this match. Or an error message.
-        -- FIXME: Use makeRegex instead of toRegex_
         erepl = replaceAllByM backrefRegex (lookupMatchGroup_ matchgroups) replpat
           where
             -- Given some match groups and a numeric backreference,

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -76,7 +76,6 @@ module Hledger.Utils.Regex (
   )
 where
 
-import Control.Arrow (first)
 import Control.Monad (foldM)
 import Data.Aeson (ToJSON(..), Value(String))
 import Data.Array ((!), elems, indices)
@@ -111,13 +110,19 @@ instance Ord Regexp where
   RegexpCI _ _ `compare` Regexp _ _ = GT
 
 instance Show Regexp where
-  showsPrec d (Regexp s _)   = showString "Regexp " . showsPrec d s
-  showsPrec d (RegexpCI s _) = showString "RegexpCI " . showsPrec d s
+  showsPrec d r = showParen (d > app_prec) $ reCons . showsPrec (app_prec+1) (reString r)
+    where app_prec = 10
+          reCons = case r of Regexp   _ _ -> showString "Regexp "
+                             RegexpCI _ _ -> showString "RegexpCI "
 
 instance Read Regexp where
-  readsPrec d ('R':'e':'g':'e':'x':'p':' ':xs)         = map (first toRegex')   $ readsPrec d xs
-  readsPrec d ('R':'e':'g':'e':'x':'p':'C':'I':' ':xs) = map (first toRegexCI') $ readsPrec d xs
-  readsPrec _ s                                        = error' $ "read: Not a valid regex " ++ s
+  readsPrec d r =  readParen (d > app_prec) (\r -> [(toRegexCI' m,t) |
+                                                    ("RegexCI",s) <- lex r,
+                                                    (m,t) <- readsPrec (app_prec+1) s]) r
+                ++ readParen (d > app_prec) (\r -> [(toRegex' m, t) |
+                                                    ("Regex",s) <- lex r,
+                                                    (m,t) <- readsPrec (app_prec+1) s]) r
+    where app_prec = 10
 
 instance Data Regexp where
   toConstr _   = error' "No toConstr for Regex"

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 {-|
 
 Easy regular expression helpers, currently based on regex-tdfa. These should:
@@ -42,48 +46,120 @@ Current limitations:
 -}
 
 module Hledger.Utils.Regex (
+  -- * Regexp type and constructors
+   Regexp(reString)
+  ,toRegex_
+  ,toRegexCI_
+  ,toRegex'
+  ,toRegexCI'
    -- * type aliases
-   Regexp
   ,Replacement
   ,RegexError
    -- * partial regex operations (may call error)
-  ,regexMatches
-  ,regexMatchesCI
-  ,regexReplace
-  ,regexReplaceCI
-  ,regexReplaceMemo
-  ,regexReplaceCIMemo
-  ,regexReplaceBy
-  ,regexReplaceByCI
+--   ,regexMatches
+--   ,regexMatchesCI
+--   ,regexReplaceCI
+--   ,regexReplaceCIMemo
+--   ,regexReplaceByCI
    -- * total regex operations
-  ,regexMatches_
-  ,regexMatchesCI_
-  ,regexReplace_
-  ,regexReplaceCI_
+  ,match
+  ,regexReplace
   ,regexReplaceMemo_
-  ,regexReplaceCIMemo_
-  ,regexReplaceBy_
-  ,regexReplaceByCI_
-  ,toRegex_
+--   ,replaceAllBy
+--   ,regexMatches_
+--   ,regexMatchesCI_
+--   ,regexReplace_
+--   ,regexReplaceCI_
+--   ,regexReplaceMemo_
+--   ,regexReplaceCIMemo_
+  ,replaceAllBy
   )
 where
 
+import Control.Arrow (first)
 import Control.Monad (foldM)
-import Data.Array
-import Data.Char
+import Data.Aeson (ToJSON(..), Value(String))
+import Data.Array ((!), elems, indices)
+import Data.Char (isDigit)
+import Data.Data (Data(..), mkNoRepType)
 import Data.List (foldl')
-import Data.Maybe (fromMaybe)
 import Data.MemoUgly (memo)
+import qualified Data.Text as T
 import Text.Regex.TDFA (
-  Regex, CompOption(..), ExecOption(..), defaultCompOpt, defaultExecOpt,
-  makeRegexOptsM, AllMatches(getAllMatches), match, (=~), MatchText
+  Regex, CompOption(..), defaultCompOpt, defaultExecOpt,
+  makeRegexOptsM, AllMatches(getAllMatches), match, MatchText,
+  RegexLike(..), RegexMaker(..), RegexOptions(..), RegexContext(..)
   )
 
 import Hledger.Utils.UTF8IOCompat (error')
 
 
 -- | Regular expression. Extended regular expression-ish syntax ? But does not support eg (?i) syntax.
-type Regexp = String
+data Regexp
+  = Regexp   { reString :: String, reCompiled :: Regex }
+  | RegexpCI { reString :: String, reCompiled :: Regex }
+
+instance Eq Regexp where
+  Regexp   s1 _ == Regexp   s2 _ = s1 == s2
+  RegexpCI s1 _ == RegexpCI s2 _ = s1 == s2
+  _ == _ = False
+
+instance Ord Regexp where
+  Regexp   s1 _ `compare` Regexp   s2 _ = s1 `compare` s2
+  RegexpCI s1 _ `compare` RegexpCI s2 _ = s1 `compare` s2
+  Regexp _ _ `compare` RegexpCI _ _ = LT
+  RegexpCI _ _ `compare` Regexp _ _ = GT
+
+instance Show Regexp where
+  showsPrec d (Regexp s _)   = showString "Regexp " . showsPrec d s
+  showsPrec d (RegexpCI s _) = showString "RegexpCI " . showsPrec d s
+
+instance Read Regexp where
+  readsPrec d ('R':'e':'g':'e':'x':'p':' ':xs)         = map (first toRegex')   $ readsPrec d xs
+  readsPrec d ('R':'e':'g':'e':'x':'p':'C':'I':' ':xs) = map (first toRegexCI') $ readsPrec d xs
+  readsPrec _ s                                        = error' $ "read: Not a valid regex " ++ s
+
+instance Data Regexp where
+  toConstr _   = error' "No toConstr for Regex"
+  gunfold _ _  = error' "No gunfold for Regex"
+  dataTypeOf _ = mkNoRepType "Hledger.Utils.Regex"
+
+instance ToJSON Regexp where
+  toJSON (Regexp   s _) = String . T.pack $ "Regexp "   ++ s
+  toJSON (RegexpCI s _) = String . T.pack $ "RegexpCI " ++ s
+
+instance RegexLike Regexp String where
+  matchOnce = matchOnce . reCompiled
+  matchAll = matchAll . reCompiled
+  matchCount = matchCount . reCompiled
+  matchTest = matchTest . reCompiled
+  matchAllText = matchAllText . reCompiled
+  matchOnceText = matchOnceText . reCompiled
+
+instance RegexContext Regexp String String where
+  match = match . reCompiled
+  matchM = matchM . reCompiled
+
+-- Convert a Regexp string to a compiled Regex, or return an error message.
+toRegex_ :: String -> Either RegexError Regexp
+toRegex_ = memo $ \s -> mkRegexErr s (Regexp s <$> makeRegexM s)
+
+-- Like toRegex_, but make a case-insensitive Regex.
+toRegexCI_ :: String -> Either RegexError Regexp
+toRegexCI_ = memo $ \s -> mkRegexErr s (RegexpCI s <$> makeRegexOptsM defaultCompOpt{caseSensitive=False} defaultExecOpt s)
+
+-- | Make a nice error message for a regexp error.
+mkRegexErr :: String -> Maybe a -> Either RegexError a
+mkRegexErr s = maybe (Left errmsg) Right
+  where errmsg = "this regular expression could not be compiled: " ++ s
+
+-- Convert a Regexp string to a compiled Regex, throw an error
+toRegex' :: String -> Regexp
+toRegex' = either error' id . toRegex_
+
+-- Like toRegex', but make a case-insensitive Regex.
+toRegexCI' :: String -> Regexp
+toRegexCI' = either error' id . toRegexCI_
 
 -- | A replacement pattern. May include numeric backreferences (\N).
 type Replacement = String
@@ -91,61 +167,10 @@ type Replacement = String
 -- | An regular expression compilation/processing error message.
 type RegexError = String
 
---------------------------------------------------------------------------------
--- old partial functions  -- PARTIAL:
-
--- regexMatch' :: RegexContext Regexp String a => Regexp -> String -> a
--- regexMatch' r s = s =~ (toRegex' r)
-
-regexMatches :: Regexp -> String -> Bool
-regexMatches = flip (=~)
-
-regexMatchesCI :: Regexp -> String -> Bool
-regexMatchesCI r = match (toRegexCI r)
-
--- | Replace all occurrences of the regexp with the replacement
--- pattern. The replacement pattern supports numeric backreferences
--- (\N) but no other RE syntax.
-regexReplace :: Regexp -> Replacement -> String -> String
-regexReplace re = replaceRegex (toRegex re)
-
-regexReplaceCI :: Regexp -> Replacement -> String -> String
-regexReplaceCI re = replaceRegex (toRegexCI re)
-
--- | A memoising version of regexReplace. Caches the result for each
--- search pattern, replacement pattern, target string tuple.
-regexReplaceMemo :: Regexp -> Replacement -> String -> String
-regexReplaceMemo re repl = memo (regexReplace re repl)
-
-regexReplaceCIMemo :: Regexp -> Replacement -> String -> String
-regexReplaceCIMemo re repl = memo (regexReplaceCI re repl)
-
--- | Replace all occurrences of the regexp, transforming each match with the given function.
-regexReplaceBy :: Regexp -> (String -> String) -> String -> String
-regexReplaceBy r = replaceAllBy (toRegex r)
-
-regexReplaceByCI :: Regexp -> (String -> String) -> String -> String
-regexReplaceByCI r = replaceAllBy (toRegexCI r)
-
 -- helpers
 
--- | Convert our string-based Regexp to a real Regex.
--- Or if it's not well formed, call error with a "malformed regexp" message.
-toRegex :: Regexp -> Regex
-toRegex = memo (compileRegex defaultCompOpt defaultExecOpt)  -- PARTIAL:
-
--- | Like toRegex but make a case-insensitive Regex.
-toRegexCI :: Regexp -> Regex
-toRegexCI = memo (compileRegex defaultCompOpt{caseSensitive=False} defaultExecOpt)  -- PARTIAL:
-
-compileRegex :: CompOption -> ExecOption -> Regexp -> Regex
-compileRegex compopt execopt r =
-  fromMaybe
-  (error $ "this regular expression could not be compiled: " ++ show r) $  -- PARTIAL:
-  makeRegexOptsM compopt execopt r
-
-replaceRegex :: Regex -> Replacement -> String -> String
-replaceRegex re repl s = foldl (replaceMatch repl) s (reverse $ match re s :: [MatchText String])
+regexReplace :: Regexp -> Replacement -> String -> String
+regexReplace re repl s = foldl (replaceMatch repl) s (reverse $ match (reCompiled re) s :: [MatchText String])
   where
     replaceMatch :: Replacement -> String -> MatchText String -> String
     replaceMatch replpat s matchgroups = pre ++ repl ++ post
@@ -153,7 +178,7 @@ replaceRegex re repl s = foldl (replaceMatch repl) s (reverse $ match re s :: [M
         ((_,(off,len)):_) = elems matchgroups  -- groups should have 0-based indexes, and there should always be at least one, since this is a match
         (pre, post') = splitAt off s
         post = drop len post'
-        repl = replaceAllBy (toRegex "\\\\[0-9]+") (lookupMatchGroup matchgroups) replpat
+        repl = replaceAllBy backrefRegex (lookupMatchGroup matchgroups) replpat
           where
             lookupMatchGroup :: MatchText String -> String -> String
             lookupMatchGroup grps ('\\':s@(_:_)) | all isDigit s =
@@ -161,68 +186,22 @@ replaceRegex re repl s = foldl (replaceMatch repl) s (reverse $ match re s :: [M
               -- PARTIAL:
                              _                         -> error' $ "no match group exists for backreference \"\\"++s++"\""
             lookupMatchGroup _ s = error' $ "lookupMatchGroup called on non-numeric-backreference \""++s++"\", shouldn't happen"
+    backrefRegex = toRegex' "\\\\[0-9]+"  -- PARTIAL: should not error happen
 
 --------------------------------------------------------------------------------
 -- new total functions
 
--- | Does this regexp match the given string ?
--- Or return an error if the regexp is malformed.
-regexMatches_ :: Regexp -> String -> Either RegexError Bool
-regexMatches_ r s = (`match` s) <$> toRegex_ r
-
--- | Like regexMatches_ but match case-insensitively.
-regexMatchesCI_ :: Regexp -> String -> Either RegexError Bool
-regexMatchesCI_ r s = (`match` s) <$> toRegexCI_ r
-
--- | Replace all occurrences of the regexp with the replacement
--- pattern, or return an error message. The replacement pattern
--- supports numeric backreferences (\N) but no other RE syntax.
-regexReplace_ :: Regexp -> Replacement -> String -> Either RegexError String
-regexReplace_ re repl s = toRegex_ re >>= \rx -> replaceRegex_ rx repl s
-
--- | Like regexReplace_ but match occurrences case-insensitively.
-regexReplaceCI_ :: Regexp -> Replacement -> String -> Either RegexError String
-regexReplaceCI_ re repl s = toRegexCI_ re >>= \rx -> replaceRegex_ rx repl s
-
 -- | A memoising version of regexReplace_. Caches the result for each
 -- search pattern, replacement pattern, target string tuple.
 regexReplaceMemo_ :: Regexp -> Replacement -> String -> Either RegexError String
-regexReplaceMemo_ re repl = memo (regexReplace_ re repl)
-
--- | Like regexReplaceMemo_ but match occurrences case-insensitively.
-regexReplaceCIMemo_ :: Regexp -> Replacement -> String -> Either RegexError String
-regexReplaceCIMemo_ re repl = memo (regexReplaceCI_ re repl)
-
--- | Replace all occurrences of the regexp, transforming each match
--- with the given function, or return an error message.
-regexReplaceBy_ :: Regexp -> (String -> String) -> String -> Either RegexError String
-regexReplaceBy_ r f s = toRegex_ r >>= \rx -> Right $ replaceAllBy rx f s
-
--- | Like regexReplaceBy_ but match occurrences case-insensitively.
-regexReplaceByCI_ :: Regexp -> (String -> String) -> String -> Either RegexError String
-regexReplaceByCI_ r f s = toRegexCI_ r >>= \rx -> Right $ replaceAllBy rx f s
+regexReplaceMemo_ re repl = memo (replaceRegexUnmemo_ re repl)
 
 -- helpers:
 
--- Convert a Regexp string to a compiled Regex, or return an error message.
-toRegex_ :: Regexp -> Either RegexError Regex
-toRegex_ = memo (compileRegex_ defaultCompOpt defaultExecOpt)
-
--- Like toRegex, but make a case-insensitive Regex.
-toRegexCI_ :: Regexp -> Either RegexError Regex
-toRegexCI_ = memo (compileRegex_ defaultCompOpt{caseSensitive=False} defaultExecOpt)
-
--- Compile a Regexp string to a Regex with the given options, or return an
--- error message if this fails.
-compileRegex_ :: CompOption -> ExecOption -> Regexp -> Either RegexError Regex
-compileRegex_ compopt execopt r =
-  maybe (Left $ "this regular expression could not be compiled: " ++ show r) Right $
-  makeRegexOptsM compopt execopt r
-
 -- Replace this regular expression with this replacement pattern in this
 -- string, or return an error message.
-replaceRegex_ :: Regex -> Replacement -> String -> Either RegexError String
-replaceRegex_ re repl s = foldM (replaceMatch_ repl) s (reverse $ match re s :: [MatchText String])
+replaceRegexUnmemo_ :: Regexp -> Replacement -> String -> Either RegexError String
+replaceRegexUnmemo_ re repl s = foldM (replaceMatch_ repl) s (reverse $ match (reCompiled re) s :: [MatchText String])
   where
     -- Replace one match within the string with the replacement text
     -- appropriate for this match. Or return an error message.
@@ -236,7 +215,8 @@ replaceRegex_ re repl s = foldM (replaceMatch_ repl) s (reverse $ match re s :: 
         -- The replacement text: the replacement pattern with all
         -- numeric backreferences replaced by the appropriate groups
         -- from this match. Or an error message.
-        erepl = toRegex_ "\\\\[0-9]+" >>= \rx -> replaceAllByM rx (lookupMatchGroup_ matchgroups) replpat
+        -- FIXME: Use makeRegex instead of toRegex_
+        erepl = replaceAllByM backrefRegex (lookupMatchGroup_ matchgroups) replpat
           where
             -- Given some match groups and a numeric backreference,
             -- return the referenced group text, or an error message.
@@ -245,6 +225,7 @@ replaceRegex_ re repl s = foldM (replaceMatch_ repl) s (reverse $ match re s :: 
               case read s of n | n `elem` indices grps -> Right $ fst (grps ! n)
                              _                         -> Left $ "no match group exists for backreference \"\\"++s++"\""
             lookupMatchGroup_ _ s = Left $ "lookupMatchGroup called on non-numeric-backreference \""++s++"\", shouldn't happen"
+    backrefRegex = toRegex' "\\\\[0-9]+"  -- PARTIAL: should not happen
 
 -- helpers
 
@@ -252,12 +233,12 @@ replaceRegex_ re repl s = foldM (replaceMatch_ repl) s (reverse $ match re s :: 
 
 -- Replace all occurrences of a regexp in a string, transforming each match
 -- with the given pure function.
-replaceAllBy :: Regex -> (String -> String) -> String -> String
+replaceAllBy :: Regexp -> (String -> String) -> String -> String
 replaceAllBy re transform s = prependdone rest
   where
     (_, rest, prependdone) = foldl' go (0, s, id) matches
       where
-        matches = getAllMatches $ match re s :: [(Int, Int)]  -- offset and length
+        matches = getAllMatches $ match (reCompiled re) s :: [(Int, Int)]  -- offset and length
         go :: (Int,String,String->String) -> (Int,Int) ->  (Int,String,String->String)
         go (pos,todo,prepend) (off,len) =
           let (prematch, matchandrest) = splitAt (off - pos) todo
@@ -268,11 +249,11 @@ replaceAllBy re transform s = prependdone rest
 -- with the given monadic function. Eg if the monad is Either, a Left result
 -- from the transform function short-circuits and is returned as the overall
 -- result.
-replaceAllByM :: forall m. Monad m => Regex -> (String -> m String) -> String -> m String
+replaceAllByM :: forall m. Monad m => Regexp -> (String -> m String) -> String -> m String
 replaceAllByM re transform s =
   foldM go (0, s, id) matches >>= \(_, rest, prependdone) -> pure $ prependdone rest
   where
-    matches = getAllMatches $ match re s :: [(Int, Int)]  -- offset and length
+    matches = getAllMatches $ match (reCompiled re) s :: [(Int, Int)]  -- offset and length
     go :: (Int,String,String->String) -> (Int,Int) -> m (Int,String,String->String)
     go (pos,todo,prepend) (off,len) =
       let (prematch, matchandrest) = splitAt (off - pos) todo

--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -134,10 +134,10 @@ whitespacechars = " \t\n\r"
 redirectchars   = "<>"
 
 escapeDoubleQuotes :: String -> String
-escapeDoubleQuotes = regexReplace "\"" "\""
+escapeDoubleQuotes = id  -- regexReplace "\"" "\""
 
 escapeQuotes :: String -> String
-escapeQuotes = regexReplace "([\"'])" "\\1"
+escapeQuotes = id  -- regexReplace "([\"'])" "\\1"
 
 -- | Quote-aware version of words - don't split on spaces which are inside quotes.
 -- NB correctly handles "a'b" but not "''a''". Can raise an error if parsing fails.
@@ -346,7 +346,7 @@ strWidth s = maximum $ map (foldr (\a b -> charWidth a + b) 0) $ lines s'
   where s' = stripAnsi s
 
 stripAnsi :: String -> String
-stripAnsi = regexReplace "\ESC\\[([0-9]+;)*([0-9]+)?[ABCDHJKfmsu]" ""
+stripAnsi = regexReplace (toRegex' "\ESC\\[([0-9]+;)*([0-9]+)?[ABCDHJKfmsu]") "" -- PARTIAL: should never happen, no backreferences
 
 -- | Get the designated render width of a character: 0 for a combining
 -- character, 1 for a regular character, 2 for a wide character.

--- a/hledger-lib/Hledger/Utils/Tree.hs
+++ b/hledger-lib/Hledger/Utils/Tree.hs
@@ -1,77 +1,18 @@
-module Hledger.Utils.Tree where
+module Hledger.Utils.Tree
+( FastTree(..)
+, treeFromPaths
+) where
 
 -- import Data.Char
 import Data.List (foldl')
 import qualified Data.Map as M
-import Data.Tree
--- import Text.Megaparsec
--- import Text.Printf
-
-import Hledger.Utils.Regex
--- import Hledger.Utils.UTF8IOCompat (error')
-
--- standard tree helpers
-
-root = rootLabel
-subs = subForest
-branches = subForest
-
--- | List just the leaf nodes of a tree
-leaves :: Tree a -> [a]
-leaves (Node v []) = [v]
-leaves (Node _ branches) = concatMap leaves branches
-
--- | get the sub-tree rooted at the first (left-most, depth-first) occurrence
--- of the specified node value
-subtreeat :: Eq a => a -> Tree a -> Maybe (Tree a)
-subtreeat v t
-    | root t == v = Just t
-    | otherwise = subtreeinforest v $ subs t
-
--- | get the sub-tree for the specified node value in the first tree in
--- forest in which it occurs.
-subtreeinforest :: Eq a => a -> [Tree a] -> Maybe (Tree a)
-subtreeinforest _ [] = Nothing
-subtreeinforest v (t:ts) = case (subtreeat v t) of
-                             Just t' -> Just t'
-                             Nothing -> subtreeinforest v ts
-
--- | remove all nodes past a certain depth
-treeprune :: Int -> Tree a -> Tree a
-treeprune 0 t = Node (root t) []
-treeprune d t = Node (root t) (map (treeprune $ d-1) $ branches t)
-
--- | apply f to all tree nodes
-treemap :: (a -> b) -> Tree a -> Tree b
-treemap f t = Node (f $ root t) (map (treemap f) $ branches t)
-
--- | remove all subtrees whose nodes do not fulfill predicate
-treefilter :: (a -> Bool) -> Tree a -> Tree a
-treefilter f t = Node
-                 (root t)
-                 (map (treefilter f) $ filter (treeany f) $ branches t)
-
--- | is predicate true in any node of tree ?
-treeany :: (a -> Bool) -> Tree a -> Bool
-treeany f t = f (root t) || any (treeany f) (branches t)
-
--- treedrop -- remove the leaves which do fulfill predicate.
--- treedropall -- do this repeatedly.
-
--- | show a compact ascii representation of a tree
-showtree :: Show a => Tree a -> String
-showtree = unlines . filter (regexMatches "[^ \\|]") . lines . drawTree . treemap show
-
--- | show a compact ascii representation of a forest
-showforest :: Show a => Forest a -> String
-showforest = concatMap showtree
-
 
 -- | An efficient-to-build tree suggested by Cale Gibbard, probably
 -- better than accountNameTreeFrom.
 newtype FastTree a = T (M.Map a (FastTree a))
   deriving (Show, Eq, Ord)
 
+emptyTree :: FastTree a
 emptyTree = T M.empty
 
 mergeTrees :: (Ord a) => FastTree a -> FastTree a -> FastTree a
@@ -83,5 +24,3 @@ treeFromPath (x:xs) = T (M.singleton x (treeFromPath xs))
 
 treeFromPaths :: (Ord a) => [[a]] -> FastTree a
 treeFromPaths = foldl' mergeTrees emptyTree . map treeFromPath
-
-

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ca2b9f025d75c0b65f91b2e5fe7203d00d1d9f8c423c8c4f0cb7675df848a5aa
+-- hash: e8ee8c99329f53fe86ae9df138d05c8c39726a66da2ad1da3ae27500c45b2591
 
 name:           hledger-lib
 version:        1.18.99
@@ -124,7 +124,6 @@ library
     , cmdargs >=0.10
     , containers
     , data-default >=0.5
-    , deepseq
     , directory
     , extra >=1.6.3
     , fgl >=5.5.4.0
@@ -177,7 +176,6 @@ test-suite doctest
     , cmdargs >=0.10
     , containers
     , data-default >=0.5
-    , deepseq
     , directory
     , doctest >=0.16.3
     , extra >=1.6.3
@@ -233,7 +231,6 @@ test-suite unittest
     , cmdargs >=0.10
     , containers
     , data-default >=0.5
-    , deepseq
     , directory
     , extra >=1.6.3
     , fgl >=5.5.4.0

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -59,7 +59,6 @@ dependencies:
 - cassava-megaparsec
 - data-default >=0.5
 - Decimal >=0.5.1
-- deepseq
 - directory
 - fgl >=5.5.4.0
 - file-embed >=0.0.10

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -90,7 +90,7 @@ asInit d reset ui@UIState{
         excludeforecastq Nothing  =  -- not:date:tomorrow- not:tag:generated-transaction
           And [
              Not (Date $ DateSpan (Just $ addDays 1 d) Nothing)
-            ,Not (Tag "generated-transaction" Nothing)
+            ,Not (Tag (toRegexCI' "generated-transaction") Nothing)
           ]
 
     -- run the report

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -122,7 +122,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportopts_=rop
         where
           acct = headDef
                  (error' $ "--register "++apat++" did not match any account")  -- PARTIAL:
-                 $ filter (regexMatches apat . T.unpack) $ journalAccountNames j
+                 $ filter (match (toRegexCI' apat) . T.unpack) $ journalAccountNames j
           -- Initialising the accounts screen is awkward, requiring
           -- another temporary UIState value..
           ascr' = aScreen $

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -76,7 +76,7 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportopts_=ropts
         excludeforecastq Nothing  =  -- not:date:tomorrow- not:tag:generated-transaction
           And [
              Not (Date $ DateSpan (Just $ addDays 1 d) Nothing)
-            ,Not (Tag "generated-transaction" Nothing)
+            ,Not (Tag (toRegexCI' "generated-transaction") Nothing)
           ]
 
     (_label,items) = accountTransactionsReport ropts' j q thisacctq

--- a/hledger-ui/Hledger/UI/UIOptions.hs
+++ b/hledger-ui/Hledger/UI/UIOptions.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
 {-|
 

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -106,16 +106,13 @@ addForm j today = identifyForm "add" $ \extra -> do
         intercalate "," $ map (
           ("{\"value\":" ++).
           (++"}").
-          escapeJSSpecialChars .
-          drop 7 .  -- "String "
           show .
-          toJSON
+          -- avoid https://github.com/simonmichael/hledger/issues/236
+          T.replace "</script>" "<\\/script>"
           ) ts,
         "]"
         ]
       where
-        -- avoid https://github.com/simonmichael/hledger/issues/236
-        escapeJSSpecialChars = regexReplace (toRegexCI' "</script>") "<\\/script>"
 
 validateTransaction ::
      FormResult Day

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -115,7 +115,7 @@ addForm j today = identifyForm "add" $ \extra -> do
         ]
       where
         -- avoid https://github.com/simonmichael/hledger/issues/236
-        escapeJSSpecialChars = regexReplaceCI "</script>" "<\\/script>"
+        escapeJSSpecialChars = regexReplace (toRegexCI' "</script>") "<\\/script>"
 
 validateTransaction ::
      FormResult Day

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -72,7 +72,7 @@ writeJournalTextIfValidAndChanged f t = do
   -- Ensure unix line endings, since both readJournal (cf
   -- formatdirectivep, #1194) writeFileWithBackupIfChanged require them.
   -- XXX klunky. Any equivalent of "hSetNewlineMode h universalNewlineMode" for form posts ?
-  let t' = T.pack $ regexReplace (toRegex' "\r") "" $ T.unpack t
+  let t' = T.replace "\r" "" t
   liftIO (readJournal def (Just f) t') >>= \case
     Left e -> return (Left e)
     Right _ -> do

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -72,7 +72,7 @@ writeJournalTextIfValidAndChanged f t = do
   -- Ensure unix line endings, since both readJournal (cf
   -- formatdirectivep, #1194) writeFileWithBackupIfChanged require them.
   -- XXX klunky. Any equivalent of "hSetNewlineMode h universalNewlineMode" for form posts ?
-  let t' = T.pack $ regexReplace "\r" "" $ T.unpack t
+  let t' = T.pack $ regexReplace (toRegex' "\r") "" $ T.unpack t
   liftIO (readJournal def (Just f) t') >>= \case
     Left e -> return (Left e)
     Right _ -> do

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -5,7 +5,7 @@ related utilities used by hledger commands.
 
 -}
 
-{-# LANGUAGE CPP, ScopedTypeVariables, DeriveDataTypeable, FlexibleContexts, TypeFamilies, OverloadedStrings, PackageImports #-}
+{-# LANGUAGE CPP, ScopedTypeVariables, FlexibleContexts, TypeFamilies, OverloadedStrings, PackageImports #-}
 
 module Hledger.Cli.CliOptions (
 
@@ -413,7 +413,7 @@ data CliOpts = CliOpts {
                                         -- 1. the COLUMNS env var, if set
                                         -- 2. the width reported by the terminal, if supported
                                         -- 3. the default (80)
- } deriving (Show, Data, Typeable)
+ } deriving (Show)
 
 instance Default CliOpts where def = defcliopts
 

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -3,7 +3,7 @@ A history-aware add command to help with data entry.
 |-}
 
 {-# OPTIONS_GHC -fno-warn-missing-signatures -fno-warn-unused-do-bind #-}
-{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, RecordWildCards, TypeOperators, FlexibleContexts, OverloadedStrings, PackageImports, LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables, RecordWildCards, TypeOperators, FlexibleContexts, OverloadedStrings, PackageImports, LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Hledger.Cli.Commands.Add (
@@ -32,7 +32,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
 import Data.Time.Format (formatTime, defaultTimeLocale, iso8601DateFormat)
-import Data.Typeable (Typeable)
 import Safe (headDef, headMay, atMay)
 import System.Console.CmdArgs.Explicit
 import System.Console.Haskeline (runInputT, defaultSettings, setComplete)
@@ -65,7 +64,7 @@ data EntryState = EntryState {
   ,esJournal            :: Journal           -- ^ the journal we are adding to
   ,esSimilarTransaction :: Maybe Transaction -- ^ the most similar historical txn
   ,esPostings           :: [Posting]         -- ^ postings entered so far in the current txn
-  } deriving (Show,Typeable)
+  } deriving (Show)
 
 defEntryState = EntryState {
    esOpts               = defcliopts
@@ -77,10 +76,10 @@ defEntryState = EntryState {
   ,esPostings           = []
 }
 
-data RestartTransactionException = RestartTransactionException deriving (Typeable,Show)
+data RestartTransactionException = RestartTransactionException deriving (Show)
 instance Exception RestartTransactionException
 
--- data ShowHelpException = ShowHelpException deriving (Typeable,Show)
+-- data ShowHelpException = ShowHelpException deriving (Show)
 -- instance Exception ShowHelpException
 
 -- | Read multiple transactions from the console, prompting for each

--- a/hledger/Hledger/Cli/Commands/Files.hs
+++ b/hledger/Hledger/Cli/Commands/Files.hs
@@ -33,8 +33,8 @@ filesmode = hledgerCommandMode
 files :: CliOpts -> Journal -> IO ()
 files CliOpts{rawopts_=rawopts} j = do
   let args = listofstringopt "args" rawopts
-      regex = headMay args
-      files = maybe id (filter . regexMatches) regex
+  regex <- mapM (either fail pure . toRegex_) $ headMay args
+  let files = maybe id (filter . match) regex
               $ map fst
               $ jfiles j
   mapM_ putStrLn files

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -7,6 +7,7 @@ module Hledger.Cli.Commands.Tags (
 )
 where
 
+import qualified Control.Monad.Fail as Fail
 import Data.List.Extra (nubSort)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -24,11 +25,13 @@ tagsmode = hledgerCommandMode
   hiddenflags
   ([], Just $ argsFlag "[TAGREGEX [QUERY...]]")
 
+tags :: CliOpts -> Journal -> IO ()
 tags CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
   d <- getCurrentDay
   let
     args      = listofstringopt "args" rawopts
-    mtagpat   = headMay args
+  mtagpat <- mapM (either Fail.fail pure . toRegexCI_) $ headMay args
+  let
     queryargs = drop 1 args
     values    = boolopt "values" rawopts
     parsed    = boolopt "parsed" rawopts
@@ -39,7 +42,7 @@ tags CliOpts{rawopts_=rawopts,reportopts_=ropts} j = do
       (if parsed then id else nubSort)
       [ r
       | (t,v) <- concatMap transactionAllTags txns
-      , maybe True (`regexMatchesCI` T.unpack t) mtagpat
+      , maybe True (`match` T.unpack t) mtagpat
       , let r = if values then v else t
       , not (values && T.null v && not empty)
       ]

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -82,14 +82,14 @@ mainmode addons = defMode {
         [detailedversionflag]
         -- ++ inputflags -- included here so they'll not raise a confusing error if present with no COMMAND
     }
- ,modeHelpSuffix = map (regexReplace "PROGNAME" progname) [
-     "Examples:"
-    ,"PROGNAME                         list commands"
-    ,"PROGNAME CMD [--] [OPTS] [ARGS]  run a command (use -- with addon commands)"
-    ,"PROGNAME-CMD [OPTS] [ARGS]       or run addon commands directly"
-    ,"PROGNAME -h                      show general usage"
-    ,"PROGNAME CMD -h                  show command usage"
-    ,"PROGNAME help [MANUAL]           show any of the hledger manuals in various formats"
+ ,modeHelpSuffix = "Examples:" :
+    map (progname ++) [
+     "                         list commands"
+    ," CMD [--] [OPTS] [ARGS]  run a command (use -- with addon commands)"
+    ,"-CMD [OPTS] [ARGS]       or run addon commands directly"
+    ," -h                      show general usage"
+    ," CMD -h                  show command usage"
+    ," help [MANUAL]           show any of the hledger manuals in various formats"
     ]
  }
 


### PR DESCRIPTION
This is a work in progress, dealing with option 2 of #1312. I'd be interested in people's opinions.

It compiles and passes all tests, but some things are perhaps not quite right, in particular, the `Data` instance of `Regexp` calls error a lot. This was taken from similar instances in `Data.Generics.Instances`, but who knows if it's the right thing to do.

A lot of instances of `Data`, `NFData` may not serve any purpose. If we can remove them without compliation errors, should that happen?

Sorry it's a bit of a monolithic PR.