### PR TITLE
lib,cli: Extend --value=then valuation to all report types.

### DIFF
--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -594,9 +594,9 @@ transactionTransformPostings f t@Transaction{tpostings=ps} = t{tpostings=map f p
 -- the provided price oracle, commodity styles, reference dates, and
 -- whether this is for a multiperiod report or not. See
 -- amountApplyValuation.
-transactionApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> Transaction -> ValuationType -> Transaction
-transactionApplyValuation priceoracle styles periodlast today t v =
-  transactionTransformPostings (\p -> postingApplyValuation priceoracle styles periodlast today p v) t
+transactionApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> ValuationType -> Transaction -> Transaction
+transactionApplyValuation priceoracle styles periodlast today v =
+  transactionTransformPostings (postingApplyValuation priceoracle styles periodlast today v)
 
 -- | Convert this transaction's amounts to cost, and apply the appropriate amount styles.
 transactionToCost :: M.Map CommoditySymbol AmountStyle -> Transaction -> Transaction

--- a/hledger-lib/Hledger/Data/Valuation.hs
+++ b/hledger-lib/Hledger/Data/Valuation.hs
@@ -15,7 +15,6 @@ module Hledger.Data.Valuation (
    ValuationType(..)
   ,PriceOracle
   ,journalPriceOracle
-  ,unsupportedValueThenError
   -- ,amountApplyValuation
   -- ,amountValueAtDate
   ,mixedAmountApplyValuation
@@ -97,9 +96,9 @@ priceDirectiveToMarketPrice PriceDirective{..} =
 -- provided price oracle, commodity styles, reference dates, and
 -- whether this is for a multiperiod report or not.
 -- See amountApplyValuation.
-mixedAmountApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> ValuationType -> MixedAmount -> MixedAmount
-mixedAmountApplyValuation priceoracle styles periodlast today v (Mixed as) =
-  Mixed $ map (amountApplyValuation priceoracle styles periodlast today v) as
+mixedAmountApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> Day -> ValuationType -> MixedAmount -> MixedAmount
+mixedAmountApplyValuation priceoracle styles periodlast today postingdate v =
+  mapMixedAmount (amountApplyValuation priceoracle styles periodlast today postingdate v)
 
 -- | Apply a specified valuation to this amount, using the provided
 -- price oracle, reference dates, and whether this is for a
@@ -125,27 +124,19 @@ mixedAmountApplyValuation priceoracle styles periodlast today v (Mixed as) =
 -- - the provided "today" date - (--value=now, or -V/X with no report
 --   end date).
 -- 
--- Note --value=then is not supported by this function, and will cause an error;
--- use postingApplyValuation for that.
--- 
 -- This is all a bit complicated. See the reference doc at
 -- https://hledger.org/hledger.html#effect-of-valuation-on-reports
 -- (hledger_options.m4.md "Effect of valuation on reports"), and #1083.
 --
-amountApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> ValuationType -> Amount -> Amount
-amountApplyValuation priceoracle styles periodlast today v a =
+amountApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> Day -> ValuationType -> Amount -> Amount
+amountApplyValuation priceoracle styles periodlast today postingdate v a =
   case v of
     AtCost    Nothing -> styleAmount styles $ amountCost a
-    AtCost    mc      -> amountValueAtDate priceoracle styles mc periodlast $ styleAmount styles $ amountCost a
-    AtThen    _mc     -> error' unsupportedValueThenError  -- PARTIAL:
-                      -- amountValueAtDate priceoracle styles mc periodlast a  -- posting date unknown, handle like AtEnd
+    AtCost    mc      -> amountValueAtDate priceoracle styles mc periodlast . styleAmount styles $ amountCost a
+    AtThen    mc      -> amountValueAtDate priceoracle styles mc postingdate a
     AtEnd     mc      -> amountValueAtDate priceoracle styles mc periodlast a
     AtNow     mc      -> amountValueAtDate priceoracle styles mc today a
     AtDate d  mc      -> amountValueAtDate priceoracle styles mc d a
-
--- | Standard error message for a report not supporting --value=then.
-unsupportedValueThenError :: String
-unsupportedValueThenError = "Sorry, --value=then is not yet supported for this kind of report."
 
 -- | Find the market value of each component amount in the given
 -- commodity, or its default valuation commodity, at the given
@@ -153,7 +144,7 @@ unsupportedValueThenError = "Sorry, --value=then is not yet supported for this k
 -- When market prices available on that date are not sufficient to
 -- calculate the value, amounts are left unchanged.
 mixedAmountValueAtDate :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Maybe CommoditySymbol -> Day -> MixedAmount -> MixedAmount
-mixedAmountValueAtDate priceoracle styles mc d (Mixed as) = Mixed $ map (amountValueAtDate priceoracle styles mc d) as
+mixedAmountValueAtDate priceoracle styles mc d = mapMixedAmount (amountValueAtDate priceoracle styles mc d)
 
 -- | Find the market value of this amount in the given valuation
 -- commodity if any, otherwise the default valuation commodity, at the

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -111,9 +111,7 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
     periodlast =
       fromMaybe (error' "journalApplyValuation: expected a non-empty journal") $ -- XXX shouldn't happen
       reportPeriodOrJournalLastDay rspec j
-    tval = case value_ ropts of
-             Just v  -> \t -> transactionApplyValuation prices styles periodlast (rsToday rspec) t v
-             Nothing -> id
+    tval = maybe id (transactionApplyValuation prices styles periodlast (rsToday rspec)) $ value_ ropts
     ts4 =
       ptraceAtWith 5 (("ts4:\n"++).pshowTransactions) $
       map tval ts3

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -228,7 +228,7 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
     title = "Budget performance in " <> showDateSpan (periodicReportSpan budgetr)
            <> (case value_ of
                  Just (AtCost _mc)   -> ", valued at cost"
-                 Just (AtThen _mc)   -> error' unsupportedValueThenError  -- PARTIAL:
+                 Just (AtThen _mc)   -> ", valued at posting date"
                  Just (AtEnd _mc)    -> ", valued at period ends"
                  Just (AtNow _mc)    -> ", current value"
                  Just (AtDate d _mc) -> ", valued at " <> showDate d

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -40,8 +40,8 @@ entriesReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j@Journal{..} =
     -- We may be converting posting amounts to value, per hledger_options.m4.md "Effect of --value on reports".
     tvalue t@Transaction{..} = t{tpostings=map pvalue tpostings}
       where
-        pvalue p = maybe p
-          (postingApplyValuation (journalPriceOracle infer_value_ j) (journalCommodityStyles j) periodlast (rsToday rspec) p)
+        pvalue = maybe id
+          (postingApplyValuation (journalPriceOracle infer_value_ j) (journalCommodityStyles j) periodlast (rsToday rspec))
           value_
           where
             periodlast  = fromMaybe (rsToday rspec) $ reportPeriodOrJournalLastDay rspec j

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -564,10 +564,9 @@ subtractAcct a@Account{aibalance=i1,aebalance=e1} Account{aibalance=i2,aebalance
 -- different report periods.
 changingValuation :: ReportOpts -> Bool
 changingValuation ropts = case value_ ropts of
-    Just (AtCost (Just _)) -> multiperiod
-    Just (AtEnd  _)        -> multiperiod
+    Just (AtCost (Just _)) -> True
+    Just (AtEnd  _)        -> True
     _                      -> False
-  where multiperiod = interval_ ropts /= NoInterval
 
 -- | Extract period changes from a cumulative list
 periodChanges :: Account -> Map k Account -> Map k Account

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -81,8 +81,7 @@ tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{
 
       render . defaultLayout toplabel bottomlabel . str
         . T.unpack . showTransactionOneLineAmounts
-        . maybe t (transactionApplyValuation prices styles periodlast (rsToday rspec) t)
-        $ value_ ropts
+        $ maybe id (transactionApplyValuation prices styles periodlast (rsToday rspec)) (value_ ropts) t
         -- (if real_ ropts then filterTransactionPostings (Real True) else id) -- filter postings by --real
       where
         toplabel =

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -577,7 +577,7 @@ multiBalanceReportAsText ropts@ReportOpts{..} r = TB.toLazyText $
         HistoricalBalance                -> "Ending balances (historical)"
     valuationdesc = case value_ of
         Just (AtCost _mc)    -> ", valued at cost"
-        Just (AtThen _mc)    -> error' unsupportedValueThenError  -- TODO -- ", valued at period ends"  -- handled like AtEnd for now  -- PARTIAL:
+        Just (AtThen _mc)    -> ", valued at posting date"
         Just (AtEnd _mc) | changingValuation -> ""
         Just (AtEnd _mc)     -> ", valued at period ends"
         Just (AtNow _mc)     -> ", current value"

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -141,7 +141,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
 
         valuationdesc = case value_ of
           Just (AtCost _mc)       -> ", valued at cost"
-          Just (AtThen _mc)       -> error' unsupportedValueThenError  -- TODO
+          Just (AtThen _mc)       -> ", valued at posting date"
           Just (AtEnd _mc) | changingValuation -> ""
           Just (AtEnd _mc)        -> ", valued at period ends"
           Just (AtNow _mc)        -> ", current value"

--- a/hledger/test/journal/valuation.test
+++ b/hledger/test/journal/valuation.test
@@ -569,8 +569,7 @@ Budget performance in 2000-01-01..2000-04-30, valued at 2000-01-15:
 ---++----------------------------------------------------------------------------------------------------------------
    || 5 B [50% of 10 B]  5 B [50% of 10 B]  5 B [50% of 10 B]  0 [0% of 10 B]  15 B [38% of 40 B]  4 B [38% of 10 B] 
 
-# 50. --value=then with --historical. How is the starting total valued ?
-# Currently not supported.
+# 50. --value=then with --historical. The starting total is valued individually for each posting at its posting time.
 <
 P 2020-01-01 A 1 B
 P 2020-02-01 A 2 B
@@ -590,8 +589,9 @@ P 2020-04-01 A 4 B
    (a)  1 A
 
 $ hledger -f- reg --value=then -b 2020-03 -H
->2 /not yet supported/
->=1
+2020-03-01                      (a)                            3 B           6 B
+2020-04-01                      (a)                            4 B          10 B
+>=0
 
 # 51. --value=then with a report interval. How are the summary amounts valued ?
 # Currently each interval's unvalued sum is valued on its first day.


### PR DESCRIPTION
Addresses #1428. @aragaer, could you let me know if this gives you the results you expect?

Also adds a postingDate argument to amountApplyValuation, and re-orders the ValuationType and (Transaction/Posting) arguments to (transaction/posting)ApplyValuation, to be consistent with amountApplyValuation.

Also addresses #1424.

The test failures are present in master. I've put a fix in commit a023fc880b00b85be3cde19f16af014c81edfde5 in PR #1427. I'll rebase this once that is merged or cherry-picked.