### PR TITLE
MixedAmount and other cleanups

### DIFF
--- a/bin/_hledger-chart.hs
+++ b/bin/_hledger-chart.hs
@@ -162,7 +162,7 @@ sameSignNonZero is
  | otherwise = (map pos $ filter (test.fourth4) nzs, sign)
  where
    nzs = filter ((/=0).fourth4) is
-   pos (acct,_,_,Mixed as) = (acct, abs $ read $ show $ maybe 0 aquantity $ headMay as)
+   pos (acct,_,_,as) = (acct, abs $ read $ show $ maybe 0 aquantity $ headMay $ amounts as)
    sign = if fourth4 (head nzs) >= 0 then 1 else (-1)
    test = if sign > 0 then (>0) else (<0)
 

--- a/bin/hledger-check-fancyassertions.hs
+++ b/bin/hledger-check-fancyassertions.hs
@@ -223,10 +223,10 @@ checkAssertion accounts = checkAssertion'
 
     -- Add missing amounts (with 0 value), normalise, throw away style
     -- information, and sort by commodity name.
-    fixup (H.Mixed m1) (H.Mixed m2) = H.Mixed $
-      let m = H.Mixed (m1 ++ [m_ { H.aquantity = 0 } | m_ <- m2])
-          (H.Mixed as) = H.normaliseMixedAmount m
-      in sortOn H.acommodity . map (\a -> a { H.astyle = H.amountstyle }) $ as
+    fixup m1 m2 =
+      let m = H.mixed $ amounts m1 ++ [m_ { H.aquantity = 0 } | m_ <- amounts m2]
+          as = amounts $ H.normaliseMixedAmount m
+      in H.mixed $ sortOn H.acommodity . map (\a -> a { H.astyle = H.amountstyle }) $ as
 
 -- | Check if an account name is mentioned in an assertion.
 inAssertion :: H.AccountName -> Predicate -> Bool

--- a/bin/hledger-check-fancyassertions.hs
+++ b/bin/hledger-check-fancyassertions.hs
@@ -218,7 +218,7 @@ checkAssertion accounts = checkAssertion'
     evaluate (Account account) =
       fromMaybe H.nullmixedamt $ lookup account accounts
     evaluate (AccountNested account) =
-      sum [m | (a,m) <- accounts, account == a || (a <> pack ":") `isPrefixOf` account]
+      maSum [m | (a,m) <- accounts, account == a || (a <> pack ":") `isPrefixOf` account]
     evaluate (Amount amount) = H.mixed [amount]
 
     -- Add missing amounts (with 0 value), normalise, throw away style
@@ -279,7 +279,7 @@ closingBalances' postings =
 
 -- | Add balances in matching accounts.
 addAccounts :: [(H.AccountName, H.MixedAmount)] -> [(H.AccountName, H.MixedAmount)] -> [(H.AccountName, H.MixedAmount)]
