### PR TITLE
Generate conversion postings for priced amounts.

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -80,6 +80,7 @@ module Hledger.Data.Amount (
   amountUnstyled,
   showAmountB,
   showAmount,
+  showAmountPrice,
   cshowAmount,
   showAmountWithZeroCommodity,
   showAmountDebug,

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -202,9 +202,11 @@ transactionApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle ->
 transactionApplyValuation priceoracle styles periodlast today v =
   transactionTransformPostings (postingApplyValuation priceoracle styles periodlast today v)
 
--- | Convert this transaction's amounts to cost, and apply the appropriate amount styles.
-transactionToCost :: M.Map CommoditySymbol AmountStyle -> Transaction -> Transaction
-transactionToCost styles = transactionTransformPostings (postingToCost styles)
+-- | Maybe convert this 'Transaction's amounts to cost and apply the
+-- appropriate amount styles; or in --infer-equity mode, replace any
+-- transaction prices by a pair of equity postings.
+transactionToCost :: Text -> M.Map CommoditySymbol AmountStyle -> ConversionOp -> Transaction -> Transaction
+transactionToCost equityAcct styles cost t = t{tpostings=concatMap (postingToCost equityAcct styles cost) $ tpostings t}
 
 -- | Apply some account aliases to all posting account names in the transaction, as described by accountNameApplyAliases.
 -- This can fail due to a bad replacement pattern in a regular expression alias.

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -151,6 +151,7 @@ data AccountType =
   | Revenue
   | Expense
   | Cash  -- ^ a subtype of Asset - liquid assets to show in cashflow report
+  | Conversion -- ^ a subtype of Equity - account in which to generate conversion postings for transaction prices
   deriving (Show,Eq,Ord,Generic)
 
 -- not worth the trouble, letters defined in accountdirectivep for now

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -351,7 +351,7 @@ accountdirectivep = do
   -- XXX added in 1.11, deprecated in 1.13, remove in 1.14
   mtypecode :: Maybe Char <- lift $ optional $ try $ do
     skipNonNewlineSpaces1 -- at least one more space in addition to the one consumed by modifiedaccountp
-    choice $ map char "ALERX"
+    choice $ map char "ALERXV"
 
   -- maybe a comment, on this and/or following lines
   (cmt, tags) <- lift transactioncommentp
@@ -378,22 +378,24 @@ accountTypeTagName = "type"
 parseAccountTypeCode :: Text -> Either String AccountType
 parseAccountTypeCode s =
   case T.toLower s of
-    "asset"     -> Right Asset
-    "a"         -> Right Asset
-    "liability" -> Right Liability
-    "l"         -> Right Liability
-    "equity"    -> Right Equity
-    "e"         -> Right Equity
-    "revenue"   -> Right Revenue
-    "r"         -> Right Revenue
-    "expense"   -> Right Expense
-    "x"         -> Right Expense
-    "cash"      -> Right Cash
-    "c"         -> Right Cash
-    _           -> Left err
+    "asset"      -> Right Asset
+    "a"          -> Right Asset
+    "liability"  -> Right Liability
+    "l"          -> Right Liability
+    "equity"     -> Right Equity
+    "e"          -> Right Equity
+    "revenue"    -> Right Revenue
+    "r"          -> Right Revenue
+    "expense"    -> Right Expense
+    "x"          -> Right Expense
+    "cash"       -> Right Cash
+    "c"          -> Right Cash
+    "conversion" -> Right Conversion
+    "v"          -> Right Conversion
+    _            -> Left err
   where
     err = T.unpack $ "invalid account type code "<>s<>", should be one of " <>
-            T.intercalate ", " ["A","L","E","R","X","C","Asset","Liability","Equity","Revenue","Expense","Cash"]
+            T.intercalate ", " ["A","L","E","R","X","C","V","Asset","Liability","Equity","Revenue","Expense","Cash","Conversion"]
 
 -- Add an account declaration to the journal, auto-numbering it.
 addAccountDeclaration :: (AccountName,Text,[Tag]) -> JournalParser m ()

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -313,7 +313,7 @@ tests_BalanceReport = testGroup "BalanceReport" [
                 ,"  a:b          10h @ $50"
                 ,"  c:d                   "
                 ]) >>= either error' return
