### PR TITLE
Tolerate spaces in amount fields in CSV files

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -1182,6 +1182,8 @@ type CsvAmountString = Text
 -- ""
 simplifySign :: CsvAmountString -> CsvAmountString
 simplifySign amtstr
+  | Just (' ',t) <- T.uncons amtstr = simplifySign t
+  | Just (t,' ') <- T.unsnoc amtstr = simplifySign t
   | Just ('(',t) <- T.uncons amtstr, Just (amt,')') <- T.unsnoc t = simplifySign $ negateStr amt
   | Just ('-',b) <- T.uncons amtstr, Just ('(',t) <- T.uncons b, Just (amt,')') <- T.unsnoc t = simplifySign amt
   | Just ('-',m) <- T.uncons amtstr, Just ('-',amt) <- T.uncons m = amt

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -960,6 +960,42 @@ $  ./csvtest.sh --alias expenses=FOO
 
 >=
 
+# 48. Allow for whitespace in csv amounts
+<
+2009-09-10,+ $20
+2009-09-10, $ +30
+2009-09-10, ( 40 ) 
+2009-09-10, $ - 50 
+2009-09-10,- $60 
+
+RULES
+fields date, amount
+date-format %Y-%m-%d
+account1 assets:myacct
+
+$  ./csvtest.sh
+2009-09-10
+    assets:myacct              $20
+    income:unknown            $-20
+
+2009-09-10
+    assets:myacct              $30
+    income:unknown            $-30
+
+2009-09-10
+    assets:myacct                -40
+    expenses:unknown              40
+
+2009-09-10
+    assets:myacct               $-50
+    expenses:unknown             $50
+
+2009-09-10
+    assets:myacct               $-60
+    expenses:unknown             $60
+
+>=0
+
 ## . 
 #<
 #$  ./csvtest.sh


### PR DESCRIPTION
This allows the sign simplification to ignore leading and trailing spaces. This is especially important for leading spaces where a leading space causes the eventual amountp parser to fail.

Example problem input now allowed: `"+ $1"`