### PR TITLE
lib: better message when roi fails to value commodity, fixes #1446

### DIFF
--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -263,6 +263,6 @@ total trans query = unMix $ sumPostings $  filter (matchesPosting query) $ conca
 
 unMix :: MixedAmount -> Quantity
 unMix a =
-  case (normaliseMixedAmount $ mixedAmountCost a) of
-    (Mixed [a]) -> aquantity a
-    _ -> error' "MixedAmount failed to normalize"  -- PARTIAL:
+  case (unifyMixedAmount $ mixedAmountCost a) of
+    Just a -> aquantity a
+    Nothing -> error' $ "Amounts could not be converted to a single cost basis: " ++ show (map showAmount $ amounts a)

--- a/hledger/test/roi.test
+++ b/hledger/test/roi.test
@@ -225,3 +225,18 @@ hledger -f- roi -p 2019-11
 +---++------------+------------++---------------+----------+-------------+-----++-------+-------+
 
 >>>=0
+
+# 9. Fail with a nice error message when commodity can't be valued
+hledger -f- roi -p 2019-11 --inv Investment --pnl PnL
+<<<
+2019/11/01 Example
+  Assets:Checking  -1 A
+  Investment       10 B
+
+2019/11/02 Example
+  Investment        -10 B @@ 1 A
+  Assets:Checking    12 A
+  Unrealized PnL
+>>>2
+hledger: Amounts could not be converted to a single cost basis: ["10 B","-10 B @@ 1 A"]
+>>>=1

--- a/hledger/test/roi.test
+++ b/hledger/test/roi.test
@@ -230,13 +230,35 @@ hledger -f- roi -p 2019-11
 hledger -f- roi -p 2019-11 --inv Investment --pnl PnL
 <<<
 2019/11/01 Example
-  Assets:Checking  -1 A
+  Assets:Checking  -100 A
   Investment       10 B
 
 2019/11/02 Example
-  Investment        -10 B @@ 1 A
-  Assets:Checking    12 A
+  Investment        -10 B @@ 100 A
+  Assets:Checking    101 A
   Unrealized PnL
 >>>2
-hledger: Amounts could not be converted to a single cost basis: ["10 B","-10 B @@ 1 A"]
+hledger: Amounts could not be converted to a single cost basis: ["10 B","-10 B @@ 100 A"]
+Consider using --value to force all costs to be in a single commodity.
+For example, "--value cost,<commodity> --infer-value", where commodity is the one that was used to pay for the investment.
 >>>=1
+
+# 10. Forcing valuation via --value
+hledger -f- roi -p 2019-11 --inv Investment --pnl PnL --value cost,A --infer-value
+<<<
+2019/11/01 Example
+  Assets:Checking  -100 A
+  Investment       10 B
+
+2019/11/02 Example
+  Investment        -10 B @@ 100 A
+  Assets:Checking   101 A
+  Unrealized PnL
+>>>
++---++------------+------------++---------------+----------+-------------+-----++----------+-------+
+|   ||      Begin |        End || Value (begin) | Cashflow | Value (end) | PnL ||      IRR |   TWR |
++===++============+============++===============+==========+=============+=====++==========+=======+
+| 1 || 2019-11-01 | 2019-11-30 ||             0 |       -1 |           0 |   1 || 3678.34% | 0.00% |
++---++------------+------------++---------------+----------+-------------+-----++----------+-------+
+
+>>>=0


### PR DESCRIPTION
This fixes #1446 by providing a better error message. 

I can write a better code that makes sure that all amounts could be valued (based on inferred prices) via `mixedAmountValueOnDate`  later, but I will not be able to do it in time for 1.20.3. 

I am not sure that I need to use `mixedAmountValueOnDate` explicitly -- i would prefer for journal reading code to do this for me, but it does not seem to work. I was sure that simply adding `--value ... --infer-value` to roi invocation will infer missing prices for me, but it does not seem to be the case.

Example journal:
```
2019/11/01 Example
  Assets:Checking  -1 A
  Investment       10 B

2019/11/02 Example
  Investment        -10 B @@ 1 A
  Assets:Checking    12 A
  Unrealized PnL
```

Command: `hledger -f example.journal roi -p 2019-11 --inv Investment --pnl PnL --debug 3`. Based on debug output, no combination of `-V/-X A/--value A/--infer-value` causes the first transaction to have an inferred price for the "10 B" amount, which looks weird to me. What am I missing?