### PR TITLE
Introduce lenses for ReportOpts, ReportSpec, CliOpts, etc.

### DIFF
--- a/bin/hledger-balance-as-budget.hs
+++ b/bin/hledger-balance-as-budget.hs
@@ -43,4 +43,4 @@ main = do
       opts@CliOpts{reportspec_=rspec} <- getHledgerCliOpts' cmdmode args
       d <- getCurrentDay
       (report,j) <- withJournalDo opts $ \j -> return (multiBalanceReport rspec j, j)
-      return (rsOpts rspec,j,report)
+      return (reportopts_ rspec,j,report)

--- a/bin/hledger-combine-balances.hs
+++ b/bin/hledger-combine-balances.hs
@@ -65,7 +65,7 @@ main = do
   (_,report1) <- mbReport report1args
   (rspec2,report2) <- mbReport report2args
   let merged = appendReports report1 report2
-  TL.putStrLn $ multiBalanceReportAsText (rsOpts rspec2) merged
+  TL.putStrLn $ multiBalanceReportAsText (reportopts_ rspec2) merged
   where
     mbReport args = do
       opts@CliOpts{reportspec_=rspec} <- getHledgerCliOpts' cmdmode args

--- a/bin/hledger-smooth.hs
+++ b/bin/hledger-smooth.hs
@@ -57,21 +57,21 @@ _FLAGS
 main :: IO ()
 main = do
   copts@CliOpts{reportspec_=rspec, rawopts_} <- getHledgerCliOpts cmdmode
-  let ropts = rsOpts rspec
+  let ropts = reportopts_ rspec
       copts' = copts{
         -- One of our postings will probably have a missing amount; this ensures it's
         -- explicit on all the others.
         rawopts_ = setboolopt "explicit" rawopts_
         -- Don't let our ACCT argument be interpreted as a query by print
-        ,reportspec_ = rspec{rsOpts=ropts{querystring_=[]}}
+        ,reportspec_ = rspec{reportopts_=ropts{querystring_=[]}}
         }
   withJournalDo copts' $ \j -> do
     today <- getCurrentDay
     let
       menddate = reportPeriodLastDay rspec
