### PR TITLE
web: Put session file in $XDG_DATA_DIR.

### DIFF
--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -31,7 +31,9 @@ import Data.Time.Calendar (Day)
 import Network.HTTP.Conduit (Manager)
 import Network.HTTP.Types (status403)
 import Network.Wai (requestHeaders)
-import System.FilePath (takeFileName)
+import System.Directory (XdgDirectory (..), createDirectoryIfMissing,
+                         getXdgDirectory)
+import System.FilePath (takeFileName, (</>))
 import Text.Blaze (Markup)
 import Text.Hamlet (hamletFile)
 import Yesod
@@ -100,9 +102,11 @@ type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
 instance Yesod App where
   approot = ApprootMaster $ appRoot . settings
 
-  makeSessionBackend _ =
+  makeSessionBackend _ = do
+    hledgerdata <- getXdgDirectory XdgData "hledger"
+    createDirectoryIfMissing True hledgerdata
     let sessionexpirysecs = 120
-    in  Just <$> defaultClientSessionBackend sessionexpirysecs ".hledger-web_client_session_key.aes"
+    Just <$> defaultClientSessionBackend sessionexpirysecs (hledgerdata </> "hledger-web_client_session_key.aes")
 
   -- defaultLayout :: WidgetFor site () -> HandlerFor site Html
   defaultLayout widget = do

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -103,7 +103,7 @@ instance Yesod App where
   approot = ApprootMaster $ appRoot . settings
 
   makeSessionBackend _ = do
-    hledgerdata <- getXdgDirectory XdgData "hledger"
+    hledgerdata <- getXdgDirectory XdgCache "hledger"
     createDirectoryIfMissing True hledgerdata
     let sessionexpirysecs = 120
     Just <$> defaultClientSessionBackend sessionexpirysecs (hledgerdata </> "hledger-web_client_session_key.aes")

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3781a0068e7647eb59ffb0c20198955f86df134e69d18ed657cbddf233258217
+-- hash: aa718b67789de795338ed7fcf056b830cbc3b021a58c77af16e221a6ccb70b5b
 
 name:           hledger-web
 version:        1.19
@@ -166,7 +166,7 @@ library
     , conduit-extra >=1.1
     , containers
     , data-default
-    , directory
+    , directory >=1.2.3.0
     , extra >=1.6.3
     , filepath
     , hjsmin

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aa718b67789de795338ed7fcf056b830cbc3b021a58c77af16e221a6ccb70b5b
+-- hash: 3781a0068e7647eb59ffb0c20198955f86df134e69d18ed657cbddf233258217
 
 name:           hledger-web
 version:        1.19
@@ -166,7 +166,7 @@ library
     , conduit-extra >=1.1
     , containers
     , data-default
-    , directory >=1.2.3.0
+    , directory
     , extra >=1.6.3
     , filepath
     , hjsmin

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -115,7 +115,7 @@ library:
   - containers
   - data-default
   - Decimal >=0.5.1
-  - directory
+  - directory >=1.2.3.0
   - extra >=1.6.3
   - filepath
   - hjsmin


### PR DESCRIPTION
https://github.com/simonmichael/hledger/pull/1228
#1081 

It would be more correct to put the file in XDG_RUNTIME_DIR, but it is not supported by `directory`. But XDG_DATA_DIR seems OK, too. `directory` handles platforms other than Linux.
