### PR TITLE
lib,cli: Fix ledgerDateSpan, so that in takes transaction dates into account.

### DIFF
--- a/hledger-lib/Hledger/Data/Ledger.hs
+++ b/hledger-lib/Hledger/Data/Ledger.hs
@@ -31,9 +31,7 @@ import Text.Printf
 import Hledger.Utils.Test
 import Hledger.Data.Types
 import Hledger.Data.Account
-import Hledger.Data.Dates (daysSpan)
 import Hledger.Data.Journal
-import Hledger.Data.Posting (postingDate)
 import Hledger.Query
 
 
@@ -94,7 +92,7 @@ ledgerPostings = journalPostings . ljournal
 -- | The (fully specified) date span containing all the ledger's (filtered) transactions,
 -- or DateSpan Nothing Nothing if there are none.
 ledgerDateSpan :: Ledger -> DateSpan
-ledgerDateSpan = daysSpan . map postingDate . ledgerPostings
+ledgerDateSpan = journalDateSpanBothDates . ljournal
 
 -- | All commodities used in this ledger.
 ledgerCommodities :: Ledger -> [CommoditySymbol]

--- a/hledger/Hledger/Cli/Commands/Stats.hs
+++ b/hledger/Hledger/Cli/Commands/Stats.hs
@@ -46,7 +46,7 @@ stats opts@CliOpts{reportspec_=rspec} j = do
   d <- getCurrentDay
   let q = rsQuery rspec
       l = ledgerFromJournal q j
-      reportspan = (ledgerDateSpan l) `spanDefaultsFrom` (queryDateSpan False q)
+      reportspan = ledgerDateSpan l `spanDefaultsFrom` queryDateSpan False q
       intervalspans = splitSpan (interval_ $ rsOpts rspec) reportspan
       showstats = showLedgerStats l d
       s = intercalate "\n" $ map showstats intervalspans


### PR DESCRIPTION
Fixes #772.

There may be a conversation to be had here on the value of `Hledger.Data.Ledger`. Aside from `ledgerFromJournal`, these functions are only used in two places in our codebase. As seen here, this kind of little-used functionality can lead to bugs. We could just trim out all functions aside from `ledgerFromJournal`, but this will affect the API.