-      q = rsQuery rspec
+      q = query_ rspec
       acct = headDef (error' "Please provide an account name argument") $ querystring_ ropts
-      pr = postingsReport rspec{rsQuery = And [Acct $ accountNameToAccountRegexCI acct, q]} j
+      pr = postingsReport rspec{query_ = And [Acct $ accountNameToAccountRegexCI acct, q]} j
 
       -- dates of postings to acct (in report)
       pdates = map (postingDate . fourth5) pr

--- a/bin/hledger-swap-dates.hs
+++ b/bin/hledger-swap-dates.hs
@@ -33,7 +33,7 @@ main = do
    \j -> do
     d <- getCurrentDay
     let
-      q = rsQuery rspec
+      q = query_ rspec
       ts = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
       ts' = map transactionSwapDates ts
     mapM_ (T.putStrLn . showTransaction) ts'

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -881,7 +881,7 @@ balanceTransactionAndCheckAssertionsB (Right t@Transaction{tpostings=ps}) = do
   ps' <- mapM (addOrAssignAmountAndCheckAssertionB . postingStripPrices) ps
   -- infer any remaining missing amounts, and make sure the transaction is now fully balanced
   styles <- R.reader bsStyles
-  case balanceTransactionHelper balancingOpts{commodity_styles_=styles} t{tpostings=ps'} of
+  case balanceTransactionHelper defbalancingopts{commodity_styles_=styles} t{tpostings=ps'} of
     Left err -> throwError err
     Right (t', inferredacctsandamts) -> do
       -- for each amount just inferred, update the running balance

--- a/hledger-lib/Hledger/Data/RawOptions.hs
+++ b/hledger-lib/Hledger/Data/RawOptions.hs
@@ -24,6 +24,7 @@ module Hledger.Data.RawOptions (
   maybeintopt,
   maybeposintopt,
   maybecharopt,
+  defrawopts,
   overRawOpts
 )
 where
@@ -39,7 +40,11 @@ import Hledger.Utils
 newtype RawOpts = RawOpts { unRawOpts :: [(String,String)] }
   deriving (Show)
 
-instance Default RawOpts where def = RawOpts []
+instance Default RawOpts where def = defrawopts
+
+-- | Empty RawOpts.
+defrawopts :: RawOpts
+defrawopts = RawOpts []
 
 overRawOpts f = RawOpts . f . unRawOpts
 

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -9,11 +9,12 @@ tags.
 
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types        #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
-{-# LANGUAGE NamedFieldPuns #-}
 module Hledger.Data.Transaction (
   -- * Transaction
   nulltransaction,
@@ -30,7 +31,8 @@ module Hledger.Data.Transaction (
   balancedVirtualPostings,
   transactionsPostings,
   BalancingOpts(..),
-  balancingOpts,
+  HasBalancingOpts(..),
+  defbalancingopts,
   isTransactionBalanced,
   balanceTransaction,
   balanceTransactionHelper,
@@ -77,6 +79,7 @@ import qualified Data.Map as M
 import Safe (maximumDef)
 
 import Hledger.Utils
+import Hledger.Utils.TH (makeClassyLensesTrailing)
 import Hledger.Data.Types
 import Hledger.Data.Dates
 import Hledger.Data.Posting
@@ -360,10 +363,10 @@ data BalancingOpts = BalancingOpts
   , commodity_styles_  :: Maybe (M.Map CommoditySymbol AmountStyle)  -- ^ commodity display styles
   } deriving (Show)
 
-instance Default BalancingOpts where def = balancingOpts
+instance Default BalancingOpts where def = defbalancingopts
 
-balancingOpts :: BalancingOpts
-balancingOpts = BalancingOpts
+defbalancingopts :: BalancingOpts
+defbalancingopts = BalancingOpts
   { ignore_assertions_ = False
   , infer_prices_      = True
   , commodity_styles_  = Nothing
@@ -661,6 +664,10 @@ transactionFile Transaction{tsourcepos} =
   case tsourcepos of
     GenericSourcePos f _ _ -> f
     JournalSourcePos f _   -> f
+
+-- lenses
+
+makeClassyLensesTrailing ''BalancingOpts
 
 -- tests
 

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -199,7 +199,7 @@ data InputOpts = InputOpts {
                                                 --   by a filename prefix. Nothing means try all.
     ,mrules_file_       :: Maybe FilePath       -- ^ a conversion rules file to use (when reading CSV)
     ,aliases_           :: [String]             -- ^ account name aliases to apply
-    ,anon_              :: Bool                 -- ^ do light anonymisation/obfuscation of the data
+    ,anonymise_         :: Bool                 -- ^ do light anonymisation/obfuscation of the data
     ,new_               :: Bool                 -- ^ read only new transactions since this file was last read
     ,new_save_          :: Bool                 -- ^ save latest new transactions state for next time
     ,pivot_             :: String               -- ^ use the given field's value as the account name
@@ -215,7 +215,7 @@ definputopts = InputOpts
     { mformat_           = Nothing
     , mrules_file_       = Nothing
     , aliases_           = []
-    , anon_              = False
+    , anonymise_         = False
     , new_               = False
     , new_save_          = True
     , pivot_             = ""
@@ -230,7 +230,7 @@ rawOptsToInputOpts rawopts = InputOpts{
      mformat_           = Nothing
     ,mrules_file_       = maybestringopt "rules-file" rawopts
     ,aliases_           = listofstringopt "alias" rawopts
-    ,anon_              = boolopt "anon" rawopts
+    ,anonymise_         = boolopt "anon" rawopts
     ,new_               = boolopt "new" rawopts
     ,new_save_          = True
     ,pivot_             = stringopt "pivot" rawopts

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -23,13 +23,16 @@ Some of these might belong in Hledger.Read.JournalReader or Hledger.Read.
 {-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 --- ** exports
 module Hledger.Read.Common (
-  Reader (..),
-  InputOpts (..),
+  Reader(..),
+  InputOpts(..),
+  HasInputOpts(inputOpts, mformat, mrules_file, aliases, anonymise,
+               new, new_save, pivot, auto, strict),
   definputopts,
   rawOptsToInputOpts,
 
@@ -153,6 +156,8 @@ import Text.Megaparsec.Custom
   (FinalParseError, attachSource, customErrorBundlePretty,
   finalErrorBundlePretty, parseErrorAt, parseErrorAtRegion)
 
+import Hledger.Utils.TH (makeClassyLensesTrailing)
+
 import Hledger.Data
 import Hledger.Utils
 import Text.Printf (printf)
@@ -207,6 +212,10 @@ data InputOpts = InputOpts {
     ,balancingopts_     :: BalancingOpts        -- ^ options for balancing transactions
     ,strict_            :: Bool                 -- ^ do extra error checking (eg, all posted accounts are declared, no prices are inferred)
  } deriving (Show)
+
+makeClassyLensesTrailing ''InputOpts
+
+instance HasBalancingOpts InputOpts where balancingOpts = balancingopts
 
 instance Default InputOpts where def = definputopts
 

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -74,6 +74,7 @@ import Text.Megaparsec hiding (match, parse)
 import Text.Megaparsec.Char (char, newline, string)
 import Text.Megaparsec.Custom (customErrorBundlePretty, parseErrorAt)
 import Text.Printf (printf)
+import Lens.Micro (set)
 
 import Hledger.Data
 import Hledger.Utils
@@ -116,7 +117,7 @@ parse iopts f t = do
               -- apply any command line account aliases. Can fail with a bad replacement pattern.
               in case journalApplyAliases (aliasesFromOpts iopts) pj' of
                   Left e -> throwError e
-                  Right pj'' -> journalFinalise iopts{balancingopts_=(balancingopts_ iopts){ignore_assertions_=True}} f t pj''
+                  Right pj'' -> journalFinalise (set ignore_assertions True iopts) f t pj''
 
 --- ** reading rules files
 --- *** rules utilities

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -79,7 +79,7 @@ type AccountTransactionsReportItem =
   )
 
 accountTransactionsReport :: ReportSpec -> Journal -> Query -> Query -> AccountTransactionsReport
-accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = items
+accountTransactionsReport rspec@ReportSpec{reportopts_=ropts} j reportq thisacctq = items
   where
     -- a depth limit should not affect the account transactions report
     -- seems unnecessary for some reason XXX

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -78,7 +78,7 @@ balanceReport rspec j = (rows, total)
 -- tests
 
 Right samplejournal2 =
-  journalBalanceTransactions balancingOpts
+  journalBalanceTransactions defbalancingopts
     nulljournal{
       jtxns = [
         txnTieKnot Transaction{

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -104,7 +104,7 @@ tests_BalanceReport = tests "BalanceReport" [
 
   let
     (rspec,journal) `gives` r = do
-      let opts' = rspec{rsQuery=And [queryFromFlags $ rsOpts rspec, rsQuery rspec]}
+      let opts' = rspec{query_=And [queryFromFlags $ reportopts_ rspec, query_ rspec]}
           (eitems, etotal) = r
           (aitems, atotal) = balanceReport opts' journal
           showw (acct,acct',indent,amt) = (acct, acct', indent, showMixedAmountDebug amt)
@@ -130,7 +130,7 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with --tree" $
-     (defreportspec{rsOpts=defreportopts{accountlistmode_=ALTree}}, samplejournal) `gives`
+     (defreportspec{reportopts_=defreportopts{accountlistmode_=ALTree}}, samplejournal) `gives`
       ([
         ("assets","assets",0, mamountp' "$0.00")
        ,("assets:bank","bank",1, mamountp' "$2.00")
@@ -147,7 +147,7 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with --depth=N" $
-     (defreportspec{rsOpts=defreportopts{depth_=Just 1}}, samplejournal) `gives`
+     (defreportspec{reportopts_=defreportopts{depth_=Just 1}}, samplejournal) `gives`
       ([
        ("expenses",    "expenses",    0, mamountp'  "$2.00")
        ,("income",      "income",      0, mamountp' "$-2.00")
@@ -155,7 +155,7 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with depth:N" $
-     (defreportspec{rsQuery=Depth 1}, samplejournal) `gives`
+     (defreportspec{query_=Depth 1}, samplejournal) `gives`
       ([
        ("expenses",    "expenses",    0, mamountp'  "$2.00")
        ,("income",      "income",      0, mamountp' "$-2.00")
@@ -163,11 +163,11 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with date:" $
-     (defreportspec{rsQuery=Date $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
+     (defreportspec{query_=Date $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
       ([], nullmixedamt)
 
     ,test "with date2:" $
-     (defreportspec{rsQuery=Date2 $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
+     (defreportspec{query_=Date2 $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
       ([
         ("assets:bank:checking","assets:bank:checking",0,mamountp' "$1.00")
        ,("income:salary","income:salary",0,mamountp' "$-1.00")
@@ -175,7 +175,7 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with desc:" $
-     (defreportspec{rsQuery=Desc $ toRegexCI' "income"}, samplejournal) `gives`
+     (defreportspec{query_=Desc $ toRegexCI' "income"}, samplejournal) `gives`
       ([
         ("assets:bank:checking","assets:bank:checking",0,mamountp' "$1.00")
        ,("income:salary","income:salary",0, mamountp' "$-1.00")
@@ -183,7 +183,7 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with not:desc:" $
-     (defreportspec{rsQuery=Not . Desc $ toRegexCI' "income"}, samplejournal) `gives`
+     (defreportspec{query_=Not . Desc $ toRegexCI' "income"}, samplejournal) `gives`
       ([
         ("assets:bank:saving","assets:bank:saving",0, mamountp' "$1.00")
        ,("assets:cash","assets:cash",0, mamountp' "$-2.00")
@@ -194,7 +194,7 @@ tests_BalanceReport = tests "BalanceReport" [
        mixedAmount (usd 0))
 
     ,test "with period on a populated period" $
-      (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2)}}, samplejournal) `gives`
+      (defreportspec{reportopts_=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2)}}, samplejournal) `gives`
        (
         [
          ("assets:bank:checking","assets:bank:checking",0, mamountp' "$1.00")
@@ -203,7 +203,7 @@ tests_BalanceReport = tests "BalanceReport" [
         mixedAmount (usd 0))
 
      ,test "with period on an unpopulated period" $
-      (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 2) (fromGregorian 2008 1 3)}}, samplejournal) `gives`
+      (defreportspec{reportopts_=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 2) (fromGregorian 2008 1 3)}}, samplejournal) `gives`
        ([], nullmixedamt)
 
 

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -297,7 +297,7 @@ tests_BalanceReport = tests "BalanceReport" [
        ]
 
       ,test "accounts report with -E shows zero-balance accounts" ~:
-       defreportopts{patterns_=["assets"],empty_=True} `gives`
+       defreportopts{patterns_=["assets"],showempty_=True} `gives`
        ["                 $-1  assets"
        ,"                  $1    bank"
        ,"                   0      checking"

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -68,7 +68,7 @@ budgetReport rspec bopts reportspan j = dbg4 "sortedbudgetreport" budgetreport
   where
     -- Budget report demands ALTree mode to ensure subaccounts and subaccount budgets are properly handled
     -- and that reports with and without --empty make sense when compared side by side
-    ropts = (rsOpts rspec){ accountlistmode_ = ALTree }
+    ropts = (reportopts_ rspec){ accountlistmode_ = ALTree }
     showunbudgeted = empty_ ropts
     budgetedaccts =
       dbg3 "budgetedacctsinperiod" $
@@ -81,9 +81,9 @@ budgetReport rspec bopts reportspan j = dbg4 "sortedbudgetreport" budgetreport
     actualj = journalWithBudgetAccountNames budgetedaccts showunbudgeted j
     budgetj = journalAddBudgetGoalTransactions bopts ropts reportspan j
     actualreport@(PeriodicReport actualspans _ _) =
-        dbg5 "actualreport" $ multiBalanceReport rspec{rsOpts=ropts{empty_=True}} actualj
+        dbg5 "actualreport" $ multiBalanceReport rspec{reportopts_=ropts{empty_=True}} actualj
     budgetgoalreport@(PeriodicReport _ budgetgoalitems budgetgoaltotals) =
-        dbg5 "budgetgoalreport" $ multiBalanceReport rspec{rsOpts=ropts{empty_=True}} budgetj
+        dbg5 "budgetgoalreport" $ multiBalanceReport rspec{reportopts_=ropts{empty_=True}} budgetj
     budgetgoalreport'
       -- If no interval is specified:
       -- budgetgoalreport's span might be shorter actualreport's due to periodic txns;

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -34,14 +34,14 @@ type EntriesReportItem = Transaction
 
 -- | Select transactions for an entries report.
 entriesReport :: ReportSpec -> Journal -> EntriesReport
-entriesReport rspec@ReportSpec{rsOpts=ropts} =
-    sortBy (comparing $ transactionDateFn ropts) . jtxns . filterJournalTransactions (rsQuery rspec)
-    . journalApplyValuationFromOpts rspec{rsOpts=ropts{show_costs_=True}}
+entriesReport rspec@ReportSpec{reportopts_=ropts} =
+    sortBy (comparing $ transactionDateFn ropts) . jtxns . filterJournalTransactions (query_ rspec)
+    . journalApplyValuationFromOpts rspec{reportopts_=ropts{show_costs_=True}}
 
 tests_EntriesReport = tests "EntriesReport" [
   tests "entriesReport" [
-     test "not acct" $ (length $ entriesReport defreportspec{rsQuery=Not . Acct $ toRegex' "bank"} samplejournal) @?= 1
-    ,test "date" $ (length $ entriesReport defreportspec{rsQuery=Date $ DateSpan (Just $ fromGregorian 2008 06 01) (Just $ fromGregorian 2008 07 01)} samplejournal) @?= 3
+     test "not acct" $ (length $ entriesReport defreportspec{query_=Not . Acct $ toRegex' "bank"} samplejournal) @?= 1
+    ,test "date" $ (length $ entriesReport defreportspec{query_=Date $ DateSpan (Just $ fromGregorian 2008 06 01) (Just $ fromGregorian 2008 07 01)} samplejournal) @?= 3
   ]
  ]
 

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -391,20 +391,20 @@ displayedAccounts ReportSpec{query_=query,reportopts_=ropts} valuedaccts
         ALTree -> DisplayName name leaf . max 0 $ level - boringParents
         ALFlat -> DisplayName name droppedName 1
       where
-        droppedName = accountNameDrop (drop_ ropts) name
+        droppedName = accountNameDrop (droplevels_ ropts) name
         leaf = accountNameFromComponents . reverse . map accountLeafName $
             droppedName : takeWhile notDisplayed parents
 
-        level = max 0 $ accountNameLevel name - drop_ ropts
+        level = max 0 $ accountNameLevel name - droplevels_ ropts
         parents = take (level - 1) $ parentAccountNames name
         boringParents = if no_elide_ ropts then 0 else length $ filter notDisplayed parents
         notDisplayed = not . (`HM.member` displayedAccts)
 
     -- Accounts interesting for their own sake
     isInteresting name amts =
-        d <= depth                                     -- Throw out anything too deep
-        && ((empty_ ropts && all (null . asubs) amts)  -- Keep all leaves when using empty_
-           || not (isZeroRow balance amts))            -- Throw out anything with zero balance
+        d <= depth                                         -- Throw out anything too deep
+        && ((showempty_ ropts && all (null . asubs) amts)  -- Keep all leaves when using showempty_
+           || not (isZeroRow balance amts))                -- Throw out anything with zero balance
       where
         d = accountNameLevel name
         balance | ALTree <- accountlistmode_ ropts, d == depth = maybeStripPrices . aibalance
@@ -416,7 +416,7 @@ displayedAccounts ReportSpec{query_=query,reportopts_=ropts} valuedaccts
         ALTree -> HM.filterWithKey hasEnoughSubs numSubs
         ALFlat -> mempty
       where
-        hasEnoughSubs name nsubs = nsubs >= minSubs && accountNameLevel name > drop_ ropts
+        hasEnoughSubs name nsubs = nsubs >= minSubs && accountNameLevel name > droplevels_ ropts
         minSubs = if no_elide_ ropts then 1 else 2
 
     isZeroRow balance = all (mixedAmountLooksZero . balance)

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -45,6 +45,7 @@ import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Ord (Down(..))
 import Data.Semigroup (sconcat)
 import Data.Time.Calendar (Day, fromGregorian)
+import Lens.Micro ((^.))
 import Safe (lastDef, minimumMay)
 
 import Hledger.Data
@@ -95,8 +96,7 @@ type ClippedAccountName = AccountName
 -- by the balance command (in multiperiod mode) and (via compoundBalanceReport)
 -- by the bs/cf/is commands.
 multiBalanceReport :: ReportSpec -> Journal -> MultiBalanceReport
-multiBalanceReport rspec j = multiBalanceReportWith rspec j (journalPriceOracle infer j)
-  where infer = infer_value_ $ reportopts_ rspec
+multiBalanceReport rspec j = multiBalanceReportWith rspec j $ journalPriceOracle (rspec ^. infer_value) j
 
 -- | A helper for multiBalanceReport. This one takes an extra argument,
 -- a PriceOracle to be used for looking up market prices. Commands which
@@ -125,8 +125,7 @@ multiBalanceReportWith rspec' j priceoracle = report
 -- shares postings between the subreports.
 compoundBalanceReport :: ReportSpec -> Journal -> [CBCSubreportSpec a]
                       -> CompoundPeriodicReport a MixedAmount
-compoundBalanceReport rspec j = compoundBalanceReportWith rspec j (journalPriceOracle infer j)
-  where infer = infer_value_ $ reportopts_ rspec
+compoundBalanceReport rspec j = compoundBalanceReportWith rspec j $ journalPriceOracle (rspec ^. infer_value) j
 
 -- | A helper for compoundBalanceReport, similar to multiBalanceReportWith.
 compoundBalanceReportWith :: ReportSpec -> Journal -> PriceOracle

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -96,7 +96,7 @@ type ClippedAccountName = AccountName
 -- by the bs/cf/is commands.
 multiBalanceReport :: ReportSpec -> Journal -> MultiBalanceReport
 multiBalanceReport rspec j = multiBalanceReportWith rspec j (journalPriceOracle infer j)
-  where infer = infer_value_ $ rsOpts rspec
+  where infer = infer_value_ $ reportopts_ rspec
 
 -- | A helper for multiBalanceReport. This one takes an extra argument,
 -- a PriceOracle to be used for looking up market prices. Commands which
@@ -126,7 +126,7 @@ multiBalanceReportWith rspec' j priceoracle = report
 compoundBalanceReport :: ReportSpec -> Journal -> [CBCSubreportSpec a]
                       -> CompoundPeriodicReport a MixedAmount
 compoundBalanceReport rspec j = compoundBalanceReportWith rspec j (journalPriceOracle infer j)
-  where infer = infer_value_ $ rsOpts rspec
+  where infer = infer_value_ $ reportopts_ rspec
 
 -- | A helper for compoundBalanceReport, similar to multiBalanceReportWith.
 compoundBalanceReportWith :: ReportSpec -> Journal -> PriceOracle
@@ -151,14 +151,14 @@ compoundBalanceReportWith rspec' j priceoracle subreportspecs = cbr
             ( cbcsubreporttitle
             -- Postprocess the report, negating balances and taking percentages if needed
             , cbcsubreporttransform $
-                generateMultiBalanceReport rspec{rsOpts=ropts} j priceoracle colps' startbals'
+                generateMultiBalanceReport rspec{reportopts_=ropts} j priceoracle colps' startbals'
             , cbcsubreportincreasestotal
             )
           where
             -- Filter the column postings according to each subreport
             colps'     = filter (matchesPosting q) <$> colps
             startbals' = HM.filterWithKey (\k _ -> matchesAccount q k) startbals
-            ropts      = cbcsubreportoptions $ rsOpts rspec
+            ropts      = cbcsubreportoptions $ reportopts_ rspec
             q          = cbcsubreportquery j
 
     -- Sum the subreport totals by column. Handle these cases:
@@ -183,13 +183,13 @@ compoundBalanceReportWith rspec' j priceoracle subreportspecs = cbr
 -- and startDate is not nothing, otherwise mempty? This currently gives a
 -- failure with some totals which are supposed to be 0 being blank.
 startingBalances :: ReportSpec -> Journal -> PriceOracle -> DateSpan -> HashMap AccountName Account
-startingBalances rspec@ReportSpec{rsQuery=query,rsOpts=ropts} j priceoracle reportspan =
+startingBalances rspec@ReportSpec{query_=query,reportopts_=ropts} j priceoracle reportspan =
     fmap (M.findWithDefault nullacct precedingspan) acctmap
   where
     acctmap = calculateReportMatrix rspec' j priceoracle mempty
             . M.singleton precedingspan . map fst $ getPostings rspec' j priceoracle
 
-    rspec' = rspec{rsQuery=startbalq,rsOpts=ropts'}
+    rspec' = rspec{query_=startbalq,reportopts_=ropts'}
     -- If we're re-valuing every period, we need to have the unvalued start
     -- balance, so we can do it ourselves later.
     ropts' = case value_ ropts of
@@ -217,12 +217,12 @@ startingBalances rspec@ReportSpec{rsQuery=query,rsOpts=ropts} j priceoracle repo
 makeReportQuery :: ReportSpec -> DateSpan -> ReportSpec
 makeReportQuery rspec reportspan
     | reportspan == nulldatespan = rspec
-    | otherwise = rspec{rsQuery=query}
+    | otherwise = rspec{query_=query}
   where
-    query            = simplifyQuery $ And [dateless $ rsQuery rspec, reportspandatesq]
+    query            = simplifyQuery $ And [dateless $ query_ rspec, reportspandatesq]
     reportspandatesq = dbg3 "reportspandatesq" $ dateqcons reportspan
     dateless         = dbg3 "dateless" . filterQuery (not . queryIsDateOrDate2)
-    dateqcons        = if date2_ (rsOpts rspec) then Date2 else Date
+    dateqcons        = if date2_ (reportopts_ rspec) then Date2 else Date
 
 -- | Group postings, grouped by their column
 getPostingsByColumn :: ReportSpec -> Journal -> PriceOracle -> DateSpan -> Map DateSpan [Posting]
@@ -232,7 +232,7 @@ getPostingsByColumn rspec j priceoracle reportspan = columns
     ps :: [(Posting, Day)] = dbg5 "getPostingsByColumn" $ getPostings rspec j priceoracle
 
     -- The date spans to be included as report columns.
-    colspans = dbg3 "colspans" $ splitSpan (interval_ $ rsOpts rspec) reportspan
+    colspans = dbg3 "colspans" $ splitSpan (interval_ $ reportopts_ rspec) reportspan
     addPosting (p, d) = maybe id (M.adjust (p:)) $ latestSpanContaining colspans d
     emptyMap = M.fromList . zip colspans $ repeat []
 
@@ -241,7 +241,7 @@ getPostingsByColumn rspec j priceoracle reportspan = columns
 
 -- | Gather postings matching the query within the report period.
 getPostings :: ReportSpec -> Journal -> PriceOracle -> [(Posting, Day)]
-getPostings rspec@ReportSpec{rsQuery=query,rsOpts=ropts} j priceoracle =
+getPostings rspec@ReportSpec{query_=query,reportopts_=ropts} j priceoracle =
     map (\p -> (p, date p)) .
     journalPostings .
     filterJournalAmounts symq .      -- remove amount parts excluded by cur:
@@ -267,7 +267,7 @@ getPostings rspec@ReportSpec{rsQuery=query,rsOpts=ropts} j priceoracle =
 -- each. Accounts and amounts will be depth-clipped appropriately if
 -- a depth limit is in effect.
 acctChangesFromPostings :: ReportSpec -> [Posting] -> HashMap ClippedAccountName Account
-acctChangesFromPostings ReportSpec{rsQuery=query,rsOpts=ropts} ps =
+acctChangesFromPostings ReportSpec{query_=query,reportopts_=ropts} ps =
     HM.fromList [(aname a, a) | a <- as]
   where
     as = filterAccounts . drop 1 $ accountsFromPostings ps
@@ -285,7 +285,7 @@ calculateReportMatrix :: ReportSpec -> Journal -> PriceOracle
                       -> HashMap ClippedAccountName Account
                       -> Map DateSpan [Posting]
                       -> HashMap ClippedAccountName (Map DateSpan Account)
-calculateReportMatrix rspec@ReportSpec{rsOpts=ropts} j priceoracle startbals colps =  -- PARTIAL:
+calculateReportMatrix rspec@ReportSpec{reportopts_=ropts} j priceoracle startbals colps =  -- PARTIAL:
     -- Ensure all columns have entries, including those with starting balances
     HM.mapWithKey rowbals allchanges
   where
@@ -316,7 +316,7 @@ calculateReportMatrix rspec@ReportSpec{rsOpts=ropts} j priceoracle startbals col
 
     avalue = acctApplyBoth . mixedAmountApplyValuationAfterSumFromOptsWith ropts j priceoracle
     acctApplyBoth f a = a{aibalance = f $ aibalance a, aebalance = f $ aebalance a}
-    addElided = if queryDepth (rsQuery rspec) == Just 0 then HM.insert "..." zeros else id
+    addElided = if queryDepth (query_ rspec) == Just 0 then HM.insert "..." zeros else id
     historicalDate = minimumMay $ mapMaybe spanStart colspans
     zeros = M.fromList [(span, nullacct) | span <- colspans]
     colspans = M.keys colps
@@ -328,7 +328,7 @@ calculateReportMatrix rspec@ReportSpec{rsOpts=ropts} j priceoracle startbals col
 generateMultiBalanceReport :: ReportSpec -> Journal -> PriceOracle
                            -> Map DateSpan [Posting] -> HashMap AccountName Account
                            -> MultiBalanceReport
-generateMultiBalanceReport rspec@ReportSpec{rsOpts=ropts} j priceoracle colps startbals =
+generateMultiBalanceReport rspec@ReportSpec{reportopts_=ropts} j priceoracle colps startbals =
     report
   where
     -- Process changes into normal, cumulative, or historical amounts, plus value them
@@ -378,7 +378,7 @@ buildReportRows ropts displaynames =
 -- their name and depth
 displayedAccounts :: ReportSpec -> HashMap AccountName (Map DateSpan Account)
                   -> HashMap AccountName DisplayName
-displayedAccounts ReportSpec{rsQuery=query,rsOpts=ropts} valuedaccts
+displayedAccounts ReportSpec{query_=query,reportopts_=ropts} valuedaccts
     | depth == 0 = HM.singleton "..." $ DisplayName "..." "..." 1
     | otherwise  = HM.mapWithKey (\a _ -> displayedName a) displayedAccts
   where
@@ -561,7 +561,7 @@ tests_MultiBalanceReport = tests "MultiBalanceReport" [
   let
     amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = Precision 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}, aismultiplier=False}
     (rspec,journal) `gives` r = do
-      let rspec' = rspec{rsQuery=And [queryFromFlags $ rsOpts rspec, rsQuery rspec]}
+      let rspec' = rspec{query_=And [queryFromFlags $ reportopts_ rspec, query_ rspec]}
           (eitems, etotal) = r
           (PeriodicReport _ aitems atotal) = multiBalanceReport rspec' journal
           showw (PeriodicReportRow a lAmt amt amt')
@@ -574,7 +574,7 @@ tests_MultiBalanceReport = tests "MultiBalanceReport" [
       (defreportspec, nulljournal) `gives` ([], nullmixedamt)
 
      ,test "with -H on a populated period"  $
-      (defreportspec{rsOpts=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2), balancetype_=HistoricalBalance}}, samplejournal) `gives`
+      (defreportspec{reportopts_=defreportopts{period_= PeriodBetween (fromGregorian 2008 1 1) (fromGregorian 2008 1 2), balancetype_=HistoricalBalance}}, samplejournal) `gives`
        (
         [ PeriodicReportRow (flatDisplayName "assets:bank:checking") [mamountp' "$1.00"]  (mamountp' "$1.00")  (mixedAmount amt0{aquantity=1})
         , PeriodicReportRow (flatDisplayName "income:salary")        [mamountp' "$-1.00"] (mamountp' "$-1.00") (mixedAmount amt0{aquantity=(-1)})

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -63,11 +63,11 @@ type SummaryPosting = (Posting, Day)
 -- | Select postings from the journal and add running balance and other
 -- information to make a postings report. Used by eg hledger's register command.
 postingsReport :: ReportSpec -> Journal -> PostingsReport
-postingsReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j = items
+postingsReport rspec@ReportSpec{reportopts_=ropts@ReportOpts{..}} j = items
     where
       reportspan  = reportSpanBothDates j rspec
       whichdate   = whichDateFromOpts ropts
-      mdepth      = queryDepth $ rsQuery rspec
+      mdepth      = queryDepth $ query_ rspec
       multiperiod = interval_ /= NoInterval
 
       -- postings to be included in the report, and similarly-matched postings before the report start date
@@ -114,7 +114,7 @@ registerRunningCalculationFn ropts
 -- Date restrictions and depth restrictions in the query are ignored.
 -- A helper for the postings report.
 matchedPostingsBeforeAndDuring :: ReportSpec -> Journal -> DateSpan -> ([Posting],[Posting])
-matchedPostingsBeforeAndDuring rspec@ReportSpec{rsOpts=ropts,rsQuery=q} j reportspan =
+matchedPostingsBeforeAndDuring rspec@ReportSpec{reportopts_=ropts,query_=q} j reportspan =
   dbg5 "beforeps, duringps" $ span (beforestartq `matchesPosting`) beforeandduringps
   where
     beforestartq = dbg3 "beforestartq" $ dateqtype $ DateSpan Nothing $ spanStart reportspan
@@ -223,7 +223,7 @@ negatePostingAmount = postingTransformAmount negate
 tests_PostingsReport = tests "PostingsReport" [
 
    test "postingsReport" $ do
-    let (query, journal) `gives` n = (length $ postingsReport defreportspec{rsQuery=query} journal) @?= n
+    let (query, journal) `gives` n = (length $ postingsReport defreportspec{query_=query} journal) @?= n
     -- with the query specified explicitly
     (Any, nulljournal) `gives` 0
     (Any, samplejournal) `gives` 13
@@ -233,9 +233,9 @@ tests_PostingsReport = tests "PostingsReport" [
     (And [And [Depth 1, StatusQ Cleared], Acct (toRegex' "expenses")], samplejournal) `gives` 2
     -- with query and/or command-line options
     (length $ postingsReport defreportspec samplejournal) @?= 13
-    (length $ postingsReport defreportspec{rsOpts=defreportopts{interval_=Months 1}} samplejournal) @?= 11
-    (length $ postingsReport defreportspec{rsOpts=defreportopts{interval_=Months 1, empty_=True}} samplejournal) @?= 20
-    (length $ postingsReport defreportspec{rsQuery=Acct $ toRegex' "assets:bank:checking"} samplejournal) @?= 5
+    (length $ postingsReport defreportspec{reportopts_=defreportopts{interval_=Months 1}} samplejournal) @?= 11
+    (length $ postingsReport defreportspec{reportopts_=defreportopts{interval_=Months 1, empty_=True}} samplejournal) @?= 20
+    (length $ postingsReport defreportspec{query_=Acct $ toRegex' "assets:bank:checking"} samplejournal) @?= 5
 
      -- (defreportopts, And [Acct "a a", Acct "'b"], samplejournal2) `gives` 0
      -- [(Just (fromGregorian 2008 01 01,"income"),assets:bank:checking             $1,$1)

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -78,8 +78,7 @@ postingsReport rspec@ReportSpec{reportopts_=ropts@ReportOpts{..}} j = items
         | multiperiod = [(p, Just periodend) | (p, periodend) <- summariseps reportps]
         | otherwise   = [(p, Nothing) | p <- reportps]
         where
-          summariseps = summarisePostingsByInterval interval_ whichdate mdepth showempty reportspan
-          showempty = empty_ || average_
+          summariseps = summarisePostingsByInterval interval_ whichdate mdepth (showempty_ || average_) reportspan
 
       -- Posting report items ready for display.
       items =
@@ -234,7 +233,7 @@ tests_PostingsReport = tests "PostingsReport" [
     -- with query and/or command-line options
     (length $ postingsReport defreportspec samplejournal) @?= 13
     (length $ postingsReport defreportspec{reportopts_=defreportopts{interval_=Months 1}} samplejournal) @?= 11
-    (length $ postingsReport defreportspec{reportopts_=defreportopts{interval_=Months 1, empty_=True}} samplejournal) @?= 20
+    (length $ postingsReport defreportspec{reportopts_=defreportopts{interval_=Months 1, showempty_=True}} samplejournal) @?= 20
     (length $ postingsReport defreportspec{query_=Acct $ toRegex' "assets:bank:checking"} samplejournal) @?= 5
 
      -- (defreportopts, And [Acct "a a", Acct "'b"], samplejournal2) `gives` 0
@@ -358,7 +357,7 @@ tests_PostingsReport = tests "PostingsReport" [
          ]
         let opts = defreportopts{period_=maybePeriod date1 "quarterly"}
         registerdates (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` ["2008/01/01","2008/04/01","2008/10/01"]
-        let opts = defreportopts{period_=maybePeriod date1 "quarterly",empty_=True}
+        let opts = defreportopts{period_=maybePeriod date1 "quarterly",showempty_=True}
         registerdates (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` ["2008/01/01","2008/04/01","2008/07/01","2008/10/01"]
 
       ]

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -102,7 +102,7 @@ data ReportOpts = ReportOpts {
     ,infer_value_    :: Bool      -- ^ Infer market prices from transactions ?
     ,depth_          :: Maybe Int
     ,date2_          :: Bool
-    ,empty_          :: Bool
+    ,showempty_      :: Bool
     ,no_elide_       :: Bool
     ,real_           :: Bool
     ,format_         :: StringFormat
@@ -117,7 +117,7 @@ data ReportOpts = ReportOpts {
     ,reporttype_     :: ReportType
     ,balancetype_    :: BalanceType
     ,accountlistmode_ :: AccountListMode
-    ,drop_           :: Int
+    ,droplevels_     :: Int
     ,row_total_      :: Bool
     ,no_total_       :: Bool
     ,show_costs_     :: Bool  -- ^ Whether to show costs for reports which normally don't show them
@@ -133,13 +133,13 @@ data ReportOpts = ReportOpts {
       -- - It helps compound balance report commands (is, bs etc.) do
       --   sign normalisation, converting normally negative subreports to
       --   normally positive for a more conventional display.
-    ,color_          :: Bool
+    ,showcolor_      :: Bool
       -- ^ Whether to use ANSI color codes in text output.
       --   Influenced by the --color/colour flag (cf CliOptions),
       --   whether stdout is an interactive terminal, and the value of
       --   TERM and existence of NO_COLOR environment variables.
     ,forecast_       :: Maybe DateSpan
-    ,transpose_      :: Bool
+    ,transposetable_ :: Bool
  } deriving (Show)
 
 instance Default ReportOpts where def = defreportopts
@@ -154,7 +154,7 @@ defreportopts = ReportOpts
     , infer_value_     = False
     , depth_           = Nothing
     , date2_           = False
-    , empty_           = False
+    , showempty_       = False
     , no_elide_        = False
     , real_            = False
     , format_          = def
@@ -165,7 +165,7 @@ defreportopts = ReportOpts
     , reporttype_      = def
     , balancetype_     = def
     , accountlistmode_ = ALFlat
-    , drop_            = 0
+    , droplevels_      = 0
     , row_total_       = False
     , no_total_        = False
     , show_costs_      = False
@@ -174,9 +174,9 @@ defreportopts = ReportOpts
     , percent_         = False
     , invert_          = False
     , normalbalance_   = Nothing
-    , color_           = False
+    , showcolor_       = False
     , forecast_        = Nothing
-    , transpose_       = False
+    , transposetable_  = False
     }
 
 rawOptsToReportOpts :: RawOpts -> IO ReportOpts
@@ -193,36 +193,36 @@ rawOptsToReportOpts rawopts = do
         Just (Left err) -> fail $ "could not parse format option: " ++ err
 
     return defreportopts
-          {period_      = periodFromRawOpts d rawopts
-          ,interval_    = intervalFromRawOpts rawopts
-          ,statuses_    = statusesFromRawOpts rawopts
-          ,cost_        = costing
-          ,value_       = valuation
-          ,infer_value_ = boolopt "infer-market-price" rawopts
-          ,depth_       = maybeposintopt "depth" rawopts
-          ,date2_       = boolopt "date2" rawopts
-          ,empty_       = boolopt "empty" rawopts
-          ,no_elide_    = boolopt "no-elide" rawopts
-          ,real_        = boolopt "real" rawopts
-          ,format_      = format
-          ,querystring_ = querystring
-          ,average_     = boolopt "average" rawopts
-          ,related_     = boolopt "related" rawopts
-          ,txn_dates_   = boolopt "txn-dates" rawopts
-          ,reporttype_  = reporttypeopt rawopts
-          ,balancetype_ = balancetypeopt rawopts
+          {period_          = periodFromRawOpts d rawopts
+          ,interval_        = intervalFromRawOpts rawopts
+          ,statuses_        = statusesFromRawOpts rawopts
+          ,cost_            = costing
+          ,value_           = valuation
+          ,infer_value_     = boolopt "infer-market-price" rawopts
+          ,depth_           = maybeposintopt "depth" rawopts
+          ,date2_           = boolopt "date2" rawopts
+          ,showempty_       = boolopt "empty" rawopts
+          ,no_elide_        = boolopt "no-elide" rawopts
+          ,real_            = boolopt "real" rawopts
+          ,format_          = format
+          ,querystring_     = querystring
+          ,average_         = boolopt "average" rawopts
+          ,related_         = boolopt "related" rawopts
+          ,txn_dates_       = boolopt "txn-dates" rawopts
+          ,reporttype_      = reporttypeopt rawopts
+          ,balancetype_     = balancetypeopt rawopts
           ,accountlistmode_ = accountlistmodeopt rawopts
-          ,drop_        = posintopt "drop" rawopts
-          ,row_total_   = boolopt "row-total" rawopts
-          ,no_total_    = boolopt "no-total" rawopts
-          ,show_costs_  = boolopt "show-costs" rawopts
-          ,sort_amount_ = boolopt "sort-amount" rawopts
-          ,percent_     = boolopt "percent" rawopts
-          ,invert_      = boolopt "invert" rawopts
-          ,pretty_tables_ = boolopt "pretty-tables" rawopts
-          ,color_       = useColorOnStdout -- a lower-level helper
-          ,forecast_    = forecastPeriodFromRawOpts d rawopts
-          ,transpose_   = boolopt "transpose" rawopts
+          ,droplevels_      = posintopt "drop" rawopts
+          ,row_total_       = boolopt "row-total" rawopts
+          ,no_total_        = boolopt "no-total" rawopts
+          ,show_costs_      = boolopt "show-costs" rawopts
+          ,sort_amount_     = boolopt "sort-amount" rawopts
+          ,percent_         = boolopt "percent" rawopts
+          ,invert_          = boolopt "invert" rawopts
+          ,pretty_tables_   = boolopt "pretty-tables" rawopts
+          ,showcolor_       = useColorOnStdout -- a lower-level helper
+          ,forecast_        = forecastPeriodFromRawOpts d rawopts
+          ,transposetable_  = boolopt "transpose" rawopts
           }
 
 -- | The result of successfully parsing a ReportOpts on a particular

--- a/hledger-lib/Hledger/Reports/TransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/TransactionsReport.hs
@@ -67,7 +67,7 @@ transactionsReport rspec j q = items
      -- XXX items' first element should be the full transaction with all postings
      items = reverse $ accountTransactionsReportItems q None nullmixedamt id ts
      ts    = sortBy (comparing date) $ filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
-     date = transactionDateFn $ rsOpts rspec
+     date = transactionDateFn $ reportopts_ rspec
 
 -- | Split a transactions report whose items may involve several commodities,
 -- into one or more single-commodity transactions reports.

--- a/hledger-lib/Hledger/Utils/TH.hs
+++ b/hledger-lib/Hledger/Utils/TH.hs
@@ -1,0 +1,14 @@
+module Hledger.Utils.TH
+( makeClassyLensesTrailing
+) where
+
+import Data.List.Extra (unsnoc)
+import Language.Haskell.TH (mkName, nameBase)
+import Lens.Micro ((&), (.~))
+import Lens.Micro.TH (DefName(TopName), lensField, makeLensesWith, classyRules)
+
+makeClassyLensesTrailing x = flip makeLensesWith x $
+  classyRules & lensField .~ (\_ _ n -> case unsnoc (nameBase n) of
+      Just (name, '_') -> [TopName (mkName name)]
+      _                -> []
+      )

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -85,6 +85,7 @@ library
       Hledger.Utils.String
       Hledger.Utils.Test
       Hledger.Utils.Text
+      Hledger.Utils.TH
       Hledger.Utils.Tree
       Hledger.Utils.UTF8IOCompat
       Text.Tabular.AsciiWide
@@ -118,6 +119,8 @@ library
     , filepath
     , hashtables >=1.2.3.1
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
+    , microlens-th >=0.4
     , mtl >=2.2.1
     , old-time
     , parser-combinators >=0.4.0
@@ -168,6 +171,8 @@ test-suite doctest
     , filepath
     , hashtables >=1.2.3.1
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
+    , microlens-th >=0.4
     , mtl >=2.2.1
     , old-time
     , parser-combinators >=0.4.0
@@ -220,6 +225,8 @@ test-suite unittest
     , hashtables >=1.2.3.1
     , hledger-lib
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
+    , microlens-th >=0.4
     , mtl >=2.2.1
     , old-time
     , parser-combinators >=0.4.0

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -52,6 +52,8 @@ dependencies:
 - filepath
 - hashtables >=1.2.3.1
 - megaparsec >=7.0.0 && <9.1
+- microlens >=0.4
+- microlens-th >=0.4
 - mtl >=2.2.1
 - old-time
 - parser-combinators >=0.4.0
@@ -136,6 +138,7 @@ library:
   - Hledger.Utils.String
   - Hledger.Utils.Test
   - Hledger.Utils.Text
+  - Hledger.Utils.TH
   - Hledger.Utils.Tree
   - Hledger.Utils.UTF8IOCompat
   - Text.Tabular.AsciiWide

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -49,7 +49,7 @@ accountsScreen = AccountsScreen{
 
 asInit :: Day -> Bool -> UIState -> UIState
 asInit d reset ui@UIState{
-  aopts=UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}},
+  aopts=UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}},
   ajournal=j,
   aScreen=s@AccountsScreen{}
   } =
@@ -77,7 +77,7 @@ asInit d reset ui@UIState{
                         as = map asItemAccountName displayitems
 
     -- Further restrict the query based on the current period and future/forecast mode.
-    rspec' = rspec{rsQuery=simplifyQuery $ And [rsQuery rspec, periodq, excludeforecastq (forecast_ ropts)]}
+    rspec' = rspec{query_=simplifyQuery $ And [query_ rspec, periodq, excludeforecastq (forecast_ ropts)]}
       where
         periodq = Date $ periodAsDateSpan $ period_ ropts
         -- Except in forecast mode, exclude future/forecast transactions.
@@ -152,7 +152,7 @@ asDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
       render $ defaultLayout toplabel bottomlabel $ renderList (asDrawItem colwidths) True (_asList s)
 
       where
-        ropts = rsOpts rspec
+        ropts = reportopts_ rspec
         ishistorical = balancetype_ ropts == HistoricalBalance
 
         toplabel =

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -49,7 +49,7 @@ accountsScreen = AccountsScreen{
 
 asInit :: Day -> Bool -> UIState -> UIState
 asInit d reset ui@UIState{
-  aopts=UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}},
+  _aopts=UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}},
   ajournal=j,
   aScreen=s@AccountsScreen{}
   } =
@@ -112,7 +112,7 @@ asInit d reset ui@UIState{
 asInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 asDraw :: UIState -> [Widget Name]
-asDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
+asDraw UIState{_aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
               ,ajournal=j
               ,aScreen=s@AccountsScreen{}
               ,aMode=mode
@@ -232,7 +232,7 @@ asDrawItem (acctwidth, balwidth) selected AccountsScreenItem{..} =
 asHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
 asHandle ui0@UIState{
    aScreen=scr@AccountsScreen{..}
-  ,aopts=UIOpts{cliopts_=copts}
+  ,_aopts=UIOpts{cliopts_=copts}
   ,ajournal=j
   ,aMode=mode
   } ev = do

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -174,7 +174,7 @@ asDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
                            -- f:fs  -> (withAttr ("border" <> "bold") $ str $ takeFileName f) <+> str (" (& " ++ show (length fs) ++ " included files)")
             toggles = withAttr ("border" <> "query") $ str $ unwords $ concat [
                [""]
-              ,if empty_ ropts then [] else ["nonzero"]
+              ,if showempty_ ropts then [] else ["nonzero"]
               ,uiShowStatus copts $ statuses_ ropts
               ,if real_ ropts then ["real"] else []
               ]

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -162,9 +162,7 @@ asDraw UIState{_aopts=copts@CliOpts{reportspec_=rspec}
           <+> borderQueryStr (T.unpack . T.unwords . map textQuoteIfNeeded $ querystring_ ropts)
           <+> borderDepthStr mdepth
           <+> str (" ("++curidx++"/"++totidx++")")
-          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts
-               then withAttr ("border" <> "query") (str " ignoring balance assertions")
-               else str "")
+          <+> (if copts ^. ignore_assertions then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
           where
             files = case journalFilePaths j of
                            [] -> str ""

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -29,7 +29,6 @@ import System.FilePath (takeFileName)
 
 import Hledger
 import Hledger.Cli hiding (progname,prognameandversion)
-import Hledger.UI.UIOptions
 import Hledger.UI.UITypes
 import Hledger.UI.UIState
 import Hledger.UI.UIUtils
@@ -49,7 +48,7 @@ accountsScreen = AccountsScreen{
 
 asInit :: Day -> Bool -> UIState -> UIState
 asInit d reset ui@UIState{
-  _aopts=UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}},
+  _aopts=CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}},
   ajournal=j,
   aScreen=s@AccountsScreen{}
   } =
@@ -112,7 +111,7 @@ asInit d reset ui@UIState{
 asInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 asDraw :: UIState -> [Widget Name]
-asDraw UIState{_aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
+asDraw UIState{_aopts=copts@CliOpts{reportspec_=rspec}
               ,ajournal=j
               ,aScreen=s@AccountsScreen{}
               ,aMode=mode
@@ -232,7 +231,7 @@ asDrawItem (acctwidth, balwidth) selected AccountsScreenItem{..} =
 asHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
 asHandle ui0@UIState{
    aScreen=scr@AccountsScreen{..}
-  ,_aopts=UIOpts{cliopts_=copts}
+  ,_aopts=copts
   ,ajournal=j
   ,aMode=mode
   } ev = do

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -24,7 +24,6 @@ import Text.Megaparsec
 import Text.Megaparsec.Char
 
 import Hledger.Cli hiding (progname,prognameandversion)
-import Hledger.UI.UIOptions
 import Hledger.UI.UITypes
 import Hledger.UI.UIState
 import Hledger.UI.UIUtils
@@ -44,7 +43,7 @@ esInit _ _ ui@UIState{aScreen=ErrorScreen{}} = ui
 esInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 esDraw :: UIState -> [Widget Name]
-esDraw UIState{_aopts=UIOpts{cliopts_=copts@CliOpts{}}
+esDraw UIState{_aopts=copts@CliOpts{}
               ,aScreen=ErrorScreen{..}
               ,aMode=mode
               } =
@@ -76,7 +75,7 @@ esDraw _ = error "draw function called with wrong screen type, should not happen
 
 esHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
 esHandle ui@UIState{aScreen=ErrorScreen{..}
-                   ,_aopts=UIOpts{cliopts_=copts}
+                   ,_aopts=copts
                    ,ajournal=j
                    ,aMode=mode
                    }
@@ -189,7 +188,7 @@ enableForecastPreservingPeriod ui copts@CliOpts{reportspec_=rspec@ReportSpec{rep
     mforecast = asum [mprovidedforecastperiod, mstartupforecastperiod, mdefaultforecastperiod]
       where
         mprovidedforecastperiod = forecast_ ropts
-        mstartupforecastperiod  = forecast_ $ reportopts_ $ reportspec_ $ cliopts_ $ astartupopts ui
+        mstartupforecastperiod  = forecast_ . reportopts_ . reportspec_ $ astartupopts ui
         mdefaultforecastperiod  = Just nulldatespan
 
 -- Re-check any balance assertions in the current journal, and if any

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -182,13 +182,13 @@ uiReloadJournalIfChanged copts d j ui = do
 -- or in the provided UIState's startup options,
 -- it is preserved.
 enableForecastPreservingPeriod :: UIState -> CliOpts -> CliOpts
-enableForecastPreservingPeriod ui copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}} =
-  copts{reportspec_=rspec{rsOpts=ropts{forecast_=mforecast}}}
+enableForecastPreservingPeriod ui copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}} =
+  copts{reportspec_=rspec{reportopts_=ropts{forecast_=mforecast}}}
   where
     mforecast = asum [mprovidedforecastperiod, mstartupforecastperiod, mdefaultforecastperiod]
       where
         mprovidedforecastperiod = forecast_ ropts
-        mstartupforecastperiod  = forecast_ $ rsOpts $ reportspec_ $ cliopts_ $ astartupopts ui
+        mstartupforecastperiod  = forecast_ $ reportopts_ $ reportspec_ $ cliopts_ $ astartupopts ui
         mdefaultforecastperiod  = Just nulldatespan
 
 -- Re-check any balance assertions in the current journal, and if any

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -27,7 +27,6 @@ import Hledger
 import Hledger.Cli hiding (progname,prognameandversion)
 import Hledger.UI.UIOptions
 import Hledger.UI.UITypes
-import Hledger.UI.UIState (toggleHistorical)
 import Hledger.UI.Theme
 import Hledger.UI.AccountsScreen
 import Hledger.UI.RegisterScreen
@@ -108,8 +107,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
                depth_ =queryDepth $ query_ rspec,  -- query's depth part
                period_=periodfromoptsandargs,       -- query's date part
                no_elide_=True,  -- avoid squashing boring account names, for a more regular tree (unlike hledger)
-               showempty_=not $ showempty_ ropts,  -- show zero items by default, hide them with -E (unlike hledger)
-               balancetype_=HistoricalBalance  -- show historical balances by default (unlike hledger)
+               showempty_=not $ showempty_ ropts   -- show zero items by default, hide them with -E (unlike hledger)
                }
             }
          }
@@ -153,7 +151,6 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
 
     ui =
       (sInit scr) d True $
-        (if change_ uopts' then toggleHistorical else id) -- XXX
           UIState{
            astartupopts=uopts'
           ,aopts=uopts'
@@ -174,7 +171,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
 
   -- print (length (show ui)) >> exitSuccess  -- show any debug output to this point & quit
 
-  if not (watch_ uopts')
+  if not (watchfiles_ uopts')
   then
     void $ Brick.defaultMain brickapp ui
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -142,23 +142,21 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
                   asInit d True
                     UIState{
                      astartupopts=uopts'
-                    ,aopts=uopts'
+                    ,_aopts=uopts'
                     ,ajournal=j
                     ,aScreen=asSetSelectedAccount acct accountsScreen
                     ,aPrevScreens=[]
                     ,aMode=Normal
                     }
 
-    ui =
-      (sInit scr) d True $
-          UIState{
-           astartupopts=uopts'
-          ,aopts=uopts'
-          ,ajournal=j
-          ,aScreen=scr
-          ,aPrevScreens=prevscrs
-          ,aMode=Normal
-          }
+    ui = (sInit scr) d True $ UIState
+           { astartupopts=uopts'
+           , _aopts=uopts'
+           , ajournal=j
+           , aScreen=scr
+           , aPrevScreens=prevscrs
+           , aMode=Normal
+           }
 
     brickapp :: App UIState AppEvent Name
     brickapp = App {

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -43,11 +43,11 @@ writeChan = BC.writeBChan
 
 main :: IO ()
 main = do
-  opts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rspec@ReportSpec{rsOpts=ropts},rawopts_=rawopts}} <- getHledgerUIOpts
+  opts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rspec@ReportSpec{reportopts_=ropts},rawopts_=rawopts}} <- getHledgerUIOpts
   -- when (debug_ $ cliopts_ opts) $ printf "%s\n" prognameandversion >> printf "opts: %s\n" (show opts)
 
   -- always generate forecasted periodic transactions; their visibility will be toggled by the UI.
-  let copts' = copts{reportspec_=rspec{rsOpts=ropts{forecast_=Just $ fromMaybe nulldatespan (forecast_ ropts)}}}
+  let copts' = copts{reportspec_=rspec{reportopts_=ropts{forecast_=Just $ fromMaybe nulldatespan (forecast_ ropts)}}}
 
   case True of
     _ | "help"            `inRawOpts` rawopts -> putStr (showModeUsage uimode)
@@ -58,7 +58,7 @@ main = do
     _                                         -> withJournalDo copts' (runBrickUi opts)
 
 runBrickUi :: UIOpts -> Journal -> IO ()
-runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rspec@ReportSpec{rsOpts=ropts}}} j = do
+runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rspec@ReportSpec{reportopts_=ropts}}} j = do
   d <- getCurrentDay
 
   let
@@ -103,9 +103,9 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
     uopts' = uopts{
       cliopts_=copts{
          reportspec_=rspec{
-            rsQuery=filteredQuery $ rsQuery rspec,  -- query with depth/date parts removed
-            rsOpts=ropts{
-               depth_ =queryDepth $ rsQuery rspec,  -- query's depth part
+            query_=filteredQuery $ query_ rspec,  -- query with depth/date parts removed
+            reportopts_=ropts{
+               depth_ =queryDepth $ query_ rspec,  -- query's depth part
                period_=periodfromoptsandargs,       -- query's date part
                no_elide_=True,  -- avoid squashing boring account names, for a more regular tree (unlike hledger)
                empty_=not $ empty_ ropts,  -- show zero items by default, hide them with -E (unlike hledger)
@@ -115,7 +115,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
          }
       }
       where
-        datespanfromargs = queryDateSpan (date2_ ropts) $ rsQuery rspec
+        datespanfromargs = queryDateSpan (date2_ ropts) $ query_ rspec
         periodfromoptsandargs =
           dateSpanAsPeriod $ spansIntersect [periodAsDateSpan $ period_ ropts, datespanfromargs]
         filteredQuery q = simplifyQuery $ And [queryFromFlags ropts, filtered q]

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -108,7 +108,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
                depth_ =queryDepth $ query_ rspec,  -- query's depth part
                period_=periodfromoptsandargs,       -- query's date part
                no_elide_=True,  -- avoid squashing boring account names, for a more regular tree (unlike hledger)
-               empty_=not $ empty_ ropts,  -- show zero items by default, hide them with -E (unlike hledger)
+               showempty_=not $ showempty_ ropts,  -- show zero items by default, hide them with -E (unlike hledger)
                balancetype_=HistoricalBalance  -- show historical balances by default (unlike hledger)
                }
             }

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -56,7 +56,7 @@ rsSetAccount a forceinclusive scr@RegisterScreen{} =
 rsSetAccount _ _ scr = scr
 
 rsInit :: Day -> Bool -> UIState -> UIState
-rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}, ajournal=j, aScreen=s@RegisterScreen{..}} =
+rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}, ajournal=j, aScreen=s@RegisterScreen{..}} =
   ui{aScreen=s{rsList=newitems'}}
   where
     -- gather arguments and queries
@@ -77,7 +77,7 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportspec_=rspec
       updateReportSpec ropts' rspec
 
     -- Further restrict the query based on the current period and future/forecast mode.
-    q = simplifyQuery $ And [rsQuery rspec', periodq, excludeforecastq (forecast_ ropts)]
+    q = simplifyQuery $ And [query_ rspec', periodq, excludeforecastq (forecast_ ropts)]
       where
         periodq = Date $ periodAsDateSpan $ period_ ropts
         -- Except in forecast mode, exclude future/forecast transactions.
@@ -200,7 +200,7 @@ rsDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
       render $ defaultLayout toplabel bottomlabel $ renderList (rsDrawItem colwidths) True rsList
 
       where
-        ropts = rsOpts rspec
+        ropts = reportopts_ rspec
         ishistorical = balancetype_ ropts == HistoricalBalance
         -- inclusive = tree_ ropts || rsForceInclusive
 

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -88,7 +88,7 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportspec_=rspec
             ,Not generatedTransactionTag
           ]
     items = accountTransactionsReport rspec' j q thisacctq
-    items' = (if empty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $  -- without --empty, exclude no-change txns
+    items' = (if showempty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $  -- without --empty, exclude no-change txns
              reverse  -- most recent last
              items
 
@@ -224,7 +224,7 @@ rsDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
               case concat [
                    uiShowStatus copts $ statuses_ ropts
                   ,if real_ ropts then ["real"] else []
-                  ,if empty_ ropts then [] else ["nonzero"]
+                  ,if showempty_ ropts then [] else ["nonzero"]
                   ] of
                 [] -> str ""
                 fs -> withAttr ("border" <> "query") (str $ " " ++ intercalate ", " fs)

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -209,7 +209,7 @@ rsDraw UIState{_aopts=copts,aScreen=RegisterScreen{..},aMode=mode} =
           <+> str "/"
           <+> total
           <+> str ")"
-          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
+          <+> (if copts ^. ignore_assertions then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
           where
             togglefilters =
               case concat [

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -31,7 +31,6 @@ import System.Console.ANSI
 
 import Hledger
 import Hledger.Cli hiding (progname,prognameandversion)
-import Hledger.UI.UIOptions
 -- import Hledger.UI.Theme
 import Hledger.UI.UITypes
 import Hledger.UI.UIState
@@ -141,7 +140,7 @@ rsInit d reset ui@UIState{aScreen=s@RegisterScreen{..}} =
 rsInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 rsDraw :: UIState -> [Widget Name]
-rsDraw UIState{_aopts=UIOpts{cliopts_=copts},aScreen=RegisterScreen{..},aMode=mode} =
+rsDraw UIState{_aopts=copts,aScreen=RegisterScreen{..},aMode=mode} =
   case mode of
     Help       -> [helpDialog copts, maincontent]
     -- Minibuffer e -> [minibuffer e, maincontent]
@@ -279,7 +278,7 @@ rsDrawItem (datewidth,descwidth,acctswidth,changewidth,balwidth) selected Regist
 rsHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
 rsHandle ui@UIState{
    aScreen=s@RegisterScreen{..}
-  ,_aopts=UIOpts{cliopts_=copts}
+  ,_aopts=copts
   ,ajournal=j
   ,aMode=mode
   } ev = do

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -24,7 +24,6 @@ import Brick.Widgets.List (listElementsL, listMoveTo, listSelectedElement)
 
 import Hledger
 import Hledger.Cli hiding (progname,prognameandversion)
-import Hledger.UI.UIOptions
 -- import Hledger.UI.Theme
 import Hledger.UI.UITypes
 import Hledger.UI.UIState
@@ -43,7 +42,7 @@ transactionScreen = TransactionScreen{
   }
 
 tsInit :: Day -> Bool -> UIState -> UIState
-tsInit _d _reset ui@UIState{_aopts=UIOpts{cliopts_=CliOpts{reportspec_=_rspec}}
+tsInit _d _reset ui@UIState{_aopts=CliOpts{reportspec_=_rspec}
                            ,ajournal=_j
                            ,aScreen=s@TransactionScreen{tsTransaction=(_,t),tsTransactions=nts}
                            ,aPrevScreens=prevscreens
@@ -62,7 +61,7 @@ tsInit _d _reset ui@UIState{_aopts=UIOpts{cliopts_=CliOpts{reportspec_=_rspec}}
 tsInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 tsDraw :: UIState -> [Widget Name]
-tsDraw UIState{_aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}
+tsDraw UIState{_aopts=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}
               ,ajournal=j
               ,aScreen=TransactionScreen{tsTransaction=(i,t')
                                         ,tsTransactions=nts
@@ -136,7 +135,7 @@ tsHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
 tsHandle ui@UIState{aScreen=s@TransactionScreen{tsTransaction=(i,t)
                                                ,tsTransactions=nts
                                                }
-                   ,_aopts=UIOpts{cliopts_=copts}
+                   ,_aopts=copts
                    ,ajournal=j
                    ,aMode=mode
                    }

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -62,7 +62,7 @@ tsInit _d _reset ui@UIState{aopts=UIOpts{cliopts_=CliOpts{reportspec_=_rspec}}
 tsInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 tsDraw :: UIState -> [Widget Name]
-tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}
+tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}
               ,ajournal=j
               ,aScreen=TransactionScreen{tsTransaction=(i,t')
                                         ,tsTransactions=nts
@@ -87,7 +87,7 @@ tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{
 
       render . defaultLayout toplabel bottomlabel . str
         . T.unpack . showTransactionOneLineAmounts
-        . maybe id (transactionApplyValuation prices styles periodlast (rsToday rspec)) (value_ ropts)
+        . maybe id (transactionApplyValuation prices styles periodlast (reportday_ rspec)) (value_ ropts)
         $ case cost_ ropts of
                Cost   -> transactionToCost styles t
                NoCost -> t

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -43,7 +43,7 @@ transactionScreen = TransactionScreen{
   }
 
 tsInit :: Day -> Bool -> UIState -> UIState
-tsInit _d _reset ui@UIState{aopts=UIOpts{cliopts_=CliOpts{reportspec_=_rspec}}
+tsInit _d _reset ui@UIState{_aopts=UIOpts{cliopts_=CliOpts{reportspec_=_rspec}}
                            ,ajournal=_j
                            ,aScreen=s@TransactionScreen{tsTransaction=(_,t),tsTransactions=nts}
                            ,aPrevScreens=prevscreens
@@ -62,7 +62,7 @@ tsInit _d _reset ui@UIState{aopts=UIOpts{cliopts_=CliOpts{reportspec_=_rspec}}
 tsInit _ _ _ = error "init function called with wrong screen type, should not happen"  -- PARTIAL:
 
 tsDraw :: UIState -> [Widget Name]
-tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}
+tsDraw UIState{_aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}
               ,ajournal=j
               ,aScreen=TransactionScreen{tsTransaction=(i,t')
                                         ,tsTransactions=nts
@@ -136,7 +136,7 @@ tsHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
 tsHandle ui@UIState{aScreen=s@TransactionScreen{tsTransaction=(i,t)
                                                ,tsTransactions=nts
                                                }
-                   ,aopts=UIOpts{cliopts_=copts}
+                   ,_aopts=UIOpts{cliopts_=copts}
                    ,ajournal=j
                    ,aMode=mode
                    }

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -103,7 +103,7 @@ tsDraw UIState{_aopts=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=rop
           <+> togglefilters
           <+> borderQueryStr (unwords . map (quoteIfNeeded . T.unpack) $ querystring_ ropts)
           <+> str (" in "++T.unpack (replaceHiddenAccountsNameWith "All" acct)++")")
-          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
+          <+> (if copts ^. ignore_assertions then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
           where
             togglefilters =
               case concat [

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -110,7 +110,7 @@ tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{
               case concat [
                    uiShowStatus copts $ statuses_ ropts
                   ,if real_ ropts then ["real"] else []
-                  ,if empty_ ropts then [] else ["nonzero"]
+                  ,if showempty_ ropts then [] else ["nonzero"]
                   ] of
                 [] -> str ""
                 fs -> withAttr ("border" <> "query") (str $ " " ++ intercalate ", " fs)

--- a/hledger-ui/Hledger/UI/UIOptions.hs
+++ b/hledger-ui/Hledger/UI/UIOptions.hs
@@ -7,6 +7,8 @@ module Hledger.UI.UIOptions
 where
 import Data.Default
 import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
+import Lens.Micro (set)
 import System.Environment
 
 import Hledger.Cli hiding (progname,version,prognameandversion)
@@ -56,26 +58,26 @@ uimode =  (mode "hledger-ui" (setopt "command" "ui" def)
 
 -- hledger-ui options, used in hledger-ui and above
 data UIOpts = UIOpts {
-     watch_       :: Bool
-    ,change_      :: Bool
-    ,cliopts_     :: CliOpts
+     watchfiles_ :: Bool
+    ,cliopts_    :: CliOpts
  } deriving (Show)
 
 defuiopts = UIOpts
-  { watch_   = False
-  , change_  = False
-  , cliopts_ = def
+  { watchfiles_ = False
+  , cliopts_    = def
   }
 
 -- instance Default CliOpts where def = defcliopts
 
 rawOptsToUIOpts :: RawOpts -> IO UIOpts
 rawOptsToUIOpts rawopts = checkUIOpts <$> do
-  cliopts <- rawOptsToCliOpts rawopts
+  cliopts' <- rawOptsToCliOpts rawopts
+  -- show historical balances by default (unlike hledger)
+  let btype = fromMaybe HistoricalBalance $ balanceTypeOverride rawopts
+      cliopts = cliopts'{reportspec_=set balancetype btype $ reportspec_ cliopts'}
   return defuiopts {
-              watch_       = boolopt "watch" rawopts
-             ,change_      = boolopt "change" rawopts
-             ,cliopts_     = cliopts
+              watchfiles_ = boolopt "watch" rawopts
+             ,cliopts_    = cliopts
              }
 
 checkUIOpts :: UIOpts -> UIOpts

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -103,7 +103,7 @@ toggleEmpty :: UIState -> UIState
 toggleEmpty ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
   ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=toggleEmpty ropts}}}}
   where
-    toggleEmpty ropts = ropts{empty_=not $ empty_ ropts}
+    toggleEmpty ropts = ropts{showempty_=not $ showempty_ ropts}
 
 -- | Toggle between showing the primary amounts or costs.
 toggleCost :: UIState -> UIState
@@ -242,7 +242,7 @@ resetFilter ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rsp
      query_=Any
     ,queryopts_=[]
     ,reportopts_=ropts{
-       empty_=True
+       showempty_=True
       ,statuses_=[]
       ,real_=False
       ,querystring_=[]

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -100,23 +100,23 @@ complement = ([minBound..maxBound] \\)
 
 -- | Toggle between showing all and showing only nonempty (more precisely, nonzero) items.
 toggleEmpty :: UIState -> UIState
-toggleEmpty ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=toggleEmpty ropts}}}}
+toggleEmpty ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=toggleEmpty ropts}}}}
   where
     toggleEmpty ropts = ropts{empty_=not $ empty_ ropts}
 
 -- | Toggle between showing the primary amounts or costs.
 toggleCost :: UIState -> UIState
-toggleCost ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-    ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{cost_ = toggle $ cost_ ropts}}}}}
+toggleCost ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+    ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=ropts{cost_ = toggle $ cost_ ropts}}}}}
   where
     toggle Cost   = NoCost
     toggle NoCost = Cost
 
 -- | Toggle between showing primary amounts or default valuation.
 toggleValue :: UIState -> UIState
-toggleValue ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{
+toggleValue ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=ropts{
     value_ = valuationToggleValue $ value_ ropts}}}}}
 
 -- | Basic toggling of -V, for hledger-ui.
@@ -126,18 +126,18 @@ valuationToggleValue _                = Just $ AtEnd Nothing
 
 -- | Set hierarchic account tree mode.
 setTree :: UIState -> UIState
-setTree ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{accountlistmode_=ALTree}}}}}
+setTree ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=ropts{accountlistmode_=ALTree}}}}}
 
 -- | Set flat account list mode.
 setList :: UIState -> UIState
-setList ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{accountlistmode_=ALFlat}}}}}
+setList ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=ropts{accountlistmode_=ALFlat}}}}}
 
 -- | Toggle between flat and tree mode. If current mode is unspecified/default, assume it's flat.
 toggleTree :: UIState -> UIState
-toggleTree ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=toggleTreeMode ropts}}}}
+toggleTree ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=toggleTreeMode ropts}}}}
   where
     toggleTreeMode ropts
       | accountlistmode_ ropts == ALTree = ropts{accountlistmode_=ALFlat}
@@ -145,8 +145,8 @@ toggleTree ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspe
 
 -- | Toggle between historical balances and period balances.
 toggleHistorical :: UIState -> UIState
-toggleHistorical ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{balancetype_=b}}}}}
+toggleHistorical ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=ropts{balancetype_=b}}}}}
   where
     b | balancetype_ ropts == HistoricalBalance = PeriodChange
       | otherwise                               = HistoricalBalance
@@ -157,7 +157,7 @@ toggleHistorical ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec
 -- (which are usually but not necessarily future-dated).
 -- In normal mode, both of these are hidden.
 toggleForecast :: Day -> UIState -> UIState
-toggleForecast d ui@UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=ReportSpec{rsOpts=ropts}}}} =
+toggleForecast d ui@UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=ReportSpec{reportopts_=ropts}}}} =
   uiSetForecast ui $
     case forecast_ ropts of
       Just _  -> Nothing
@@ -166,10 +166,10 @@ toggleForecast d ui@UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=Repo
 -- | Helper: set forecast mode (with the given forecast period) on or off in the UI state.
 uiSetForecast :: UIState -> Maybe DateSpan -> UIState
 uiSetForecast
-  ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}}
+  ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}}
   mforecast =
   -- we assume forecast mode has no effect on ReportSpec's derived fields
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{forecast_=mforecast}}}}}
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{reportopts_=ropts{forecast_=mforecast}}}}}
 
 -- | Toggle between showing all and showing only real (non-virtual) items.
 toggleReal :: UIState -> UIState
@@ -209,7 +209,7 @@ moveReportPeriodToDate d = updateReportPeriod (periodMoveTo d)
 
 -- | Get the report period.
 reportPeriod :: UIState -> Period
-reportPeriod = period_ . rsOpts . reportspec_ . cliopts_ . aopts
+reportPeriod = period_ . reportopts_ . reportspec_ . cliopts_ . aopts
 
 -- | Set the report period.
 setReportPeriod :: Period -> UIState -> UIState
@@ -237,11 +237,11 @@ setFilter s ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rsp
 
 -- | Reset some filters & toggles.
 resetFilter :: UIState -> UIState
-resetFilter ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
+resetFilter ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_=ropts}}}} =
   ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{
-     rsQuery=Any
-    ,rsQueryOpts=[]
-    ,rsOpts=ropts{
+     query_=Any
+    ,queryopts_=[]
+    ,reportopts_=ropts{
        empty_=True
       ,statuses_=[]
       ,real_=False
@@ -282,7 +282,7 @@ setDepth :: Maybe Int -> UIState -> UIState
 setDepth mdepth = updateReportDepth (const mdepth)
 
 getDepth :: UIState -> Maybe Int
-getDepth = depth_ . rsOpts . reportspec_ . cliopts_ . aopts
+getDepth = depth_ . reportopts_ . reportspec_ . cliopts_ . aopts
 
 -- | Update report depth by a applying a function. If asked to set a depth less
 -- than zero, it will leave it unchanged.
@@ -302,7 +302,7 @@ showMinibuffer ui = setMode (Minibuffer e) ui
   where
     e = applyEdit gotoEOL $ editor MinibufferEditor (Just 1) oldq
     oldq = T.unpack . T.unwords . map textQuoteIfNeeded
-         . querystring_ . rsOpts . reportspec_ . cliopts_ $ aopts ui
+         . querystring_ . reportopts_ . reportspec_ . cliopts_ $ aopts ui
 
 -- | Close the minibuffer, discarding any edit in progress.
 closeMinibuffer :: UIState -> UIState

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -22,7 +22,7 @@ Brick.defaultMain brickapp st
     st :: UIState
     st = (sInit s) d
          UIState{
-            aopts=uopts'
+            _aopts=uopts'
            ,ajournal=j
            ,aScreen=s
            ,aPrevScreens=prevscrs
@@ -36,7 +36,19 @@ Brick.defaultMain brickapp st
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 
-module Hledger.UI.UITypes where
+module Hledger.UI.UITypes
+( UIState(..)
+, AppEvent(..)
+, Mode(..)
+, Name(..)
+, Screen(..)
+, AccountsScreenItem(..)
+, RegisterScreenItem(..)
+-- * Lenses
+, aopts
+, asList
+, asSelectedAccount
+) where
 
 import Data.Text (Text)
 import Data.Time.Calendar (Day)
@@ -44,10 +56,10 @@ import Brick
 import Brick.Widgets.List (List)
 import Brick.Widgets.Edit (Editor)
 import Lens.Micro.Platform
-import Text.Show.Functions ()
-  -- import the Show instance for functions. Warning, this also re-exports it
+import Text.Show.Functions ()  -- import the Show instance for functions.
 
 import Hledger
+import Hledger.Cli.CliOptions (HasCliOpts(..))
 import Hledger.UI.UIOptions
 
 -- | hledger-ui's application state. This holds one or more stateful screens.
@@ -56,7 +68,7 @@ import Hledger.UI.UIOptions
 -- showing a help dialog, entering data in the minibuffer etc.
 data UIState = UIState {
    astartupopts :: UIOpts    -- ^ the command-line options and query arguments specified at startup
-  ,aopts        :: UIOpts    -- ^ the command-line options and query arguments currently in effect
+  ,_aopts       :: UIOpts    -- ^ the command-line options and query arguments currently in effect
   ,ajournal     :: Journal   -- ^ the journal being viewed
   ,aPrevScreens :: [Screen]  -- ^ previously visited screens, most recent first
   ,aScreen      :: Screen    -- ^ the currently active screen
@@ -160,7 +172,11 @@ type NumberedTransaction = (Integer, Transaction)
 --    mempty        = list "" V.empty 1  -- XXX problem in 0.7, every list requires a unique Name
 --    mappend l1 l2 = l1 & listElementsL .~ (l1^.listElementsL <> l2^.listElementsL)
 
-concat <$> mapM makeLenses [
-   ''Screen
-  ]
+concat <$> mapM makeLenses [ ''Screen, ''UIState ]
 
+instance HasUIOpts        UIState where uIOpts        = aopts
+instance HasCliOpts       UIState where cliOpts       = aopts . cliOpts
+instance HasInputOpts     UIState where inputOpts     = aopts . inputOpts
+instance HasBalancingOpts UIState where balancingOpts = aopts . balancingOpts
+instance HasReportSpec    UIState where reportSpec    = aopts . reportSpec
+instance HasReportOpts    UIState where reportOpts    = aopts . reportOpts

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -59,16 +59,15 @@ import Lens.Micro.Platform
 import Text.Show.Functions ()  -- import the Show instance for functions.
 
 import Hledger
-import Hledger.Cli.CliOptions (HasCliOpts(..))
-import Hledger.UI.UIOptions
+import Hledger.Cli.CliOptions (CliOpts, HasCliOpts(..))
 
 -- | hledger-ui's application state. This holds one or more stateful screens.
 -- As you navigate through screens, the old ones are saved in a stack.
 -- The app can be in one of several modes: normal screen operation,
 -- showing a help dialog, entering data in the minibuffer etc.
 data UIState = UIState {
-   astartupopts :: UIOpts    -- ^ the command-line options and query arguments specified at startup
-  ,_aopts       :: UIOpts    -- ^ the command-line options and query arguments currently in effect
+   astartupopts :: CliOpts   -- ^ the command-line options and query arguments specified at startup
+  ,_aopts       :: CliOpts   -- ^ the command-line options and query arguments currently in effect
   ,ajournal     :: Journal   -- ^ the journal being viewed
   ,aPrevScreens :: [Screen]  -- ^ previously visited screens, most recent first
   ,aScreen      :: Screen    -- ^ the currently active screen
@@ -174,8 +173,7 @@ type NumberedTransaction = (Integer, Transaction)
 
 concat <$> mapM makeLenses [ ''Screen, ''UIState ]
 
-instance HasUIOpts        UIState where uIOpts        = aopts
-instance HasCliOpts       UIState where cliOpts       = aopts . cliOpts
+instance HasCliOpts       UIState where cliOpts       = aopts
 instance HasInputOpts     UIState where inputOpts     = aopts . inputOpts
 instance HasBalancingOpts UIState where balancingOpts = aopts . balancingOpts
 instance HasReportSpec    UIState where reportSpec    = aopts . reportSpec

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -116,12 +116,12 @@ instance Yesod App where
     hideEmptyAccts <- (== Just "1") . lookup "hideemptyaccts" . reqCookies <$> getRequest
 
     let rspec = reportspec_ (cliopts_ opts)
-        ropts = rsOpts rspec
-        ropts' = (rsOpts rspec)
+        ropts = reportopts_ rspec
+        ropts' = (reportopts_ rspec)
           {accountlistmode_ = ALTree  -- force tree mode for sidebar
           ,empty_           = not (empty_ ropts)  -- show zero items by default
           }
-        rspec' = rspec{rsQuery=m,rsOpts=ropts'}
+        rspec' = rspec{query_=m,reportopts_=ropts'}
         accounts =
           balanceReportAsHtml (JournalR, RegisterR) here hideEmptyAccts j q qopts $
           balanceReport rspec' j
@@ -198,14 +198,14 @@ instance Show Text.Blaze.Markup where show _ = "<blaze markup>"
 -- | Gather data used by handlers and templates in the current request.
 getViewData :: Handler ViewData
 getViewData = do
-  App{appOpts=opts@WebOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts}}}, appJournal} <- getYesod
+  App{appOpts=opts@WebOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{reportopts_}}}, appJournal} <- getYesod
   today <- liftIO getCurrentDay
 
   -- try to read the latest journal content, keeping the old content
   -- if there's an error
   (j, mjerr) <- getCurrentJournal
                 appJournal
