### PR TITLE
Performance cleanups

### DIFF
--- a/hledger-lib/Hledger/Data/AccountName.hs
+++ b/hledger-lib/Hledger/Data/AccountName.hs
@@ -41,11 +41,12 @@ module Hledger.Data.AccountName (
 )
 where
 
-import Data.List.Extra (nubSort)
+import Data.Foldable (toList)
 import qualified Data.List.NonEmpty as NE
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup ((<>))
 #endif
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Tree (Tree(..))
@@ -113,7 +114,7 @@ accountNameDrop n a
 -- ie these plus all their parent accounts up to the root.
 -- Eg: ["a:b:c","d:e"] -> ["a","a:b","a:b:c","d","d:e"]
 expandAccountNames :: [AccountName] -> [AccountName]
-expandAccountNames as = nubSort $ concatMap expandAccountName as
+expandAccountNames = toList . foldMap (S.fromList . expandAccountName)
 
 -- | "a:b:c" -> ["a","a:b","a:b:c"]
 expandAccountName :: AccountName -> [AccountName]
@@ -121,7 +122,7 @@ expandAccountName = map accountNameFromComponents . NE.tail . NE.inits . account
 
 -- | ["a:b:c","d:e"] -> ["a","d"]
 topAccountNames :: [AccountName] -> [AccountName]
-topAccountNames as = [a | a <- expandAccountNames as, accountNameLevel a == 1]
+topAccountNames = filter ((1==) . accountNameLevel) . expandAccountNames
 
 parentAccountName :: AccountName -> AccountName
 parentAccountName = accountNameFromComponents . init . accountNameComponents

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -147,7 +147,7 @@ import Control.Monad (foldM)
 import Data.Decimal (DecimalRaw(..), decimalPlaces, normalizeDecimal, roundTo)
 import Data.Default (Default(..))
 import Data.Foldable (toList)
