### PR TITLE
;lib,cli: Add Functor and Foldable instances for Journal and other types

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 {-|
 
@@ -1640,4 +1642,10 @@ tests_Journal = tests "Journal" [
 
      ]
 
+    , tests "foldable" $ [
+      test "transactionsPostings" $ do
+        assertEqual "" (journalPostings samplejournal) ((toList <=< toList) samplejournal)
+      ,test "transactionsPostingsMixedAmount" $ do
+        assertEqual "" "0" (showMixedAmount $ sum $ (toList <=< toList <=< toList) samplejournal)
+      ]
   ]

--- a/hledger/Hledger/Cli/Anon.hs
+++ b/hledger/Hledger/Cli/Anon.hs
@@ -6,6 +6,9 @@ Note that there is no clear way to anonymize numbers.
 
 -}
 
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
 module Hledger.Cli.Anon
     ( Anon(..)
     , anonAccount


### PR DESCRIPTION
This redefines `Journal`, `Transaction`, `Posting` and `MixedAmount` as synonyms `Journal' Transaction`, `Transaction' Posting`, `Posting' MixedAmount` and `MixedAmount' Amount`, respectively.

`Journal'` and `Transaction'` get `Foldable` and `Functor` instances, `Posting'` gets `Functor` and `MixedAmount'` gets `Foldable`.

This allows using much of Haskell's base libraries for manipulating journals. Get all transactions? `toList`. Get all postings in a transaction? `toList`. Transform a Posting's amount? `fmap`. Get the list of amounts in the whole journal? `join . map (toList . pamount) . (toList <=< toList)`. Well okay, that last one isn't that practical.