### PR TITLE
lib: quoteIfNeeded should not escape the backslashes in unicode points

### DIFF
--- a/hledger-lib/Hledger/Utils/String.hs
+++ b/hledger-lib/Hledger/Utils/String.hs
@@ -118,13 +118,17 @@ underline s = s' ++ replicate (length s) '-' ++ "\n"
 -- | Double-quote this string if it contains whitespace, single quotes
 -- or double-quotes, escaping the quotes as needed.
 quoteIfNeeded :: String -> String
-quoteIfNeeded s | any (`elem` s) (quotechars++whitespacechars++redirectchars) = show s
+quoteIfNeeded s | any (`elem` s) (quotechars++whitespacechars++redirectchars) = showChar '"' $ escapeQuotes s "\""
                 | otherwise = s
+  where
+    escapeQuotes []       x = x
+    escapeQuotes ('"':cs) x = showString "\\\"" $ escapeQuotes cs x
+    escapeQuotes (c:cs)   x = showChar c        $ escapeQuotes cs x
 
 -- | Single-quote this string if it contains whitespace or double-quotes.
 -- No good for strings containing single quotes.
 singleQuoteIfNeeded :: String -> String
-singleQuoteIfNeeded s | any (`elem` s) whitespacechars = "'"++s++"'"
+singleQuoteIfNeeded s | any (`elem` s) (quotechars++whitespacechars) = "'"++s++"'"
                       | otherwise = s
 
 quotechars, whitespacechars, redirectchars :: [Char]

--- a/tests/i18n/unicode-account-matching.test
+++ b/tests/i18n/unicode-account-matching.test
@@ -6,3 +6,12 @@ hledger -f - register τράπ
 >>>
 2009-01-01 проверка             τράπεζα                     10 руб        10 руб
 >>>=0
+
+hledger -f - balance -N " ét"
+<<<
+2020-09-19 Test
+    assets:a ét            5
+    assets:b
+>>>
+                   5  assets:a ét
+>>>=0


### PR DESCRIPTION
Addresses #1364.

The commit which broke this was 7d1e6d7d12f3c3a042661c1d6963523b5d5f676b, which changed `quoteIfNeeded` so that it actually quotes things (albeit apparently incorrectly). It previously spent several years as the identity function with nobody noticing. This raises the question: is this function actually needed at all?

Edit: Correction to the above. quoteIfNeeded was not the identity function, but it did spend several years not escaping quotes. Should it attempt to do so? Can we find an example of something which doesn't work if it doesn't escape quotes?