-         let j' = journalCanonicaliseAmounts $ journalToCost j -- enable cost basis adjustment
+         let j' = journalCanonicaliseAmounts $ journalToCost ToCost j -- enable cost basis adjustment
          balanceReportAsText defreportopts (balanceReport defreportopts Any j') `is`
            ["                $500  a:b"
            ,"               $-500  c:d"

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -218,9 +218,9 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
       balanceReportTableAsText ropts (budgetReportAsTable ropts budgetr)
   where
     title = "Budget performance in " <> showDateSpan (periodicReportSpan budgetr)
-           <> (case cost_ of
-                 Cost   -> ", converted to cost"
-                 NoCost -> "")
+           <> (case conversionop_ of
+                 Just ToCost -> ", converted to cost"
+                 _           -> "")
            <> (case value_ of
                  Just (AtThen _mc)   -> ", valued at posting date"
                  Just (AtEnd _mc)    -> ", valued at period ends"
@@ -386,9 +386,9 @@ budgetReportAsTable
         _   -> -- trace (pshow $ (maybecost actual, maybecost budget))  -- debug missing percentage
                Nothing
       where
-        costedAmounts = case cost_ of
-            Cost   -> amounts . mixedAmountCost
-            NoCost -> amounts
+        costedAmounts = case conversionop_ of
+            Just ToCost -> amounts . mixedAmountCost
+            _           -> amounts
 
     -- | Calculate the percentage of actual change to budget goal for a particular commodity
     percentage' :: Change -> BudgetGoal -> CommoditySymbol -> Maybe Percentage

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -36,7 +36,7 @@ type EntriesReportItem = Transaction
 entriesReport :: ReportSpec -> Journal -> EntriesReport
 entriesReport rspec@ReportSpec{_rsReportOpts=ropts} =
     sortBy (comparing $ transactionDateFn ropts) . jtxns
-    . journalApplyValuationFromOpts rspec{_rsReportOpts=ropts{show_costs_=True}}
+    . journalApplyValuationFromOpts (setDefaultConversionOp NoConversionOp rspec)
     . filterJournalTransactions (_rsQuery rspec)
 
 tests_EntriesReport = testGroup "EntriesReport" [

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -257,7 +257,7 @@ getPostings rspec@ReportSpec{_rsQuery=query, _rsReportOpts=ropts} j priceoracle 
   where
     rspec' = rspec{_rsQuery=depthless, _rsReportOpts = ropts'}
     ropts' = if isJust (valuationAfterSum ropts)
-        then ropts{value_=Nothing, cost_=NoCost}  -- If we're valuing after the sum, don't do it now
+        then ropts{value_=Nothing, conversionop_=Just NoConversionOp}  -- If we're valuing after the sum, don't do it now
         else ropts
 
     -- The user's query with no depth limit, and expanded to the report span
@@ -432,7 +432,7 @@ displayedAccounts ReportSpec{_rsQuery=query,_rsReportOpts=ropts} valuedaccts
         balance = maybeStripPrices . case accountlistmode_ ropts of
             ALTree | d == depth -> aibalance
             _                   -> aebalance
-          where maybeStripPrices = if show_costs_ ropts then id else mixedAmountStripPrices
+          where maybeStripPrices = if conversionop_ ropts == Just NoConversionOp then id else mixedAmountStripPrices
 
     -- Accounts interesting because they are a fork for interesting subaccounts
     interestingParents = dbg5 "interestingParents" $ case accountlistmode_ ropts of

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -286,7 +286,7 @@ asHandle ui0@UIState{
         VtyEvent (EvKey (KChar 'a') []) -> suspendAndResume $ clearScreen >> setCursorPosition 0 0 >> add copts j >> uiReloadJournalIfChanged copts d j ui
         VtyEvent (EvKey (KChar 'A') []) -> suspendAndResume $ void (runIadd (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
         VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor endPosition (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
-        VtyEvent (EvKey (KChar 'B') []) -> continue $ regenerateScreens j d $ toggleCost ui
+        VtyEvent (EvKey (KChar 'B') []) -> continue $ regenerateScreens j d $ toggleConversionOp ui
         VtyEvent (EvKey (KChar 'V') []) -> continue $ regenerateScreens j d $ toggleValue ui
         VtyEvent (EvKey (KChar '0') []) -> continue $ regenerateScreens j d $ setDepth (Just 0) ui
         VtyEvent (EvKey (KChar '1') []) -> continue $ regenerateScreens j d $ setDepth (Just 1) ui

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -335,7 +335,7 @@ rsHandle ui@UIState{
                           rsItemTransaction=Transaction{tsourcepos=(SourcePos f l c,_)}}) -> (Just (unPos l, Just $ unPos c),f)
 
         -- display mode/query toggles
-        VtyEvent (EvKey (KChar 'B') []) -> rsCenterAndContinue $ regenerateScreens j d $ toggleCost ui
+        VtyEvent (EvKey (KChar 'B') []) -> rsCenterAndContinue $ regenerateScreens j d $ toggleConversionOp ui
         VtyEvent (EvKey (KChar 'V') []) -> rsCenterAndContinue $ regenerateScreens j d $ toggleValue ui
         VtyEvent (EvKey (KChar 'H') []) -> rsCenterAndContinue $ regenerateScreens j d $ toggleHistorical ui
         VtyEvent (EvKey (KChar 't') []) -> rsCenterAndContinue $ regenerateScreens j d $ toggleTree ui

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -97,11 +97,13 @@ toggleEmpty :: UIState -> UIState
 toggleEmpty = over empty__ not
 
 -- | Toggle between showing the primary amounts or costs.
-toggleCost :: UIState -> UIState
-toggleCost = over cost toggleCostMode
+toggleConversionOp :: UIState -> UIState
+toggleConversionOp = over conversionop toggleCostMode
   where
-    toggleCostMode Cost   = NoCost
-    toggleCostMode NoCost = Cost
+    toggleCostMode Nothing               = Just ToCost
+    toggleCostMode (Just NoConversionOp) = Just ToCost
+    toggleCostMode (Just InferEquity)    = Just ToCost
+    toggleCostMode (Just ToCost)         = Just NoConversionOp
 
 -- | Toggle between showing primary amounts or default valuation.
 toggleValue :: UIState -> UIState

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -181,6 +181,8 @@ reportflags = [
      ,"'now':  convert to current market value, in default valuation commodity or COMM"
      ,"YYYY-MM-DD: convert to market value on the given date, in default valuation commodity or COMM"
      ])
+  ,flagNone ["infer-equity"] (setboolopt "infer-equity")
+    "in conversion transactions, replace costs (transaction prices) with equity postings, to keep the transactions balanced"
   
   -- history of this flag so far, lest we be confused:
   --  originally --infer-value

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -652,9 +652,9 @@ multiBalanceReportAsText ropts@ReportOpts{..} r = TB.toLazyText $
         (_,               Cumulative ) -> "Ending balances (cumulative)"
         (_,               Historical)  -> "Ending balances (historical)"
     valuationdesc =
-        (case cost_ of
-            Cost   -> ", converted to cost"
-            NoCost -> "")
+        (case conversionop_ of
+            Just ToCost -> ", converted to cost"
+            _           -> "")
         <> (case value_ of
             Just (AtThen _mc)    -> ", valued at posting date"
             Just (AtEnd _mc) | changingValuation -> ""

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -66,7 +66,7 @@ roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsReportOpts=ReportO
     styles = journalCommodityStyles j
     mixedAmountValue periodlast date =
         maybe id (mixedAmountApplyValuation priceOracle styles periodlast today date) value_
-        . mixedAmountToCost cost_ styles
+      . maybe id (mixedAmountToCost styles) conversionop_
 
   let
     ropts = _rsReportOpts rspec

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -152,9 +152,9 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
             _                                              -> Nothing
 
         valuationdesc =
-          (case cost_ of
-               Cost   -> ", converted to cost"
-               NoCost -> "")
+          (case conversionop_ of
+               Just ToCost -> ", converted to cost"
+               _           -> "")
           <> (case value_ of
                Just (AtThen _mc)       -> ", valued at posting date"
                Just (AtEnd _mc) | changingValuation -> ""

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -917,15 +917,22 @@ see the discussion at [#1625](https://github.com/simonmichael/hledger/issues/162
 
 # COSTING
 
-The `-B/--cost` flag converts amounts to their cost or sale amount at transaction time,
-if they have a [transaction price](#transaction-prices) specified.
-If this flag is supplied, hledger will perform cost conversion first, and will apply
-any market price valuations (if requested) afterwards.
+The `-B/--cost` flag converts amounts to their cost or sale amount at
+transaction time, if they have a [transaction price](#transaction-prices)
+specified.
+
+The `--infer-equity` flag generates conversion postings within equity to
+balance any transaction prices.
+The account used is "equity:conversion" by default, but this can be customised
+with an account declaration: `account <conversion_account>  Conversion`.
+
+If either of these flags are supplied, hledger will perform cost conversion
+first, and will apply any market price valuations (if requested) afterwards.
+
 
 # VALUATION
 
-Instead of reporting amounts in their original commodity,
-hledger can convert them to
+Instead of reporting amounts in their original commodity, hledger can convert them to
 cost/sale amount (using the conversion rate recorded in the transaction),
 and/or to market value (using some market price on a certain date).
 This is controlled by the `--value=TYPE[,COMMODITY]` option, which will be described below.
@@ -2914,8 +2921,8 @@ account ACCTNAME  [ACCTTYPE] [;COMMENT]
 
 By adding a `type` tag to the [account directive],
 with value
-`A`, `L`, `E`, `R`, `X`, `C`
-(or if you prefer: `Asset`, `Liability`, `Equity`, `Revenue`, `Expense`, `Cash`),
+`A`, `L`, `E`, `R`, `X`, `C`, `V`
+(or if you prefer: `Asset`, `Liability`, `Equity`, `Revenue`, `Expense`, `Cash`, `Conversion`),
 you can declare hledger accounts to be of a certain type:
 
 - **asset**, 
@@ -2927,6 +2934,9 @@ you can declare hledger accounts to be of a certain type:
 
 - **cash**\
   a subtype of asset, used for [liquid assets][CCE].
+
+- **conversion**\
+  a subtype of equity, used for [conversion postings](#costing)
 
 Declaring account types is a good idea, since it helps enable the easy 
 [balancesheet], [balancesheetequity], [incomestatement] and [cashflow] reports, 

--- a/hledger/test/journal/transaction-prices.test
+++ b/hledger/test/journal/transaction-prices.test
@@ -25,7 +25,50 @@ hledger -f- print --explicit --cost
 
 >>>=0
 
-# 3. print a transaction with a total price
+# 3. --infer-equity generates conversion postings
+hledger -f- print --infer-equity
+<<<
+2011/01/01
+    expenses:foreign currency       €100 @ $1.35
+    assets
+>>>
+2011-01-01
+    expenses:foreign currency            €100  ; cost: @ $1.35
+    equity:conversion:$-€:€             €-100  ; generated-posting:
+    equity:conversion:$-€:$           $135.00  ; generated-posting:
+    assets
+
+>>>=0
+
+# 4. With --infer-equity and --show-costs, the cost is still shown
+hledger -f- print --infer-equity --show-costs
+<<<
+2011/01/01
+    expenses:foreign currency       €100 @ $1.35
+    assets
+>>>
+2011-01-01
+    expenses:foreign currency    €100 @ $1.35  ; cost: @ $1.35
+    equity:conversion:$-€:€             €-100  ; generated-posting:
+    equity:conversion:$-€:$           $135.00  ; generated-posting:
+    assets
+
+>>>=0
+
+# 5. With --cost, --infer-equity is ignored
+hledger -f- print --explicit --cost --infer-equity
+<<<
+2011/01/01
+    expenses:foreign currency       €100 @ $1.35
+    assets
+>>>
+2011-01-01
+    expenses:foreign currency         $135.00
+    assets                           $-135.00
+
+>>>=0
+
+# 6. print a transaction with a total price
 hledger -f - print --explicit
 <<<
 2011/01/01
@@ -38,7 +81,7 @@ hledger -f - print --explicit
 
 >>>=0
 
-# 4. when the balance has exactly two commodities, both unpriced, infer an
+# 7. when the balance has exactly two commodities, both unpriced, infer an
 # implicit conversion price for the first one in terms of the second.
 hledger -f - print --explicit
 <<<
@@ -60,7 +103,7 @@ hledger -f - print --explicit
 
 >>>=0
 
-## 5. another, from ledger tests. Just one posting to price so uses @@.
+# 8. another, from ledger tests. Just one posting to price so uses @@.
 hledger -f - print --explicit
 <<<
 2002/09/30 * 1a1a6305d06ce4b284dba0d267c23f69d70c20be
@@ -73,7 +116,7 @@ hledger -f - print --explicit
 
 >>>=0
 
-# 6. when the balance has more than two commodities, don't bother
+# 9. when the balance has more than two commodities, don't bother
 hledger -f - print
 <<<
 2011/01/01
@@ -82,7 +125,7 @@ hledger -f - print
     expenses:other                    £200
 >>>= !0
 
-# 7. another
+# 10. another
 hledger -f - balance -B
 <<<
 2011/01/01
@@ -97,7 +140,7 @@ hledger -f - balance -B
                    0  
 >>>=0
 
-# 8. transaction in two commodities should balance out properly
+# 11. transaction in two commodities should balance out properly
 hledger -f - balance --cost
 <<<
 2011/01/01 x
@@ -110,10 +153,52 @@ hledger -f - balance --cost
                    0  
 >>>=0
 
-# 9. When commodity price is specified implicitly, transaction should
-#    be considered balanced out even when first amount is negative
-#    (that is, price for it should be determined properly, with proper sign)
+# 12. --value=cost,XXX is deprecated, but should still work (for now)
+hledger -f - balance --value=cost,XXX
+<<<
+2011/01/01 x
+  a  10£ @@ 16$
+  b
+>>>
+                 16$  a
+                -16$  b
+--------------------
+                   0  
+>>>=0
+
+# 13. conversion postings should be generated when called --infer-equity
+hledger -f - balance --infer-equity
+<<<
+2011/01/01 x
+  a  10£ @@ 16$
+  b
+>>>
+                 10£  a
+                -16$  b
+                 16$  equity:conversion:$-£:$
+                -10£  equity:conversion:$-£:£
+--------------------
+                   0  
+>>>=0
+
+# 14. transaction should be left unbalanced when called without --cost or --infer-equity
 hledger -f - balance
+<<<
+2011/01/01 x
+  a  10£ @@ 16$
+  b
+>>>
+                 10£  a
+                -16$  b
+--------------------
+                -16$
+                 10£  
+>>>=0
+
+# 15. When commodity price is specified implicitly, transaction should
+#     be considered balanced out even when first amount is negative
+#     (that is, price for it should be determined properly, with proper sign)
+hledger -f - balance -N
 <<<
 2011/01/01 x
   a  -10£
@@ -121,12 +206,9 @@ hledger -f - balance
 >>>
                 -10£  a
                  16$  b
---------------------
-                 16$
-                -10£  
 >>>=0
 
-# 10. Should not infer prices when --strict is specified
+# 16. Should not infer prices when --strict is specified
 hledger -f - balance --strict
 <<<
 2011/01/01 x
@@ -135,7 +217,7 @@ hledger -f - balance --strict
 >>>
 >>>=1
 
-# 11. When commodity price is specified implicitly, transaction should
+# 17. When commodity price is specified implicitly, transaction should
 #     NOT be considered balanced out when BOTH amounts are negative
 hledger -f - balance
 <<<
@@ -145,7 +227,7 @@ hledger -f - balance
 >>>
 >>>=1
 
-# 12. Differently-priced lots of a commodity should be merged in balance report
+# 18. Differently-priced lots of a commodity should be merged in balance report
 hledger -f - balance
 <<<
 2011/1/1
@@ -159,7 +241,7 @@ hledger -f - balance
                   £2  
 >>>=0
 
-# 13. this should balance
+# 19. this should balance
 hledger -f - balance
 <<<
 2011/1/1
@@ -168,7 +250,7 @@ hledger -f - balance
     c  $-30
 >>>= 0
 
-# 14. these balance because of the unit prices, and should parse successfully
+# 20. these balance because of the unit prices, and should parse successfully
 hledger -f - balance --no-total
 <<<
 1/1
@@ -178,7 +260,7 @@ hledger -f - balance --no-total
                  -1X  a
 >>>= 0
 
-# 15.
+# 21.
 hledger -f - balance --no-total -B
 <<<
 1/1
@@ -187,7 +269,7 @@ hledger -f - balance --no-total -B
 >>>
 >>>= 0
 
-# 16. likewise with total prices. Note how the primary amount's sign is used.
+# 22. likewise with total prices. Note how the primary amount's sign is used.
 hledger -f - balance --no-total
 <<<
 1/1
@@ -197,7 +279,7 @@ hledger -f - balance --no-total
                  -1X  a
 >>>= 0
 
-# 17.
+# 23.
 hledger -f - balance --no-total -B
 <<<
 1/1
@@ -206,7 +288,7 @@ hledger -f - balance --no-total -B
 >>>
 >>>= 0
 
-# 18. here, a's primary amount is 0, and its cost is 1Y; b is the assigned auto-balancing amount of -1Y (per issue 69)
+# 24. here, a's primary amount is 0, and its cost is 1Y; b is the assigned auto-balancing amount of -1Y (per issue 69)
 hledger -f - balance --no-total -E
 <<<
 1/1
@@ -219,7 +301,7 @@ hledger -f - balance --no-total -E
                  -1Y  b
 >>>= 0
 
-# 19. Without -E, a should be hidden because its balance is zero, even though it has a non-zero cost.
+# 25. Without -E, a should be hidden because its balance is zero, even though it has a non-zero cost.
 hledger -f - balance --no-total
 <<<
 1/1
@@ -231,7 +313,7 @@ hledger -f - balance --no-total
                  -1Y  b
 >>>= 0
 
-# 20. the above with -B
+# 26. the above with -B
 hledger -f - balance --no-total -E -B
 <<<
 1/1
@@ -243,6 +325,23 @@ hledger -f - balance --no-total -E -B
                   1Y  a
                  -1Y  b
 >>>= 0
+
+# 27. The equity account used by --infer-equity can be customised
+hledger -f- print --infer-equity
+<<<
+account  equity:trades   V
+
+2011/01/01
+    expenses:foreign currency       €100 @ $1.35
+    assets
+>>>
+2011-01-01
+    expenses:foreign currency            €100  ; cost: @ $1.35
+    equity:trades:$-€:€                 €-100  ; generated-posting:
+    equity:trades:$-€:$               $135.00  ; generated-posting:
+    assets
+
+>>>=0
 
 # # when the *cost-basis* balance has exactly two commodities, both
 # # unpriced, infer an implicit conversion price for the first one in terms


### PR DESCRIPTION
A potential implementation of the proposals in #1177. This is almost certainly not the final behaviour, but I'm putting this up to solicit feedback on a solid proposal. Let me know your thoughts!


This means there will no longer be unbalanced transactions, but will be
offsetting conversion postings to balance things out. For example.

```
2000-01-01
  a   1 AAA @@ 2 BBB
  b  -2 BBB
```

When converting to cost, this is treated the same as before.
When not converting to cost, this is now treated as:

```
2000-01-01
  a                           1 AAA
  b                          -2 BBB
  equity:conversion:AAA:BBB  -1 AAA
  equity:conversion:BBB:AAA   2 BBB
```