### PR TITLE
bal: keep csv column and row labels consistently lower case

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -477,9 +477,9 @@ multiBalanceReportAsCsv :: ReportOpts -> MultiBalanceReport -> CSV
 multiBalanceReportAsCsv opts@ReportOpts{average_, row_total_}
     (PeriodicReport colspans items (PeriodicReportRow _ coltotals tot avg)) =
   maybetranspose $
-  ("Account" : map showDateSpan colspans
-   ++ ["Total"   | row_total_]
-   ++ ["Average" | average_]
+  ("account" : map showDateSpan colspans
+   ++ ["total"   | row_total_]
+   ++ ["average" | average_]
   ) :
   [displayName a :
    map (wbToText . showMixedAmountB oneLine)
@@ -490,7 +490,7 @@ multiBalanceReportAsCsv opts@ReportOpts{average_, row_total_}
   ++
   if no_total_ opts
   then []
-  else ["Total:" :
+  else ["total" :
         map (wbToText . showMixedAmountB oneLine) (
           coltotals
           ++ [tot | row_total_]

--- a/hledger/test/balance/transpose.test
+++ b/hledger/test/balance/transpose.test
@@ -13,12 +13,12 @@ Balance changes in 2012-12-01..2013-03-31:
 
 hledger -f balance-multicol.journal balance -M -A -O csv --transpose
 >>>
-"Account","assets","assets:cash","assets:checking","Total:"
+"account","assets","assets:cash","assets:checking","total"
 "2012-12","0","0","10","10"
 "2013-01","0","0","0","0"
 "2013-02","1","1","0","2"
 "2013-03","0","0","1","1"
-"Average","0","0","3","3"
+"average","0","0","3","3"
 >>>=0
 
 


### PR DESCRIPTION
It was reported on #hledger that bal -O csv capitalises "account"
differently for single and multi-period reports. All lower case seems
to be the most common, so I have dropped the capitalisation. Also
the trailing colon from --transpose's "total:".
