### PR TITLE
ui: In account screen, elide amounts which go past the specified width.

### DIFF
--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -133,12 +133,11 @@ data Screen =
 
 -- | An item in the accounts screen's list of accounts and balances.
 data AccountsScreenItem = AccountsScreenItem {
-   asItemIndentLevel        :: Int          -- ^ indent level
-  ,asItemAccountName        :: AccountName  -- ^ full account name
-  ,asItemDisplayAccountName :: AccountName  -- ^ full or short account name to display
-  ,asItemRenderedAmounts    :: [String]     -- ^ rendered amounts
-  }
-  deriving (Show)
+   asItemIndentLevel        :: Int                -- ^ indent level
+  ,asItemAccountName        :: AccountName        -- ^ full account name
+  ,asItemDisplayAccountName :: AccountName        -- ^ full or short account name to display
+  ,asItemMixedAmount        :: Maybe MixedAmount  -- ^ mixed amount to display
+  } deriving (Show)
 
 -- | An item in the register screen's list of transactions in the current account.
 data RegisterScreenItem = RegisterScreenItem {


### PR DESCRIPTION
Also leave at least 15 spaces for account names.

This addresses #1474 , and goes some way to addressing #1478.