### PR TITLE
web: Fix keypress listener in final input of AddForm not getting initialized correctly

### DIFF
--- a/hledger-web/static/hledger.js
+++ b/hledger-web/static/hledger.js
@@ -23,6 +23,12 @@ $(document).ready(function() {
       dateEl.datepicker('hide');
     });
 
+  // ensure that the keypress listener on the final amount input is always active
+  $('#addform')
+    .on('focus', '.amount-input:last', function() {
+      addformLastAmountBindKey();
+    });
+
   // keyboard shortcuts
   // 'body' seems to hold focus better than document in FF
   $('body').bind('keydown', 'h',       function(){ $('#helpmodal').modal('toggle'); return false; });


### PR DESCRIPTION
### Summary

This fixes an issue in `hledger-web` related to the final amount input in the AddForm not getting initialized correctly. I discussed this issue with @simonmichael in the #hledger IRC channel.

### Additional Details

The AddForm is the form that is used to add a transaction, and includes inputs for the date, description, and four account/amount input field pairs. Typing in the final amount input should add additional rows for more accounts/amounts, but is not working correctly as of `hledger-web-1.21`.

Currently the AddForm can be accessed in one of three ways:

1. Via keypress, by pressing `e` or `a` on your keyboard
2. Via the "Add a transaction" `<a>` tag on the `/journal` page
3. Via the `/add` page

Prior to the change in this PR, only (1) above would correctly initialize the event listeners in the AddForm. To ensure that the keypress event is initialized in the other cases, I added a jQuery delegated event on the `#addform` element in `hledger.js`, so that anytime the `.amount-input:last` element is focused on, the keypress event gets bound to the element with the same selector. This solves the issue described above and ensures new rows are always added to the form when the final amount is edited.