-                copts{reportspec_=rspec{rsOpts=rsOpts{no_elide_=True}}}
+                copts{reportspec_=rspec{reportopts_=reportopts_{no_elide_=True}}}
                 today
 
   -- try to parse the query param, assuming no query if there's an error
@@ -259,7 +259,7 @@ getCurrentJournal jref opts d = do
   j <- liftIO (readIORef jref)
   (ej, changed) <- liftIO $ journalReloadIfChanged opts d j
   -- re-apply any initial filter specified at startup
-  let initq = rsQuery $ reportspec_ opts
+  let initq = query_ $ reportspec_ opts
   case (changed, filterJournalTransactions initq <$> ej) of
     (False, _) -> return (j, Nothing)
     (True, Right j') -> do

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -119,7 +119,7 @@ instance Yesod App where
         ropts = reportopts_ rspec
         ropts' = (reportopts_ rspec)
           {accountlistmode_ = ALTree  -- force tree mode for sidebar
-          ,empty_           = not (empty_ ropts)  -- show zero items by default
+          ,showempty_       = not (showempty_ ropts)  -- show zero items by default
           }
         rspec' = rspec{query_=m,reportopts_=ropts'}
         accounts =

--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -13,7 +13,7 @@ import qualified Data.Text as T
 import Text.Hamlet (hamletFile)
 
 import Hledger
