### PR TITLE
lib: Include empty columns in a MultiBalanceReports.

### DIFF
--- a/hledger/test/balance/depth.test
+++ b/hledger/test/balance/depth.test
@@ -14,7 +14,7 @@ hledger -f sample.journal balance --no-total --depth 0
 >>>=0
 
 # 3. Ditto in a multi-column balance report.
-hledger -f sample.journal balance -M -e 2008/4 --depth 0
+hledger -f sample.journal balance -M -e 2008/2 --depth 0
 >>>
 Balance changes in 2008-01:
 

--- a/hledger/test/balance/intervals.test
+++ b/hledger/test/balance/intervals.test
@@ -12,15 +12,16 @@ hledger -f balance-multicol.journal register
 >>>=0
 
 # 2. A period balance (flow) report. --no-total also works but isn't pretty.
+# Includes leading/trailing empty periods.
 hledger -f balance-multicol.journal balance -p 'monthly in 2013' --no-total
 >>>
-Balance changes in 2013Q1:
+Balance changes in 2013:
 
-                 || Jan  Feb  Mar 
-=================++===============
- assets          ||   0    1    0 
- assets:cash     ||   0    1    0 
- assets:checking ||   0    0    1 
+                 || Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sep  Oct  Nov  Dec 
+=================++============================================================
+ assets          ||   0    1    0    0    0    0    0    0    0    0    0    0 
+ assets:cash     ||   0    1    0    0    0    0    0    0    0    0    0    0 
+ assets:checking ||   0    0    1    0    0    0    0    0    0    0    0    0 
 >>>=0
 
 # 3. With --empty, includes leading/trailing empty periods
@@ -45,7 +46,7 @@ Balance changes in 2013:
 
 # 4. A cumulative ending balance report. Column totals are the sum of
 # the highest-level displayed accounts (here, assets).
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --cumulative
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --cumulative
 >>>
 Ending balances (cumulative) in 2013Q1:
 
@@ -61,7 +62,7 @@ Ending balances (cumulative) in 2013Q1:
 # 5. With the assets:cash account excluded.  As with a single-column
 # balance --flat report, or ledger's balance --flat, assets' balance
 # includes the displayed subaccount and not the excluded one.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --cumulative not:cash
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --cumulative not:cash
 >>>
 Ending balances (cumulative) in 2013Q1:
 
@@ -74,7 +75,7 @@ Ending balances (cumulative) in 2013Q1:
 >>>=0
 
 # 6. A historical ending balance report.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --historical
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --historical
 >>>
 Ending balances (historical) in 2013Q1:
 
@@ -89,7 +90,7 @@ Ending balances (historical) in 2013Q1:
 
 # 7. With top-level accounts excluded. As always, column totals are the sum of
 # the highest-level displayed accounts, now assets:cash and assets:checking.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' not:assets$
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' not:assets$
 >>>
 Balance changes in 2013Q1:
 
@@ -102,7 +103,7 @@ Balance changes in 2013Q1:
 >>>=0
 
 # 8. cumulative:
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' not:assets$ --cumulative
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' not:assets$ --cumulative
 >>>
 Ending balances (cumulative) in 2013Q1:
 
@@ -115,7 +116,7 @@ Ending balances (cumulative) in 2013Q1:
 >>>=0
 
 # 9. historical
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --historical
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --historical
 >>>
 Ending balances (historical) in 2013Q1:
 
@@ -131,7 +132,7 @@ Ending balances (historical) in 2013Q1:
 # --depth
 
 # 10. A flow report with depth limiting. The depth limit aggregates the three accounts as "assets".
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --depth 1
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --depth 1
 >>>
 Balance changes in 2013Q1:
 
@@ -143,7 +144,7 @@ Balance changes in 2013Q1:
 >>>=0
 
 # 11. As above, but postings in the top-level assets account have been excluded.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --depth 1 assets:
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --depth 1 assets:
 >>>
 Balance changes in 2013Q1:
 
@@ -155,7 +156,7 @@ Balance changes in 2013Q1:
 >>>=0
 
 # 12. A cumulative balance report with depth limiting.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --depth 1 --cumulative
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --depth 1 --cumulative
 >>>
 Ending balances (cumulative) in 2013Q1:
 
@@ -167,7 +168,7 @@ Ending balances (cumulative) in 2013Q1:
 >>>=0
 
 # 13. A historical balance report with depth limiting.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --depth 1 --historical
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --depth 1 --historical
 >>>
 Ending balances (historical) in 2013Q1:
 
@@ -179,7 +180,7 @@ Ending balances (historical) in 2013Q1:
 >>>=0
 
 # 14. The three multicol balance report types again, this time with --tree
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --tree
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --tree
 >>>
 Balance changes in 2013Q1:
 
@@ -193,7 +194,7 @@ Balance changes in 2013Q1:
 >>>=0
 
 # 15.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --cumulative --tree
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --cumulative --tree
 >>>
 Ending balances (cumulative) in 2013Q1:
 
@@ -207,7 +208,7 @@ Ending balances (cumulative) in 2013Q1:
 >>>=0
 
 # 16.
