### PR TITLE
[RFC] cli: drop deprecated command aliases a, b, p, r, txns

### DIFF
--- a/hledger/Hledger/Cli/Commands/Accounts.md
+++ b/hledger/Hledger/Cli/Commands/Accounts.md
@@ -1,4 +1,4 @@
-accounts, a\
+accounts\
 Show account names.
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Accounts.txt
+++ b/hledger/Hledger/Cli/Commands/Accounts.txt
@@ -1,4 +1,4 @@
-accounts, a
+accounts
 Show account names.
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -1,4 +1,4 @@
-balance, bal, b\
+balance, bal\
 Show accounts and their balances.
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Balance.txt
+++ b/hledger/Hledger/Cli/Commands/Balance.txt
@@ -1,4 +1,4 @@
-balance, bal, b
+balance, bal
 Show accounts and their balances.
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Print.md
+++ b/hledger/Hledger/Cli/Commands/Print.md
@@ -1,4 +1,4 @@
-print, txns, p\
+print\
 Show transaction journal entries, sorted by date. 
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Print.txt
+++ b/hledger/Hledger/Cli/Commands/Print.txt
@@ -1,4 +1,4 @@
-print, txns, p
+print
 Show transaction journal entries, sorted by date.
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Register.md
+++ b/hledger/Hledger/Cli/Commands/Register.md
@@ -1,4 +1,4 @@
-register, reg, r\
+register, reg\
 Show postings and their running total.
 
 _FLAGS

--- a/hledger/Hledger/Cli/Commands/Register.txt
+++ b/hledger/Hledger/Cli/Commands/Register.txt
@@ -1,4 +1,4 @@
-register, reg, r
+register, reg
 Show postings and their running total.
 
 _FLAGS


### PR DESCRIPTION
These one-letter a, b, p, r command aliases for accounts, balance, print, register are less good than the more common three-letter ones: less mnemonic, less clear when reading, and impractical with shell completions. (And "txns" for print will never catch on I think.) So in master I deprecated these aliases, hiding them from the commands list, though they still work. 

Too many alternatives creates confusion, and I'd like to remove them entirely, but I have seen a few people using them.  I have posted this PR for discussion, and will cc the mail list. Any thoughts ?

A related change that might help with backward compabitility, at the cost of less careful command selection: always run the first command whose name matches the command argument, rather than requiring an unambiguous prefix. [ First alphabetically or first in the command list ? On second thought, might complicate life too much.]

[PS I should also have said: 

The goal of command abbreviations is to save typing. But "hledger b" is not much easier to type than "hledger bal". In practice, to really save typing you'll use eg a shell alias like "alias bal='hledger bal'".

And, the reason for defining "standard" abbreviations was to facilitate discussion and sharing examples, so fewer is better. (The other reason was to disambiguate collisions with other commands, so "bal" would always mean "balance" even as other "bal..." commands are added.)]