### PR TITLE
lib,cli: Allow adjusting the maximum width used for columns of MultiBalanceReports using the --width flag.

### DIFF
--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -54,6 +54,8 @@ module Hledger.Cli.CliOptions (
   replaceNumericFlags,
   -- | For register:
   registerWidthsFromOpts,
+  -- | For balance:
+  balanceWidthFromOpts,
 
   -- * Other utils
   hledgerAddons,
@@ -638,6 +640,15 @@ registerWidthsFromOpts CliOpts{width_=Just s}  =
           descwidth <- optional (char ',' >> read `fmap` some digitChar)
           eof
           return (totalwidth, descwidth)
+
+-- for balance:
+
+-- | Get the width in characters to use for the balance command's amount widths.
+-- This comes from the --width option.
+-- Will raise a parse error for a malformed --width argument.
+balanceWidthFromOpts :: CliOpts -> Maybe Int
+balanceWidthFromOpts CliOpts{width_=Nothing} = Nothing
+balanceWidthFromOpts copts@CliOpts{width_=Just _} = Just $ widthFromOpts copts
 
 -- Other utils
 

--- a/hledger/test/balance/format.test
+++ b/hledger/test/balance/format.test
@@ -1,3 +1,4 @@
+# 1. Test basic format string
 $ hledger -f sample.journal balance --tree --format="%30(account) %-.20(total)"
 >
                         assets $-1
@@ -19,14 +20,14 @@ $ hledger -f sample.journal balance --tree --format="%30(account) %-.20(total)"
     a  -500 AAA
     b
 
-# Test too-small maximum balance widths
+# 2. Test too-small maximum balance widths
 $ hledger -f - balance -N --format="%7.7(total) %(account)"
 >
 1 mor.. a
 500 AAA b
 >= 0
 
-# Check that maximum balance widths works with colour
+# 3. Check that maximum balance widths works with colour
 $ hledger -f - balance -N --format="%8.8(total) %(account)" --color=yes
 >
 [31m-500 AAA[m a

--- a/hledger/test/balance/multicommodity.test
+++ b/hledger/test/balance/multicommodity.test
@@ -17,7 +17,17 @@ Balance changes in 2020:
 ---++-------------------------------
    || 1.00A, 1.00B, 1.00C, 3 more.. 
 
-# 2. Unless --no-elide is used.
+# 2. Can change the width used with the --width flag
+$ hledger -f- bal -Y -w 25
+Balance changes in 2020:
+
+   ||                   2020 
+===++========================
+ a || 1.00A, 1.00B, 4 more.. 
+---++------------------------
+   || 1.00A, 1.00B, 4 more.. 
+
+# 3. If --no-elide is used, display all.
 $ hledger -f- bal -Y --no-elide
 Balance changes in 2020:
 
@@ -48,7 +58,7 @@ Balance changes in 2020:
     ea50865f:3bfb86b7:bf72f75a:a7cad1ac       C$ -26.00
     ea50865f:325566ed:216fec7e:7b433efb         C$ 1.44
 
-# 3. Make sure all amounts up to the largest fit
+# 4. Make sure all amounts up to the largest fit
 $ hledger -f- bal -Y --color=yes
 Balance changes in 2020:
 


### PR DESCRIPTION
This re-uses the --width flag, which is not currently used in the balance reports or compound balance reports, to control the maximum width of columns. This allows you to make them larger if you have a lot of commodities you want to display.