### PR TITLE
lib: Fix some space leaks

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -91,6 +91,7 @@ module Hledger.Data.Journal (
 )
 where
 
+import Control.Applicative ((<|>))
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError)
 import "extra" Control.Monad.Extra (whenM)
 import Control.Monad.Reader as R
@@ -100,9 +101,9 @@ import Data.Default (Default(..))
 import Data.Function ((&))
 import qualified Data.HashTable.Class as H (toList)
 import qualified Data.HashTable.ST.Cuckoo as H
-import Data.List (find, sortOn)
-import Data.List.Extra (groupSort, nubSort)
-import qualified Data.Map as M
+import Data.List (find, foldl', sortOn)
+import Data.List.Extra (nubSort)
+import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromJust, fromMaybe, isJust, mapMaybe)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))
@@ -1051,42 +1052,40 @@ journalInferCommodityStyles j =
 -- and this function never reports an error.
 --
 commodityStylesFromAmounts :: [Amount] -> Either String (M.Map CommoditySymbol AmountStyle)
-commodityStylesFromAmounts amts =
-  Right $ M.fromList commstyles
-  where
-    commamts = groupSort [(acommodity as, as) | as <- amts]
-    commstyles = [(c, canonicalStyleFrom $ map astyle as) | (c,as) <- commamts]
+commodityStylesFromAmounts =
+    Right . foldr (\a -> M.insertWith canonicalStyle (acommodity a) (astyle a)) mempty
+
+-- | Given a list of amount styles (assumed to be from parsed amounts
+-- in a single commodity), in parse order, choose a canonical style.
+canonicalStyleFrom :: [AmountStyle] -> AmountStyle
+-- canonicalStyleFrom [] = amountstyle
+canonicalStyleFrom ss = foldl' canonicalStyle amountstyle ss
 
 -- TODO: should probably detect and report inconsistencies here.
 -- Though, we don't have the info for a good error message, so maybe elsewhere.
--- | Given a list of amount styles (assumed to be from parsed amounts
--- in a single commodity), in parse order, choose a canonical style.
+-- | Given a pair of AmountStyles, choose a canonical style.
 -- This is:
--- the general style of the first amount, 
+-- the general style of the first amount,
 -- with the first digit group style seen,
 -- with the maximum precision of all.
---
-canonicalStyleFrom :: [AmountStyle] -> AmountStyle
-canonicalStyleFrom [] = amountstyle
-canonicalStyleFrom ss@(s:_) =
-  s{asprecision=prec, asdecimalpoint=Just decmark, asdigitgroups=mgrps}
+canonicalStyle :: AmountStyle -> AmountStyle -> AmountStyle
+canonicalStyle a b = a{asprecision=prec, asdecimalpoint=decmark, asdigitgroups=mgrps}
   where
     -- precision is maximum of all precisions
-    prec = maximumStrict $ map asprecision ss
+    prec = max (asprecision a) (asprecision b)
     -- identify the digit group mark (& group sizes)
-    mgrps = headMay $ mapMaybe asdigitgroups ss
+    mgrps = asdigitgroups a <|> asdigitgroups b
     -- if a digit group mark was identified above, we can rely on that;
     -- make sure the decimal mark is different. If not, default to period.
-    defdecmark =
-      case mgrps of
+    defdecmark = case mgrps of
         Just (DigitGroups '.' _) -> ','
         _                        -> '.'
     -- identify the decimal mark: the first one used, or the above default,
     -- but never the same character as the digit group mark.
     -- urgh.. refactor..
     decmark = case mgrps of
-                Just _ -> defdecmark
-                _      -> headDef defdecmark $ mapMaybe asdecimalpoint ss
+        Just _  -> Just defdecmark
+        Nothing -> asdecimalpoint a <|> asdecimalpoint b <|> Just defdecmark
 
 -- -- | Apply this journal's historical price records to unpriced amounts where possible.
 -- journalApplyPriceDirectives :: Journal -> Journal

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -257,7 +257,7 @@ isPostingInDateSpan' PrimaryDate   s = spanContainsDate s . postingDate
 isPostingInDateSpan' SecondaryDate s = spanContainsDate s . postingDate2
 
 isEmptyPosting :: Posting -> Bool
