### PR TITLE
roi: use Valuations throughout the code

### DIFF
--- a/examples/roi-unrealised.ledger
+++ b/examples/roi-unrealised.ledger
@@ -3,14 +3,14 @@
 ; By adding some fake transactions you can make it show unrealised gains.
 
 comment
-$ hledger -f examples/roi-unrealised.ledger roi --inv Assets -b 2015-01-01 -e 2019-01-01 --pnl  Income --yearly
+$ hledger -f examples/roi-unrealised.ledger roi --inv Assets -b 2015-01-01 -e 2019-01-01 --pnl  Income --yearly --value=then
 +---++------------+------------++---------------+----------+-------------+--------++--------+--------+
 |   ||      Begin |        End || Value (begin) | Cashflow | Value (end) |    PnL ||    IRR |    TWR |
 +===++============+============++===============+==========+=============+========++========+========+
-| 1 || 2015/01/01 | 2015/12/31 ||         717.4 |        0 |      756.30 |  38.90 ||  5.42% |  5.42% |
-| 2 || 2016/01/01 | 2016/12/31 ||        756.30 |        0 |      998.80 | 242.50 || 31.96% | 31.96% |
-| 3 || 2017/01/01 | 2017/12/31 ||        998.80 |        0 |     1151.20 | 152.40 || 15.26% | 15.26% |
-| 4 || 2018/01/01 | 2018/12/31 ||       1151.20 |        0 |     1145.00 |  -6.20 || -0.54% | -0.54% |
+| 1 || 2015-01-01 | 2015-12-31 ||        725.50 |        0 |      756.30 |  30.80 ||  4.24% |  4.25% |
+| 2 || 2016-01-01 | 2016-12-31 ||        756.30 |        0 |      998.80 | 242.50 || 31.96% | 31.96% |
+| 3 || 2017-01-01 | 2017-12-31 ||        998.80 |        0 |     1151.20 | 152.40 || 15.26% | 15.26% |
+| 4 || 2018-01-01 | 2018-12-31 ||       1151.20 |        0 |     1145.00 |  -6.20 || -0.54% | -0.54% |
 +---++------------+------------++---------------+----------+-------------+--------++--------+--------+
 end comment
 
@@ -116,56 +116,3 @@ P 2016-12-30 RY 93.56
 P 2017-12-30 RY 105.32
 P 2018-12-30 RY 100.02
 P 2019-11-10 RY 108.44
-
-; Here begins the fake transactions that allow the roi command to give an estimate for the unrealized yearly investment, these are not actual buy and sell transactions!
-
-2015-12-31 Pretend to Sell all to get PnL value for end of 2015
-    Income:PnL
-    Assets:Trading:RY     -10 RY @ 71.74
-    Assets:Cash            725.50
-
-2016-01-01 Reverse Pretend to Sell all to get PnL value for end of 2015
-    Income:PnL
-    Assets:Trading:RY     10 RY @ 71.74
-    Assets:Cash           -725.50
-
-2016-12-31 Pretend to Sell all to get PnL value for end of 2016
-    Income:PnL
-    Assets:Trading:RY     -10 RY @ 71.74
-    Assets:Cash            935.60
-
-2017-01-01 Reverse Pretend to Sell all to get PnL value for end of 2016
-    Income:PnL
-    Assets:Trading:RY     10 RY @ 71.74
-    Assets:Cash           -935.60
-
-2017-12-31 Pretend to Sell all to get PnL value for end of 2017
-    Income:PnL
-    Assets:Trading:RY     -10 RY @ 71.74
-    Assets:Cash            1053.20
-
-2018-01-01 Reverse Pretend to Sell all to get PnL value for end of 2017
-    Income:PnL
-    Assets:Trading:RY     10 RY @ 71.74
-    Assets:Cash           -1053.20
-
-2018-12-31 Pretend to Sell all to get PnL value for end of 2018
-    Income:PnL
-    Assets:Trading:RY     -10 RY @ 71.74
-    Assets:Cash            1000.20
-
-2019-01-01 Reverse Pretend to Sell all to get PnL value for end of 2018
-    Income:PnL
-    Assets:Trading:RY     10 RY @ 71.74
-    Assets:Cash           -1000.20
-
-2019-11-09 Pretend to Sell all to get PnL value for end of 2019-11-10
-    Income:PnL
-    Assets:Trading:RY     -10 RY @ 71.74
-    Assets:Cash            1084.40
-
-2019-11-10 Reverse Pretend to Sell all to get PnL value for end of 2019-11-10
-    Income:PnL
-    Assets:Trading:RY     10 RY @ 71.74
-    Assets:Cash           -1084.40
-

--- a/hledger/test/roi.test
+++ b/hledger/test/roi.test
@@ -263,8 +263,30 @@ hledger -f- roi -p 2019-11 --inv Investment --pnl PnL --cost --value=then,A --in
 
 >>>=0
 
-# 11. Dont use crazy amount of decimal places
-hledger -f - roi --inv assets:investment --pnl income:investment -X '$'
+# 11. Use "then" prices. 10000/76.20 = 131.23, 11000/73.88=148.89
+hledger -f - roi --inv assets:investment --pnl income:investment --value=then,'$'
+<<<
+P 2020-12-01 $ 76.20
+P 2021-01-01 $ 73.88
+
+2020-12-02 invest
+ assets:investment  10000
+ assets
+
+2021-01-02 get profit
+ assets:investment  =11000
+ income:investment
+>>>
++---++------------+------------++---------------+----------+-------------+-----++---------+---------+
+|   ||      Begin |        End || Value (begin) | Cashflow | Value (end) | PnL ||     IRR |     TWR |
++===++============+============++===============+==========+=============+=====++=========+=========+
+| 1 || 2020-12-02 | 2021-01-02 ||             0 |     $131 |        $149 | $18 || 321.99% | 321.81% |
++---++------------+------------++---------------+----------+-------------+-----++---------+---------+
+
+>>>=0
+
+# 12. Use "end" prices. 10000/73.88=135.35
+hledger -f - roi --inv assets:investment --pnl income:investment --value=end,'$'
 <<<
 P 2020-12-01 $ 76.20
 P 2021-01-01 $ 73.88


### PR DESCRIPTION
with this change, roi supports full variety of --value switches AND takes into account value changes due to price directives.

Instead of valuing all transactions upfront and working with the result, roi now applies valuations if/when needed, with proper date/periodend values, and additionally visits all dates on which we have price directives to make sure it "samples" value of the investment on that date.

This renders unnecessary "fake sell-rebuy" transactions that were shown in examples/roi-unrealised.journal (and mentioned as part of the workaround script in #1473) and closes #1267