### PR TITLE
ci: also test compilation of bin/ add-on scripts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -214,7 +214,7 @@ jobs:
         stack: ${{ matrix.plan.stack }}
       run: |
         export PATH=~/.local/bin:$PATH
-        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /bin -x /addons
+        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons
 
     - name: Test haddock generation
       env:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -158,7 +158,7 @@ jobs:
         stack: ${{ matrix.plan.stack }}
       run: |
         export PATH=~/.local/bin:$PATH
-        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /bin -x /addons
+        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons
 
     # artifacts:
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -151,4 +151,4 @@ jobs:
         stack: ${{ matrix.plan.stack }}
       run: |
         export PATH=~/.local/bin:$PATH
-        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /bin -x /addons
+        COLUMNS=80 $stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,7 @@ jobs:
 
     # run hledger-lib/hledger functional tests, skipping the ones for addons
     ## - export PATH=~/.local/bin:$PATH
-    #- COLUMNS=80 stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /bin -x /addons
+    #- COLUMNS=80 stack exec -- shelltest --execdir -j16 hledger/test -x /_ -x /addons
 
     # artifacts:
 

--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,7 @@ builtintest: $(call def-help,builtintest, run hledgers built in test command)
 functest: hledger/test/addons/hledger-addon \
 	$(call def-help,functest, build hledger quickly and run the functional tests (and some unit tests) )
 	@$(STACK) build --fast hledger
-	@($(SHELLTESTSTK) -w `$(STACK) exec -- which hledger` hledger/test/ \
+	@($(SHELLTESTSTK) -w `$(STACK) exec -- which hledger` hledger/test/ bin/ \
 		&& echo $@ PASSED) || (echo $@ FAILED; false)
 
 functest-%: hledger/test/addons/hledger-addon \

--- a/bin/compile.sh
+++ b/bin/compile.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
-# Run this script (or "make addons") to compile all addons in this directory.
-cd "$(dirname "$0")"
-echo "building dependencies"
+# Compile all add-on scrips in this directory.
+
+cd "$(dirname "$0")" || exit
+
+echo "building hledger libraries"
 stack build hledger
-# additional deps needed by addons
-stack install Diff here #Chart Chart-diagrams colour 
-echo "building add-on commands"
-for f in hledger-*.hs; do stack ghc -- -Wall -Werror $f; done
+
+echo "installing extra libraries needed by scripts"
+stack install string-qq
+
+echo "compiling hledger-* scripts"
+for f in hledger-*.hs; do stack ghc -- "$f"; done
+  # stack script --compile would install extra libs more automatically
+  # but would also run scripts, which we don't want

--- a/bin/hledger-balance-as-budget.hs
+++ b/bin/hledger-balance-as-budget.hs
@@ -31,13 +31,13 @@ main = do
   args <- getArgs
   let report1args = takeWhile (/= "--") args
   let report2args = drop 1 $ dropWhile (/= "--") args
-  (_,report1) <- mbReport report1args
-  (ropts2,report2) <- mbReport report2args
-  let pastAsBudget = combineBudgetAndActual report1{prDates=prDates report2} report2 
+  (_,_,report1) <- mbReport report1args
+  (ropts2,j,report2) <- mbReport report2args
+  let pastAsBudget = combineBudgetAndActual ropts2 j report1{prDates=prDates report2} report2
   putStrLn $ budgetReportAsText ropts2 pastAsBudget
   where
     mbReport args = do
-      opts@CliOpts{reportopts_=ropts} <- getHledgerCliOpts' cmdmode args
+      opts@CliOpts{reportspec_=rspec} <- getHledgerCliOpts' cmdmode args
       d <- getCurrentDay
-      report <- withJournalDo opts (return . multiBalanceReport d ropts)
-      return (ropts,report)
+      (report,j) <- withJournalDo opts $ \j -> return (multiBalanceReport rspec j, j)
+      return (rsOpts rspec,j,report)

--- a/bin/hledger-check-fancyassertions.hs
+++ b/bin/hledger-check-fancyassertions.hs
@@ -335,7 +335,7 @@ data Opts = Opts
     , assertionsAlways :: [(String, Predicate)]
     -- ^ Account assertions that must hold after each txn.
     }
-  deriving (Eq, Ord, Show)
+  deriving (Show)
 
 -- | Command-line arguments.
 args :: ParserInfo Opts

--- a/bin/hledger-combine-balances.hs
+++ b/bin/hledger-combine-balances.hs
@@ -14,23 +14,22 @@ appendReports :: MultiBalanceReport -> MultiBalanceReport -> MultiBalanceReport
 appendReports r1 r2 =
   PeriodicReport
   { prDates = prDates r1 ++ prDates r2
-  , prRows = map snd $ M.toAscList mergedRows 
+  , prRows = map snd $ M.toAscList mergedRows
   , prTotals = mergeRows (prTotals r1) (prTotals r2)
   }
   where
     rowsByAcct report = M.fromList $ map (\r -> (prrName r, r)) (prRows report)
     r1map = rowsByAcct r1
     r2map = rowsByAcct r2