-isEmptyPosting = mixedAmountAndPriceLooksZero . pamount
+isEmptyPosting = mixedAmountLooksZero . pamount
 
 -- AccountName stuff that depends on PostingType
 

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -257,7 +257,7 @@ isPostingInDateSpan' PrimaryDate   s = spanContainsDate s . postingDate
 isPostingInDateSpan' SecondaryDate s = spanContainsDate s . postingDate2
 
 isEmptyPosting :: Posting -> Bool
-isEmptyPosting = mixedAmountLooksZero . pamount
+isEmptyPosting = mixedAmountAndPriceLooksZero . pamount
 
 -- AccountName stuff that depends on PostingType
 

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -553,8 +553,9 @@ priceInferrerFor t pt = inferprice
         = p{pamount=Mixed [a{aprice=Just conversionprice}], poriginal=Just $ originalPosting p}
       where
         fromcommodity = head $ filter (`elem` sumcommodities) pcommodities -- these heads are ugly but should be safe
+        totalpricesign = if aquantity a < 0 then negate else id
         conversionprice
-          | fromcount==1 = TotalPrice $ abs toamount `withPrecision` NaturalPrecision
+          | fromcount==1 = TotalPrice $ totalpricesign (abs toamount) `withPrecision` NaturalPrecision
           | otherwise    = UnitPrice $ abs unitprice `withPrecision` unitprecision
           where
             fromcount     = length $ filter ((==fromcommodity).acommodity) pamounts