-hledger -f balance-multicol.journal balance -p 'monthly in 2013' --historical --tree
+hledger -f balance-multicol.journal balance -p 'monthly from 2013' --historical --tree
 >>>
 Ending balances (historical) in 2013Q1:
 

--- a/hledger/test/balance/percent.test
+++ b/hledger/test/balance/percent.test
@@ -10,16 +10,16 @@ hledger -f sample.journal balance expenses -% --tree
 >>>= 0
 
 # 2. Multi column percent
-hledger -f sample.journal balance expenses -% -p daily
+hledger -f sample.journal balance expenses -% -p quarterly
 >>>
-Balance changes in 2008-06-03:
+Balance changes in 2008:
 
-                   || 2008-06-03 
-===================++============
- expenses:food     ||     50.0 % 
- expenses:supplies ||     50.0 % 
--------------------++------------
-                   ||    100.0 % 
+                   || 2008Q1   2008Q2  2008Q3  2008Q4 
+===================++=================================
+ expenses:food     ||      0   50.0 %       0       0 
+ expenses:supplies ||      0   50.0 %       0       0 
+-------------------++---------------------------------
+                   ||      0  100.0 %       0       0 
 >>>= 0
 
 # 3. In a balanced ledger everything should sum up to zero, therefore all percentages should be zero.

--- a/hledger/test/forecast.test
+++ b/hledger/test/forecast.test
@@ -16,18 +16,18 @@ hledger bal -M -b 2016-11 -e 2017-02 -f - --forecast
     expenses:grocery  $30
     assets:cash
 >>>
-Balance changes in 2016-12-01..2017-01-31:
+Balance changes in 2016-11-01..2017-01-31:
 
-                  || 2016-12  2017-01 
-==================++==================
- assets:cash      ||   $-600     $935 
- expenses:food    ||       0      $20 
- expenses:grocery ||       0      $30 
- expenses:housing ||    $600        0 
- expenses:leisure ||       0      $15 
- income           ||       0   $-1000 
-------------------++------------------
-                  ||       0        0 
+                  || 2016-11  2016-12  2017-01 
+==================++===========================
+ assets:cash      ||       0    $-600     $935 
+ expenses:food    ||       0        0      $20 
+ expenses:grocery ||       0        0      $30 
+ expenses:housing ||       0     $600        0 
+ expenses:leisure ||       0        0      $15 
+ income           ||       0        0   $-1000 
+------------------++---------------------------
+                  ||       0        0        0 
 >>>2
 >>>=0
 

--- a/hledger/test/journal/valuation.test
+++ b/hledger/test/journal/valuation.test
@@ -347,10 +347,10 @@ $ hledger -f- reg -V -M
 # 29. single column balance report valued at cost
 $ hledger -f- bal -N --value=cost
                 21 B  a
- 
-# 30. single column balance report valued at period end
+
+# 30. single column balance report valued at period end (which includes market price declarations, see #1405)
 $ hledger -f- bal -N --value=end
-                 9 B  a
+                12 B  a
 
 # 31. single column balance report valued at specified date
 $ hledger -f- bal -N --value=2000-01-15
@@ -368,63 +368,63 @@ $ hledger -f- bal -N -V
 
 # 34. multicolumn balance report valued at cost
 $ hledger -f- bal -MTA --value=cost
-Balance changes in 2000Q1, valued at cost:
+Balance changes in 2000-01-01..2000-04-30, valued at cost:
 
-   || Jan  Feb  Mar    Total  Average 
-===++=================================
- a || 6 B  7 B  8 B     21 B      7 B 
----++---------------------------------
-   || 6 B  7 B  8 B     21 B      7 B 
+   || Jan  Feb  Mar  Apr    Total  Average 
+===++======================================
+ a || 6 B  7 B  8 B    0     21 B      5 B 
+---++--------------------------------------
+   || 6 B  7 B  8 B    0     21 B      5 B 
 
 # 35. multicolumn balance report showing changes in period-end values
 $ hledger -f- bal -M --value=end
-Period-end value changes in 2000Q1:
+Period-end value changes in 2000-01-01..2000-04-30:
 
-   || Jan   Feb  Mar 
-===++================
- a || 5 B  -1 B  5 B 
----++----------------
-   || 5 B  -1 B  5 B 
+   || Jan   Feb  Mar  Apr 
+===++=====================
+ a || 5 B  -1 B  5 B  3 B 
+---++---------------------
+   || 5 B  -1 B  5 B  3 B 
 
 # 36. multicolumn balance report showing changes in period-end values with -T or -A
 $ hledger -f- bal -MTA --value=end
-Period-end value changes in 2000Q1:
+Period-end value changes in 2000-01-01..2000-04-30:
 
-   || Jan   Feb  Mar    Total  Average 
-===++==================================
- a || 5 B  -1 B  5 B      9 B      3 B 
----++----------------------------------
-   || 5 B  -1 B  5 B      9 B      3 B 
+   || Jan   Feb  Mar  Apr    Total  Average 
+===++=======================================
+ a || 5 B  -1 B  5 B  3 B     12 B      3 B 
+---++---------------------------------------
+   || 5 B  -1 B  5 B  3 B     12 B      3 B 
 
 # 37. multicolumn balance report valued at other date
 $ hledger -f- bal -MTA --value=2000-01-15
