### PR TITLE
Add option to disable automatic price inferral in unbalanced multicommodity transactions.

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -722,7 +722,7 @@ journalModifyTransactions d j =
 -- | Check any balance assertions in the journal and return an error message
 -- if any of them fail (or if the transaction balancing they require fails).
 journalCheckBalanceAssertions :: Journal -> Maybe String
-journalCheckBalanceAssertions = either Just (const Nothing) . journalBalanceTransactions True
+journalCheckBalanceAssertions = either Just (const Nothing) . journalBalanceTransactions def
 
 -- "Transaction balancing", including: inferring missing amounts,
 -- applying balance assignments, checking transaction balancedness,
@@ -822,13 +822,14 @@ updateTransactionB t = withRunningBalance $ \BalancingState{bsTransactions}  ->
 --
 -- This does multiple things at once because amount inferring, balance
 -- assignments, balance assertions and posting dates are interdependent.
-journalBalanceTransactions :: Bool -> Journal -> Either String Journal
-journalBalanceTransactions assrt j' =
+journalBalanceTransactions :: BalancingOpts -> Journal -> Either String Journal
+journalBalanceTransactions bopts' j' =
   let
     -- ensure transactions are numbered, so we can store them by number
     j@Journal{jtxns=ts} = journalNumberTransactions j'
     -- display precisions used in balanced checking
     styles = Just $ journalCommodityStyles j
+    bopts = bopts'{commodity_styles_=styles}
     -- balance assignments will not be allowed on these
     txnmodifieraccts = S.fromList $ map paccount $ concatMap tmpostingrules $ jtxnmodifiers j
   in
@@ -845,7 +846,7 @@ journalBalanceTransactions assrt j' =
         -- and leaving the others for later. The balanced ones are split into their postings.
         -- The postings and not-yet-balanced transactions remain in the same relative order.
         psandts :: [Either Posting Transaction] <- fmap concat $ forM ts $ \case
