### PR TITLE
journal: Ignore AUTO commodity when strict checking

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -401,7 +401,7 @@ journalCheckCommoditiesDeclared j =
         mfirstundeclaredcomm = 
           headMay $ filter (not . (`elem` cs)) $ catMaybes $
           (acommodity . baamount <$> pbalanceassertion) :
-          (map (Just . acommodity) $ amounts pamount)
+          (map (Just . acommodity) . filter (/= missingamt) $ amounts pamount)
         cs = journalCommoditiesDeclared j
 
 setYear :: Year -> JournalParser m ()


### PR DESCRIPTION
AUTO commodity is a placeholder for postings with missing amounts. It
should be ignored when doing a strict commodity check.

Fixes #1419