@@ -923,7 +924,7 @@ tests_Transaction =
                ""
                []
                [ posting {paccount = "a", pamount = Mixed [usd 1 @@ eur 1]}
-               , posting {paccount = "a", pamount = Mixed [usd (-2) @@ eur 1]}
+               , posting {paccount = "a", pamount = Mixed [usd (-2) @@ eur (-1)]}
                ])
         ]
     , tests "isTransactionBalanced" [

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -368,7 +368,7 @@ transactionCheckBalanced mstyles t = errs
     -- check for mixed signs, detecting nonzeros at display precision
     canonicalise = maybe id canonicaliseMixedAmount mstyles
     signsOk ps =
-      case filter (not.mixedAmountAndPriceLooksZero) $ map (canonicalise.mixedAmountCost.pamount) ps of
+      case filter (not.mixedAmountLooksZero) $ map (canonicalise.mixedAmountCost.pamount) ps of
         nonzeros | length nonzeros >= 2
                    -> length (nubSort $ mapMaybe isNegativeMixedAmount nonzeros) > 1
         _          -> True
@@ -378,7 +378,7 @@ transactionCheckBalanced mstyles t = errs
     (rsum, bvsum)               = (sumPostings rps, sumPostings bvps)
     (rsumcost, bvsumcost)       = (mixedAmountCost rsum, mixedAmountCost bvsum)
     (rsumdisplay, bvsumdisplay) = (canonicalise rsumcost, canonicalise bvsumcost)
-    (rsumok, bvsumok)           = (mixedAmountAndPriceLooksZero rsumdisplay, mixedAmountAndPriceLooksZero bvsumdisplay)
+    (rsumok, bvsumok)           = (mixedAmountLooksZero rsumdisplay, mixedAmountLooksZero bvsumdisplay)
 
     -- generate error messages, showing amounts with their original precision
     errs = filter (not.null) [rmsg, bvmsg]

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -367,8 +367,8 @@ transactionCheckBalanced mstyles t = errs
 
     -- check for mixed signs, detecting nonzeros at display precision
     canonicalise = maybe id canonicaliseMixedAmount mstyles
-    signsOk ps = 
-      case filter (not.mixedAmountLooksZero) $ map (canonicalise.mixedAmountCost.pamount) ps of
+    signsOk ps =
+      case filter (not.mixedAmountAndPriceLooksZero) $ map (canonicalise.mixedAmountCost.pamount) ps of
         nonzeros | length nonzeros >= 2
                    -> length (nubSort $ mapMaybe isNegativeMixedAmount nonzeros) > 1
         _          -> True
@@ -378,7 +378,7 @@ transactionCheckBalanced mstyles t = errs
     (rsum, bvsum)               = (sumPostings rps, sumPostings bvps)
     (rsumcost, bvsumcost)       = (mixedAmountCost rsum, mixedAmountCost bvsum)
     (rsumdisplay, bvsumdisplay) = (canonicalise rsumcost, canonicalise bvsumcost)
-    (rsumok, bvsumok)           = (mixedAmountLooksZero rsumdisplay, mixedAmountLooksZero bvsumdisplay)
+    (rsumok, bvsumok)           = (mixedAmountAndPriceLooksZero rsumdisplay, mixedAmountAndPriceLooksZero bvsumdisplay)
 
     -- generate error messages, showing amounts with their original precision
     errs = filter (not.null) [rmsg, bvmsg]

--- a/hledger-lib/Hledger/Data/TransactionModifier.hs
+++ b/hledger-lib/Hledger/Data/TransactionModifier.hs
@@ -120,7 +120,7 @@ tmPostingRuleToFunction querytxt pr =
             -- Approach 1: convert to a unit price and increase the display precision slightly
             -- Mixed as = dbg6 "multipliedamount" $ n `multiplyMixedAmount` mixedAmountTotalPriceToUnitPrice matchedamount
             -- Approach 2: multiply the total price (keeping it positive) as well as the quantity
-            Mixed as = dbg6 "multipliedamount" $ n `multiplyMixedAmountAndPrice` matchedamount
+            Mixed as = dbg6 "multipliedamount" $ n `multiplyMixedAmount` matchedamount
           in
             case acommodity pramount of
               "" -> Mixed as

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -178,16 +178,16 @@ instance ToMarkup Quantity
 -- | An amount's per-unit or total cost/selling price in another
 -- commodity, as recorded in the journal entry eg with @ or @@.
 -- Docs call this "transaction price". The amount is always positive.
-data AmountPrice = UnitPrice Amount | TotalPrice Amount
+data AmountPrice = UnitPrice !Amount | TotalPrice !Amount
   deriving (Eq,Ord,Generic,Show)
 
 -- | Display style for an amount.
 data AmountStyle = AmountStyle {
-      ascommodityside   :: Side,                 -- ^ does the symbol appear on the left or the right ?
-      ascommodityspaced :: Bool,                 -- ^ space between symbol and quantity ?
-      asprecision       :: !AmountPrecision,     -- ^ number of digits displayed after the decimal point
-      asdecimalpoint    :: Maybe Char,           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
-      asdigitgroups     :: Maybe DigitGroupStyle -- ^ style for displaying digit groups, if any
+      ascommodityside   :: !Side,                   -- ^ does the symbol appear on the left or the right ?
+      ascommodityspaced :: !Bool,                   -- ^ space between symbol and quantity ?
+      asprecision       :: !AmountPrecision,        -- ^ number of digits displayed after the decimal point
+      asdecimalpoint    :: !(Maybe Char),           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
+      asdigitgroups     :: !(Maybe DigitGroupStyle) -- ^ style for displaying digit groups, if any
 } deriving (Eq,Ord,Read,Generic)
 
 instance Show AmountStyle where
@@ -211,7 +211,7 @@ data AmountPrecision = Precision !Word8 | NaturalPrecision deriving (Eq,Ord,Read
 -- point), and the size of each group, starting with the one nearest
 -- the decimal point. The last group size is assumed to repeat. Eg,
 -- comma between thousands is DigitGroups ',' [3].
-data DigitGroupStyle = DigitGroups Char [Word8]
+data DigitGroupStyle = DigitGroups !Char ![Word8]
   deriving (Eq,Ord,Read,Show,Generic)
 
 type CommoditySymbol = Text
@@ -222,12 +222,12 @@ data Commodity = Commodity {
   } deriving (Show,Eq,Generic) --,Ord)
 
 data Amount = Amount {
-      acommodity  :: CommoditySymbol,   -- commodity symbol, or special value "AUTO"
-      aquantity   :: Quantity,          -- numeric quantity, or zero in case of "AUTO"
-      aismultiplier :: Bool,            -- ^ kludge: a flag marking this amount and posting as a multiplier
-                                        --   in a TMPostingRule. In a regular Posting, should always be false.
-      astyle      :: AmountStyle,
-      aprice      :: Maybe AmountPrice  -- ^ the (fixed, transaction-specific) price for this amount, if any
+      acommodity  :: !CommoditySymbol,     -- commodity symbol, or special value "AUTO"
+      aquantity   :: !Quantity,            -- numeric quantity, or zero in case of "AUTO"
+      aismultiplier :: !Bool,              -- ^ kludge: a flag marking this amount and posting as a multiplier
+                                           --   in a TMPostingRule. In a regular Posting, should always be false.
+      astyle      :: !AmountStyle,
+      aprice      :: !(Maybe AmountPrice)  -- ^ the (fixed, transaction-specific) price for this amount, if any
     } deriving (Eq,Ord,Generic,Show)
 
 newtype MixedAmount = Mixed [Amount] deriving (Eq,Ord,Generic,Show)