-import Hledger.Cli.CliOptions
+import Hledger.Cli.CliOptions hiding (width)
 import Hledger.Web.Import
 import Hledger.Web.WebOptions
 import Hledger.Web.Widget.AddForm (addModal)

--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -46,7 +46,7 @@ getRegisterR = do
           tail $ (", "<$xs) ++ [""]
       items = accountTransactionsReport rspec j m acctQuery
       balancelabel
-        | isJust (inAccount qopts), balancetype_ (rsOpts rspec) == HistoricalBalance = "Historical Total"
+        | isJust (inAccount qopts), balancetype_ (reportopts_ rspec) == HistoricalBalance = "Historical Total"
         | isJust (inAccount qopts) = "Period Total"
         | otherwise                = "Total"
       transactionFrag = transactionFragment j

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -66,7 +66,7 @@ hledgerWebMain = do
 -- | The hledger web command.
 web :: WebOpts -> Journal -> IO ()
 web opts j = do
-  let initq = rsQuery . reportspec_ $ cliopts_ opts
+  let initq = query_ . reportspec_ $ cliopts_ opts
       j' = filterJournalTransactions initq j
       h = host_ opts
       p = port_ opts

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -16,7 +16,7 @@ import System.Environment (getArgs)
 import Network.Wai as WAI
 import Network.Wai.Middleware.Cors
 
