### PR TITLE
Allow showing lists of Amounts, make showing register reports and lists of postings more efficient.

### DIFF
--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -273,10 +273,10 @@ postingAsLines elideamount onelineamounts pstoalignwith p =
     -- currently prices are considered part of the amount string when right-aligning amounts
     shownAmounts
       | elideamount || null (amounts $ pamount p) = [mempty]
-      | otherwise = showMixedAmountLinesB displayopts $ pamount p
+      | otherwise = showAmountsLinesB displayopts . amounts $ pamount p
       where
-        displayopts = noColour{displayOneLine=onelineamounts, displayMinWidth = Just amtwidth, displayNormalised=False}
-        amtwidth = maximum $ 12 : map (wbWidth . showMixedAmountB displayopts{displayMinWidth=Nothing} . pamount) pstoalignwith  -- min. 12 for backwards compatibility
+        displayopts = noColour{displayOneLine=onelineamounts, displayMinWidth = Just amtwidth}
+        amtwidth = maximum $ 12 : map (wbWidth . showAmountsB displayopts{displayMinWidth=Nothing} . amounts . pamount) pstoalignwith  -- min. 12 for backwards compatibility
 
     (samelinecomment, newlinecomments) =
       case renderCommentLines (pcomment p) of []   -> ("",[])

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -91,10 +91,13 @@ postingsReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j = items
             fromMaybe (error' "postingsReport: expected a non-empty journal") $  -- PARTIAL: shouldn't happen
             reportPeriodOrJournalLastDay rspec j
 
+      -- Posting report does not use prices after valuation, so remove them.
+      displaypsnoprices = map (\(p,md) -> (removePrices p, md)) displayps
+
       -- Posting report items ready for display.
       items =
         dbg4 "postingsReport items" $
-        postingsReportItems displayps (nullposting,Nothing) whichdate mdepth startbal runningcalc startnum
+        postingsReportItems displaypsnoprices (nullposting,Nothing) whichdate mdepth startbal runningcalc startnum
         where
           -- In historical mode we'll need a starting balance, which we
           -- may be converting to value per hledger_options.m4.md "Effect

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -28,9 +28,10 @@ import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import System.Console.CmdArgs.Explicit (flagNone, flagReq)
-import Hledger.Read.CsvReader (CSV, CsvRecord, printCSV)
+import Safe (maximumDef)
 
 import Hledger
+import Hledger.Read.CsvReader (CSV, CsvRecord, printCSV)
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
 import Text.Tabular (Header(..), Properties(..))
@@ -97,15 +98,18 @@ postingsReportItemAsCsvRecord (_, _, _, p, b) = [idx,date,code,desc,acct,amt,bal
 
 -- | Render a register report as plain text suitable for console output.
 postingsReportAsText :: CliOpts -> PostingsReport -> TL.Text
-postingsReportAsText opts items =
-    TB.toLazyText . unlinesB $
-      map (postingsReportItemAsText opts amtwidth balwidth) items
+postingsReportAsText opts items = TB.toLazyText $ foldMap first3 linesWithWidths
   where
-    amtwidth = maximumStrict $ map (wbWidth . showAmt . itemamt) items
-    balwidth = maximumStrict $ map (wbWidth . showAmt . itembal) items
-    itemamt (_,_,_,Posting{pamount=a},_) = a
-    itembal (_,_,_,_,a) = a
-    showAmt = showMixedAmountB noColour{displayMinWidth=Just 12}
+    linesWithWidths = map (postingsReportItemAsText opts amtwidth balwidth) items
+    -- Tying this knot seems like it will save work, but ends up creating a big
+    -- space leak. Can we fix that leak without recalculating everything?
+    -- amtwidth = maximum $ 12 : map second3 linesWithWidths
+    -- balwidth = maximum $ 12 : map third3 linesWithWidths
+    amtwidth = maximumStrict $ 12 : widths (map itemamt items)
+    balwidth = maximumStrict $ 12 : widths (map itembal items)
+    widths = map wbWidth . concatMap (showAmountsLinesB noPrice)
+    itemamt (_,_,_,Posting{pamount=a},_) = amounts a
+    itembal (_,_,_,_,a) = amounts a
 
 -- | Render one register report line item as plain text. Layout is like so:
 -- @
@@ -129,62 +133,68 @@ postingsReportAsText opts items =
 -- has multiple commodities. Does not yet support formatting control
 -- like balance reports.
 --
-postingsReportItemAsText :: CliOpts -> Int -> Int -> PostingsReportItem -> TB.Builder
+-- Also returns the natural width (without padding) of the amount and balance
+-- fields.
+postingsReportItemAsText :: CliOpts -> Int -> Int -> PostingsReportItem -> (TB.Builder, Int, Int)
 postingsReportItemAsText opts preferredamtwidth preferredbalwidth (mdate, menddate, mdesc, p, b) =
-    render
+    (table <> TB.singleton '\n', thisamtwidth, thisbalwidth)
+  where
+    table = renderRowB def{tableBorders=False, borderSpaces=False} . Group NoLine $ map Header
       [ textCell TopLeft $ fitText (Just datewidth) (Just datewidth) True True date
       , spacerCell
       , textCell TopLeft $ fitText (Just descwidth) (Just descwidth) True True desc
       , spacerCell2
       , textCell TopLeft $ fitText (Just acctwidth) (Just acctwidth) True True acct
       , spacerCell2
-      , Cell TopRight amt
+      , Cell TopRight $ map (pad amtwidth) amt
       , spacerCell2
-      , Cell BottomRight bal
+      , Cell BottomRight $ map (pad balwidth) bal
       ]
-    where
-      render = renderRowB def{tableBorders=False, borderSpaces=False} . Group NoLine . map Header
-      spacerCell  = Cell BottomLeft [WideBuilder (TB.singleton ' ') 1]
-      spacerCell2 = Cell BottomLeft [WideBuilder (TB.fromString "  ") 2]
-      -- calculate widths
-      (totalwidth,mdescwidth) = registerWidthsFromOpts opts
-      (datewidth, date) = case (mdate,menddate) of
-                            (Just _, Just _)   -> (21, showDateSpan (DateSpan mdate menddate))
-                            (Nothing, Just _)  -> (21, "")
-                            (Just d, Nothing)  -> (10, showDate d)
-                            _                  -> (10, "")
-      (amtwidth, balwidth)
-        | shortfall <= 0 = (preferredamtwidth, preferredbalwidth)
-        | otherwise      = (adjustedamtwidth, adjustedbalwidth)
-        where
-          mincolwidth = 2 -- columns always show at least an ellipsis
-          maxamtswidth = max 0 (totalwidth - (datewidth + 1 + mincolwidth + 2 + mincolwidth + 2 + 2))
-          shortfall = (preferredamtwidth + preferredbalwidth) - maxamtswidth
-          amtwidthproportion = fromIntegral preferredamtwidth / fromIntegral (preferredamtwidth + preferredbalwidth)
-          adjustedamtwidth = round $ amtwidthproportion * fromIntegral maxamtswidth
-          adjustedbalwidth = maxamtswidth - adjustedamtwidth
+    spacerCell  = Cell BottomLeft [WideBuilder (TB.singleton ' ') 1]
+    spacerCell2 = Cell BottomLeft [WideBuilder (TB.fromString "  ") 2]
+    pad fullwidth amt = WideBuilder (TB.fromText $ T.replicate w " ") w <> amt
+      where w = fullwidth - wbWidth amt
+    -- calculate widths
+    (totalwidth,mdescwidth) = registerWidthsFromOpts opts
+    (datewidth, date) = case (mdate,menddate) of
+        (Just _, Just _)   -> (21, showDateSpan (DateSpan mdate menddate))
+        (Nothing, Just _)  -> (21, "")
+        (Just d, Nothing)  -> (10, showDate d)
+        _                  -> (10, "")
+    (amtwidth, balwidth)
+      | shortfall <= 0 = (preferredamtwidth, preferredbalwidth)
+      | otherwise      = (adjustedamtwidth, adjustedbalwidth)
+      where
+        mincolwidth = 2 -- columns always show at least an ellipsis
+        maxamtswidth = max 0 (totalwidth - (datewidth + 1 + mincolwidth + 2 + mincolwidth + 2 + 2))
+        shortfall = (preferredamtwidth + preferredbalwidth) - maxamtswidth
+        amtwidthproportion = fromIntegral preferredamtwidth / fromIntegral (preferredamtwidth + preferredbalwidth)
+        adjustedamtwidth = round $ amtwidthproportion * fromIntegral maxamtswidth
+        adjustedbalwidth = maxamtswidth - adjustedamtwidth
 
-      remaining = totalwidth - (datewidth + 1 + 2 + amtwidth + 2 + balwidth)
-      (descwidth, acctwidth)
-        | hasinterval = (0, remaining - 2)
-        | otherwise   = (w, remaining - 2 - w)
-        where
-            hasinterval = isJust menddate
-            w = fromMaybe ((remaining - 2) `div` 2) mdescwidth
+    remaining = totalwidth - (datewidth + 1 + 2 + amtwidth + 2 + balwidth)
+    (descwidth, acctwidth)
+      | hasinterval = (0, remaining - 2)
+      | otherwise   = (w, remaining - 2 - w)
+      where
+        hasinterval = isJust menddate
+        w = fromMaybe ((remaining - 2) `div` 2) mdescwidth
 
-      -- gather content
-      desc = fromMaybe "" mdesc
-      acct = parenthesise . elideAccountName awidth $ paccount p
-         where
-          (parenthesise, awidth) =
-            case ptype p of
-              BalancedVirtualPosting -> (\s -> wrap "[" "]" s, acctwidth-2)
-              VirtualPosting         -> (\s -> wrap "(" ")" s, acctwidth-2)
-              _                      -> (id,acctwidth)
-          wrap a b x = a <> x <> b
-      amt = showAmountsLinesB (dopts amtwidth) . (\x -> if null x then [nullamt] else x) . amounts $ pamount p
-      bal = showAmountsLinesB (dopts balwidth) $ amounts b
-      dopts w = noPrice{displayColour=color_ . rsOpts $ reportspec_ opts, displayMinWidth=Just w, displayMaxWidth=Just w}
+    -- gather content
+    desc = fromMaybe "" mdesc
+    acct = parenthesise . elideAccountName awidth $ paccount p
+      where
+        (parenthesise, awidth) = case ptype p of
+            BalancedVirtualPosting -> (wrap "[" "]", acctwidth-2)
+            VirtualPosting         -> (wrap "(" ")", acctwidth-2)
+            _                      -> (id,acctwidth)
+    amt = showAmountsLinesB dopts . (\x -> if null x then [nullamt] else x) . amounts $ pamount p
+    bal = showAmountsLinesB dopts $ amounts b
+    dopts = noPrice{displayColour=color_ . rsOpts $ reportspec_ opts}
+    -- Since this will usually be called with the knot tied between this(amt|bal)width and
+    -- preferred(amt|bal)width, make sure the former do not depend on the latter to avoid loops.
+    thisamtwidth = maximumDef 0 $ map wbWidth amt
+    thisbalwidth = maximumDef 0 $ map wbWidth bal
 
 -- tests
 


### PR DESCRIPTION
These are the commits from #1491 concerning the `showMixedAmountB` function, and splitting it into `showMixedAmountB` and `showAmountsB`.

It continues to be the case that most users should continue using the simple `MixedAmount -> String` variants, and for those who want more control, `showMixedAmountB` is almost always what you want. `showAmountsB` is for when you have a list of amounts which you do not want normalised before being shown, as in when you're showing a transaction or posting (in which case, you should probably be using `postingsAsLines`, which calls this internally). `showAmountsLinesB` is a minor variant which gives you a builder for each line (since we're using builders for efficiency, we cannot call T.lines without strictifying).