-          t | null $ assignmentPostings t -> case balanceTransaction styles t of
+          t | null $ assignmentPostings t -> case balanceTransaction bopts t of
               Left  e  -> throwError e
               Right t' -> do
                 lift $ writeArray balancedtxns (tindex t') t'
@@ -855,7 +856,7 @@ journalBalanceTransactions assrt j' =
         -- 2. Sort these items by date, preserving the order of same-day items,
         -- and step through them while keeping running account balances,
         runningbals <- lift $ H.newSized (length $ journalAccountNamesUsed j)
-        flip runReaderT (BalancingState styles txnmodifieraccts assrt runningbals balancedtxns) $ do
+        flip runReaderT (BalancingState styles txnmodifieraccts (not $ ignore_assertions_ bopts) runningbals balancedtxns) $ do
           -- performing balance assignments in, and balancing, the remaining transactions,
           -- and checking balance assertions as each posting is processed.
           void $ mapM' balanceTransactionAndCheckAssertionsB $ sortOn (either postingDate tdate) psandts
@@ -884,7 +885,7 @@ balanceTransactionAndCheckAssertionsB (Right t@Transaction{tpostings=ps}) = do
   ps' <- mapM (addOrAssignAmountAndCheckAssertionB . postingStripPrices) ps
   -- infer any remaining missing amounts, and make sure the transaction is now fully balanced
   styles <- R.reader bsStyles
-  case balanceTransactionHelper styles t{tpostings=ps'} of
+  case balanceTransactionHelper balancingOpts{commodity_styles_=styles} t{tpostings=ps'} of
     Left err -> throwError err
     Right (t', inferredacctsandamts) -> do
       -- for each amount just inferred, update the running balance
@@ -1409,7 +1410,7 @@ journalApplyAliases aliases j =
 --     liabilities:debts  $1
 --     assets:bank:checking
 --
-Right samplejournal = journalBalanceTransactions False $
+Right samplejournal = journalBalanceTransactions def $
          nulljournal
          {jtxns = [
            txnTieKnot $ Transaction {
@@ -1552,7 +1553,7 @@ tests_Journal = tests "Journal" [
   ,tests "journalBalanceTransactions" [
 
      test "balance-assignment" $ do
-      let ej = journalBalanceTransactions True $
+      let ej = journalBalanceTransactions def $
             --2019/01/01
             --  (a)            = 1
             nulljournal{ jtxns = [
@@ -1563,7 +1564,7 @@ tests_Journal = tests "Journal" [
       (jtxns j & head & tpostings & head & pamount & amountsRaw) @?= [num 1]
 
     ,test "same-day-1" $ do
-      assertRight $ journalBalanceTransactions True $
+      assertRight $ journalBalanceTransactions def $
             --2019/01/01
             --  (a)            = 1
             --2019/01/01
@@ -1574,7 +1575,7 @@ tests_Journal = tests "Journal" [
             ]}
 
     ,test "same-day-2" $ do
-      assertRight $ journalBalanceTransactions True $
+      assertRight $ journalBalanceTransactions def $
             --2019/01/01
             --    (a)                  2 = 2
             --2019/01/01
@@ -1592,7 +1593,7 @@ tests_Journal = tests "Journal" [
             ]}
 
     ,test "out-of-order" $ do
-      assertRight $ journalBalanceTransactions True $
+      assertRight $ journalBalanceTransactions def $
             --2019/1/2
             --  (a)    1 = 2
             --2019/1/1

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -118,7 +118,7 @@ parse iopts f t = do
               -- apply any command line account aliases. Can fail with a bad replacement pattern.
               in case journalApplyAliases (aliasesFromOpts iopts) pj' of
                   Left e -> throwError e
-                  Right pj'' -> journalFinalise iopts{ignore_assertions_=True} f t pj''
+                  Right pj'' -> journalFinalise iopts{balancingopts_=(balancingopts_ iopts){ignore_assertions_=True}} f t pj''
 
 --- ** reading rules files
 --- *** rules utilities

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -76,7 +76,7 @@ balanceReport rspec j = (rows, total)
 -- tests
 
 Right samplejournal2 =
-  journalBalanceTransactions False
+  journalBalanceTransactions balancingOpts
     nulljournal{
       jtxns = [
         txnTieKnot Transaction{

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -71,8 +71,8 @@ type BudgetDisplayCell = ((Text, Int), Maybe ((Text, Int), Maybe (Text, Int)))
 -- from all periodic transactions, calculate actual balance changes 
 -- from the regular transactions, and compare these to get a 'BudgetReport'.
 -- Unbudgeted accounts may be hidden or renamed (see journalWithBudgetAccountNames).
-budgetReport :: ReportSpec -> Bool -> DateSpan -> Journal -> BudgetReport
-budgetReport rspec assrt reportspan j = dbg4 "sortedbudgetreport" budgetreport
+budgetReport :: ReportSpec -> BalancingOpts -> DateSpan -> Journal -> BudgetReport
+budgetReport rspec bopts reportspan j = dbg4 "sortedbudgetreport" budgetreport
   where
     -- Budget report demands ALTree mode to ensure subaccounts and subaccount budgets are properly handled
     -- and that reports with and without --empty make sense when compared side by side
@@ -87,7 +87,7 @@ budgetReport rspec assrt reportspan j = dbg4 "sortedbudgetreport" budgetreport
       concatMap (`runPeriodicTransaction` reportspan) $
       jperiodictxns j
     actualj = journalWithBudgetAccountNames budgetedaccts showunbudgeted j
-    budgetj = journalAddBudgetGoalTransactions assrt ropts reportspan j
+    budgetj = journalAddBudgetGoalTransactions bopts ropts reportspan j
     actualreport@(PeriodicReport actualspans _ _) =
         dbg5 "actualreport" $ multiBalanceReport rspec{rsOpts=ropts{empty_=True}} actualj
     budgetgoalreport@(PeriodicReport _ budgetgoalitems budgetgoaltotals) =
@@ -105,9 +105,9 @@ budgetReport rspec assrt reportspan j = dbg4 "sortedbudgetreport" budgetreport
 -- Budget goal transactions are similar to forecast transactions except
 -- their purpose and effect is to define balance change goals, per account and period,
 -- for BudgetReport.
-journalAddBudgetGoalTransactions :: Bool -> ReportOpts -> DateSpan -> Journal -> Journal
-journalAddBudgetGoalTransactions assrt _ropts reportspan j =
-  either error' id $ journalBalanceTransactions assrt j{ jtxns = budgetts }  -- PARTIAL:
+journalAddBudgetGoalTransactions :: BalancingOpts -> ReportOpts -> DateSpan -> Journal -> Journal
+journalAddBudgetGoalTransactions bopts _ropts reportspan j =
+  either error' id $ journalBalanceTransactions bopts j{ jtxns = budgetts }  -- PARTIAL:
   where
     budgetspan = dbg3 "budget span" $ reportspan
     budgetts =

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -167,7 +167,7 @@ asDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
           <+> borderQueryStr (T.unpack . T.unwords . map textQuoteIfNeeded $ querystring_ ropts)
           <+> borderDepthStr mdepth
           <+> str (" ("++curidx++"/"++totidx++")")
-          <+> (if ignore_assertions_ $ inputopts_ copts
+          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts
                then withAttr ("border" <> "query") (str " ignoring balance assertions")
                else str "")
           where

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -198,7 +198,7 @@ enableForecastPreservingPeriod ui copts@CliOpts{reportspec_=rspec@ReportSpec{rsO
 -- are disabled, do nothing.
 uiCheckBalanceAssertions :: Day -> UIState -> UIState
 uiCheckBalanceAssertions d ui@UIState{aopts=UIOpts{cliopts_=copts}, ajournal=j}
-  | ignore_assertions_ $ inputopts_ copts = ui
+  | ignore_assertions_ . balancingopts_ $ inputopts_ copts = ui
   | otherwise =
     case journalCheckBalanceAssertions j of
       Nothing  -> ui

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -220,7 +220,7 @@ rsDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
           <+> str "/"
           <+> total
           <+> str ")"
-          <+> (if ignore_assertions_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
+          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
           where
             togglefilters =
               case concat [

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -97,7 +97,7 @@ tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{
           <+> togglefilters
           <+> borderQueryStr (unwords . map (quoteIfNeeded . T.unpack) $ querystring_ ropts)
           <+> str (" in "++T.unpack (replaceHiddenAccountsNameWith "All" acct)++")")
-          <+> (if ignore_assertions_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
+          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
           where
             togglefilters =
               case concat [

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -187,8 +187,8 @@ toggleReal ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspe
 
 -- | Toggle the ignoring of balance assertions.
 toggleIgnoreBalanceAssertions :: UIState -> UIState
-toggleIgnoreBalanceAssertions ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=iopts}}} =
-  ui{aopts=uopts{cliopts_=copts{inputopts_=iopts{ignore_assertions_=not $ ignore_assertions_ iopts}}}}
+toggleIgnoreBalanceAssertions ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=iopts@InputOpts{balancingopts_=bopts}}}} =
+  ui{aopts=uopts{cliopts_=copts{inputopts_=iopts{balancingopts_=bopts{ignore_assertions_=not $ ignore_assertions_ bopts}}}}}
 
 -- | Step through larger report periods, up to all.
 growReportPeriod :: Day -> UIState -> UIState

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -122,7 +122,7 @@ validateTransaction ::
   -> FormResult Transaction
 validateTransaction dateRes descRes postingsRes =
   case makeTransaction <$> dateRes <*> descRes <*> postingsRes of
-    FormSuccess txn -> case balanceTransaction Nothing txn of
+    FormSuccess txn -> case balanceTransaction balancingOpts txn of
       Left e -> FormFailure [T.pack e]
       Right txn' -> FormSuccess txn'
     x -> x

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -203,7 +203,7 @@ confirmedTransactionWizard prevInput es@EntryState{..} stack@(currentStage : _) 
                              ,tcomment=txnCmnt
                              ,tpostings=esPostings
                              }
-      case balanceTransaction Nothing t of -- imprecise balancing (?)
+      case balanceTransaction balancingOpts t of -- imprecise balancing (?)
         Right t' ->
           confirmedTransactionWizard prevInput es (EndStage t' : stack)
         Left err -> do
@@ -292,7 +292,7 @@ descriptionAndCommentWizard PrevInput{..} EntryState{..} = do
       return $ Just (desc, comment)
 
 postingsBalanced :: [Posting] -> Bool
-postingsBalanced ps = isRight $ balanceTransaction Nothing nulltransaction{tpostings=ps}
+postingsBalanced ps = isRight $ balanceTransaction balancingOpts nulltransaction{tpostings=ps}
 
 accountWizard PrevInput{..} EntryState{..} = do
   let pnum = length esPostings + 1

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -318,9 +318,7 @@ balance :: CliOpts -> Journal -> IO ()
 balance opts@CliOpts{reportspec_=rspec} j = case reporttype_ of
     BudgetReport -> do  -- single or multi period budget report
       let reportspan = reportSpan j rspec
-          budgetreport = budgetReport rspec assrt reportspan j
-            where
-              assrt = not $ ignore_assertions_ $ inputopts_ opts
+          budgetreport = budgetReport rspec (balancingopts_ $ inputopts_ opts) reportspan j
           render = case fmt of
             "txt"  -> budgetReportAsText ropts
             "json" -> (<>"\n") . toJsonText

--- a/hledger/Hledger/Cli/Commands/Check.hs
+++ b/hledger/Hledger/Cli/Commands/Check.hs
@@ -9,17 +9,18 @@ module Hledger.Cli.Commands.Check (
  ,check
 ) where
 
+import Data.Char (toLower,toUpper)
+import Data.Either (partitionEithers)
+import Data.List (isPrefixOf, find)
+import Control.Monad (forM_)
+import System.Console.CmdArgs.Explicit
+import System.Exit (exitFailure)
+import System.IO (stderr, hPutStrLn)
+
 import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Commands.Check.Ordereddates (journalCheckOrdereddates)
 import Hledger.Cli.Commands.Check.Uniqueleafnames (journalCheckUniqueleafnames)
-import System.Console.CmdArgs.Explicit
-import Data.Either (partitionEithers)
-import Data.Char (toLower,toUpper)
-import Data.List (isPrefixOf, find)
-import Control.Monad (forM_)
-import System.IO (stderr, hPutStrLn)
-import System.Exit (exitFailure)
 
 checkmode :: Mode RawOpts
 checkmode = hledgerCommandMode
@@ -53,17 +54,18 @@ cliOptsUpdateReportSpecWith roptsupdate copts@CliOpts{reportspec_} =
 
 -- | A type of error check that we can perform on the data.
 -- Some of these imply other checks that are done first,
--- eg currently Parseable and Autobalanced are always done,
+-- eg currently Parseable and Balancedwithautoconversion are always done,
 -- and Assertions are always done unless -I is in effect.
 data Check =
   -- done always
     Parseable
-  | Autobalanced
+  | Balancedwithautoconversion
   -- done always unless -I is used
   | Assertions
   -- done when -s is used, or on demand by check
   | Accounts
   | Commodities
+  | Balancednoautoconversion
   -- done on demand by check
   | Ordereddates
   | Payees

--- a/hledger/Hledger/Cli/Commands/Check.md
+++ b/hledger/Hledger/Cli/Commands/Check.md
@@ -28,7 +28,7 @@ including `check`:
 - **parseable** - data files are well-formed and can be 
   [successfully parsed](hledger.html#input-files)
 
-- **autobalanced** - all transactions are [balanced](hledger.html#postings), 
+- **balancedwithautoconversion** - all transactions are [balanced](hledger.html#postings),
   inferring missing amounts where necessary, and possibly converting commodities 
   using [transaction prices] or automatically-inferred transaction prices
 
@@ -45,6 +45,9 @@ Or, they can be run by giving their names as arguments to `check`:
 
 - **commodities** - all commodity symbols used 
   [have been declared](hledger.html#commodity-error-checking)
+
+- **balancednoautoconversion** - transactions are balanced, possibly using
+  explicit transaction prices but not [inferred ones](#transaction-prices)
 
 ### Other checks
 

--- a/hledger/Hledger/Cli/Commands/Diff.hs
+++ b/hledger/Hledger/Cli/Commands/Diff.hs
@@ -87,7 +87,7 @@ matching ppl ppr = do
 
 readJournalFile' :: FilePath -> IO Journal
 readJournalFile' fn =
-    readJournalFile definputopts {ignore_assertions_ = True} fn >>= either error' return  -- PARTIAL:
+    readJournalFile definputopts{balancingopts_=balancingOpts{ignore_assertions_=True}} fn >>= either error' return  -- PARTIAL:
 
 matchingPostings :: AccountName -> Journal -> [PostingWithPath]
 matchingPostings acct j = filter ((== acct) . paccount . ppposting) $ allPostingsWithPath j

--- a/hledger/Hledger/Cli/Commands/Import.hs
+++ b/hledger/Hledger/Cli/Commands/Import.hs
@@ -33,7 +33,7 @@ importcmd opts@CliOpts{rawopts_=rawopts,inputopts_=iopts} j = do
     inputstr = intercalate ", " $ map quoteIfNeeded inputfiles
     catchup = boolopt "catchup" rawopts
     dryrun = boolopt "dry-run" rawopts
-    iopts' = iopts{new_=True, new_save_=not dryrun, commoditystyles_=Just $ journalCommodityStyles j}
+    iopts' = iopts{new_=True, new_save_=not dryrun, balancingopts_=balancingOpts{commodity_styles_=Just $ journalCommodityStyles j}}
   case inputfiles of
     [] -> error' "please provide one or more input files as arguments"  -- PARTIAL:
     fs -> do

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -152,9 +152,7 @@ journalAddForecast CliOpts{inputopts_=iopts, reportspec_=rspec} j =
       forecasttxns
 
     journalBalanceTransactions' iopts j =
-      let assrt = not . ignore_assertions_ $ iopts
-      in
-       either error' id $ journalBalanceTransactions assrt j  -- PARTIAL:
+       either error' id $ journalBalanceTransactions (balancingopts_ iopts) j  -- PARTIAL:
 
 -- | Write some output to stdout or to a file selected by --output-file.
 -- If the file exists it will be overwritten.

--- a/hledger/test/check-balancednoautoconversion.test
+++ b/hledger/test/check-balancednoautoconversion.test
@@ -1,0 +1,8 @@
+# 1. Check that prices balance without auto-inferring prices
+<
+2011/01/01 x
+  a  -10£
+  b  16$
+$ hledger -f - check balancednoautoconversion
+>2 /real postings' sum should be 0 but is:  16\$/
+>=1

--- a/hledger/test/journal/transaction-prices.test
+++ b/hledger/test/journal/transaction-prices.test
@@ -126,7 +126,16 @@ hledger -f - balance
                 -10£  
 >>>=0
 
-# 10. When commodity price is specified implicitly, transaction should
+# 10. Should not infer prices when --strict is specified
+hledger -f - balance --strict
+<<<
+2011/01/01 x
+  a  -10£
+  b  16$
+>>>
+>>>=1
+
+# 11. When commodity price is specified implicitly, transaction should
 #     NOT be considered balanced out when BOTH amounts are negative
 hledger -f - balance
 <<<
@@ -136,7 +145,7 @@ hledger -f - balance
 >>>
 >>>=1
 
-# 11. Differently-priced lots of a commodity should be merged in balance report
+# 12. Differently-priced lots of a commodity should be merged in balance report
 hledger -f - balance
 <<<
 2011/1/1
@@ -150,7 +159,7 @@ hledger -f - balance
                   £2  
 >>>=0
 
-# 12. this should balance
+# 13. this should balance
 hledger -f - balance
 <<<
 2011/1/1
@@ -159,7 +168,7 @@ hledger -f - balance
     c  $-30
 >>>= 0
 
-# 13. these balance because of the unit prices, and should parse successfully
+# 14. these balance because of the unit prices, and should parse successfully
 hledger -f - balance --no-total
 <<<
 1/1
@@ -169,7 +178,7 @@ hledger -f - balance --no-total
                  -1X  a
 >>>= 0
 
-# 14.
+# 15.
 hledger -f - balance --no-total -B
 <<<
 1/1
@@ -178,7 +187,7 @@ hledger -f - balance --no-total -B
 >>>
 >>>= 0
 
-# 15. likewise with total prices. Note how the primary amount's sign is used.
+# 16. likewise with total prices. Note how the primary amount's sign is used.
 hledger -f - balance --no-total
 <<<
 1/1
@@ -188,7 +197,7 @@ hledger -f - balance --no-total
                  -1X  a
 >>>= 0
 
-# 16.
+# 17.
 hledger -f - balance --no-total -B
 <<<
 1/1
@@ -197,7 +206,7 @@ hledger -f - balance --no-total -B
 >>>
 >>>= 0
 
-# 17. here, a's primary amount is 0, and its cost is 1Y; b is the assigned auto-balancing amount of -1Y (per issue 69)
+# 18. here, a's primary amount is 0, and its cost is 1Y; b is the assigned auto-balancing amount of -1Y (per issue 69)
 hledger -f - balance --no-total -E
 <<<
 1/1
@@ -210,7 +219,7 @@ hledger -f - balance --no-total -E
                  -1Y  b
 >>>= 0
 
-# 18. Without -E, a should be hidden because its balance is zero, even though it has a non-zero cost.
+# 19. Without -E, a should be hidden because its balance is zero, even though it has a non-zero cost.
 hledger -f - balance --no-total
 <<<
 1/1
@@ -222,7 +231,7 @@ hledger -f - balance --no-total
                  -1Y  b
 >>>= 0
 
-# 19. the above with -B
+# 20. the above with -B
 hledger -f - balance --no-total -E -B
 <<<
 1/1


### PR DESCRIPTION
This can be used on its own with the --no-infer-prices option, but is also enabled by --strict.

This at least partially addresses #86, #115, and #1177.