-import Hledger.Cli hiding (progname, version)
+import Hledger.Cli hiding (progname, rawopts, version)
 import Hledger.Web.Settings (defhost, defport, defbaseurl)
 
 progname, version :: String

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -110,7 +110,7 @@ validateTransaction ::
   -> FormResult Transaction
 validateTransaction dateRes descRes postingsRes =
   case makeTransaction <$> dateRes <*> descRes <*> postingsRes of
-    FormSuccess txn -> case balanceTransaction balancingOpts txn of
+    FormSuccess txn -> case balanceTransaction defbalancingopts txn of
       Left e -> FormFailure [T.pack e]
       Right txn' -> FormSuccess txn'
     x -> x

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -177,6 +177,7 @@ library
     , http-conduit
     , http-types
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
     , mtl >=2.2.1
     , network
     , shakespeare >=2.0.2.2

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -122,6 +122,7 @@ library:
   - http-client
   - http-types
   - megaparsec >=7.0.0 && <9.1
+  - microlens >=0.4
   - mtl >=2.2.1
   - network
   - shakespeare >=2.0.2.2

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -527,7 +527,7 @@ getHledgerCliOpts' mode' args' = do
         putStrLn $ "running: " ++ progname'
         putStrLn $ "raw args: " ++ show args'
         putStrLn $ "processed opts:\n" ++ show opts
