### PR TITLE
lib: Remove Empty Query constructor, which does nothing and has done so for a very long time.

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -465,7 +465,6 @@ queryFromFlags :: ReportOpts -> Query
 queryFromFlags ReportOpts{..} = simplifyQuery $ And flagsq
   where
     flagsq = consIf   Real  real_
-           . consIf   Empty empty_
            . consJust Depth depth_
            $   [ (if date2_ then Date2 else Date) $ periodAsDateSpan period_
                , Or $ map StatusQ statuses_


### PR DESCRIPTION
The Empty query constructor has done nothing for at least 9 years. I think this is a reasonable candidate for removal.

The only question is whether we should continue to accept the `empty:` prefix when parsing query terms. I've removed it here, but if you think it should continue to parse successfully (presumably as `Any`), let me know. I somewhat doubt anybody uses this ever.