-import Data.List (foldl', intercalate, intersperse, mapAccumL, partition)
+import Data.List (find, foldl', intercalate, intersperse, mapAccumL, partition)
 import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
@@ -637,10 +637,10 @@ normaliseMixedAmount = normaliseHelper False
 normaliseHelper :: Bool -> MixedAmount -> MixedAmount
 normaliseHelper squashprices (Mixed as)
   | missingkey `M.member` amtMap = missingmixedamt -- missingamt should always be alone, but detect it even if not
-  | M.null nonzeros= Mixed [newzero]
-  | otherwise      = Mixed $ toList nonzeros
+  | M.null nonzeros = Mixed [newzero]
+  | otherwise       = Mixed $ toList nonzeros
   where
-    newzero = maybe nullamt snd . M.lookupMin $ M.filter (not . T.null . acommodity) zeros
+    newzero = fromMaybe nullamt $ find (not . T.null . acommodity) zeros
     (zeros, nonzeros) = M.partition amountIsZero amtMap
     amtMap = foldr (\a -> M.insertWith sumSimilarAmountsUsingFirstPrice (key a) a) mempty as
     key Amount{acommodity=c,aprice=p} = (c, if squashprices then Nothing else priceKey <$> p)

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -324,11 +324,15 @@ testAmountAndTotalPrice f amt = case aprice amt of
 -- | Do this Amount and (and its total price, if it has one) appear to be zero when rendered with its
 -- display precision ?
 amountLooksZero :: Amount -> Bool
-amountLooksZero = testAmountAndTotalPrice ((0==) . amountRoundedQuantity)
+amountLooksZero = testAmountAndTotalPrice looksZero
+  where
+    looksZero Amount{aquantity=Decimal e q, astyle=AmountStyle{asprecision=p}} = case p of
+        Precision d      -> if e > d then abs q <= 5*10^(e-d-1) else q == 0
+        NaturalPrecision -> q == 0
 
 -- | Is this Amount (and its total price, if it has one) exactly zero, ignoring its display precision ?
 amountIsZero :: Amount -> Bool
-amountIsZero = testAmountAndTotalPrice ((0==) . aquantity)
+amountIsZero = testAmountAndTotalPrice (\Amount{aquantity=Decimal _ q} -> q == 0)
 
 -- | Set an amount's display precision, flipped.
 withPrecision :: Amount -> AmountPrecision -> Amount

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -151,7 +151,6 @@ import Text.Megaparsec.Custom
 
 import Hledger.Data
 import Hledger.Utils
-import Safe (headMay)
 import Text.Printf (printf)
 
 --- ** doctest setup
@@ -423,10 +422,8 @@ journalCheckCommoditiesDeclared j =
                           (linesPrepend "  " . (<>"\n") . textChomp $ showTransaction t)
       where
         mfirstundeclaredcomm =
-          headMay $ filter (not . (`elem` cs)) $ catMaybes $
-          (acommodity . baamount <$> pbalanceassertion) :
-          (map (Just . acommodity) . filter (/= missingamt) $ amounts pamount)
-        cs = journalCommoditiesDeclared j
+          find (`M.notMember` jcommodities j) . map acommodity $
+          (maybe id ((:) . baamount) pbalanceassertion) (filter (/= missingamt) $ amounts pamount)
 
 
 setYear :: Year -> JournalParser m ()

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -515,8 +515,7 @@ sortRowsLike sortedas rows = mapMaybe (`HM.lookup` rowMap) sortedas
 -- those which fork between different branches
 subaccountTallies :: [AccountName] -> HashMap AccountName Int
 subaccountTallies = foldr incrementParent mempty . expandAccountNames
-  where
-    incrementParent a = HM.insertWith (+) (parentAccountName a) 1
+  where incrementParent a = HM.insertWith (+) (parentAccountName a) 1
 
 -- | A helper: what percentage is the second mixed amount of the first ?
 -- Keeps the sign of the first amount.

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -519,8 +519,6 @@ queryFromFlags ReportOpts{..} = simplifyQuery $ And flagsq
 -- options or queries, or otherwise the earliest and latest transaction or
 -- posting dates in the journal. If no dates are specified by options/queries
 -- and the journal is empty, returns the null date span.
--- The boolean argument flags whether primary and secondary dates are considered
--- equivalently.
 reportSpan :: Journal -> ReportSpec -> DateSpan
 reportSpan = reportSpanHelper False
 

--- a/hledger-lib/Text/Megaparsec/Custom.hs
+++ b/hledger-lib/Text/Megaparsec/Custom.hs
@@ -52,8 +52,8 @@ import "base-compat-batteries" Prelude.Compat hiding (readFile)
 
 import Control.Monad.Except
 import Control.Monad.State.Strict (StateT, evalStateT)
-import Data.Foldable (asum, toList)
 import qualified Data.List.NonEmpty as NE
+import Data.Monoid (Alt(..))
 import qualified Data.Set as S
 import Data.Text (Text)
 import Text.Megaparsec
@@ -244,7 +244,7 @@ customErrorBundlePretty errBundle =
       _ -> Nothing
 
     finds :: (Foldable t) => (a -> Maybe b) -> t a -> Maybe b
-    finds f = asum . map f . toList
+    finds f = getAlt . foldMap (Alt . f)
 
 
 --- * "Final" parse errors

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -10,6 +10,7 @@ where
 import Brick.Widgets.Edit
 import Data.List ((\\), foldl', sort)
 import Data.Maybe (fromMaybe)
+import Data.Semigroup (Max(..))
 import qualified Data.Text as T
 import Data.Text.Zipper (gotoEOL)
 import Data.Time.Calendar (Day)
@@ -264,7 +265,7 @@ resetDepth = updateReportDepth (const Nothing)
 
 -- | Get the maximum account depth in the current journal.
 maxDepth :: UIState -> Int
-maxDepth UIState{ajournal=j} = maximum $ map accountNameLevel $ journalAccountNames j
+maxDepth UIState{ajournal=j} = getMax . foldMap (Max . accountNameLevel) $ journalAccountNamesDeclaredOrImplied j
 
 -- | Decrement the current depth limit towards 0. If there was no depth limit,
 -- set it to one less than the maximum account depth.

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -13,11 +13,13 @@ module Hledger.Web.Widget.AddForm
 
 import Control.Monad.State.Strict (evalStateT)
 import Data.Bifunctor (first)
+import Data.Foldable (toList)
 import Data.List (dropWhileEnd, intercalate, unfoldr)
 import Data.Maybe (isJust)
 #if !(MIN_VERSION_base(4,13,0))
 import Data.Semigroup ((<>))
 #endif
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time (Day)
@@ -27,7 +29,6 @@ import Yesod
 
 import Hledger
 import Hledger.Web.Settings (widgetFile)
-import Data.List.Extra (nubSort)
 
 addModal ::
      ( MonadWidget m
@@ -72,7 +73,7 @@ addForm j today = identifyForm "add" $ \extra -> do
   let (postRes, displayRows) = validatePostings acctRes amtRes
 
   -- bindings used in add-form.hamlet
-  let descriptions = nubSort $ journalPayeesDeclaredOrUsed j ++ journalDescriptions j
+  let descriptions = foldMap S.fromList [journalPayeesDeclaredOrUsed j, journalDescriptions j]
       journals = fst <$> jfiles j
 
   pure (validateTransaction dateRes descRes postRes, $(widgetFile "add-form"))

--- a/hledger-web/templates/add-form.hamlet
+++ b/hledger-web/templates/add-form.hamlet
@@ -1,7 +1,7 @@
 <script>
   jQuery(document).ready(function() {
     descriptionsSuggester = new Bloodhound({
-      local:#{toBloodhoundJson descriptions},
+      local:#{toBloodhoundJson (toList descriptions)},
       limit:100,
       datumTokenizer: function(d) { return [d.value]; },
       queryTokenizer: function(q) { return [q]; }

--- a/hledger/Hledger/Cli/Commands/Check/Uniqueleafnames.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Uniqueleafnames.hs
@@ -9,7 +9,6 @@ where
 
 import Data.Function (on)
 import Data.List (groupBy, sortBy)
-import Data.List.Extra (nubSort)
 import Data.Text (Text)
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup ((<>))
@@ -25,9 +24,9 @@ journalCheckUniqueleafnames j = do
   -- find all duplicate leafnames, and the full account names they appear in
   case finddupes $ journalLeafAndFullAccountNames j of
     [] -> Right ()
-    dupes -> 
+    dupes ->
       -- report the first posting that references one of them (and its position), for now
-      sequence_ $ map (checkposting dupes) $ journalPostings j
+      mapM_ (checkposting dupes) $ journalPostings j
 
 finddupes :: (Ord leaf, Eq full) => [(leaf, full)] -> [(leaf, [full])]
 finddupes leafandfullnames = zip dupLeafs dupAccountNames
@@ -39,10 +38,8 @@ finddupes leafandfullnames = zip dupLeafs dupAccountNames
           . sortBy (compare `on` fst)
 
 journalLeafAndFullAccountNames :: Journal -> [(Text, AccountName)]
-journalLeafAndFullAccountNames j = map leafAndAccountName as
+journalLeafAndFullAccountNames = map leafAndAccountName . journalAccountNamesUsed
   where leafAndAccountName a = (accountLeafName a, a)
-        ps = journalPostings j
-        as = nubSort $ map paccount ps
 
 checkposting :: [(Text,[AccountName])] -> Posting -> Either String ()
 checkposting leafandfullnames Posting{paccount,ptransaction} =

--- a/hledger/Hledger/Cli/Commands/Commodities.hs
+++ b/hledger/Hledger/Cli/Commands/Commodities.hs
@@ -12,9 +12,7 @@ module Hledger.Cli.Commands.Commodities (
  ,commodities
 ) where
 
-import Control.Monad
-import Data.List.Extra (nubSort)
-import qualified Data.Map as M
+import qualified Data.Set as S
 import qualified Data.Text.IO as T
 
 import Hledger
@@ -30,7 +28,5 @@ commoditiesmode = hledgerCommandMode
   ([], Nothing)
 
 commodities :: CliOpts -> Journal -> IO ()
-commodities _copts j = do
-  let cs = filter (/= "AUTO") $
-           nubSort $ M.keys (jcommodities j) ++ M.keys (jinferredcommodities j)
-  forM_ cs T.putStrLn
+commodities _copts =
+  mapM_ T.putStrLn . S.filter (/= "AUTO") . journalCommodities


### PR DESCRIPTION
I've broken off some of the simpler commits originally in #1491. All these commits are minor refactors, documentation fixups, and efficiency improvements which are mostly minor, but become significant with larger journals.

The only API changes are the addition of a few Set-based functions getting various journal parameters, a list of which is in e120861.