-        putStrLn $ "search query: " ++ show (rsQuery $ reportspec_ opts)
+        putStrLn $ "search query: " ++ show (query_ $ reportspec_ opts)
 
 getHledgerCliOpts :: Mode RawOpts -> IO CliOpts
 getHledgerCliOpts mode' = do

--- a/hledger/Hledger/Cli/Commands/Accounts.hs
+++ b/hledger/Hledger/Cli/Commands/Accounts.hs
@@ -81,5 +81,5 @@ accounts CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{query_=query,reportopt
           ALTree -> T.replicate indent " " <> accountLeafName droppedName
           ALFlat -> droppedName
         where
-          indent = 2 * (max 0 (accountNameLevel a - drop_ ropts) - 1)
-          droppedName = accountNameDrop (drop_ ropts) a
+          indent = 2 * (max 0 (accountNameLevel a - droplevels_ ropts) - 1)
+          droppedName = accountNameDrop (droplevels_ ropts) a

--- a/hledger/Hledger/Cli/Commands/Accounts.hs
+++ b/hledger/Hledger/Cli/Commands/Accounts.hs
@@ -44,7 +44,7 @@ accountsmode = hledgerCommandMode
 
 -- | The accounts command.
 accounts :: CliOpts -> Journal -> IO ()
-accounts CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{rsQuery=query,rsOpts=ropts}} j = do
+accounts CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{query_=query,reportopts_=ropts}} j = do
 
   -- 1. identify the accounts we'll show
   let tree     = tree_ ropts