-addAccounts as1 as2 = [ (a, a1 + a2)
+addAccounts as1 as2 = [ (a, a1 `maPlus` a2)
                       | a <- nub (map fst as1 ++ map fst as2)
                       , let a1 = fromMaybe H.nullmixedamt $ lookup a as1
                       , let a2 = fromMaybe H.nullmixedamt $ lookup a as2

--- a/bin/hledger-combine-balances.hs
+++ b/bin/hledger-combine-balances.hs
@@ -34,7 +34,7 @@ appendReports r1 r2 =
     mergeRows (PeriodicReportRow name amt1 tot1 avg1) (PeriodicReportRow _ amt2 tot2 avg2) =
       PeriodicReportRow { prrName = name
         , prrAmounts = amt1++amt2
-        , prrTotal = tot1+tot2
+        , prrTotal = tot1 `maPlus` tot2
         , prrAverage = averageMixedAmounts [avg1,avg2]
         }
 

--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -65,7 +65,7 @@ accountsFromPostings ps =
   let
     grouped = groupSort [(paccount p,pamount p) | p <- ps]
     counted = [(aname, length amts) | (aname, amts) <- grouped]
-    summed =  [(aname, sumStrict amts) | (aname, amts) <- grouped]  -- always non-empty
+    summed =  [(aname, maSum amts) | (aname, amts) <- grouped]  -- always non-empty
     acctstree      = accountTree "root" $ map fst summed
     acctswithnumps = mapAccounts setnumps    acctstree      where setnumps    a = a{anumpostings=fromMaybe 0 $ lookup (aname a) counted}
     acctswithebals = mapAccounts setebalance acctswithnumps where setebalance a = a{aebalance=lookupJustDef nullmixedamt (aname a) summed}
@@ -122,7 +122,7 @@ sumAccounts a
   | otherwise      = a{aibalance=ibal, asubs=subs}
   where
     subs = map sumAccounts $ asubs a
-    ibal = sum $ aebalance a : map aibalance subs
+    ibal = maSum $ aebalance a : map aibalance subs
 
 -- | Remove all subaccounts below a certain depth.
 clipAccounts :: Int -> Account -> Account
@@ -139,7 +139,7 @@ clipAccountsAndAggregate Nothing  as = as
 clipAccountsAndAggregate (Just d) as = combined
     where
       clipped  = [a{aname=clipOrEllipsifyAccountName (Just d) $ aname a} | a <- as]
-      combined = [a{aebalance=sum $ map aebalance same}
+      combined = [a{aebalance=maSum $ map aebalance same}
                  | same@(a:_) <- groupOn aname clipped]
 {-
 test cases, assuming d=1:

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -524,7 +524,7 @@ filterTransactionAmounts q t@Transaction{tpostings=ps} = t{tpostings=map (filter
 
 -- | Filter out all parts of this posting's amount which do not match the query.
 filterPostingAmount :: Query -> Posting -> Posting
-filterPostingAmount q p@Posting{pamount=Mixed as} = p{pamount=Mixed $ filter (q `matchesAmount`) as}
+filterPostingAmount q p@Posting{pamount=as} = p{pamount=filterMixedAmount (q `matchesAmount`) as}
 
 filterTransactionPostings :: Query -> Transaction -> Transaction
 filterTransactionPostings q t@Transaction{tpostings=ps} = t{tpostings=filter (q `matchesPosting`) ps}
@@ -897,21 +897,15 @@ addOrAssignAmountAndCheckAssertionB p@Posting{paccount=acc, pamount=amt, pbalanc
       return p
 
   -- no explicit posting amount, but there is a balance assignment
-  -- TODO this doesn't yet handle inclusive assignments right, #1207
   | Just BalanceAssertion{baamount,batotal,bainclusive} <- mba = do
-      (diff,newbal) <- case batotal of
-        -- a total balance assignment (==, all commodities)
-        True  -> do
-          let newbal = Mixed [baamount]
-          diff <- (if bainclusive then setInclusiveRunningBalanceB else setRunningBalanceB) acc newbal
-          return (diff,newbal)
-        -- a partial balance assignment (=, one commodity)
-        False -> do
-          oldbalothercommodities <- filterMixedAmount ((acommodity baamount /=) . acommodity) <$> getRunningBalanceB acc
-          let assignedbalthiscommodity = Mixed [baamount]
-              newbal = maPlus oldbalothercommodities assignedbalthiscommodity
-          diff <- (if bainclusive then setInclusiveRunningBalanceB else setRunningBalanceB) acc newbal
-          return (diff,newbal)
+      newbal <- if batotal
+                   -- a total balance assignment (==, all commodities)
+                   then return $ mixedAmount baamount
+                   -- a partial balance assignment (=, one commodity)
+                   else do
+                     oldbalothercommodities <- filterMixedAmount ((acommodity baamount /=) . acommodity) <$> getRunningBalanceB acc
+                     return $ maAddAmount oldbalothercommodities baamount
+      diff <- (if bainclusive then setInclusiveRunningBalanceB else setRunningBalanceB) acc newbal
       let p' = p{pamount=diff, poriginal=Just $ originalPosting p}
       whenM (R.reader bsAssrt) $ checkBalanceAssertionB p' newbal
       return p'
@@ -1153,7 +1147,7 @@ canonicalStyle a b = a{asprecision=prec, asdecimalpoint=decmark, asdigitgroups=m
 --       fixtransaction t@Transaction{tdate=d, tpostings=ps} = t{tpostings=map fixposting ps}
 --        where
 --         fixposting p@Posting{pamount=a} = p{pamount=fixmixedamount a}
---         fixmixedamount (Mixed as) = Mixed $ map fixamount as
+--         fixmixedamount = mapMixedAmount fixamount
 --         fixamount = fixprice
 --         fixprice a@Amount{price=Just _} = a
 --         fixprice a@Amount{commodity=c} = a{price=maybe Nothing (Just . UnitPrice) $ journalPriceDirectiveFor j d c}
@@ -1182,8 +1176,8 @@ journalInferMarketPricesFromTransactions j =
 postingInferredmarketPrice :: Posting -> Maybe MarketPrice
 postingInferredmarketPrice p@Posting{pamount} =
   -- convert any total prices to unit prices
-  case mixedAmountTotalPriceToUnitPrice pamount of
-    Mixed ( Amount{acommodity=fromcomm, aprice = Just (UnitPrice Amount{acommodity=tocomm, aquantity=rate})} : _) ->
+  case amounts $ mixedAmountTotalPriceToUnitPrice pamount of
+    Amount{acommodity=fromcomm, aprice = Just (UnitPrice Amount{acommodity=tocomm, aquantity=rate})}:_ ->
       Just MarketPrice {
          mpdate = postingDate p
         ,mpfrom = fromcomm
@@ -1561,7 +1555,7 @@ tests_Journal = tests "Journal" [
             ]}
       assertRight ej
       let Right j = ej
-      (jtxns j & head & tpostings & head & pamount) @?= Mixed [num 1]
+      (jtxns j & head & tpostings & head & pamount) @?= mixedAmount (num 1)
 
     ,test "same-day-1" $ do
       assertRight $ journalBalanceTransactions True $

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -202,8 +202,7 @@ sumPostings = foldl' (\amt p -> maPlus amt $ pamount p) nullmixedamt
 
 -- | Remove all prices of a posting
 removePrices :: Posting -> Posting
-removePrices p = p{ pamount = Mixed $ remove <$> amounts (pamount p) }
-  where remove a = a { aprice = Nothing }
+removePrices = postingTransformAmount (mapMixedAmount $ \a -> a{aprice=Nothing})
 
 -- | Get a posting's (primary) date - it's own primary date if specified,
 -- otherwise the parent transaction's primary date, or the null date if

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -75,15 +75,16 @@ import Control.Monad (foldM)
 import Data.Foldable (asum)
 import Data.List.Extra (nubSort)
 import qualified Data.Map as M
-import Data.Maybe
+import Data.Maybe (fromMaybe, isJust)
 import Data.MemoUgly (memo)
+import Data.List (foldl')
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Monoid
 #endif
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Time.Calendar
-import Safe
+import Data.Time.Calendar (Day)
+import Safe (headDef)
 
 import Hledger.Utils
 import Hledger.Data.Types
@@ -197,7 +198,7 @@ accountNamesFromPostings :: [Posting] -> [AccountName]
 accountNamesFromPostings = nubSort . map paccount
 
 sumPostings :: [Posting] -> MixedAmount
-sumPostings = sumStrict . map pamount
+sumPostings = foldl' (\amt p -> maPlus amt $ pamount p) nullmixedamt
 
 -- | Remove all prices of a posting
 removePrices :: Posting -> Posting

--- a/hledger-lib/Hledger/Data/Timeclock.hs
+++ b/hledger-lib/Hledger/Data/Timeclock.hs
@@ -121,7 +121,7 @@ entryFromTimeclockInOut i o
       showtime = take 5 . show
       hours    = elapsedSeconds (toutc otime) (toutc itime) / 3600 where toutc = localTimeToUTC utc
       acctname = tlaccount i
-      amount   = Mixed [hrs hours]
+      amount   = mixedAmount $ hrs hours
       ps       = [posting{paccount=acctname, pamount=amount, ptype=VirtualPosting, ptransaction=Just t}]
 
 

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -471,9 +471,9 @@ inferBalancingAmount styles t@Transaction{tpostings=ps}
         in Right (t{tpostings=map fst psandinferredamts}, inferredacctsandamts)
   where
     (amountfulrealps, amountlessrealps) = partition hasAmount (realPostings t)
-    realsum = sumStrict $ map pamount amountfulrealps
+    realsum = sumPostings amountfulrealps
     (amountfulbvps, amountlessbvps) = partition hasAmount (balancedVirtualPostings t)
-    bvsum = sumStrict $ map pamount amountfulbvps
+    bvsum = sumPostings amountfulbvps
 
     inferamount :: Posting -> (Posting, Maybe MixedAmount)
     inferamount p =
@@ -490,7 +490,7 @@ inferBalancingAmount styles t@Transaction{tpostings=ps}
               -- Inferred amounts are converted to cost.
               -- Also ensure the new amount has the standard style for its commodity
               -- (since the main amount styling pass happened before this balancing pass);
-              a' = styleMixedAmount styles $ normaliseMixedAmount $ mixedAmountCost (-a)
+              a' = styleMixedAmount styles . normaliseMixedAmount . mixedAmountCost $ maNegate a
 
 -- | Infer prices for this transaction's posting amounts, if needed to make
 -- the postings balance, and if possible. This is done once for the real
@@ -542,10 +542,9 @@ priceInferrerFor :: Transaction -> PostingType -> (Posting -> Posting)
 priceInferrerFor t pt = inferprice
   where
     postings       = filter ((==pt).ptype) $ tpostings t
-    pmixedamounts  = map pamount postings
-    pamounts       = concatMap amounts pmixedamounts
+    pamounts       = concatMap (amounts . pamount) postings
     pcommodities   = map acommodity pamounts
-    sumamounts     = amounts $ sumStrict pmixedamounts -- sum normalises to one amount per commodity & price
+    sumamounts     = amounts $ sumPostings postings  -- sum normalises to one amount per commodity & price
     sumcommodities = map acommodity sumamounts
     sumprices      = filter (/=Nothing) $ map aprice sumamounts
     caninferprices = length sumcommodities == 2 && null sumprices

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -551,7 +551,7 @@ priceInferrerFor t pt = inferprice
 
     inferprice p@Posting{pamount=Mixed [a]}
       | caninferprices && ptype p == pt && acommodity a == fromcommodity
-        = p{pamount=Mixed [a{aprice=Just conversionprice}], poriginal=Just $ originalPosting p}
+        = p{pamount=mixedAmount $ a{aprice=Just conversionprice}, poriginal=Just $ originalPosting p}
       where
         fromcommodity = head $ filter (`elem` sumcommodities) pcommodities -- these heads are ugly but should be safe
         totalpricesign = if aquantity a < 0 then negate else id

--- a/hledger-lib/Hledger/Data/TransactionModifier.hs
+++ b/hledger-lib/Hledger/Data/TransactionModifier.hs
@@ -120,14 +120,14 @@ tmPostingRuleToFunction querytxt pr =
             -- Approach 1: convert to a unit price and increase the display precision slightly
             -- Mixed as = dbg6 "multipliedamount" $ n `multiplyMixedAmount` mixedAmountTotalPriceToUnitPrice matchedamount
             -- Approach 2: multiply the total price (keeping it positive) as well as the quantity
-            Mixed as = dbg6 "multipliedamount" $ n `multiplyMixedAmount` matchedamount
+            as = dbg6 "multipliedamount" $ n `multiplyMixedAmount` matchedamount
           in
             case acommodity pramount of
-              "" -> Mixed as
+              "" -> as
               -- TODO multipliers with commodity symbols are not yet a documented feature.
               -- For now: in addition to multiplying the quantity, it also replaces the
               -- matched amount's commodity, display style, and price with those of the posting rule.
-              c  -> Mixed [a{acommodity = c, astyle = astyle pramount, aprice = aprice pramount} | a <- as]
+              c  -> mapMixedAmount (\a -> a{acommodity = c, astyle = astyle pramount, aprice = aprice pramount}) as
 
 postingRuleMultiplier :: TMPostingRule -> Maybe Quantity
 postingRuleMultiplier p =

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -729,7 +729,7 @@ spaceandamountormissingp :: JournalParser m MixedAmount
 spaceandamountormissingp =
   option missingmixedamt $ try $ do
     lift $ skipNonNewlineSpaces1
-    Mixed . (:[]) <$> amountp
+    mixedAmount <$> amountp
 
 -- | Parse a single-commodity amount, with optional symbol on the left
 -- or right, followed by, in any order: an optional transaction price,
@@ -855,7 +855,7 @@ amountp' s =
 
 -- | Parse a mixed amount from a string, or get an error.
 mamountp' :: String -> MixedAmount
-mamountp' = Mixed . (:[]) . amountp'
+mamountp' = mixedAmount . amountp'
 
 -- | Parse a minus or plus sign followed by zero or more spaces,
 -- or nothing, returning a function that negates or does nothing.
@@ -1560,7 +1560,7 @@ tests_Common = tests "Common" [
      assertParseError p "1.5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555" ""
 
   ,tests "spaceandamountormissingp" [
-     test "space and amount" $ assertParseEq spaceandamountormissingp " $47.18" (Mixed [usd 47.18])
+     test "space and amount" $ assertParseEq spaceandamountormissingp " $47.18" (mixedAmount $ usd 47.18)
     ,test "empty string" $ assertParseEq spaceandamountormissingp "" missingmixedamt
     -- ,test "just space" $ assertParseEq spaceandamountormissingp " " missingmixedamt  -- XXX should it ?
     -- ,test "just amount" $ assertParseError spaceandamountormissingp "$47.18" ""  -- succeeds, consuming nothing

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -1048,7 +1048,7 @@ getBalance rules record currency n = do
 -- The whole CSV record is provided for the error message.
 parseAmount :: CsvRules -> CsvRecord -> Text -> Text -> MixedAmount
 parseAmount rules record currency s =
-    either mkerror (Mixed . (:[])) $  -- PARTIAL:
+    either mkerror mixedAmount $  -- PARTIAL:
     runParser (evalStateT (amountp <* eof) journalparsestate) "" $
     currency <> simplifySign s
   where

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -995,7 +995,7 @@ getAmount rules record currency p1IsVirtual n =
                           , let a = parseAmount rules record currency v
                           -- With amount/amount-in/amount-out, in posting 2,
                           -- flip the sign and convert to cost, as they did before 1.17
-                          , let a' = if f `elem` unnumberedfieldnames && n==2 then mixedAmountCost (-a) else a
+                          , let a' = if f `elem` unnumberedfieldnames && n==2 then mixedAmountCost (maNegate a) else a
                           ]
 
     -- if any of the numbered field names are present, discard all the unnumbered ones
@@ -1013,7 +1013,7 @@ getAmount rules record currency p1IsVirtual n =
   in case -- dbg0 ("amounts for posting "++show n)
           assignments'' of
       [] -> Nothing
-      [(f,a)] | "-out" `T.isSuffixOf` f -> Just (-a)  -- for -out fields, flip the sign
+      [(f,a)] | "-out" `T.isSuffixOf` f -> Just (maNegate a)  -- for -out fields, flip the sign
       [(_,a)] -> Just a
       fs      -> error' . T.unpack . T.unlines $ [  -- PARTIAL:
          "multiple non-zero amounts or multiple zero amounts assigned,"

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -711,7 +711,7 @@ postingp mTransactionYear = do
     return (status, account)
   let (ptype, account') = (accountNamePostingType account, textUnbracket account)
   lift skipNonNewlineSpaces
-  amount <- option missingmixedamt $ Mixed . (:[]) <$> amountp
+  amount <- option missingmixedamt $ mixedAmount <$> amountp
   lift skipNonNewlineSpaces
   massertion <- optional balanceassertionp
   lift skipNonNewlineSpaces

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -125,7 +125,7 @@ tests_BalanceReport = tests "BalanceReport" [
        ,("income:gifts","income:gifts",0, mamountp' "$-1.00")
        ,("income:salary","income:salary",0, mamountp' "$-1.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with --tree" $
      (defreportspec{rsOpts=defreportopts{accountlistmode_=ALTree}}, samplejournal) `gives`
@@ -142,7 +142,7 @@ tests_BalanceReport = tests "BalanceReport" [
        ,("income:gifts","gifts",1, mamountp' "$-1.00")
        ,("income:salary","salary",1, mamountp' "$-1.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with --depth=N" $
      (defreportspec{rsOpts=defreportopts{depth_=Just 1}}, samplejournal) `gives`
@@ -150,7 +150,7 @@ tests_BalanceReport = tests "BalanceReport" [
        ("expenses",    "expenses",    0, mamountp'  "$2.00")
        ,("income",      "income",      0, mamountp' "$-2.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with depth:N" $
      (defreportspec{rsQuery=Depth 1}, samplejournal) `gives`
@@ -158,7 +158,7 @@ tests_BalanceReport = tests "BalanceReport" [
        ("expenses",    "expenses",    0, mamountp'  "$2.00")
        ,("income",      "income",      0, mamountp' "$-2.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with date:" $
      (defreportspec{rsQuery=Date $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
@@ -170,7 +170,7 @@ tests_BalanceReport = tests "BalanceReport" [
         ("assets:bank:checking","assets:bank:checking",0,mamountp' "$1.00")
        ,("income:salary","income:salary",0,mamountp' "$-1.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with desc:" $
      (defreportspec{rsQuery=Desc $ toRegexCI' "income"}, samplejournal) `gives`
@@ -178,7 +178,7 @@ tests_BalanceReport = tests "BalanceReport" [
         ("assets:bank:checking","assets:bank:checking",0,mamountp' "$1.00")
        ,("income:salary","income:salary",0, mamountp' "$-1.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with not:desc:" $
      (defreportspec{rsQuery=Not . Desc $ toRegexCI' "income"}, samplejournal) `gives`
@@ -189,7 +189,7 @@ tests_BalanceReport = tests "BalanceReport" [
        ,("expenses:supplies","expenses:supplies",0, mamountp' "$1.00")
        ,("income:gifts","income:gifts",0, mamountp' "$-1.00")
        ],
-       Mixed [usd 0])
+       mixedAmount (usd 0))
 
     ,test "with period on a populated period" $
       (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2)}}, samplejournal) `gives`
@@ -198,7 +198,7 @@ tests_BalanceReport = tests "BalanceReport" [
          ("assets:bank:checking","assets:bank:checking",0, mamountp' "$1.00")
         ,("income:salary","income:salary",0, mamountp' "$-1.00")
         ],
-        Mixed [usd 0])
+        mixedAmount (usd 0))
 
      ,test "with period on an unpopulated period" $
       (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 2) (fromGregorian 2008 1 3)}}, samplejournal) `gives`

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -112,7 +112,7 @@ tests_BalanceReport = tests "BalanceReport" [
     tests "balanceReport" [
 
      test "no args, null journal" $
-     (defreportspec, nulljournal) `gives` ([], 0)
+     (defreportspec, nulljournal) `gives` ([], nullmixedamt)
 
     ,test "no args, sample journal" $
      (defreportspec, samplejournal) `gives`
@@ -162,7 +162,7 @@ tests_BalanceReport = tests "BalanceReport" [
 
     ,test "with date:" $
      (defreportspec{rsQuery=Date $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
-      ([], 0)
+      ([], nullmixedamt)
 
     ,test "with date2:" $
      (defreportspec{rsQuery=Date2 $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
@@ -202,7 +202,7 @@ tests_BalanceReport = tests "BalanceReport" [
 
      ,test "with period on an unpopulated period" $
       (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 2) (fromGregorian 2008 1 3)}}, samplejournal) `gives`
-       ([], 0)
+       ([], nullmixedamt)
 
 
 

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -206,7 +206,7 @@ combineBudgetAndActual ropts j
     sortedrows :: [BudgetReportRow] = sortRowsLike (mbrsorted unbudgetedrows ++ mbrsorted rows') rows
       where
         (unbudgetedrows, rows') = partition ((==unbudgetedAccountName) . prrFullName) rows
-        mbrsorted = map prrFullName . sortRows ropts j . map (fmap $ fromMaybe 0 . fst)
+        mbrsorted = map prrFullName . sortRows ropts j . map (fmap $ fromMaybe nullmixedamt . fst)
         rows = rows1 ++ rows2
 
     -- TODO: grand total & average shows 0% when there are no actual amounts, inconsistent with other cells
@@ -244,7 +244,7 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
 
     displayCell (actual, budget) = (showamt actual', budgetAndPerc <$> budget)
       where
-        actual' = fromMaybe 0 actual
+        actual' = fromMaybe nullmixedamt actual
         budgetAndPerc b = (showamt b, showper <$> percentage actual' b)
         showamt = (\(WideBuilder b w) -> (TL.toStrict $ TB.toLazyText b, w)) . showMixedAmountB oneLine{displayColour=color_, displayMaxWidth=Just 32}
         showper p = let str = T.pack (show $ roundTo 0 p) in (str, T.length str)

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -280,15 +280,15 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
     -- - the goal is zero
     percentage :: Change -> BudgetGoal -> Maybe Percentage
     percentage actual budget =
-      case (maybecost $ normaliseMixedAmount actual, maybecost $ normaliseMixedAmount budget) of
-        (Mixed [a], Mixed [b]) | (acommodity a == acommodity b || amountLooksZero a) && not (amountLooksZero b)
+      case (costedAmounts actual, costedAmounts budget) of
+        ([a], [b]) | (acommodity a == acommodity b || amountLooksZero a) && not (amountLooksZero b)
             -> Just $ 100 * aquantity a / aquantity b
         _   -> -- trace (pshow $ (maybecost actual, maybecost budget))  -- debug missing percentage
                Nothing
       where
-        maybecost = case cost_ of
-            Cost   -> mixedAmountCost
-            NoCost -> id
+        costedAmounts = case cost_ of
+            Cost   -> amounts . mixedAmountCost . normaliseMixedAmount
+            NoCost -> amounts . normaliseMixedAmount
 
     maybetranspose | transpose_ = \(Table rh ch vals) -> Table ch rh (transpose vals)
                    | otherwise  = id

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -591,8 +591,8 @@ tests_MultiBalanceReport = tests "MultiBalanceReport" [
      ,test "with -H on a populated period"  $
       (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2), balancetype_=HistoricalBalance}}, samplejournal) `gives`
        (
-        [ PeriodicReportRow (flatDisplayName "assets:bank:checking") [mamountp' "$1.00"]  (mamountp' "$1.00")  (Mixed [amt0 {aquantity=1}])
-        , PeriodicReportRow (flatDisplayName "income:salary")        [mamountp' "$-1.00"] (mamountp' "$-1.00") (Mixed [amt0 {aquantity=(-1)}])
+        [ PeriodicReportRow (flatDisplayName "assets:bank:checking") [mamountp' "$1.00"]  (mamountp' "$1.00")  (mixedAmount amt0{aquantity=1})
+        , PeriodicReportRow (flatDisplayName "income:salary")        [mamountp' "$-1.00"] (mamountp' "$-1.00") (mixedAmount amt0{aquantity=(-1)})
         ],
         mamountp' "$0.00")
 
@@ -600,23 +600,23 @@ tests_MultiBalanceReport = tests "MultiBalanceReport" [
      --  (defreportopts{period_= PeriodBetween (fromGregorian 2008 1 2) (fromGregorian 2008 1 3), balancetype_=HistoricalBalance}, samplejournal) `gives`
      --   (
      --    [
-     --     ("assets:bank:checking","checking",3, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amt0 {aquantity=1}])
-     --    ,("income:salary","salary",2, [mamountp' "$-1.00"], mamountp' "$-1.00",Mixed [amt0 {aquantity=(-1)}])
+     --     ("assets:bank:checking","checking",3, [mamountp' "$1.00"], mamountp' "$1.00",mixedAmount amt0 {aquantity=1})
+     --    ,("income:salary","salary",2, [mamountp' "$-1.00"], mamountp' "$-1.00",mixedAmount amt0 {aquantity=(-1)})
      --    ],
-     --    Mixed [usd0])
+     --    mixedAmount usd0)
 
      -- ,test "a valid history on an empty period (more complex)"  $
      --  (defreportopts{period_= PeriodBetween (fromGregorian 2009 1 1) (fromGregorian 2009 1 2), balancetype_=HistoricalBalance}, samplejournal) `gives`
      --   (
      --    [
-     --    ("assets:bank:checking","checking",3, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amt0 {aquantity=1}])
-     --    ,("assets:bank:saving","saving",3, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amt0 {aquantity=1}])
-     --    ,("assets:cash","cash",2, [mamountp' "$-2.00"], mamountp' "$-2.00",Mixed [amt0 {aquantity=(-2)}])
-     --    ,("expenses:food","food",2, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amt0 {aquantity=(1)}])
-     --    ,("expenses:supplies","supplies",2, [mamountp' "$1.00"], mamountp' "$1.00",Mixed [amt0 {aquantity=(1)}])
-     --    ,("income:gifts","gifts",2, [mamountp' "$-1.00"], mamountp' "$-1.00",Mixed [amt0 {aquantity=(-1)}])
-     --    ,("income:salary","salary",2, [mamountp' "$-1.00"], mamountp' "$-1.00",Mixed [amt0 {aquantity=(-1)}])
+     --    ("assets:bank:checking","checking",3, [mamountp' "$1.00"], mamountp' "$1.00",mixedAmount amt0 {aquantity=1})
+     --    ,("assets:bank:saving","saving",3, [mamountp' "$1.00"], mamountp' "$1.00",mixedAmount amt0 {aquantity=1})
+     --    ,("assets:cash","cash",2, [mamountp' "$-2.00"], mamountp' "$-2.00",mixedAmount amt0 {aquantity=(-2)})
+     --    ,("expenses:food","food",2, [mamountp' "$1.00"], mamountp' "$1.00",mixedAmount amt0 {aquantity=(1)})
+     --    ,("expenses:supplies","supplies",2, [mamountp' "$1.00"], mamountp' "$1.00",mixedAmount amt0 {aquantity=(1)})
+     --    ,("income:gifts","gifts",2, [mamountp' "$-1.00"], mamountp' "$-1.00",mixedAmount amt0 {aquantity=(-1)})
+     --    ,("income:salary","salary",2, [mamountp' "$-1.00"], mamountp' "$-1.00",mixedAmount amt0 {aquantity=(-1)})
      --    ],
-     --    Mixed [usd0])
+     --    mixedAmount usd0)
     ]
  ]

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -406,10 +406,10 @@ tests_PostingsReport = tests "PostingsReport" [
     --           (summarisePostingsInDateSpan (DateSpan b e) depth showempty ps `is`)
     --   let ps =
     --           [
-    --            nullposting{lpdescription="desc",lpaccount="expenses:food:groceries",lpamount=Mixed [usd 1]}
-    --           ,nullposting{lpdescription="desc",lpaccount="expenses:food:dining",   lpamount=Mixed [usd 2]}
-    --           ,nullposting{lpdescription="desc",lpaccount="expenses:food",          lpamount=Mixed [usd 4]}
-    --           ,nullposting{lpdescription="desc",lpaccount="expenses:food:dining",   lpamount=Mixed [usd 8]}
+    --            nullposting{lpdescription="desc",lpaccount="expenses:food:groceries",lpamount=mixedAmount (usd 1)}
+    --           ,nullposting{lpdescription="desc",lpaccount="expenses:food:dining",   lpamount=mixedAmount (usd 2)}
+    --           ,nullposting{lpdescription="desc",lpaccount="expenses:food",          lpamount=mixedAmount (usd 4)}
+    --           ,nullposting{lpdescription="desc",lpaccount="expenses:food:dining",   lpamount=mixedAmount (usd 8)}
     --           ]
     --   ("2008/01/01","2009/01/01",0,9999,False,[]) `gives`
     --    []
@@ -419,21 +419,21 @@ tests_PostingsReport = tests "PostingsReport" [
     --    ]
     --   ("2008/01/01","2009/01/01",0,9999,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food",          lpamount=Mixed [usd 4]}
-    --    ,nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food:dining",   lpamount=Mixed [usd 10]}
-    --    ,nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food:groceries",lpamount=Mixed [usd 1]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food",          lpamount=mixedAmount (usd 4)}
+    --    ,nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food:dining",   lpamount=mixedAmount (usd 10)}
+    --    ,nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food:groceries",lpamount=mixedAmount (usd 1)}
     --    ]
     --   ("2008/01/01","2009/01/01",0,2,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food",lpamount=Mixed [usd 15]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses:food",lpamount=mixedAmount (usd 15)}
     --    ]
     --   ("2008/01/01","2009/01/01",0,1,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses",lpamount=Mixed [usd 15]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="expenses",lpamount=mixedAmount (usd 15)}
     --    ]
     --   ("2008/01/01","2009/01/01",0,0,False,ts) `gives`
     --    [
-    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="",lpamount=Mixed [usd 15]}
+    --     nullposting{lpdate=fromGregorian 2008 01 01,lpdescription="- 2008/12/31",lpaccount="",lpamount=mixedAmount (usd 15)}
     --    ]
 
  ]

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -4,11 +4,11 @@ Postings report, used by the register command.
 
 -}
 
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Hledger.Reports.PostingsReport (
   PostingsReport,
@@ -21,11 +21,11 @@ module Hledger.Reports.PostingsReport (
 )
 where
 
-import Data.List
+import Data.List (nub, sortOn)
 import Data.List.Extra (nubSort)
-import Data.Maybe
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Text (Text)
-import Data.Time.Calendar
+import Data.Time.Calendar (Day, addDays)
 import Safe (headMay, lastMay)
 
 import Hledger.Data
@@ -101,12 +101,11 @@ postingsReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j = items
           -- of --value on reports".
           -- XXX balance report doesn't value starting balance.. should this ?
           historical = balancetype_ == HistoricalBalance
-          startbal | average_  = if historical then precedingavg else 0
-                   | otherwise = if historical then precedingsum else 0
+          startbal | average_  = if historical then precedingavg else nullmixedamt
+                   | otherwise = if historical then precedingsum else nullmixedamt
             where
               precedingsum = sumPostings $ map (pvalue daybeforereportstart) precedingps
-              precedingavg | null precedingps = 0
-                           | otherwise        = divideMixedAmount (fromIntegral $ length precedingps) precedingsum
+              precedingavg = divideMixedAmount (fromIntegral $ length precedingps) precedingsum
               daybeforereportstart =
                 maybe (error' "postingsReport: expected a non-empty journal")  -- PARTIAL: shouldn't happen
                 (addDays (-1))
@@ -121,8 +120,8 @@ postingsReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j = items
 -- and return the new average/total.
 registerRunningCalculationFn :: ReportOpts -> (Int -> MixedAmount -> MixedAmount -> MixedAmount)
 registerRunningCalculationFn ropts
-  | average_ ropts = \i avg amt -> avg + divideMixedAmount (fromIntegral i) (amt - avg)
-  | otherwise      = \_ bal amt -> bal + amt
+  | average_ ropts = \i avg amt -> avg `maPlus` divideMixedAmount (fromIntegral i) (amt `maMinus` avg)
+  | otherwise      = \_ bal amt -> bal `maPlus` amt
 
 -- | Find postings matching a given query, within a given date span,
 -- and also any similarly-matched postings before that date span.
@@ -218,7 +217,7 @@ summarisePostingsInDateSpan (DateSpan b e) wd mdepth showempty ps
     e' = fromMaybe (maybe (addDays 1 nulldate) postingdate $ lastMay ps) e
     summaryp = nullposting{pdate=Just b'}
     clippedanames = nub $ map (clipAccountName mdepth) anames
-    summaryps | mdepth == Just 0 = [summaryp{paccount="...",pamount=sum $ map pamount ps}]
+    summaryps | mdepth == Just 0 = [summaryp{paccount="...",pamount=sumPostings ps}]
               | otherwise        = [summaryp{paccount=a,pamount=balance a} | a <- clippedanames]
     summarypes = map (, e') $ (if showempty then id else filter (not . mixedAmountLooksZero . pamount)) summaryps
     anames = nubSort $ map paccount ps
@@ -230,7 +229,7 @@ summarisePostingsInDateSpan (DateSpan b e) wd mdepth showempty ps
         isclipped a = maybe True (accountNameLevel a >=) mdepth
 
 negatePostingAmount :: Posting -> Posting
-negatePostingAmount p = p { pamount = negate $ pamount p }
+negatePostingAmount p = p { pamount = maNegate $ pamount p }
 
 
 -- tests

--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -98,11 +98,11 @@ data PeriodicReportRow a b =
   , prrAverage :: b    -- The average of this row's values.
   } deriving (Show, Functor, Generic, ToJSON)
 
-instance Num b => Semigroup (PeriodicReportRow a b) where
+instance Semigroup b => Semigroup (PeriodicReportRow a b) where
   (PeriodicReportRow _ amts1 t1 a1) <> (PeriodicReportRow n2 amts2 t2 a2) =
-      PeriodicReportRow n2 (sumPadded amts1 amts2) (t1 + t2) (a1 + a2)
+      PeriodicReportRow n2 (sumPadded amts1 amts2) (t1 <> t2) (a1 <> a2)
     where
-      sumPadded (a:as) (b:bs) = (a + b) : sumPadded as bs
+      sumPadded (a:as) (b:bs) = (a <> b) : sumPadded as bs
       sumPadded as     []     = as
       sumPadded []     bs     = bs
 

--- a/hledger-lib/Hledger/Reports/TransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/TransactionsReport.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 {-|
 
 A transactions report. Like an EntriesReport, but with more
@@ -21,10 +23,10 @@ module Hledger.Reports.TransactionsReport (
 )
 where
 
-import Data.List
+import Data.List (sortBy)
 import Data.List.Extra (nubSort)
+import Data.Ord (comparing)
 import Data.Text (Text)
-import Data.Ord
 
 import Hledger.Data
 import Hledger.Query
@@ -99,7 +101,7 @@ filterTransactionsReportByCommodity c =
         startbal = filterMixedAmountByCommodity c $ triBalance i
         go _ [] = []
         go bal ((t,t2,s,o,amt,_):is) = (t,t2,s,o,amt,bal'):go bal' is
-          where bal' = bal + amt
+          where bal' = bal `maPlus` amt
 
 -- tests
 

--- a/hledger-lib/Hledger/Utils.hs
+++ b/hledger-lib/Hledger/Utils.hs
@@ -4,7 +4,9 @@ Standard imports and utilities which are useful everywhere, or needed low
 in the module hierarchy. This is the bottom of hledger's module graph.
 
 -}
-{-# LANGUAGE OverloadedStrings, LambdaCase #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Hledger.Utils (---- provide these frequently used modules - or not, for clearer api:
                           -- module Control.Monad,
@@ -35,25 +37,21 @@ module Hledger.Utils (---- provide these frequently used modules - or not, for c
 where
 
 import Control.Monad (liftM, when)
--- import Data.Char
 import Data.FileEmbed (makeRelativeToProject, embedStringFile)
-import Data.List
--- import Data.Maybe
--- import Data.PPrint
+import Data.List (foldl', foldl1')
 -- import Data.String.Here (hereFile)
 import Data.Text (Text)
 import qualified Data.Text.IO as T
-import Data.Time.Clock
-import Data.Time.LocalTime
--- import Data.Text (Text)
--- import qualified Data.Text as T
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.LocalTime (LocalTime, ZonedTime, getCurrentTimeZone,
+                            utcToLocalTime, utcToZonedTime)
 -- import Language.Haskell.TH.Quote (QuasiQuoter(..))
 import Language.Haskell.TH.Syntax (Q, Exp)
 import System.Directory (getHomeDirectory)
-import System.FilePath((</>), isRelative)
+import System.FilePath (isRelative, (</>))
 import System.IO
--- import Text.Printf
--- import qualified Data.Map as Map
+  (Handle, IOMode (..), hGetEncoding, hSetEncoding, hSetNewlineMode,
+   openFile, stdin, universalNewlineMode, utf8_bom)
 
 import Hledger.Utils.Debug
 import Hledger.Utils.Parse
@@ -160,7 +158,7 @@ expandPath :: FilePath -> FilePath -> IO FilePath -- general type sig for use in
 expandPath _ "-" = return "-"
 expandPath curdir p = (if isRelative p then (curdir </>) else id) `liftM` expandHomePath p
 -- PARTIAL:
-  
+
 -- | Expand user home path indicated by tilde prefix
 expandHomePath :: FilePath -> IO FilePath
 expandHomePath = \case

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -103,8 +103,7 @@ asInit d reset ui@UIState{
                         ,asItemRenderedAmounts    = map showAmountWithoutPrice amts
                         }
       where
-        Mixed amts = normaliseMixedAmountSquashPricesForDisplay $ stripPrices bal
-        stripPrices (Mixed as) = Mixed $ map stripprice as where stripprice a = a{aprice=Nothing}
+        amts = amounts . normaliseMixedAmountSquashPricesForDisplay $ mixedAmountStripPrices bal
     displayitems = map displayitem items
     -- blanks added for scrolling control, cf RegisterScreen.
     -- XXX Ugly. Changing to 0 helps when debugging.

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -360,8 +360,8 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
         c <- T.pack <$> fromMaybe "" `fmap` optional (char ';' >> many anySingle)
         -- eof
         return (a,c)
-      balancingamt = negate $ sum $ map pamount realps where realps = filter isReal esPostings
-      balancingamtfirstcommodity = Mixed $ take 1 $ amounts balancingamt
+      balancingamt = maNegate . sumPostings $ filter isReal esPostings
+      balancingamtfirstcommodity = Mixed . take 1 $ amounts balancingamt
       showamt =
         showMixedAmount . mixedAmountSetPrecision
                   -- what should this be ?

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -329,7 +329,7 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
       (mhistoricalp,followedhistoricalsofar) =
           case esSimilarTransaction of
             Nothing                        -> (Nothing,False)
-            Just Transaction{tpostings=ps} -> 
+            Just Transaction{tpostings=ps} ->
               ( if length ps >= pnum then Just (ps !! (pnum-1)) else Nothing
               , all sameamount $ zip esPostings ps
               )
@@ -343,7 +343,7 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
   retryMsg "A valid hledger amount is required. Eg: 1, $2, 3 EUR, \"4 red apples\"." $
    parser parseAmountAndComment $
    withCompletion (amountCompleter def) $
-   defaultTo' def $ 
+   defaultTo' def $
    nonEmpty $
    linePrewritten (green $ printf "Amount  %d%s: " pnum (showDefault def)) (fromMaybe "" $ prevAmountAndCmnt `atMay` length esPostings) ""
     where
@@ -361,7 +361,7 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
         -- eof
         return (a,c)
       balancingamt = maNegate . sumPostings $ filter isReal esPostings
-      balancingamtfirstcommodity = Mixed . take 1 $ amounts balancingamt
+      balancingamtfirstcommodity = mixed . take 1 $ amounts balancingamt
       showamt =
         showMixedAmount . mixedAmountSetPrecision
                   -- what should this be ?

--- a/hledger/Hledger/Cli/Commands/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Commands/Balancesheet.hs
@@ -33,7 +33,7 @@ balancesheetSpec = CompoundBalanceCommandSpec {
       cbcsubreporttitle="Liabilities"
      ,cbcsubreportquery=journalLiabilityAccountQuery
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
-     ,cbcsubreporttransform=fmap negate
+     ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=False
      }
     ],
@@ -45,4 +45,3 @@ balancesheetmode = compoundBalanceCommandMode balancesheetSpec
 
 balancesheet :: CliOpts -> Journal -> IO ()
 balancesheet = compoundBalanceCommand balancesheetSpec
-

--- a/hledger/Hledger/Cli/Commands/Balancesheetequity.hs
+++ b/hledger/Hledger/Cli/Commands/Balancesheetequity.hs
@@ -34,14 +34,14 @@ balancesheetequitySpec = CompoundBalanceCommandSpec {
       cbcsubreporttitle="Liabilities"
      ,cbcsubreportquery=journalLiabilityAccountQuery
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
-     ,cbcsubreporttransform=fmap negate
+     ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=False
      }
     ,CBCSubreportSpec{
       cbcsubreporttitle="Equity"
      ,cbcsubreportquery=journalEquityAccountQuery
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
-     ,cbcsubreporttransform=fmap negate
+     ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=False
      }
     ],

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -89,7 +89,7 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec} j = do
 
     -- the balances to close
     (acctbals,_) = balanceReport rspec_ j
-    totalamt = sum $ map (\(_,_,_,b) -> normalise b) acctbals
+    totalamt = maSum $ map (\(_,_,_,b) -> normalise b) acctbals
 
     -- since balance assertion amounts are required to be exact, the
     -- amounts in opening/closing transactions should be too (#941, #1137)
@@ -150,7 +150,7 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec} j = do
                            , let commoditysum = (sum bs)]
         , (b, mcommoditysum) <- bs'
         ]
-      ++ [posting{paccount=openingacct, pamount=if explicit then mapMixedAmount precise (negate totalamt) else missingmixedamt} | not interleaved]
+      ++ [posting{paccount=openingacct, pamount=if explicit then mapMixedAmount precise (maNegate totalamt) else missingmixedamt} | not interleaved]
 
   -- print them
   when closing . T.putStr $ showTransaction closingtxn

--- a/hledger/Hledger/Cli/Commands/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Commands/Incomestatement.hs
@@ -24,7 +24,7 @@ incomestatementSpec = CompoundBalanceCommandSpec {
       cbcsubreporttitle="Revenues"
      ,cbcsubreportquery=journalRevenueAccountQuery
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
-     ,cbcsubreporttransform=fmap negate
+     ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=True
      }
     ,CBCSubreportSpec{

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -181,9 +181,8 @@ postingToCSV p =
     let credit = if q < 0 then showamt $ negate a_ else "" in
     let debit  = if q >= 0 then showamt a_ else "" in
     [account, amount, c, credit, debit, status, comment])
-   amounts
+   . amounts $ pamount p
   where
-    Mixed amounts = pamount p
     status = T.pack . show $ pstatus p
     account = showAccountName Nothing (ptype p) (paccount p)
     comment = T.strip $ pcomment p

--- a/hledger/Hledger/Cli/Commands/Registermatch.hs
+++ b/hledger/Hledger/Cli/Commands/Registermatch.hs
@@ -34,7 +34,7 @@ registermatch opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j =
                                  ,Nothing
                                  ,tdescription <$> ptransaction p
                                  ,p
-                                 ,0)
+                                 ,nullmixedamt)
     _ -> putStrLn "please provide one description argument."
 
 -- Identify the closest recent match for this description in the given date-sorted postings.


### PR DESCRIPTION
This is a collection of refactorings, cleanups, and performance improvements. I think that all of this should be relatively uncontroversial, though there are a couple of follow-ups this suggests which may be controversial (I have therefore broken them off into a separate PR which will follow this).

Points to consider:
- The `Num` instance for `MixedAmount` is no longer used anywhere in this codebase. We could just remove it (morally the right thing to do), but this would have a big effect on the API.
- I have gone through and replaced every usage of `sum` for `MixedAmount` with `mconcat` (or `foldMap` applied to an appropriate function), and every usage of `sumStrict` with `foldMap'` applied to an appropriate function. Since all these locations are now marked, we may want to consider if any of the non-strict versions should be made strict (or vice versa). (Edit: Apparently I've already strictified some uses of `sum`, but there may be more.)