### PR TITLE
lib,test: Simplify the JSON representation of AmountPrecision.

### DIFF
--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -10,6 +10,7 @@ JSON instances. Should they be in Types.hs ?
 {-# LANGUAGE DeriveGeneric       #-}
 --{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE LambdaCase          #-}
 --{-# LANGUAGE NamedFieldPuns #-}
 --{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -89,7 +90,13 @@ instance ToJSON Decimal where
 
 instance ToJSON Amount
 instance ToJSON AmountStyle
-instance ToJSON AmountPrecision
+
+-- Use the same JSON serialisation as Maybe Word8
+instance ToJSON AmountPrecision where
+  toJSON = toJSON . \case
+    Precision n      -> Just n
+    NaturalPrecision -> Nothing
+
 instance ToJSON Side
 instance ToJSON DigitGroupStyle
 instance ToJSON MixedAmount
@@ -160,7 +167,11 @@ instance FromJSON Status
 instance FromJSON GenericSourcePos
 instance FromJSON Amount
 instance FromJSON AmountStyle
-instance FromJSON AmountPrecision
+
+-- Use the same JSON serialisation as Maybe Word8
+instance FromJSON AmountPrecision where
+  parseJSON = fmap (maybe NaturalPrecision Precision) . parseJSON
+
 instance FromJSON Side
 instance FromJSON DigitGroupStyle
 instance FromJSON MixedAmount

--- a/hledger/test/json.test
+++ b/hledger/test/json.test
@@ -1,0 +1,115 @@
+<
+2019-1-1
+  (a)  1.0 AAA
+
+# 1. Test the json output for register reports
+$ hledger -f- reg --output-format=json
+[
+    [
+        "2019-01-01",
+        null,
+        "",
+        {
+            "pbalanceassertion": null,
+            "pstatus": "Unmarked",
+            "pamount": [
+                {
+                    "aprice": null,
+                    "acommodity": "AAA",
+                    "aquantity": {
+                        "floatingPoint": 1,
+                        "decimalPlaces": 10,
+                        "decimalMantissa": 10000000000
+                    },
+                    "aismultiplier": false,
+                    "astyle": {
+                        "ascommodityside": "R",
+                        "asdigitgroups": null,
+                        "ascommodityspaced": true,
+                        "asprecision": 1,
+                        "asdecimalpoint": "."
+                    }
+                }
+            ],
+            "ptransaction_": "1",
+            "paccount": "a",
+            "pdate": null,
+            "ptype": "VirtualPosting",
+            "pcomment": "",
+            "pdate2": null,
+            "ptags": [],
+            "poriginal": null
+        },
+        [
+            {
+                "aprice": null,
+                "acommodity": "AAA",
+                "aquantity": {
+                    "floatingPoint": 1,
+                    "decimalPlaces": 10,
+                    "decimalMantissa": 10000000000
+                },
+                "aismultiplier": false,
+                "astyle": {
+                    "ascommodityside": "R",
+                    "asdigitgroups": null,
+                    "ascommodityspaced": true,
+                    "asprecision": 1,
+                    "asdecimalpoint": "."
+                }
+            }
+        ]
+    ]
+]
+
+# 2. Test the json output for balance reports
+$ hledger -f- bal --output-format=json
+[
+    [
+        [
+            "a",
+            "a",
+            0,
+            [
+                {
+                    "aprice": null,
+                    "acommodity": "AAA",
+                    "aquantity": {
+                        "floatingPoint": 1,
+                        "decimalPlaces": 10,
+                        "decimalMantissa": 10000000000
+                    },
+                    "aismultiplier": false,
+                    "astyle": {
+                        "ascommodityside": "R",
+                        "asdigitgroups": null,
+                        "ascommodityspaced": true,
+                        "asprecision": 1,
+                        "asdecimalpoint": "."
+                    }
+                }
+            ]
+        ]
+    ],
+    [
+        {
+            "aprice": null,
+            "acommodity": "AAA",
+            "aquantity": {
+                "floatingPoint": 1,
+                "decimalPlaces": 10,
+                "decimalMantissa": 10000000000
+            },
+            "aismultiplier": false,
+            "astyle": {
+                "ascommodityside": "R",
+                "asdigitgroups": null,
+                "ascommodityspaced": true,
+                "asprecision": 1,
+                "asdecimalpoint": "."
+            }
+        }
+    ]
+]
+
+>=0


### PR DESCRIPTION
It now uses the same JSON representation as Maybe Word8. This means that the JSON serialisation is now broadly compatible with that used before the commit f6fa76bba7530af3be825445a1097ae42498b1cd, differing only in how it handles numbers outside Word8 and that it can now produce null for NaturalPrecision.

Addresses #1360.