--- a/hledger/Hledger/Cli/Commands/Activity.hs
+++ b/hledger/Hledger/Cli/Commands/Activity.hs
@@ -33,7 +33,7 @@ activity :: CliOpts -> Journal -> IO ()
 activity CliOpts{reportspec_=rspec} j = putStr $ showHistogram rspec j
 
 showHistogram :: ReportSpec -> Journal -> String
-showHistogram ReportSpec{rsQuery=q,rsOpts=ReportOpts{interval_=i,date2_=date2}} j =
+showHistogram ReportSpec{query_=q,reportopts_=ReportOpts{interval_=i,date2_=date2}} j =
     concatMap (printDayWith countBar) spanps
   where
     interval | i == NoInterval = Days 1

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -203,7 +203,7 @@ confirmedTransactionWizard prevInput es@EntryState{..} stack@(currentStage : _) 
                              ,tcomment=txnCmnt
                              ,tpostings=esPostings
                              }
-      case balanceTransaction balancingOpts t of -- imprecise balancing (?)
+      case balanceTransaction defbalancingopts t of -- imprecise balancing (?)
         Right t' ->
           confirmedTransactionWizard prevInput es (EndStage t' : stack)
         Left err -> do
@@ -292,7 +292,7 @@ descriptionAndCommentWizard PrevInput{..} EntryState{..} = do
       return $ Just (desc, comment)
 
 postingsBalanced :: [Posting] -> Bool
-postingsBalanced ps = isRight $ balanceTransaction balancingOpts nulltransaction{tpostings=ps}
+postingsBalanced ps = isRight $ balanceTransaction defbalancingopts nulltransaction{tpostings=ps}
 
 accountWizard PrevInput{..} EntryState{..} = do
   let pnum = length esPostings + 1

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -33,6 +33,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
 import Data.Time.Calendar (Day)
 import Data.Time.Format (formatTime, defaultTimeLocale, iso8601DateFormat)
+import Lens.Micro (set)
 import Safe (headDef, headMay, atMay)
 import System.Console.CmdArgs.Explicit (flagNone)
 import System.Console.Haskeline (runInputT, defaultSettings, setComplete)
@@ -463,8 +464,7 @@ registerFromString s = do
   j <- readJournal' s
   return . postingsReportAsText opts $ postingsReport rspec j
       where
-        ropts = defreportopts{showempty_=True}
-        rspec = defreportspec{reportopts_=ropts}
+        rspec = set showempty True defreportspec
         opts = defcliopts{reportspec_=rspec}
 
 capitalize :: String -> String

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -463,7 +463,7 @@ registerFromString s = do
   j <- readJournal' s
   return . postingsReportAsText opts $ postingsReport rspec j
       where
-        ropts = defreportopts{empty_=True}
+        ropts = defreportopts{showempty_=True}
         rspec = defreportspec{reportopts_=ropts}
         opts = defcliopts{reportspec_=rspec}
 

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -464,7 +464,7 @@ registerFromString s = do
   return . postingsReportAsText opts $ postingsReport rspec j
       where
         ropts = defreportopts{empty_=True}
-        rspec = defreportspec{rsOpts=ropts}
+        rspec = defreportspec{reportopts_=ropts}
         opts = defcliopts{reportspec_=rspec}
 
 capitalize :: String -> String

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -105,7 +105,7 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     -- run the report
     -- TODO: need to also pass the queries so we can choose which date to render - move them into the report ?
     items = accountTransactionsReport rspec' j reportq thisacctq
-    items' = (if empty_ ropts' then id else filter (not . mixedAmountLooksZero . fifth6)) $
+    items' = (if showempty_ ropts' then id else filter (not . mixedAmountLooksZero . fifth6)) $
              reverse items
     -- select renderer
     render | fmt=="txt"  = accountTransactionsReportAsText opts reportq thisacctq
@@ -168,7 +168,7 @@ accountTransactionsReportAsText copts reportq thisacctq items
 --
 accountTransactionsReportItemAsText :: CliOpts -> Query -> Query -> Int -> Int -> AccountTransactionsReportItem -> TB.Builder
 accountTransactionsReportItemAsText
-  copts@CliOpts{reportspec_=ReportSpec{reportopts_=ReportOpts{color_}}}
+  copts@CliOpts{reportspec_=ReportSpec{reportopts_=ReportOpts{showcolor_}}}
   reportq thisacctq preferredamtwidth preferredbalwidth
   (t@Transaction{tdescription}, _, _issplit, otheracctsstr, change, balance) =
     -- Transaction -- the transaction, unmodified
@@ -214,7 +214,7 @@ accountTransactionsReportItemAsText
             otheracctsstr
     amt = TL.toStrict . TB.toLazyText . wbBuilder $ showamt amtwidth change
     bal = TL.toStrict . TB.toLazyText . wbBuilder $ showamt balwidth balance
-    showamt w = showMixedAmountB noPrice{displayColour=color_, displayMinWidth=Just w, displayMaxWidth=Just w}
+    showamt w = showMixedAmountB noPrice{displayColour=showcolor_, displayMinWidth=Just w, displayMaxWidth=Just w}
     -- alternate behaviour, show null amounts as 0 instead of blank
     -- amt = if null amt' then "0" else amt'
     -- bal = if null bal' then "0" else bal'

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -82,17 +82,17 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     -- gather report options
     inclusive = True  -- tree_ ropts
     thisacctq = Acct $ (if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex) acct
-    ropts' = (rsOpts rspec) {
+    ropts' = (reportopts_ rspec) {
         -- ignore any depth limit, as in postingsReport; allows register's total to match balance reports (cf #1468)
         depth_=Nothing
         -- always show historical balance
       , balancetype_= HistoricalBalance
       }
     -- and regenerate the ReportSpec, making sure to use the above
-    rspec' = rspec{ rsQuery=simplifyQuery $ And [queryFromFlags ropts', argsquery]
-                  , rsOpts=ropts'
+    rspec' = rspec{ query_=simplifyQuery $ And [queryFromFlags ropts', argsquery]
+                  , reportopts_=ropts'
                   }
-    reportq = And [rsQuery rspec', excludeforecastq (isJust $ forecast_ ropts')]
+    reportq = And [query_ rspec', excludeforecastq (isJust $ forecast_ ropts')]
       where
         -- As in RegisterScreen, why ? XXX
         -- Except in forecast mode, exclude future/forecast transactions.
@@ -143,7 +143,7 @@ accountTransactionsReportAsText copts reportq thisacctq items
     amtwidth = maximumStrict $ 12 : map (wbWidth . showamt . itemamt) items
     balwidth = maximumStrict $ 12 : map (wbWidth . showamt . itembal) items
     showamt = showMixedAmountB oneLine{displayMinWidth=Just 12, displayMaxWidth=mmax}  -- color_
-      where mmax = if no_elide_ . rsOpts . reportspec_ $ copts then Nothing else Just 32
+      where mmax = if no_elide_ . reportopts_ . reportspec_ $ copts then Nothing else Just 32
     itemamt (_,_,_,_,a,_) = a
     itembal (_,_,_,_,_,a) = a
     -- show a title indicating which account was picked, which can be confusing otherwise
@@ -168,7 +168,7 @@ accountTransactionsReportAsText copts reportq thisacctq items
 --
 accountTransactionsReportItemAsText :: CliOpts -> Query -> Query -> Int -> Int -> AccountTransactionsReportItem -> TB.Builder
 accountTransactionsReportItemAsText
-  copts@CliOpts{reportspec_=ReportSpec{rsOpts=ReportOpts{color_}}}
+  copts@CliOpts{reportspec_=ReportSpec{reportopts_=ReportOpts{color_}}}
   reportq thisacctq preferredamtwidth preferredbalwidth
   (t@Transaction{tdescription}, _, _issplit, otheracctsstr, change, balance) =
     -- Transaction -- the transaction, unmodified

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -341,7 +341,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case reporttype_ of
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render ropts report
   where
-    ropts@ReportOpts{..} = rsOpts rspec
+    ropts@ReportOpts{..} = reportopts_ rspec
     multiperiod = interval_ /= NoInterval
     fmt         = outputFormatFromOpts opts
 
@@ -661,8 +661,8 @@ tests_Balance = tests "Balance" [
    tests "balanceReportAsText" [
     test "unicode in balance layout" $ do
       j <- readJournal' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
-      let rspec = defreportspec{rsOpts=defreportopts{no_total_=True}}
-      TB.toLazyText (balanceReportAsText (rsOpts rspec) (balanceReport rspec{rsToday=fromGregorian 2008 11 26} j))
+      let rspec = defreportspec{reportopts_=defreportopts{no_total_=True}}
+      TB.toLazyText (balanceReportAsText (reportopts_ rspec) (balanceReport rspec{reportday_=fromGregorian 2008 11 26} j))
         @?=
         TL.unlines
         ["                -100  актив:наличные"

--- a/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
@@ -12,12 +12,12 @@ import Data.List (groupBy)
 journalCheckOrdereddates :: CliOpts -> Journal -> Either String ()
 journalCheckOrdereddates CliOpts{reportspec_=rspec} j = do
   let 
-    ropts = (rsOpts rspec){accountlistmode_=ALFlat}
+    ropts = (reportopts_ rspec){accountlistmode_=ALFlat}
     -- check date ordering within each file, not across files
     filets = 
       groupBy (\t1 t2 -> transactionFile t1 == transactionFile t2) $
-      filter (rsQuery rspec `matchesTransaction`) $
-      jtxns $ journalApplyValuationFromOpts rspec j
+      filter (query_ rspec `matchesTransaction`) $
+      jtxns $ journalApplyValuationFromOpts rspec{reportopts_=ropts} j
     checkunique = False -- boolopt "unique" rawopts  XXX was supported by checkdates command
     compare a b = if checkunique then getdate a < getdate b else getdate a <= getdate b
       where getdate = transactionDateFn ropts

--- a/hledger/Hledger/Cli/Commands/Checkdates.hs
+++ b/hledger/Hledger/Cli/Commands/Checkdates.hs
@@ -23,9 +23,9 @@ checkdatesmode = hledgerCommandMode
 
 checkdates :: CliOpts -> Journal -> IO ()
 checkdates CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
-  let ropts = (rsOpts rspec){accountlistmode_=ALFlat}
-  let ts = filter (rsQuery rspec `matchesTransaction`) $
-           jtxns $ journalApplyValuationFromOpts rspec{rsOpts=ropts} j
+  let ropts = (reportopts_ rspec){accountlistmode_=ALFlat}
+  let ts = filter (query_ rspec `matchesTransaction`) $
+           jtxns $ journalApplyValuationFromOpts rspec{reportopts_=ropts} j
   -- pprint rawopts
   let unique = boolopt "--unique" rawopts  -- TEMP: it's this for hledger check dates
             || boolopt "unique" rawopts    -- and this for hledger check-dates (for some reason)

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -89,11 +89,9 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec} j = do
     -- - `-e 2021-01-01`  (remember `-e` specifies an exclusive report end date)
     -- - `-e 2021`"
     --
-    q = rsQuery rspec
+    q = query_ rspec
     yesterday = addDays (-1) today
-    yesterdayorjournalend = case journalLastDay False j of
-      Just journalend -> max yesterday journalend
-      Nothing         -> yesterday
+    yesterdayorjournalend = maybe yesterday (max yesterday) $ journalLastDay False j
     mreportlastday = addDays (-1) <$> queryEndDate False q
     closingdate = fromMaybe yesterdayorjournalend  mreportlastday
     openingdate = addDays 1 closingdate
@@ -102,8 +100,8 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec} j = do
     explicit = boolopt "explicit" rawopts
 
     -- the balances to close
-    ropts = (rsOpts rspec){balancetype_=HistoricalBalance, accountlistmode_=ALFlat}
-    rspec_ = rspec{rsOpts=ropts}
+    ropts = (reportopts_ rspec){balancetype_=HistoricalBalance, accountlistmode_=ALFlat}
+    rspec_ = rspec{reportopts_=ropts}
     (acctbals',_) = balanceReport rspec_ j
     acctbals = map (\(a,_,_,b) -> (a, if show_costs_ ropts then b else mixedAmountStripPrices b)) acctbals'
     totalamt = maSum $ map snd acctbals

--- a/hledger/Hledger/Cli/Commands/Codes.hs
+++ b/hledger/Hledger/Cli/Commands/Codes.hs
@@ -34,6 +34,6 @@ codesmode = hledgerCommandMode
 codes :: CliOpts -> Journal -> IO ()
 codes CliOpts{reportspec_=rspec} j = do
   let ts = entriesReport rspec j
-      codes = (if empty_ (reportopts_ rspec) then id else filter (not . T.null)) $
+      codes = (if showempty_ (reportopts_ rspec) then id else filter (not . T.null)) $
               map tcode ts
   mapM_ T.putStrLn codes

--- a/hledger/Hledger/Cli/Commands/Codes.hs
+++ b/hledger/Hledger/Cli/Commands/Codes.hs
@@ -34,6 +34,6 @@ codesmode = hledgerCommandMode
 codes :: CliOpts -> Journal -> IO ()
 codes CliOpts{reportspec_=rspec} j = do
   let ts = entriesReport rspec j
-      codes = (if empty_ (rsOpts rspec) then id else filter (not . T.null)) $
+      codes = (if empty_ (reportopts_ rspec) then id else filter (not . T.null)) $
               map tcode ts
   mapM_ T.putStrLn codes

--- a/hledger/Hledger/Cli/Commands/Diff.hs
+++ b/hledger/Hledger/Cli/Commands/Diff.hs
@@ -87,7 +87,7 @@ matching ppl ppr = do
 
 readJournalFile' :: FilePath -> IO Journal
 readJournalFile' fn =
-    readJournalFile definputopts{balancingopts_=balancingOpts{ignore_assertions_=True}} fn >>= either error' return  -- PARTIAL:
+    readJournalFile definputopts{balancingopts_=defbalancingopts{ignore_assertions_=True}} fn >>= either error' return  -- PARTIAL:
 
 matchingPostings :: AccountName -> Journal -> [PostingWithPath]
 matchingPostings acct j = filter ((== acct) . paccount . ppposting) $ allPostingsWithPath j

--- a/hledger/Hledger/Cli/Commands/Diff.hs
+++ b/hledger/Hledger/Cli/Commands/Diff.hs
@@ -19,6 +19,7 @@ import Data.Maybe (fromJust)
 import Data.Time (diffDays)
 import Data.Either (partitionEithers)
 import qualified Data.Text.IO as T
+import Lens.Micro (set)
 import System.Exit (exitFailure)
 
 import Hledger
@@ -87,7 +88,7 @@ matching ppl ppr = do
 
 readJournalFile' :: FilePath -> IO Journal
 readJournalFile' fn =
-    readJournalFile definputopts{balancingopts_=defbalancingopts{ignore_assertions_=True}} fn >>= either error' return  -- PARTIAL:
+    readJournalFile (set ignore_assertions True definputopts) fn >>= either error' return  -- PARTIAL:
 
 matchingPostings :: AccountName -> Journal -> [PostingWithPath]
 matchingPostings acct j = filter ((== acct) . paccount . ppposting) $ allPostingsWithPath j

--- a/hledger/Hledger/Cli/Commands/Diff.hs
+++ b/hledger/Hledger/Cli/Commands/Diff.hs
@@ -102,7 +102,7 @@ unmatchedtxns s pp m =
 
 -- | The diff command.
 diff :: CliOpts -> Journal -> IO ()
-diff CliOpts{file_=[f1, f2], reportspec_=ReportSpec{rsQuery=Acct acctRe}} _ = do
+diff CliOpts{file_=[f1, f2], reportspec_=ReportSpec{query_=Acct acctRe}} _ = do
   j1 <- readJournalFile' f1
   j2 <- readJournalFile' f2
 

--- a/hledger/Hledger/Cli/Commands/Import.hs
+++ b/hledger/Hledger/Cli/Commands/Import.hs
@@ -33,7 +33,7 @@ importcmd opts@CliOpts{rawopts_=rawopts,inputopts_=iopts} j = do
     inputstr = intercalate ", " $ map quoteIfNeeded inputfiles
     catchup = boolopt "catchup" rawopts
     dryrun = boolopt "dry-run" rawopts
-    iopts' = iopts{new_=True, new_save_=not dryrun, balancingopts_=balancingOpts{commodity_styles_=Just $ journalCommodityStyles j}}
+    iopts' = iopts{new_=True, new_save_=not dryrun, balancingopts_=defbalancingopts{commodity_styles_=Just $ journalCommodityStyles j}}
   case inputfiles of
     [] -> error' "please provide one or more input files as arguments"  -- PARTIAL:
     fs -> do

--- a/hledger/Hledger/Cli/Commands/Payees.hs
+++ b/hledger/Hledger/Cli/Commands/Payees.hs
@@ -34,7 +34,7 @@ payeesmode = hledgerCommandMode
 
 -- | The payees command.
 payees :: CliOpts -> Journal -> IO ()
-payees CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{rsQuery=query}} j = do
+payees CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{query_=query}} j = do
   let
     declared = boolopt "declared" rawopts
     used     = boolopt "used"     rawopts

