### PR TITLE
lib,cli,ui: Remove old CPP directives made redundant by version bounds.

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -37,7 +37,6 @@ module Hledger.Data.Dates (
   spanContainsDate,
   periodContainsDate,
   parsedateM,
-  parsedate,
   showDate,
   showDateSpan,
   showDateSpanMonthAbbrev,
@@ -73,7 +72,6 @@ module Hledger.Data.Dates (
   yearp,
   daysInSpan,
   maybePeriod,
-  mkdatespan,
 )
 where
 
@@ -172,34 +170,34 @@ spansSpan spans = DateSpan (maybe Nothing spanStart $ headMay spans) (maybe Noth
 --
 --
 -- ==== Examples:
--- >>> let t i d1 d2 = splitSpan i $ mkdatespan d1 d2
--- >>> t NoInterval "2008/01/01" "2009/01/01"
+-- >>> let t i y1 m1 d1 y2 m2 d2 = splitSpan i $ DateSpan (Just $ fromGregorian y1 m1 d1) (Just $ fromGregorian y2 m2 d2)
+-- >>> t NoInterval 2008 01 01 2009 01 01
 -- [DateSpan 2008]
--- >>> t (Quarters 1) "2008/01/01" "2009/01/01"
+-- >>> t (Quarters 1) 2008 01 01 2009 01 01
 -- [DateSpan 2008Q1,DateSpan 2008Q2,DateSpan 2008Q3,DateSpan 2008Q4]
 -- >>> splitSpan (Quarters 1) nulldatespan
 -- [DateSpan ..]
--- >>> t (Days 1) "2008/01/01" "2008/01/01"  -- an empty datespan
+-- >>> t (Days 1) 2008 01 01 2008 01 01  -- an empty datespan
 -- []
--- >>> t (Quarters 1) "2008/01/01" "2008/01/01"
+-- >>> t (Quarters 1) 2008 01 01 2008 01 01
 -- []
--- >>> t (Months 1) "2008/01/01" "2008/04/01"
+-- >>> t (Months 1) 2008 01 01 2008 04 01
 -- [DateSpan 2008-01,DateSpan 2008-02,DateSpan 2008-03]
--- >>> t (Months 2) "2008/01/01" "2008/04/01"
+-- >>> t (Months 2) 2008 01 01 2008 04 01
 -- [DateSpan 2008-01-01..2008-02-29,DateSpan 2008-03-01..2008-04-30]
--- >>> t (Weeks 1) "2008/01/01" "2008/01/15"
+-- >>> t (Weeks 1) 2008 01 01 2008 01 15
 -- [DateSpan 2007-12-31W01,DateSpan 2008-01-07W02,DateSpan 2008-01-14W03]
--- >>> t (Weeks 2) "2008/01/01" "2008/01/15"
+-- >>> t (Weeks 2) 2008 01 01 2008 01 15
 -- [DateSpan 2007-12-31..2008-01-13,DateSpan 2008-01-14..2008-01-27]
--- >>> t (DayOfMonth 2) "2008/01/01" "2008/04/01"
+-- >>> t (DayOfMonth 2) 2008 01 01 2008 04 01
 -- [DateSpan 2007-12-02..2008-01-01,DateSpan 2008-01-02..2008-02-01,DateSpan 2008-02-02..2008-03-01,DateSpan 2008-03-02..2008-04-01]
--- >>> t (WeekdayOfMonth 2 4) "2011/01/01" "2011/02/15"
+-- >>> t (WeekdayOfMonth 2 4) 2011 01 01 2011 02 15
 -- [DateSpan 2010-12-09..2011-01-12,DateSpan 2011-01-13..2011-02-09,DateSpan 2011-02-10..2011-03-09]
--- >>> t (DayOfWeek 2) "2011/01/01" "2011/01/15"
+-- >>> t (DayOfWeek 2) 2011 01 01 2011 01 15
 -- [DateSpan 2010-12-28..2011-01-03,DateSpan 2011-01-04..2011-01-10,DateSpan 2011-01-11..2011-01-17]
--- >>> t (DayOfYear 11 29) "2011/10/01" "2011/10/15"
+-- >>> t (DayOfYear 11 29) 2011 10 01 2011 10 15
 -- [DateSpan 2010-11-29..2011-11-28]
--- >>> t (DayOfYear 11 29) "2011/12/01" "2012/12/15"
+-- >>> t (DayOfYear 11 29) 2011 12 01 2012 12 15
 -- [DateSpan 2011-11-29..2012-11-28,DateSpan 2012-11-29..2013-11-28]
 --
 splitSpan :: Interval -> DateSpan -> [DateSpan]
@@ -267,7 +265,7 @@ spansIntersect (d:ds) = d `spanIntersect` (spansIntersect ds)
 -- | Calculate the intersection of two datespans.
 --
 -- For non-intersecting spans, gives an empty span beginning on the second's start date:
--- >>> mkdatespan "2018-01-01" "2018-01-03" `spanIntersect` mkdatespan "2018-01-03" "2018-01-05"
+-- >>> DateSpan (Just $ fromGregorian 2018 01 01) (Just $ fromGregorian 2018 01 03) `spanIntersect` DateSpan (Just $ fromGregorian 2018 01 03) (Just $ fromGregorian 2018 01 05)
 -- DateSpan 2018-01-03..2018-01-02
 spanIntersect (DateSpan b1 e1) (DateSpan b2 e2) = DateSpan b e
     where
@@ -409,7 +407,7 @@ fixSmartDateStrEither' d s = case parsewith smartdateonly (T.toLower s) of
 --
 -- ==== Examples:
 -- >>> :set -XOverloadedStrings
--- >>> let t = fixSmartDateStr (parsedate "2008/11/26")
+-- >>> let t = fixSmartDateStr (fromGregorian 2008 11 26)
 -- >>> t "0000-01-01"
 -- "0000-01-01"
 -- >>> t "1999-12-02"
@@ -542,7 +540,7 @@ startofyear day = fromGregorian y 1 1 where (y,_,_) = toGregorian day
 -- Examples: lets take 2017-11-22. Year-long intervals covering it that
 -- starts before Nov 22 will start in 2017. However
 -- intervals that start after Nov 23rd should start in 2016:
--- >>> let wed22nd = parsedate "2017-11-22"
+-- >>> let wed22nd = fromGregorian 2017 11 22
 -- >>> nthdayofyearcontaining 11 21 wed22nd
 -- 2017-11-21
 -- >>> nthdayofyearcontaining 11 22 wed22nd
@@ -573,7 +571,7 @@ nthdayofyearcontaining m md date
 -- Examples: lets take 2017-11-22. Month-long intervals covering it that
 -- start on 1st-22nd of month will start in Nov. However
 -- intervals that start on 23rd-30th of month should start in Oct:
--- >>> let wed22nd = parsedate "2017-11-22"
+-- >>> let wed22nd = fromGregorian 2017 11 22
 -- >>> nthdayofmonthcontaining 1 wed22nd
 -- 2017-11-01
 -- >>> nthdayofmonthcontaining 12 wed22nd
@@ -600,7 +598,7 @@ nthdayofmonthcontaining md date
 -- Examples: 2017-11-22 is Wed. Week-long intervals that cover it and
 -- start on Mon, Tue or Wed will start in the same week. However
 -- intervals that start on Thu or Fri should start in prev week:
--- >>> let wed22nd = parsedate "2017-11-22"
+-- >>> let wed22nd = fromGregorian 2017 11 22
 -- >>> nthdayofweekcontaining 1 wed22nd
 -- 2017-11-20
 -- >>> nthdayofweekcontaining 2 wed22nd
@@ -624,7 +622,7 @@ nthdayofweekcontaining n d | nthOfSameWeek <= d = nthOfSameWeek
 -- Examples: 2017-11-22 is 3rd Wed of Nov. Month-long intervals that cover it and
 -- start on 1st-4th Wed will start in Nov. However
 -- intervals that start on 4th Thu or Fri or later should start in Oct:
--- >>> let wed22nd = parsedate "2017-11-22"
+-- >>> let wed22nd = fromGregorian 2017 11 22
 -- >>> nthweekdayofmonthcontaining 1 3 wed22nd
 -- 2017-11-01
 -- >>> nthweekdayofmonthcontaining 3 2 wed22nd
@@ -678,17 +676,6 @@ parsedateM s = asum [
      parseTimeM True defaultTimeLocale "%Y/%m/%d" s,
      parseTimeM True defaultTimeLocale "%Y.%m.%d" s
      ]
-
-
--- -- | Parse a date-time string to a time type, or raise an error.
--- parsedatetime :: String -> LocalTime
--- parsedatetime s = fromMaybe (error' $ "could not parse timestamp \"" ++ s ++ "\"")
---                             (parsedatetimeM s)
-
--- | Like parsedateM, raising an error on parse failure.
-parsedate :: String -> Day
-parsedate s = fromMaybe (error' $ "could not parse date \"" ++ s ++ "\"")  -- PARTIAL:
-            $ parsedateM s
 
 {-|
 Parse a date in any of the formats allowed in Ledger's period expressions, and some others.
@@ -835,7 +822,7 @@ weekday = do
 -- resolving any relative start/end dates (only; it is not needed for
 -- parsing the reporting interval).
 --
--- >>> let p = parsePeriodExpr (parsedate "2008-11-26")
+-- >>> let p = parsePeriodExpr (fromGregorian 2008 11 26)
 -- >>> p "from Aug to Oct"
 -- Right (NoInterval,DateSpan 2008-08-01..2008-09-30)
 -- >>> p "aug to oct"
@@ -954,7 +941,7 @@ periodexprdatespanp rdate = choice $ map try [
                            ]
 
 -- |
--- >>> parsewith (doubledatespanp (parsedate "2018/01/01") <* eof) "20180101-201804"
+-- >>> parsewith (doubledatespanp (fromGregorian 2018 01 01) <* eof) "20180101-201804"
 -- Right DateSpan 2018Q1
 doubledatespanp :: Day -> TextParser m DateSpan
 doubledatespanp rdate = liftA2 fromToSpan
@@ -965,11 +952,11 @@ doubledatespanp rdate = liftA2 fromToSpan
     fromToSpan = DateSpan `on` (Just . fixSmartDate rdate)
 
 -- |
--- >>> parsewith (quarterdatespanp (parsedate "2018/01/01") <* eof) "q1"
+-- >>> parsewith (quarterdatespanp (fromGregorian 2018 01 01) <* eof) "q1"
 -- Right DateSpan 2018Q1
--- >>> parsewith (quarterdatespanp (parsedate "2018/01/01") <* eof) "Q1"
+-- >>> parsewith (quarterdatespanp (fromGregorian 2018 01 01) <* eof) "Q1"
 -- Right DateSpan 2018Q1
--- >>> parsewith (quarterdatespanp (parsedate "2018/01/01") <* eof) "2020q4"
+-- >>> parsewith (quarterdatespanp (fromGregorian 2018 01 01) <* eof) "2020q4"
 -- Right DateSpan 2020Q4
 quarterdatespanp :: Day -> TextParser m DateSpan
 quarterdatespanp rdate = do
@@ -997,11 +984,6 @@ justdatespanp :: Day -> TextParser m DateSpan
 justdatespanp rdate =
     optional (string' "in" *> skipNonNewlineSpaces)
     *> (spanFromSmartDate rdate <$> smartdate)
-
--- | Make a datespan from two valid date strings parseable by parsedate
--- (or raise an error). Eg: mkdatespan \"2011/1/1\" \"2011/12/31\".
-mkdatespan :: String -> String -> DateSpan
-mkdatespan = DateSpan `on` (Just . parsedate)
 
 nulldatespan :: DateSpan
 nulldatespan = DateSpan Nothing Nothing

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1295,7 +1295,7 @@ Right samplejournal = journalBalanceTransactions False $
            txnTieKnot $ Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2008/01/01",
+             tdate=fromGregorian 2008 01 01,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="",
@@ -1312,7 +1312,7 @@ Right samplejournal = journalBalanceTransactions False $
            txnTieKnot $ Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2008/06/01",
+             tdate=fromGregorian 2008 06 01,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="",
@@ -1329,7 +1329,7 @@ Right samplejournal = journalBalanceTransactions False $
            txnTieKnot $ Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2008/06/02",
+             tdate=fromGregorian 2008 06 02,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="",
@@ -1346,7 +1346,7 @@ Right samplejournal = journalBalanceTransactions False $
            txnTieKnot $ Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2008/06/03",
+             tdate=fromGregorian 2008 06 03,
              tdate2=Nothing,
              tstatus=Cleared,
              tcode="",
@@ -1363,7 +1363,7 @@ Right samplejournal = journalBalanceTransactions False $
            txnTieKnot $ Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2008/10/01",
+             tdate=fromGregorian 2008 10 01,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="",
@@ -1379,7 +1379,7 @@ Right samplejournal = journalBalanceTransactions False $
            txnTieKnot $ Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2008/12/31",
+             tdate=fromGregorian 2008 12 31,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="",
@@ -1398,11 +1398,11 @@ tests_Journal = tests "Journal" [
 
    test "journalDateSpan" $
     journalDateSpan True nulljournal{
-      jtxns = [nulltransaction{tdate = parsedate "2014/02/01"
-                              ,tpostings = [posting{pdate=Just (parsedate "2014/01/10")}]
+      jtxns = [nulltransaction{tdate = fromGregorian 2014 02 01
+                              ,tpostings = [posting{pdate=Just (fromGregorian 2014 01 10)}]
                               }
-              ,nulltransaction{tdate = parsedate "2014/09/01"
-                              ,tpostings = [posting{pdate2=Just (parsedate "2014/10/10")}]
+              ,nulltransaction{tdate = fromGregorian 2014 09 01
+                              ,tpostings = [posting{pdate2=Just (fromGregorian 2014 10 10)}]
                               }
               ]
       }
@@ -1436,7 +1436,7 @@ tests_Journal = tests "Journal" [
             --2019/01/01
             --  (a)            = 1
             nulljournal{ jtxns = [
-              transaction "2019/01/01" [ vpost' "a" missingamt (balassert (num 1)) ]
+              transaction (fromGregorian 2019 01 01) [ vpost' "a" missingamt (balassert (num 1)) ]
             ]}
       assertRight ej
       let Right j = ej
@@ -1449,8 +1449,8 @@ tests_Journal = tests "Journal" [
             --2019/01/01
             --  (a)          1 = 2
             nulljournal{ jtxns = [
-               transaction "2019/01/01" [ vpost' "a" missingamt (balassert (num 1)) ]
-              ,transaction "2019/01/01" [ vpost' "a" (num 1)    (balassert (num 2)) ]
+               transaction (fromGregorian 2019 01 01) [ vpost' "a" missingamt (balassert (num 1)) ]
+              ,transaction (fromGregorian 2019 01 01) [ vpost' "a" (num 1)    (balassert (num 2)) ]
             ]}
 
     ,test "same-day-2" $ do
@@ -1463,12 +1463,12 @@ tests_Journal = tests "Journal" [
             --2019/01/01
             --    a                    0 = 1
             nulljournal{ jtxns = [
-               transaction "2019/01/01" [ vpost' "a" (num 2)    (balassert (num 2)) ]
-              ,transaction "2019/01/01" [
+               transaction (fromGregorian 2019 01 01) [ vpost' "a" (num 2)    (balassert (num 2)) ]
+              ,transaction (fromGregorian 2019 01 01) [
                  post' "b" (num 1)     Nothing
                 ,post' "a"  missingamt Nothing
               ]
-              ,transaction "2019/01/01" [ post' "a" (num 0)     (balassert (num 1)) ]
+              ,transaction (fromGregorian 2019 01 01) [ post' "a" (num 0)     (balassert (num 1)) ]
             ]}
 
     ,test "out-of-order" $ do
@@ -1478,8 +1478,8 @@ tests_Journal = tests "Journal" [
             --2019/1/1
             --  (a)    1 = 1
             nulljournal{ jtxns = [
-               transaction "2019/01/02" [ vpost' "a" (num 1)    (balassert (num 2)) ]
-              ,transaction "2019/01/01" [ vpost' "a" (num 1)    (balassert (num 1)) ]
+               transaction (fromGregorian 2019 01 02) [ vpost' "a" (num 1)    (balassert (num 2)) ]
+              ,transaction (fromGregorian 2019 01 01) [ vpost' "a" (num 1)    (balassert (num 1)) ]
             ]}
 
     ]

--- a/hledger-lib/Hledger/Data/Timeclock.hs
+++ b/hledger-lib/Hledger/Data/Timeclock.hs
@@ -6,7 +6,7 @@ converted to 'Transactions' and queried like a ledger.
 
 -}
 
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Hledger.Data.Timeclock (
    timeclockEntriesToTransactions
@@ -21,9 +21,6 @@ import Data.Time.Calendar
 import Data.Time.Clock
 import Data.Time.Format
 import Data.Time.LocalTime
-#if !(MIN_VERSION_time(1,5,0))
-import System.Locale (defaultTimeLocale)
-#endif
 import Text.Printf
 
 import Hledger.Utils
@@ -136,11 +133,7 @@ tests_Timeclock = tests "Timeclock" [
           yesterday = prevday today
           clockin = TimeclockEntry nullsourcepos In
           mktime d = LocalTime d . fromMaybe midnight .
-#if MIN_VERSION_time(1,5,0)
                      parseTimeM True defaultTimeLocale "%H:%M:%S"
-#else
-                     parseTime defaultTimeLocale "%H:%M:%S"
-#endif
           showtime = formatTime defaultTimeLocale "%H:%M"
           txndescs = map (T.unpack . tdescription) . timeclockEntriesToTransactions now
           future = utcToLocalTime tz $ addUTCTime 100 now'

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -105,8 +105,8 @@ nulltransaction = Transaction {
                   }
 
 -- | Make a simple transaction with the given date and postings.
-transaction :: String -> [Posting] -> Transaction
-transaction datestr ps = txnTieKnot $ nulltransaction{tdate=parsedate datestr, tpostings=ps}
+transaction :: Day -> [Posting] -> Transaction
+transaction day ps = txnTieKnot $ nulltransaction{tdate=day, tpostings=ps}
 
 transactionPayee :: Transaction -> Text
 transactionPayee = fst . payeeAndNoteFromDescription . tdescription
@@ -669,8 +669,8 @@ tests_Transaction =
           test "null transaction" $ showTransaction nulltransaction @?= "0000-01-01\n\n"
         , test "non-null transaction" $ showTransaction
             nulltransaction
-              { tdate = parsedate "2012/05/14"
-              , tdate2 = Just $ parsedate "2012/05/15"
+              { tdate = fromGregorian 2012 05 14
+              , tdate2 = Just $ fromGregorian 2012 05 15
               , tstatus = Unmarked
               , tcode = "code"
               , tdescription = "desc"
@@ -702,7 +702,7 @@ tests_Transaction =
                    0
                    ""
                    nullsourcepos
-                   (parsedate "2007/01/28")
+                   (fromGregorian 2007 01 28)
                    Nothing
                    Unmarked
                    ""
@@ -726,7 +726,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
-                (parsedate "2007/01/28")
+                (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
                 ""
@@ -749,7 +749,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
-                (parsedate "2007/01/28")
+                (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
                 ""
@@ -765,7 +765,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
-                (parsedate "2010/01/01")
+                (fromGregorian 2010 01 01)
                 Nothing
                 Unmarked
                 ""
@@ -786,7 +786,7 @@ tests_Transaction =
                   0
                   ""
                   nullsourcepos
-                  (parsedate "2007/01/28")
+                  (fromGregorian 2007 01 28)
                   Nothing
                   Unmarked
                   ""
@@ -802,7 +802,7 @@ tests_Transaction =
                   0
                   ""
                   nullsourcepos
-                  (parsedate "2007/01/28")
+                  (fromGregorian 2007 01 28)
                   Nothing
                   Unmarked
                   ""
@@ -820,7 +820,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
-                (parsedate "2007/01/28")
+                (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
                 ""
@@ -837,7 +837,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
-                (parsedate "2007/01/28")
+                (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
                 ""
@@ -856,7 +856,7 @@ tests_Transaction =
                0
                ""
                nullsourcepos
-               (parsedate "2011/01/01")
+               (fromGregorian 2011 01 01)
                Nothing
                Unmarked
                ""
@@ -874,7 +874,7 @@ tests_Transaction =
                0
                ""
                nullsourcepos
-               (parsedate "2011/01/01")
+               (fromGregorian 2011 01 01)
                Nothing
                Unmarked
                ""
@@ -893,7 +893,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""
@@ -911,7 +911,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""
@@ -929,7 +929,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""
@@ -944,7 +944,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""
@@ -959,7 +959,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""
@@ -978,7 +978,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""
@@ -996,7 +996,7 @@ tests_Transaction =
             0
             ""
             nullsourcepos
-            (parsedate "2009/01/01")
+            (fromGregorian 2009 01 01)
             Nothing
             Unmarked
             ""

--- a/hledger-lib/Hledger/Data/Valuation.hs
+++ b/hledger-lib/Hledger/Data/Valuation.hs
@@ -38,7 +38,7 @@ import Data.List.Extra (nubSortBy)
 import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Text as T
-import Data.Time.Calendar (Day)
+import Data.Time.Calendar (Day, fromGregorian)
 import Data.MemoUgly (memo)
 import GHC.Generics (Generic)
 import Safe (headMay)
@@ -46,7 +46,6 @@ import Safe (headMay)
 import Hledger.Utils
 import Hledger.Data.Types
 import Hledger.Data.Amount
-import Hledger.Data.Dates (parsedate)
 
 
 ------------------------------------------------------------------------------
@@ -268,21 +267,20 @@ priceLookup makepricegraph d from mto =
 
 tests_priceLookup =
   let
-    d = parsedate
-    p date from q to = MarketPrice{mpdate=d date, mpfrom=from, mpto=to, mprate=q}
+    p y m d from q to = MarketPrice{mpdate=fromGregorian y m d, mpfrom=from, mpto=to, mprate=q}
     ps1 = [
-       p "2000/01/01" "A" 10 "B"
-      ,p "2000/01/01" "B" 10 "C"
-      ,p "2000/01/01" "C" 10 "D"
-      ,p "2000/01/01" "E"  2 "D"
-      ,p "2001/01/01" "A" 11 "B"
+       p 2000 01 01 "A" 10 "B"
+      ,p 2000 01 01 "B" 10 "C"
+      ,p 2000 01 01 "C" 10 "D"
+      ,p 2000 01 01 "E"  2 "D"
+      ,p 2001 01 01 "A" 11 "B"
       ]
     makepricegraph = makePriceGraph ps1 []
   in test "priceLookup" $ do
-    priceLookup makepricegraph (d "1999/01/01") "A" Nothing    @?= Nothing
-    priceLookup makepricegraph (d "2000/01/01") "A" Nothing    @?= Just ("B",10)
-    priceLookup makepricegraph (d "2000/01/01") "B" (Just "A") @?= Just ("A",0.1)
-    priceLookup makepricegraph (d "2000/01/01") "A" (Just "E") @?= Just ("E",500)
+    priceLookup makepricegraph (fromGregorian 1999 01 01) "A" Nothing    @?= Nothing
+    priceLookup makepricegraph (fromGregorian 2000 01 01) "A" Nothing    @?= Just ("B",10)
+    priceLookup makepricegraph (fromGregorian 2000 01 01) "B" (Just "A") @?= Just ("A",0.1)
+    priceLookup makepricegraph (fromGregorian 2000 01 01) "A" (Just "E") @?= Just ("E",500)
 
 -- | Build the graph of commodity conversion prices for a given day.
 -- Converts a list of declared market prices in parse order, and a

--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -791,8 +791,8 @@ tests_Query = tests "Query" [
      (simplifyQuery $ And [Any,Any])      @?= (Any)
      (simplifyQuery $ And [Acct "b",Any]) @?= (Acct "b")
      (simplifyQuery $ And [Any,And [Date (DateSpan Nothing Nothing)]]) @?= (Any)
-     (simplifyQuery $ And [Date (DateSpan Nothing (Just $ parsedate "2013-01-01")), Date (DateSpan (Just $ parsedate "2012-01-01") Nothing)])
-       @?= (Date (DateSpan (Just $ parsedate "2012-01-01") (Just $ parsedate "2013-01-01")))
+     (simplifyQuery $ And [Date (DateSpan Nothing (Just $ fromGregorian 2013 01 01)), Date (DateSpan (Just $ fromGregorian 2012 01 01) Nothing)])
+       @?= (Date (DateSpan (Just $ fromGregorian 2012 01 01) (Just $ fromGregorian 2013 01 01)))
      (simplifyQuery $ And [Or [],Or [Desc "b b"]]) @?= (Desc "b b")
 
   ,test "parseQuery" $ do
@@ -831,9 +831,9 @@ tests_Query = tests "Query" [
      parseQueryTerm nulldate "payee:x"                          @?= Right (Left $ Tag "payee" (Just "x"))
      parseQueryTerm nulldate "note:x"                           @?= Right (Left $ Tag "note" (Just "x"))
      parseQueryTerm nulldate "real:1"                           @?= Right (Left $ Real True)
-     parseQueryTerm nulldate "date:2008"                        @?= Right (Left $ Date $ DateSpan (Just $ parsedate "2008/01/01") (Just $ parsedate "2009/01/01"))
-     parseQueryTerm nulldate "date:from 2012/5/17"              @?= Right (Left $ Date $ DateSpan (Just $ parsedate "2012/05/17") Nothing)
-     parseQueryTerm nulldate "date:20180101-201804"             @?= Right (Left $ Date $ DateSpan (Just $ parsedate "2018/01/01") (Just $ parsedate "2018/04/01"))
+     parseQueryTerm nulldate "date:2008"                        @?= Right (Left $ Date $ DateSpan (Just $ fromGregorian 2008 01 01) (Just $ fromGregorian 2009 01 01))
+     parseQueryTerm nulldate "date:from 2012/5/17"              @?= Right (Left $ Date $ DateSpan (Just $ fromGregorian 2012 05 17) Nothing)
+     parseQueryTerm nulldate "date:20180101-201804"             @?= Right (Left $ Date $ DateSpan (Just $ fromGregorian 2018 01 01) (Just $ fromGregorian 2018 04 01))
      parseQueryTerm nulldate "inacct:a"                         @?= Right (Right $ QueryOptInAcct "a")
      parseQueryTerm nulldate "tag:a"                            @?= Right (Left $ Tag "a" Nothing)
      parseQueryTerm nulldate "tag:a=some value"                 @?= Right (Left $ Tag "a" (Just "some value"))

--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -67,7 +67,7 @@ import System.Info (os)
 import System.IO (stderr, writeFile)
 import Text.Printf (hPrintf, printf)
 
-import Hledger.Data.Dates (getCurrentDay, parsedate, showDate)
+import Hledger.Data.Dates (getCurrentDay, parsedateM, showDate)
 import Hledger.Data.Types
 import Hledger.Read.Common
 import Hledger.Read.JournalReader as JournalReader
@@ -251,9 +251,11 @@ saveLatestDates dates f = writeFile (latestDatesFileFor f) $ unlines $ map showD
 previousLatestDates :: FilePath -> IO LatestDates
 previousLatestDates f = do
   let latestfile = latestDatesFileFor f
+      parsedate s = maybe (fail $ "could not parse date \"" ++ s ++ "\"") return $
+                      parsedateM s
   exists <- doesFileExist latestfile
   if exists
-  then map (parsedate . strip) . lines . strip . T.unpack <$> readFileStrictly latestfile
+  then traverse (parsedate . T.unpack . T.strip) . T.lines =<< readFileStrictly latestfile
   else return []
 
 -- | Where to save latest transaction dates for the given file path.

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -11,7 +11,6 @@ A reader for CSV data, using an extra rules file to help interpret the data.
 -- stack haddock hledger-lib --fast --no-haddock-deps --haddock-arguments='--ignore-all-exports' --open
 
 --- ** language
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -61,12 +60,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import Data.Time.Calendar (Day)
-#if MIN_VERSION_time(1,5,0)
 import Data.Time.Format (parseTimeM, defaultTimeLocale)
-#else
-import Data.Time.Format (parseTime)
-import System.Locale (defaultTimeLocale)
-#endif
 import Safe
 import System.Directory (doesFileExist)
 import System.FilePath
@@ -1229,13 +1223,7 @@ csvFieldValue rules record fieldname = do
 parseDateWithCustomOrDefaultFormats :: Maybe DateFormat -> String -> Maybe Day
 parseDateWithCustomOrDefaultFormats mformat s = asum $ map parsewith formats
   where
-    parsetime =
-#if MIN_VERSION_time(1,5,0)
-     parseTimeM True
-#else
-     parseTime
-#endif
-    parsewith = flip (parsetime defaultTimeLocale) s
+    parsewith = flip (parseTimeM True defaultTimeLocale) s
     formats = maybe
                ["%Y/%-m/%-d"
                ,"%Y-%-m-%-d"

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -887,7 +887,7 @@ transactionFromCsvRecord sourcepos rules record = t
     -- ruleval  = csvRuleValue      rules record :: DirectiveName    -> Maybe String
     field    = hledgerField      rules record :: HledgerFieldName -> Maybe FieldTemplate
     fieldval = hledgerFieldValue rules record :: HledgerFieldName -> Maybe String
-    parsedate' = parseDateWithCustomOrDefaultFormats (rule "date-format")
+    parsedate = parseDateWithCustomOrDefaultFormats (rule "date-format")
     mkdateerror datefield datevalue mdateformat = unlines
       ["error: could not parse \""++datevalue++"\" as a date using date format "
         ++maybe "\"YYYY/M/D\", \"YYYY-M-D\" or \"YYYY.M.D\"" show mdateformat
@@ -911,9 +911,9 @@ transactionFromCsvRecord sourcepos rules record = t
     mdateformat = rule "date-format"
     date        = fromMaybe "" $ fieldval "date"
     -- PARTIAL:
-    date'       = fromMaybe (error' $ mkdateerror "date" date mdateformat) $ parsedate' date
+    date'       = fromMaybe (error' $ mkdateerror "date" date mdateformat) $ parsedate date
     mdate2      = fieldval "date2"
-    mdate2'     = maybe Nothing (maybe (error' $ mkdateerror "date2" (fromMaybe "" mdate2) mdateformat) Just . parsedate') mdate2
+    mdate2'     = maybe Nothing (maybe (error' $ mkdateerror "date2" (fromMaybe "" mdate2) mdateformat) Just . parsedate) mdate2
     status      =
       case fieldval "status" of
         Nothing -> Unmarked

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -82,8 +82,8 @@ Right samplejournal2 =
         txnTieKnot Transaction{
           tindex=0,
           tsourcepos=nullsourcepos,
-          tdate=parsedate "2008/01/01",
-          tdate2=Just $ parsedate "2009/01/01",
+          tdate=fromGregorian 2008 01 01,
+          tdate2=Just $ fromGregorian 2009 01 01,
           tstatus=Unmarked,
           tcode="",
           tdescription="income",

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -14,9 +14,10 @@ module Hledger.Reports.EntriesReport (
 )
 where
 
-import Data.List
-import Data.Maybe
-import Data.Ord
+import Data.List (sortBy)
+import Data.Maybe (fromMaybe)
+import Data.Ord (comparing)
+import Data.Time (fromGregorian)
 
 import Hledger.Data
 import Hledger.Query
@@ -50,7 +51,7 @@ entriesReport ropts@ReportOpts{..} q j@Journal{..} =
 tests_EntriesReport = tests "EntriesReport" [
   tests "entriesReport" [
      test "not acct" $ (length $ entriesReport defreportopts (Not $ Acct "bank") samplejournal) @?= 1
-    ,test "date" $ (length $ entriesReport defreportopts (Date $ mkdatespan "2008/06/01" "2008/07/01") samplejournal) @?= 3
+    ,test "date" $ (length $ entriesReport defreportopts (Date $ DateSpan (Just $ fromGregorian 2008 06 01) (Just $ fromGregorian 2008 07 01)) samplejournal) @?= 3
   ]
  ]
 

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -286,7 +286,7 @@ tests_PostingsReport = tests "PostingsReport" [
     (length $ snd $ postingsReport defreportopts (Acct "assets:bank:checking") samplejournal) @?= 5
 
      -- (defreportopts, And [Acct "a a", Acct "'b"], samplejournal2) `gives` 0
-     -- [(Just (parsedate "2008-01-01","income"),assets:bank:checking             $1,$1)
+     -- [(Just (fromGregorian 2008 01 01,"income"),assets:bank:checking             $1,$1)
      -- ,(Nothing,income:salary                   $-1,0)
      -- ,(Just (2008-06-01,"gift"),assets:bank:checking             $1,$1)
      -- ,(Nothing,income:gifts                    $-1,0)
@@ -437,7 +437,7 @@ tests_PostingsReport = tests "PostingsReport" [
   -- ,tests_summarisePostingsInDateSpan = [
     --  "summarisePostingsInDateSpan" ~: do
     --   let gives (b,e,depth,showempty,ps) =
-    --           (summarisePostingsInDateSpan (mkdatespan b e) depth showempty ps `is`)
+    --           (summarisePostingsInDateSpan (DateSpan b e) depth showempty ps `is`)
     --   let ps =
     --           [
     --            nullposting{lpdescription="desc",lpaccount="expenses:food:groceries",lpamount=Mixed [usd 1]}
@@ -449,25 +449,25 @@ tests_PostingsReport = tests "PostingsReport" [
     --    []
     --   ("2008/01/01","2009/01/01",0,9999,True,[]) `gives`
     --    [
-    --     nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31"}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31"}
     --    ]
     --   ("2008/01/01","2009/01/01",0,9999,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31",lpaccount="expenses:food",          lpamount=Mixed [usd 4]}
-    --    ,nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31",lpaccount="expenses:food:dining",   lpamount=Mixed [usd 10]}
-    --    ,nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31",lpaccount="expenses:food:groceries",lpamount=Mixed [usd 1]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food",          lpamount=Mixed [usd 4]}
+    --    ,nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food:dining",   lpamount=Mixed [usd 10]}
+    --    ,nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food:groceries",lpamount=Mixed [usd 1]}
     --    ]
     --   ("2008/01/01","2009/01/01",0,2,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31",lpaccount="expenses:food",lpamount=Mixed [usd 15]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food",lpamount=Mixed [usd 15]}
     --    ]
     --   ("2008/01/01","2009/01/01",0,1,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31",lpaccount="expenses",lpamount=Mixed [usd 15]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses",lpamount=Mixed [usd 15]}
     --    ]
     --   ("2008/01/01","2009/01/01",0,0,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=parsedate "2008/01/01",lpdescription="- 2008/12/31",lpaccount="",lpamount=Mixed [usd 15]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="",lpamount=Mixed [usd 15]}
     --    ]
 
  ]

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -575,15 +575,15 @@ tests_ReportOptions = tests "ReportOptions" [
        queryFromOpts nulldate defreportopts @?= Any
        queryFromOpts nulldate defreportopts{query_="a"} @?= Acct "a"
        queryFromOpts nulldate defreportopts{query_="desc:'a a'"} @?= Desc "a a"
-       queryFromOpts nulldate defreportopts{period_=PeriodFrom (parsedate "2012/01/01"),query_="date:'to 2013'" }
-         @?= (Date $ mkdatespan "2012/01/01" "2013/01/01")
-       queryFromOpts nulldate defreportopts{query_="date2:'in 2012'"} @?= (Date2 $ mkdatespan "2012/01/01" "2013/01/01")
+       queryFromOpts nulldate defreportopts{period_=PeriodFrom (fromGregorian 2012 01 01),query_="date:'to 2013'" }
+         @?= (Date $ DateSpan (Just $ fromGregorian 2012 01 01) (Just $ fromGregorian 2013 01 01))
+       queryFromOpts nulldate defreportopts{query_="date2:'in 2012'"} @?= (Date2 $ DateSpan (Just $ fromGregorian 2012 01 01) (Just $ fromGregorian 2013 01 01))
        queryFromOpts nulldate defreportopts{query_="'a a' 'b"} @?= Or [Acct "a a", Acct "'b"]
 
   ,test "queryOptsFromOpts" $ do
       queryOptsFromOpts nulldate defreportopts @?= []
       queryOptsFromOpts nulldate defreportopts{query_="a"} @?= []
-      queryOptsFromOpts nulldate defreportopts{period_=PeriodFrom (parsedate "2012/01/01")
+      queryOptsFromOpts nulldate defreportopts{period_=PeriodFrom (fromGregorian 2012 01 01)
                                               ,query_="date:'to 2013'"} @?= []
  ]
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -33,11 +33,7 @@ import System.FilePath
 import System.FSNotify
 import Brick
 
-#if MIN_VERSION_brick(0,16,0)
 import qualified Brick.BChan as BC
-#else
-import Control.Concurrent.Chan (newChan, writeChan)
-#endif
 
 import Hledger
 import Hledger.Cli hiding (progname,prognameandversion)
@@ -50,13 +46,11 @@ import Hledger.UI.RegisterScreen
 
 ----------------------------------------------------------------------
 
-#if MIN_VERSION_brick(0,16,0)
 newChan :: IO (BC.BChan a)
 newChan = BC.newBChan 10
 
 writeChan :: BC.BChan a -> a -> IO ()
 writeChan = BC.writeBChan
-#endif
 
 
 main :: IO ()

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -16,9 +16,6 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
 import Control.Monad
 -- import Control.Monad.IO.Class (liftIO)
-#if !MIN_VERSION_vty(5,15,0)
-import Data.Default (def)
-#endif
 -- import Data.Monoid              --
 import Data.List
 import Data.List.Extra (nubSort)
@@ -227,11 +224,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportopts_=rop
             )
 
         -- and start the app. Must be inside the withManager block
-#if MIN_VERSION_vty(5,15,0)
         let mkvty = mkVty mempty
-#else
-        let mkvty = mkVty def
-#endif
 #if MIN_VERSION_brick(0,47,0)
         vty0 <- mkvty
         void $ customMain vty0 mkvty (Just eventChan) brickapp ui

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -1,6 +1,5 @@
 {- | UIState operations. -}
 
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -8,9 +7,6 @@
 module Hledger.UI.UIState
 where
 
-#if !MIN_VERSION_brick(0,19,0)
-import Brick
-#endif
 import Brick.Widgets.Edit
 import Data.List
 import Data.Text.Zipper (gotoEOL)
@@ -308,11 +304,7 @@ getDepth UIState{aopts=UIOpts{cliopts_=CliOpts{reportopts_=ropts}}} = depth_ rop
 showMinibuffer :: UIState -> UIState
 showMinibuffer ui = setMode (Minibuffer e) ui
   where
-#if MIN_VERSION_brick(0,19,0)
     e = applyEdit gotoEOL $ editor MinibufferEditor (Just 1) oldq
-#else
-    e = applyEdit gotoEOL $ editor MinibufferEditor (str . unlines) (Just 1) oldq
-#endif
     oldq = query_ $ reportopts_ $ cliopts_ $ aopts ui
 
 -- | Close the minibuffer, discarding any edit in progress.

--- a/hledger-ui/Hledger/UI/UIUtils.hs
+++ b/hledger-ui/Hledger/UI/UIUtils.hs
@@ -180,12 +180,7 @@ helpHandle ui ev = do
 minibuffer :: Editor String Name -> Widget Name
 minibuffer ed =
   forceAttr ("border" <> "minibuffer") $
-  hBox $
-#if MIN_VERSION_brick(0,19,0)
-  [txt "filter: ", renderEditor (str . unlines) True ed]
-#else
-  [txt "filter: ", renderEditor True ed]
-#endif
+  hBox [txt "filter: ", renderEditor (str . unlines) True ed]
 
 borderQueryStr :: String -> Widget Name
 borderQueryStr ""  = str ""

--- a/hledger-ui/hledger-ui.cabal
+++ b/hledger-ui/hledger-ui.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4508b3e1554f07f5381ff30cf41a11d1ddd090adf8ce181d3d5aba990fd29813
+-- hash: 67cb06231a9cca7ebcd922f7528bc853a5f78e009d69a0afc41e599c78eac8ec
 
 name:           hledger-ui
 version:        1.18.99
@@ -93,7 +93,7 @@ executable hledger-ui
     , transformers
     , unix
     , vector
-    , vty >=5.5
+    , vty >=5.15
   if os(windows)
     buildable: False
   else

--- a/hledger-ui/package.yaml
+++ b/hledger-ui/package.yaml
@@ -68,7 +68,7 @@ dependencies:
 - vector
 # not installable on windows, cf buildable flag below
 - brick >=0.23
-- vty >=5.5
+- vty >=5.15
 - unix
 
 when:

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -363,7 +363,7 @@ tests_Commands = tests "Commands" [
 
 -- test data
 
--- date1 = parsedate "2008/11/26"
+-- date1 = fromGregorian 2008 11 26
 -- t1 = LocalTime date1 midday
 
 {-
@@ -569,7 +569,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2007/01/01",
+             tdate=fromGregorian 2007 01 01,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="*",
@@ -586,7 +586,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2007/02/01",
+             tdate=fromGregorian 2007 02 01,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="*",
@@ -603,7 +603,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2007/01/02",
+             tdate=fromGregorian 2007 01 02,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="*",
@@ -620,7 +620,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2007/01/03",
+             tdate=fromGregorian 2007 01 03,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="*",
@@ -637,7 +637,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2007/01/03",
+             tdate=fromGregorian 2007 01 03,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="*",
@@ -654,7 +654,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
-             tdate=parsedate "2007/01/03",
+             tdate=fromGregorian 2007 01 03,
              tdate2=Nothing,
              tstatus=Unmarked,
              tcode="*",

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -258,6 +258,7 @@ import Data.Maybe
 --import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import Data.Time (fromGregorian)
 import System.Console.CmdArgs.Explicit as C
 import Lucid as L
 import Text.Printf (printf)
@@ -639,7 +640,7 @@ tests_Balance = tests "Balance" [
     test "unicode in balance layout" $ do
       j <- readJournal' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
       let opts = defreportopts
-      balanceReportAsText opts (balanceReport opts (queryFromOpts (parsedate "2008/11/26") opts) j)
+      balanceReportAsText opts (balanceReport opts (queryFromOpts (fromGregorian 2008 11 26) opts) j)
         @?=
         unlines
         ["                -100  актив:наличные"

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -23,6 +23,7 @@ import Data.Maybe
 -- import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import Data.Time (fromGregorian)
 import System.Console.CmdArgs.Explicit
 import Hledger.Read.CsvReader (CSV, CsvRecord, printCSV)
 
@@ -200,7 +201,7 @@ tests_Register = tests "Register" [
     test "unicode in register layout" $ do
       j <- readJournal' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
       let opts = defreportopts
-      (postingsReportAsText defcliopts $ postingsReport opts (queryFromOpts (parsedate "2008/11/26") opts) j)
+      (postingsReportAsText defcliopts $ postingsReport opts (queryFromOpts (fromGregorian 2008 11 26) opts) j)
         @?=
         unlines
         ["2009-01-01 медвежья шкура       расходы:покупки                100           100"

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE ParallelListComp, CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE TemplateHaskell  #-}
 {-|
 
 The @roi@ command prints internal rate of return and time-weighted rate of return for and investment.
@@ -205,15 +205,10 @@ internalRateOfReturn showCashFlow prettyTables (OneSpan spanBegin spanEnd valueB
   -- 0% is always a solution, so require at least something here
   case totalCF of
     [] -> return 0
-    _ -> 
-      case ridders
-#if MIN_VERSION_math_functions(0,3,0)
-        (RiddersParam 100 (AbsTol 0.00001))
-#else
-        0.00001
-#endif
-        (0.000000000001,10000) (interestSum spanEnd totalCF) of
-        Root rate -> return ((rate-1)*100)
+    _ -> case ridders (RiddersParam 100 (AbsTol 0.00001))
+                      (0.000000000001,10000)
+                      (interestSum spanEnd totalCF) of
+        Root rate    -> return ((rate-1)*100)
         NotBracketed -> error' "Error: No solution -- not bracketed."  -- PARTIAL:
         SearchFailed -> error' "Error: Failed to find solution."
 

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -303,7 +303,7 @@ tests_Cli_Utils = tests "Utils" [
   --            -- all prices for consistent timing.
   --            let ropts = defreportopts{
   --              value_=True,
-  --              period_=PeriodTo $ parsedate "3000-01-01"
+  --              period_=PeriodTo $ fromGregorian 3000 01 01
   --              }
   --            j' <- journalApplyValue ropts j
   --            sum (journalAmounts j') `seq` return ()


### PR DESCRIPTION
Also gets rid of the partial functions `parsedate` and `mkdatespan`, used entirely with hard-coded arguments (with one exception). Use the total functions `fromGregorian` or `parsedateM` instead.