### PR TITLE
lib,ui: Make sure ReportSpec is updated when updating ReportOpts.

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -18,6 +18,7 @@ module Hledger.Reports.ReportOptions (
   rawOptsToReportOpts,
   defreportspec,
   reportOptsToSpec,
+  updateReportSpecFromOpts,
   rawOptsToReportSpec,
   flat_,
   tree_,
@@ -243,6 +244,10 @@ reportOptsToSpec day ropts = do
       , rsQuery = simplifyQuery $ And [queryFromFlags ropts, argsquery]
       , rsQueryOpts = queryopts
       }
+
+-- | Regenerate a ReportSpec after updating ReportOpts.
+updateReportSpecFromOpts :: (ReportOpts -> ReportOpts) -> ReportSpec -> Either String ReportSpec
+updateReportSpecFromOpts f rspec = reportOptsToSpec (rsToday rspec) . f $ rsOpts rspec
 
 -- | Generate a ReportSpec from RawOpts and the current date.
 rawOptsToReportSpec :: RawOpts -> IO ReportSpec


### PR DESCRIPTION
Addresses some regressions. Changing the depth in hledger-ui now actually filters the postings, rather than just update the counter.

[Fix for #1340]