-Balance changes in 2000Q1, valued at 2000-01-15:
+Balance changes in 2000-01-01..2000-04-30, valued at 2000-01-15:
 
-   || Jan  Feb  Mar    Total  Average 
-===++=================================
- a || 5 B  5 B  5 B     15 B      5 B 
----++---------------------------------
-   || 5 B  5 B  5 B     15 B      5 B 
+   || Jan  Feb  Mar  Apr    Total  Average 
+===++======================================
+ a || 5 B  5 B  5 B    0     15 B      4 B 
+---++--------------------------------------
+   || 5 B  5 B  5 B    0     15 B      4 B 
 
 # 38. multicolumn balance report valued today (with today >= 2000-04-01)
 $ hledger -f- bal -M --value=now
-Balance changes in 2000Q1, current value:
+Balance changes in 2000-01-01..2000-04-30, current value:
 
-   || Jan  Feb  Mar 
-===++===============
- a || 4 B  4 B  4 B 
----++---------------
-   || 4 B  4 B  4 B 
+   || Jan  Feb  Mar  Apr 
+===++====================
+ a || 4 B  4 B  4 B    0 
+---++--------------------
+   || 4 B  4 B  4 B    0 
 
 # 39. multicolumn balance report showing changes in period-end values (same as --value=end)
 $ hledger -f- bal -M -V
-Period-end value changes in 2000Q1:
+Period-end value changes in 2000-01-01..2000-04-30:
 
-   || Jan   Feb  Mar 
-===++================
- a || 5 B  -1 B  5 B 
----++----------------
-   || 5 B  -1 B  5 B 
+   || Jan   Feb  Mar  Apr 
+===++=====================
+ a || 5 B  -1 B  5 B  3 B 
+---++---------------------
+   || 5 B  -1 B  5 B  3 B 
 
 # balance, periodic, with -H (starting balance and accumulating across periods)
 
@@ -433,37 +433,38 @@ Period-end value changes in 2000Q1:
 # February adds 1 A costing 7 B, making 13 B.
 # March adds 1 A costing 8 B, making 21 B.
 $ hledger -f- bal -M -H -b 200002 --value=cost
-Ending balances (historical) in 2000-02-01..2000-03-31, valued at cost:
+Ending balances (historical) in 2000-02-01..2000-04-30, valued at cost:
 
-   || 2000-02-29  2000-03-31 
-===++========================
- a ||       13 B        21 B 
----++------------------------
-   ||       13 B        21 B 
- 
+   || 2000-02-29  2000-03-31  2000-04-30 
+===++====================================
+ a ||       13 B        21 B        21 B 
+---++------------------------------------
+   ||       13 B        21 B        21 B 
+
 # 41. multicolumn balance report with -H valued at period end.
 # The starting balance is 1 A.
 # February adds 1 A making 2 A, which is valued at 2000/02/29 as 4 B.
 # March adds 1 A making 3 A, which is valued at 2000/03/31 as 9 B.
+# April adds 0 A making 3 A, which is valued at 2000/04/31 as 12 B.
 $ hledger -f- bal -MA -H -b 200002 --value=end
-Ending balances (historical) in 2000-02-01..2000-03-31, valued at period ends:
+Ending balances (historical) in 2000-02-01..2000-04-30, valued at period ends:
 
-   || 2000-02-29  2000-03-31  Average 
-===++=================================
- a ||        4 B         9 B      6 B 
----++---------------------------------
-   ||        4 B         9 B      6 B 
+   || 2000-02-29  2000-03-31  2000-04-30  Average 
+===++=============================================
+ a ||        4 B         9 B        12 B      8 B 
+---++---------------------------------------------
+   ||        4 B         9 B        12 B      8 B 
 
 # 42. multicolumn balance report with -H valued at other date.
 # The starting balance is 5 B (1 A valued at 2000/1/15).
 $ hledger -f- bal -M -H -b 200002 --value=2000-01-15
-Ending balances (historical) in 2000-02-01..2000-03-31, valued at 2000-01-15:
+Ending balances (historical) in 2000-02-01..2000-04-30, valued at 2000-01-15:
 
-   || 2000-02-29  2000-03-31 
-===++========================
- a ||       10 B        15 B 
----++------------------------
-   ||       10 B        15 B 
+   || 2000-02-29  2000-03-31  2000-04-30 
+===++====================================
+ a ||       10 B        15 B        15 B 
+---++------------------------------------
+   ||       10 B        15 B        15 B 
 
 # 43. multicolumn balance report with -H, valuing each period's carried-over balances at cost.
 <


### PR DESCRIPTION
This was previously done for CompoundBalanceReport and when --empty was
called; this makes the behaviour consistent.

Addresses #1396, and should also address part of #1405 (see test #30 in valuation.test).