-    
+
     mergedRows = merge (mapMissing left) (mapMissing right) (zipWithMatched both) r1map r2map
     left _ row = row{prrAmounts = prrAmounts row ++ [nullmixedamt]}
     right _ row = row{prrAmounts = nullmixedamt:(prrAmounts row) }
     both _ = mergeRows
 
     -- name/depth in the second row would be the same by contruction
-    mergeRows (PeriodicReportRow name depth amt1 tot1 avg1) (PeriodicReportRow _ _ amt2 tot2 avg2) =
+    mergeRows (PeriodicReportRow name amt1 tot1 avg1) (PeriodicReportRow _ amt2 tot2 avg2) =
       PeriodicReportRow { prrName = name
-        , prrDepth = depth
         , prrAmounts = amt1++amt2
         , prrTotal = tot1+tot2
         , prrAverage = averageMixedAmounts [avg1,avg2]
@@ -61,12 +60,11 @@ main = do
   let report1args = takeWhile (/= "--") args
   let report2args = drop 1 $ dropWhile (/= "--") args
   (_,report1) <- mbReport report1args
-  (ropts2,report2) <- mbReport report2args
+  (rspec2,report2) <- mbReport report2args
   let merged = appendReports report1 report2
-  putStrLn $ multiBalanceReportAsText ropts2 merged
+  putStrLn $ multiBalanceReportAsText (rsOpts rspec2) merged
   where
     mbReport args = do
-      opts@CliOpts{reportopts_=ropts} <- getHledgerCliOpts' cmdmode args
-      d <- getCurrentDay
-      report <- withJournalDo opts (return . multiBalanceReport d ropts)
-      return (ropts,report)
+      opts@CliOpts{reportspec_=rspec} <- getHledgerCliOpts' cmdmode args
+      report <- withJournalDo opts (return . multiBalanceReport rspec)
+      return (rspec,report)

--- a/bin/hledger-swap-dates.hs
+++ b/bin/hledger-swap-dates.hs
@@ -25,13 +25,13 @@ _FLAGS
 
 main :: IO ()
 main = do
-  opts@CliOpts{reportopts_=ropts} <- getHledgerCliOpts cmdmode
+  opts@CliOpts{reportspec_=rspec} <- getHledgerCliOpts cmdmode
   withJournalDo opts $
    \j -> do
     d <- getCurrentDay
     let
-      q = queryFromOpts d ropts
-      ts = filter (q `matchesTransaction`) $ jtxns $ journalSelectingAmountFromOpts ropts j
+      q = rsQuery rspec
+      ts = filter (q `matchesTransaction`) $ jtxns $ journalSelectingAmountFromOpts (rsOpts rspec) j
       ts' = map transactionSwapDates ts
     mapM_ (putStrLn . showTransaction) ts'
 

--- a/bin/scripts.test
+++ b/bin/scripts.test
@@ -1,0 +1,12 @@
+# Functional tests for the add-on scripts in this directory.
+
+# Check that they all (or at least these ones) still compile with this version of hledger.
+# stdout and exit code are ignored for cleaner failure output.
+# $ ./compile.sh >/dev/null
+$  stack ghc -- hledger-balance-as-budget.hs     >/dev/null || true
+$  stack ghc -- hledger-check-fancyassertions.hs >/dev/null || true
+$  stack ghc -- hledger-check-tagfiles.hs        >/dev/null || true
+$  stack ghc -- hledger-combine-balances.hs      >/dev/null || true
+$  stack ghc --package string-qq -- hledger-print-location.hs >/dev/null || true
+$  stack ghc --package string-qq -- hledger-smooth.hs         >/dev/null || true
+$  stack ghc --package string-qq -- hledger-swap-dates.hs     >/dev/null || true

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -21,6 +21,7 @@ module Hledger.Reports.BudgetReport (
   budgetReportAsCsv,
   -- * Helpers
   reportPeriodName,
+  combineBudgetAndActual,
   -- * Tests
   tests_BudgetReport
 )


### PR DESCRIPTION
The [add-on scripts in bin/](https://hledger.org/scripting.html#haskell-scripts) always fall behind hledger-lib/hledger API changes because we don't test them. We describe them as just examples and possibly broken, but that is unsatisfying and leads to intermittent manual catchup work. I think we need to include them in tests so as to keep them building, at least. This PR adds a test for that. If this is a good idea, next we need to update the scripts to make the tests pass.