### PR TITLE
Do not include price directives in report span unless valuing at period ends.

### DIFF
--- a/hledger/test/balance/budget.test
+++ b/hledger/test/balance/budget.test
@@ -158,11 +158,11 @@ Budget performance in 2018-01-01W01:
 
    ||  2018-01-01W01 
 ===++================
- a || 2 [7% of   30] 
+ a || 2 [3% of   70] 
  b || 2 [2% of  100] 
  c || 2 [0% of 1000] 
 ---++----------------
-   || 6 [1% of 1130] 
+   || 6 [1% of 1170] 
 
 # 7. A bounded two day budget. The end date is exclusive as usual.
 <
@@ -557,11 +557,12 @@ $ hledger bal -f- --budget -TA not:income -O csv
 "expenses:bills:f","$10","0","$10","0","$10","0"
 "Total:","$80","$370","$80","$370","$80","$370"
 
-# 28. You might expect this to show a budget goal in jan, feb, mar.
+# 28. You would expect this to show a budget goal in jan, feb, mar.
 # But by the usual report date logic, which picks the oldest and newest 
 # transaction date (1/15 and 3/15) as start and end date by default, 
 # and since "monthly" generates transactions on the 1st,
-# the january budget goal transaction is excluded.
+# the january budget goal transaction is excluded. Make sure we entend so
+# they're included.
 <
 ~ monthly in 2020
   (expenses:food)  $500
@@ -577,12 +578,12 @@ $ hledger bal -f- --budget -TA not:income -O csv
 $ hledger -f- bal --budget -M
 Budget performance in 2020Q1:
 
-               ||   Jan             Feb                   Mar 
-===============++=============================================
- <unbudgeted>  || $-400  0               $-600                
- expenses:food ||  $400  0 [0% of $500]   $600 [120% of $500] 
----------------++---------------------------------------------
-               ||     0  0 [0% of $500]      0 [  0% of $500] 
+               ||                 Jan             Feb                   Mar 
+===============++===========================================================
+ <unbudgeted>  || $-400                0               $-600                
+ expenses:food ||  $400 [80% of $500]  0 [0% of $500]   $600 [120% of $500] 
+---------------++-----------------------------------------------------------
+               ||     0 [ 0% of $500]  0 [0% of $500]      0 [  0% of $500] 
 
 # 29. Specifying the report period works around it.
 $ hledger -f- bal --budget -M date:2020q1

--- a/hledger/test/journal/valuation.test
+++ b/hledger/test/journal/valuation.test
@@ -368,23 +368,23 @@ $ hledger -f- bal -N -V -b 2000
 
 # 34. multicolumn balance report valued at cost
 $ hledger -f- bal -MTA --value=cost -b 2000
-Balance changes in 2000-01-01..2000-04-30, converted to cost:
+Balance changes in 2000Q1, converted to cost:
 
-   || Jan  Feb  Mar  Apr    Total  Average 
-===++======================================
- a || 6 B  7 B  8 B    0     21 B      5 B 
----++--------------------------------------
-   || 6 B  7 B  8 B    0     21 B      5 B 
+   || Jan  Feb  Mar    Total  Average 
+===++=================================
+ a || 6 B  7 B  8 B     21 B      7 B 
+---++---------------------------------
+   || 6 B  7 B  8 B     21 B      7 B 
 
 # 35. multicolumn balance report valued at posting date
 $ hledger -f- bal -M --value=then -b 2000
-Balance changes in 2000-01-01..2000-04-30, valued at posting date:
+Balance changes in 2000Q1, valued at posting date:
 
-   || Jan  Feb  Mar  Apr 
-===++====================
- a || 1 B  2 B  3 B    0 
----++--------------------
-   || 1 B  2 B  3 B    0 
+   || Jan  Feb  Mar 
+===++===============
+ a || 1 B  2 B  3 B 
+---++---------------
+   || 1 B  2 B  3 B 
 
 # 36. multicolumn balance report showing changes in period-end values with -T or -A
 $ hledger -f- bal -MTA --value=end -b 2000