### PR DESCRIPTION
Addresses #1431.

I'm sure there's more to find here, but I'm getting decent results so I thought I'd put this up at least for discussion. Here's some profiling when running on my journal files.

```
$ hledger balance -Y +RTS -s    # master
   5,382,427,616 bytes allocated in the heap
   2,018,625,736 bytes copied during GC
      57,702,808 bytes maximum residency (67 sample(s))
       1,214,056 bytes maximum slop
              55 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      5140 colls,     0 par    0.318s   0.322s     0.0001s    0.0008s
  Gen  1        67 colls,     0 par    2.873s   2.950s     0.0440s    0.0924s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time    6.228s  (  6.309s elapsed)
  GC      time    1.404s  (  1.460s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    1.787s  (  1.812s elapsed)
  EXIT    time    0.000s  (  0.001s elapsed)
  Total   time    9.422s  (  9.583s elapsed)

  Alloc rate    864,181,667 bytes per MUT second

  Productivity  85.1% of total user, 84.7% of total elapsed

$ hledger balance -Y +RTS -s    # this PR
   4,999,963,024 bytes allocated in the heap
   1,718,454,752 bytes copied during GC
      49,167,928 bytes maximum residency (63 sample(s))
       1,301,792 bytes maximum slop
              46 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      4775 colls,     0 par    0.290s   0.289s     0.0001s    0.0010s
  Gen  1        63 colls,     0 par    2.517s   2.557s     0.0406s    0.0869s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time    5.840s  (  5.847s elapsed)
  GC      time    1.182s  (  1.218s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    1.626s  (  1.629s elapsed)
  EXIT    time    0.000s  (  0.001s elapsed)
  Total   time    8.649s  (  8.695s elapsed)

  Alloc rate    856,198,369 bytes per MUT second

  Productivity  86.3% of total user, 86.0% of total elapsed

$ hledger register +RTS -s    # master
  21,222,212,224 bytes allocated in the heap
  17,586,635,464 bytes copied during GC
     356,007,792 bytes maximum residency (140 sample(s))
       3,850,384 bytes maximum slop
             339 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     20618 colls,     0 par    0.765s   0.765s     0.0000s    0.0008s
  Gen  1       140 colls,     0 par   19.332s  19.498s     0.1393s    0.4020s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time   13.573s  ( 13.629s elapsed)
  GC      time   10.619s  ( 10.788s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    9.478s  (  9.476s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   33.672s  ( 33.894s elapsed)

  Alloc rate    1,563,590,976 bytes per MUT second

  Productivity  68.5% of total user, 68.2% of total elapsed

$ hledger register +RTS -s    # this PR
  13,106,052,448 bytes allocated in the heap
   3,136,387,864 bytes copied during GC
      56,339,968 bytes maximum residency (104 sample(s))
       1,184,256 bytes maximum slop
              53 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     12614 colls,     0 par    0.397s   0.399s     0.0000s    0.0008s
  Gen  1       104 colls,     0 par    4.425s   4.507s     0.0433s    0.0948s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.002s  (  0.002s elapsed)
  MUT     time    9.914s  ( 10.035s elapsed)
  GC      time    2.126s  (  2.178s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    2.697s  (  2.728s elapsed)
  EXIT    time    0.000s  (  0.001s elapsed)
  Total   time   14.738s  ( 14.943s elapsed)

  Alloc rate    1,321,958,888 bytes per MUT second

  Productivity  85.6% of total user, 85.4% of total elapsed
```