--- a/hledger/Hledger/Cli/Commands/Prices.hs
+++ b/hledger/Hledger/Cli/Commands/Prices.hs
@@ -29,7 +29,7 @@ pricesmode = hledgerCommandMode
 prices opts j = do
   let
     styles     = journalCommodityStyles j
-    q          = rsQuery $ reportspec_ opts
+    q          = query_ $ reportspec_ opts
     ps         = filter (matchesPosting q) $ allPostings j
     mprices    = jpricedirectives j
     cprices    = map (stylePriceDirectiveExceptPrecision styles) $ concatMap postingsPriceDirectivesFromCosts ps

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -81,7 +81,7 @@ entriesReportAsText opts = TB.toLazyText . foldMap (TB.fromText . showTransactio
         -- Because of #551, and because of print -V valuing only one
         -- posting when there's an implicit txn price.
         -- So -B/-V/-X/--value implies -x. Is this ok ?
-        || (isJust . value_ . rsOpts $ reportspec_ opts) = id
+        || (isJust . value_ . reportopts_ $ reportspec_ opts) = id
       -- By default, use the original as-written-in-the-journal txn.
       | otherwise = originalTransaction
 

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -187,7 +187,7 @@ postingsReportItemAsText opts preferredamtwidth preferredbalwidth (mdate, mendda
             _                      -> (id,acctwidth)
     amt = showamt $ pamount p
     bal = showamt b
-    showamt = showMixedAmountLinesB oneLine{displayColour=color_ . rsOpts $ reportspec_ opts}
+    showamt = showMixedAmountLinesB oneLine{displayColour=color_ . reportopts_ $ reportspec_ opts}
     -- Since this will usually be called with the knot tied between this(amt|bal)width and
     -- preferred(amt|bal)width, make sure the former do not depend on the latter to avoid loops.
     thisamtwidth = maximumDef 0 $ map wbWidth amt

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -187,7 +187,7 @@ postingsReportItemAsText opts preferredamtwidth preferredbalwidth (mdate, mendda
             _                      -> (id,acctwidth)
     amt = showamt $ pamount p
     bal = showamt b
-    showamt = showMixedAmountLinesB oneLine{displayColour=color_ . reportopts_ $ reportspec_ opts}
+    showamt = showMixedAmountLinesB oneLine{displayColour=showcolor_ . reportopts_ $ reportspec_ opts}
     -- Since this will usually be called with the knot tied between this(amt|bal)width and
     -- preferred(amt|bal)width, make sure the former do not depend on the latter to avoid loops.
     thisamtwidth = maximumDef 0 $ map wbWidth amt

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -43,7 +43,7 @@ rewrite opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j@Journal{jtxns=ts} = d
   let modifiers = transactionModifierFromOpts opts : jtxnmodifiers j
   let j' = j{jtxns=either error' id $ modifyTransactions d modifiers ts}  -- PARTIAL:
   -- run the print command, showing all transactions, or show diffs
-  printOrDiff rawopts opts{reportspec_=rspec{rsQuery=Any}} j j'
+  printOrDiff rawopts opts{reportspec_=rspec{query_=Any}} j j'
 
 -- | Build a 'TransactionModifier' from any query arguments and --add-posting flags
 -- provided on the command line, or throw a parse error.

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -55,19 +55,18 @@ data OneSpan = OneSpan
 
 
 roi ::  CliOpts -> Journal -> IO ()
-roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{rsOpts=ReportOpts{..}}} j = do
+roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{reportopts_=ReportOpts{..}}} j = do
   d <- getCurrentDay
   -- We may be converting posting amounts to value, per hledger_options.m4.md "Effect of --value on reports".
   let
     priceOracle = journalPriceOracle infer_value_ j
     styles = journalCommodityStyles j
-    today = rsToday rspec
+    today = reportday_ rspec
     mixedAmountValue periodlast date =
         maybe id (mixedAmountApplyValuation priceOracle styles periodlast today date) value_
         . mixedAmountToCost cost_ styles
-
   let
-    ropts = rsOpts rspec
+    ropts = reportopts_ rspec
     showCashFlow = boolopt "cashflow" rawopts
     prettyTables = pretty_tables_
     makeQuery flag = do

--- a/hledger/Hledger/Cli/Commands/Stats.hs
+++ b/hledger/Hledger/Cli/Commands/Stats.hs
@@ -44,10 +44,10 @@ statsmode = hledgerCommandMode
 stats :: CliOpts -> Journal -> IO ()
 stats opts@CliOpts{reportspec_=rspec} j = do
   d <- getCurrentDay
-  let q = rsQuery rspec
+  let q = query_ rspec
       l = ledgerFromJournal q j
       reportspan = ledgerDateSpan l `spanDefaultsFrom` queryDateSpan False q
-      intervalspans = splitSpan (interval_ $ rsOpts rspec) reportspan
+      intervalspans = splitSpan (interval_ $ reportopts_ rspec) reportspan
       showstats = showLedgerStats l d
       s = unlinesB $ map showstats intervalspans
   writeOutputLazyText opts $ TB.toLazyText s

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -34,7 +34,7 @@ tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     querystring = map T.pack $ drop 1 args
     values      = boolopt "values" rawopts
     parsed      = boolopt "parsed" rawopts
-    empty       = empty_ $ reportopts_ rspec
+    empty       = showempty_ $ reportopts_ rspec
 
   argsquery <- either usageError (return . fst) $ parseQueryList d querystring
   let

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -34,11 +34,11 @@ tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     querystring = map T.pack $ drop 1 args
     values      = boolopt "values" rawopts
     parsed      = boolopt "parsed" rawopts
-    empty       = empty_ $ rsOpts rspec
+    empty       = empty_ $ reportopts_ rspec
 
   argsquery <- either usageError (return . fst) $ parseQueryList d querystring
   let
-    q = simplifyQuery $ And [queryFromFlags $ rsOpts rspec, argsquery]
+    q = simplifyQuery $ And [queryFromFlags $ reportopts_ rspec, argsquery]
     txns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
     tagsorvalues =
       (if parsed then id else nubSort)

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -100,7 +100,7 @@ compoundBalanceCommand :: CompoundBalanceCommandSpec -> (CliOpts -> Journal -> I
 compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=rspec, rawopts_=rawopts} j = do
     writeOutputLazyText opts $ render cbr
   where
-    ropts@ReportOpts{..} = rsOpts rspec
+    ropts@ReportOpts{..} = reportopts_ rspec
     -- use the default balance type for this report, unless the user overrides
     mBalanceTypeOverride = balanceTypeOverride rawopts
     balancetype = fromMaybe cbctype mBalanceTypeOverride
@@ -153,7 +153,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
             _                                     -> False
 
     -- make a CompoundBalanceReport.
-    cbr' = compoundBalanceReport rspec{rsOpts=ropts'} j cbcqueries
+    cbr' = compoundBalanceReport rspec{reportopts_=ropts'} j cbcqueries
     cbr  = cbr'{cbrTitle=title}
 
     -- render appropriately

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -154,9 +154,9 @@ main = do
   dbgIO "isInternalCommand" isInternalCommand
   dbgIO "isExternalCommand" isExternalCommand
   dbgIO "isBadCommand" isBadCommand
-  dbgIO "period from opts" (period_ . rsOpts $ reportspec_ opts)
-  dbgIO "interval from opts" (interval_ . rsOpts $ reportspec_ opts)
-  dbgIO "query from opts & args" (rsQuery $ reportspec_ opts)
+  dbgIO "period from opts" (period_ . reportopts_ $ reportspec_ opts)
+  dbgIO "interval from opts" (interval_ . reportopts_ $ reportspec_ opts)
+  dbgIO "query from opts & args" (query_ $ reportspec_ opts)
   let
     journallesserror = error $ cmd++" tried to read the journal but is not supposed to"
     runHledgerCommand

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -39,6 +39,7 @@ import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
 import Data.Time (UTCTime, Day, addDays)
+import Lens.Micro ((^.))
 import Safe (readMay, headMay)
 import System.Console.CmdArgs
 import System.Directory (getModificationTime, getDirectoryContents, copyFile, doesFileExist)
@@ -103,10 +104,7 @@ pivotByOpts opts =
 
 -- | Apply the anonymisation transformation on a journal, if option is present
 anonymiseByOpts :: CliOpts -> Journal -> Journal
-anonymiseByOpts opts =
-  if anonymise_ . inputopts_ $ opts
-      then anon
-      else id
+anonymiseByOpts copts = if copts ^. anonymise then anon else id
 
 -- | Generate periodic transactions from all periodic transaction rules in the journal.
 -- These transactions are added to the in-memory Journal (but not the on-disk file).

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -125,8 +125,8 @@ journalAddForecast CliOpts{inputopts_=iopts, reportspec_=rspec} j =
         Just _  -> either (error') id . journalApplyCommodityStyles $  -- PARTIAL:
                      journalBalanceTransactions' iopts j{ jtxns = concat [jtxns j, forecasttxns'] }
   where
-    today = rsToday rspec
-    ropts = rsOpts rspec
+    today = reportday_ rspec
+    ropts = reportopts_ rspec
 
     -- "They can start no earlier than: the day following the latest normal transaction in the journal (or today if there are none)."
     mjournalend   = dbg2 "journalEndDate" $ journalEndDate False j  -- ignore secondary dates
@@ -310,7 +310,7 @@ journalSimilarTransaction cliopts j desc = mbestmatch
     bestmatches =
       dbg1With (unlines . ("similar transactions:":) . map (\(score,Transaction{..}) -> printf "%0.3f %s %s" score (show tdate) tdescription)) $
       journalTransactionsSimilarTo j q desc 10
-    q = queryFromFlags $ rsOpts $ reportspec_ cliopts
+    q = queryFromFlags $ reportopts_ $ reportspec_ cliopts
 
 tests_Cli_Utils = tests "Utils" [
 

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -149,8 +149,8 @@ journalAddForecast CliOpts{inputopts_=iopts, reportspec_=rspec} j =
       (if auto_ iopts then either error' id . modifyTransactions today (jtxnmodifiers j) else id)  -- PARTIAL:
       forecasttxns
 
-    journalBalanceTransactions' iopts j =
-       either error' id $ journalBalanceTransactions (balancingopts_ iopts) j  -- PARTIAL:
+    journalBalanceTransactions' iopts =
+       either error' id . journalBalanceTransactions (balancingopts_ iopts)  -- PARTIAL:
 
 -- | Write some output to stdout or to a file selected by --output-file.
 -- If the file exists it will be overwritten.

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -104,7 +104,7 @@ pivotByOpts opts =
 -- | Apply the anonymisation transformation on a journal, if option is present
 anonymiseByOpts :: CliOpts -> Journal -> Journal
 anonymiseByOpts opts =
-  if anon_ . inputopts_ $ opts
+  if anonymise_ . inputopts_ $ opts
       then anon
       else id
 

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -157,6 +157,7 @@ library
     , lucid
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
     , mtl >=2.2.1
     , old-time
     , process
@@ -207,6 +208,7 @@ executable hledger
     , hledger-lib ==1.22.*
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
     , mtl >=2.2.1
     , old-time
     , process
@@ -258,6 +260,7 @@ test-suite unittest
     , hledger-lib ==1.22.*
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
     , mtl >=2.2.1
     , old-time
     , process
@@ -308,6 +311,7 @@ benchmark bench
     , html
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.1
+    , microlens >=0.4
     , mtl >=2.2.1
     , old-time
     , process

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -111,6 +111,7 @@ dependencies:
 - githash >=0.1.2
 - haskeline >=0.6
 - megaparsec >=7.0.0 && <9.1
+- microlens >=0.4
 - mtl >=2.2.1
 - old-time
 - process


### PR DESCRIPTION
With so many nested options, it would greatly improve developer ergonomics to have some lenses in there.

I've put together a few commits to this end, but I don't think the API is ideal yet. Since the options all have names ending in an underscore, I've generated the lenses by dropping the underscore from the end. The main problem with this is that ReportOpts has `color_`, `drop_`, `empty_`, and `transpose_`, for which dropping the underscore would result in name clashes. My proposal would be to give these slightly longer names to avoid the clash, for example `color_ -> showcolor_`, `drop_ -> dropaccount_` , `empty_ -> showempty_`, `transpose_ -> transposetable_`, or something like that. We might also want to rename `watch_` and `change_` in UIOpts.

I would be interested in hearing opinions on this.