@@ -398,23 +398,23 @@ Balance changes in 2000-01-01..2000-04-30, valued at period ends:
 
 # 37. multicolumn balance report valued at other date
 $ hledger -f- bal -MTA --value=2000-01-15 -b 2000
-Balance changes in 2000-01-01..2000-04-30, valued at 2000-01-15:
+Balance changes in 2000Q1, valued at 2000-01-15:
 
-   || Jan  Feb  Mar  Apr    Total  Average 
-===++======================================
- a || 5 B  5 B  5 B    0     15 B      4 B 
----++--------------------------------------
-   || 5 B  5 B  5 B    0     15 B      4 B 
+   || Jan  Feb  Mar    Total  Average 
+===++=================================
+ a || 5 B  5 B  5 B     15 B      5 B 
+---++---------------------------------
+   || 5 B  5 B  5 B     15 B      5 B 
 
 # 38. multicolumn balance report valued today (with today >= 2000-04-01)
 $ hledger -f- bal -M --value=now -b 2000
-Balance changes in 2000-01-01..2000-04-30, current value:
+Balance changes in 2000Q1, current value:
 
-   || Jan  Feb  Mar  Apr 
-===++====================
- a || 4 B  4 B  4 B    0 
----++--------------------
-   || 4 B  4 B  4 B    0 
+   || Jan  Feb  Mar 
+===++===============
+ a || 4 B  4 B  4 B 
+---++---------------
+   || 4 B  4 B  4 B 
 
 # 39. multicolumn balance report showing changes in period-end values (same as --value=end)
 $ hledger -f- bal -M -V -b 2000
@@ -432,14 +432,14 @@ Balance changes in 2000-01-01..2000-04-30, valued at period ends:
 # The starting balance on 2000/01/01 is 14 B (cost of the first 8A).
 # February adds 1 A costing 7 B, making 21 B.
 # March adds 1 A costing 8 B, making 29 B.
-$ hledger -f- bal -M -H -b 200002 --value=cost
-Ending balances (historical) in 2000-02-01..2000-04-30, converted to cost:
+$ hledger -f- bal -M -H -b 200002 --cost
+Ending balances (historical) in 2000-02-01..2000-03-31, converted to cost:
 
-   || 2000-02-29  2000-03-31  2000-04-30 
-===++====================================
- a ||       13 B        21 B        21 B 
----++------------------------------------
-   ||       13 B        21 B        21 B 
+   || 2000-02-29  2000-03-31 
+===++========================
+ a ||       13 B        21 B 
+---++------------------------
+   ||       13 B        21 B 
 
 # 41. multicolumn balance report with -H valued at period end.
 # The starting balance is 1 A.
@@ -458,13 +458,13 @@ Ending balances (historical) in 2000-02-01..2000-04-30, valued at period ends:
 # 42. multicolumn balance report with -H valued at other date.
 # The starting balance is 15 B (3 A valued at 2000/1/15).
 $ hledger -f- bal -M -H -b 200002 --value=2000-01-15
-Ending balances (historical) in 2000-02-01..2000-04-30, valued at 2000-01-15:
+Ending balances (historical) in 2000-02-01..2000-03-31, valued at 2000-01-15:
 
-   || 2000-02-29  2000-03-31  2000-04-30 
-===++====================================
- a ||       10 B        15 B        15 B 
----++------------------------------------
-   ||       10 B        15 B        15 B 
+   || 2000-02-29  2000-03-31 
+===++========================
+ a ||       10 B        15 B 
+---++------------------------
+   ||       10 B        15 B 
 
 # 43. multicolumn balance report with -H, valuing each period's carried-over balances at cost.
 <
@@ -531,23 +531,23 @@ P 2000/04/01 A  4 B
 
 # 46. budget report, unvalued (for reference).
 $ hledger -f- bal -M --budget
-Budget performance in 2000-01-01..2000-04-30:
+Budget performance in 2000Q1:
 
