### PR TITLE
control color in debug output

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -48,15 +48,12 @@ where
 
 import Control.Applicative ((<|>))
 import Data.List.Extra (nubSort)
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day, addDays)
 import Data.Default (Default(..))
 import Safe (headMay, lastDef, lastMay, maximumMay)
 
-import System.Console.ANSI (hSupportsANSIColor)
-import System.Environment (lookupEnv)
-import System.IO (stdout)
 import Text.Megaparsec.Custom
 
 import Hledger.Data
@@ -181,11 +178,8 @@ defreportopts = ReportOpts
 rawOptsToReportOpts :: RawOpts -> IO ReportOpts
 rawOptsToReportOpts rawopts = do
     d <- getCurrentDay
-    no_color <- isJust <$> lookupEnv "NO_COLOR"
-    supports_color <- hSupportsANSIColor stdout
 
-    let colorflag    = stringopt "color" rawopts
-        formatstring = T.pack <$> maybestringopt "format" rawopts
+    let formatstring = T.pack <$> maybestringopt "format" rawopts
         querystring  = map T.pack $ listofstringopt "args" rawopts  -- doesn't handle an arg like "" right
         (costing, valuation) = valuationTypeFromRawOpts rawopts
 
@@ -222,10 +216,7 @@ rawOptsToReportOpts rawopts = do
           ,percent_     = boolopt "percent" rawopts
           ,invert_      = boolopt "invert" rawopts
           ,pretty_tables_ = boolopt "pretty-tables" rawopts
-          ,color_       = and [not no_color
-                              ,not $ colorflag `elem` ["never","no"]
-                              ,colorflag `elem` ["always","yes"] || supports_color
-                              ]
+          ,color_       = useColor -- a lower-level helper
           ,forecast_    = forecastPeriodFromRawOpts d rawopts
           ,transpose_   = boolopt "transpose" rawopts
           }

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -216,7 +216,7 @@ rawOptsToReportOpts rawopts = do
           ,percent_     = boolopt "percent" rawopts
           ,invert_      = boolopt "invert" rawopts
           ,pretty_tables_ = boolopt "pretty-tables" rawopts
-          ,color_       = useColor -- a lower-level helper
+          ,color_       = useColorOnStdout -- a lower-level helper
           ,forecast_    = forecastPeriodFromRawOpts d rawopts
           ,transpose_   = boolopt "transpose" rawopts
           }

--- a/hledger-lib/Hledger/Utils/Debug.hs
+++ b/hledger-lib/Hledger/Utils/Debug.hs
@@ -170,11 +170,14 @@ debugLevel = case snd $ break (=="--debug") args of
 -- | Check the IO environment to see if ANSI colour codes should be used on stdout.
 -- This is done using unsafePerformIO so it can be used anywhere, eg in 
 -- low-level debug utilities, which should be ok since we are just reading.
--- (When running code in GHCI, this module must be reloaded to see a change.)
 -- The logic is: use color if 
 -- a NO_COLOR environment variable is not defined
 -- and the program was not started with --color=no|never
 -- and stdout supports ANSI color, or the program was started with --color=yes|always.
+-- Caveats:
+-- Existence of the NO_COLOR variable, and whether the output handle supports ANSI color,
+-- might not be checked at program startup, but rather when this is (first?) evaluated.
+-- When running code in GHCI, this module must be reloaded to see a change.
 -- {-# OPTIONS_GHC -fno-cse #-}
 -- {-# NOINLINE useColorOnStdout #-}
 useColorOnStdout :: Bool

--- a/hledger-lib/Hledger/Utils/Debug.hs
+++ b/hledger-lib/Hledger/Utils/Debug.hs
@@ -116,12 +116,14 @@ import System.Console.ANSI (hSupportsANSIColor)
 import System.IO (stdout)
 
 prettyopts = 
-    defaultOutputOptionsDarkBg
-    -- defaultOutputOptionsLightBg
-    -- defaultOutputOptionsNoColor
+  baseopts
     { outputOptionsIndentAmount=2
     , outputOptionsCompact=True
     }
+  where
+    baseopts
+      | useColor  = defaultOutputOptionsDarkBg -- defaultOutputOptionsLightBg
+      | otherwise = defaultOutputOptionsNoColor
 
 -- | Pretty print. Generic alias for pretty-simple's pPrint.
 pprint :: Show a => a -> IO ()


### PR DESCRIPTION
- lib: useColor, colorOption helpers usable anywhere
- lib: debug output now respects --color/NO_COLOR/ANSI support
- lib: debug output checks for color support on stderr, not stdout

I was capturing debug output into files for comparison, and couldn't turn off the ANSI codes. Debug output is part of "output" and users expect to control color there too. 

This adds a few more functions using unsafePerformIO to read IO state, similar to `debugLevel` but a little more adventurous - these ones check existence of an environment variable, and I suppose not necessarily at program startup. I think this usage is safe enough though. Also, I blindly copied the no-cse and NOINLINE pragmas, hopefully in a useful way.

Related: https://hledger.org/hledger.html#general-options -> `--color`