-   ||              Jan               Feb               Mar            Apr 
-===++=====================================================================
- a || 1 A [50% of 2 A]  1 A [50% of 2 A]  1 A [50% of 2 A]  0 [0% of 2 A] 
----++---------------------------------------------------------------------
-   || 1 A [50% of 2 A]  1 A [50% of 2 A]  1 A [50% of 2 A]  0 [0% of 2 A] 
+   ||              Jan               Feb               Mar 
+===++======================================================
+ a || 1 A [50% of 2 A]  1 A [50% of 2 A]  1 A [50% of 2 A] 
+---++------------------------------------------------------
+   || 1 A [50% of 2 A]  1 A [50% of 2 A]  1 A [50% of 2 A] 
 
 # 47. budget report, valued at cost.
 $ hledger -f- bal -MTA --budget --value=c
-Budget performance in 2000-01-01..2000-04-30, converted to cost:
+Budget performance in 2000Q1, converted to cost:
 
-   ||               Jan                Feb                Mar            Apr               Total            Average 
-===++===============================================================================================================
- a || 6 B [300% of 2 B]  7 B [350% of 2 B]  8 B [400% of 2 B]  0 [0% of 2 B]  21 B [262% of 8 B]  5 B [262% of 2 B] 
----++---------------------------------------------------------------------------------------------------------------
-   || 6 B [300% of 2 B]  7 B [350% of 2 B]  8 B [400% of 2 B]  0 [0% of 2 B]  21 B [262% of 8 B]  5 B [262% of 2 B] 
+   ||               Jan                Feb                Mar               Total            Average 
+===++================================================================================================
+ a || 6 B [300% of 2 B]  7 B [350% of 2 B]  8 B [400% of 2 B]  21 B [350% of 6 B]  7 B [350% of 2 B] 
+---++------------------------------------------------------------------------------------------------
+   || 6 B [300% of 2 B]  7 B [350% of 2 B]  8 B [400% of 2 B]  21 B [350% of 6 B]  7 B [350% of 2 B] 
 
 # 48. budget report, showing changes in period-end values.
 $ hledger -f- bal -MTA --budget --value=e
@@ -561,13 +561,13 @@ Budget performance in 2000-01-01..2000-04-30, valued at period ends:
 
 # 49. budget report, valued at other date.
 $ hledger -f- bal -MTA --budget --value=2000-01-15
-Budget performance in 2000-01-01..2000-04-30, valued at 2000-01-15:
+Budget performance in 2000Q1, valued at 2000-01-15:
 
-   ||               Jan                Feb                Mar             Apr               Total            Average 
-===++================================================================================================================
- a || 5 B [50% of 10 B]  5 B [50% of 10 B]  5 B [50% of 10 B]  0 [0% of 10 B]  15 B [38% of 40 B]  4 B [38% of 10 B] 
----++----------------------------------------------------------------------------------------------------------------
-   || 5 B [50% of 10 B]  5 B [50% of 10 B]  5 B [50% of 10 B]  0 [0% of 10 B]  15 B [38% of 40 B]  4 B [38% of 10 B] 
+   ||               Jan                Feb                Mar               Total            Average 
+===++================================================================================================
+ a || 5 B [50% of 10 B]  5 B [50% of 10 B]  5 B [50% of 10 B]  15 B [50% of 30 B]  5 B [50% of 10 B] 
+---++------------------------------------------------------------------------------------------------
+   || 5 B [50% of 10 B]  5 B [50% of 10 B]  5 B [50% of 10 B]  15 B [50% of 30 B]  5 B [50% of 10 B] 
 
 # 50. --value=then with --historical. The starting total is valued individually for each posting at its posting time.
 <


### PR DESCRIPTION
Addresses points raised in #1416. If it is decided that price directives should also be included for any valuation, rather than just period end, let me know and that can be adjusted.

Also gets rid of some code duplication for calculating report spans.

As a side effect, this enlarges the reportspan to encompass full intervals for budget goals. This was documented in the tests, but it's not clear whether that was desired behaviour or just documenting quirks. If we want budget goals to have a different range than the actual report, let me know and I can reinstate the old behaviour.