### PR TITLE
Remove CPP and other pragmas needed for ghc<8.6.

### DIFF
--- a/hledger-lib/Hledger/Data/AccountName.hs
+++ b/hledger-lib/Hledger/Data/AccountName.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 {-|
 
 'AccountName's are strings like @assets:cash:petty@, with multiple
@@ -43,9 +42,6 @@ where
 
 import Data.Foldable (toList)
 import qualified Data.List.NonEmpty as NE
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -41,7 +41,6 @@ exchange rates.
 -}
 
 {-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -517,9 +516,6 @@ instance Semigroup MixedAmount where
 instance Monoid MixedAmount where
   mempty = nullmixedamt
   mconcat = maSum
-#if !(MIN_VERSION_base(4,11,0))
-  mappend = (<>)
-#endif
 
 instance Num MixedAmount where
     fromInteger = mixedAmount . fromInteger

--- a/hledger-lib/Hledger/Data/Commodity.hs
+++ b/hledger-lib/Hledger/Data/Commodity.hs
@@ -8,7 +8,6 @@ are thousands separated by comma, significant decimal places and so on.
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 module Hledger.Data.Commodity
 where
@@ -16,9 +15,6 @@ import Control.Applicative (liftA2)
 import Data.Char (isDigit)
 import Data.List
 import Data.Maybe (fromMaybe)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import qualified Data.Text as T
 -- import qualified Data.Map as M
 

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1,10 +1,9 @@
-{-# LANGUAGE PackageImports #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PackageImports      #-}
+{-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 {-|
 

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE PackageImports #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -110,9 +109,6 @@ import Data.List (find, foldl', sortOn)
 import Data.List.Extra (nubSort)
 import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, fromJust, fromMaybe, isJust, mapMaybe, maybeToList)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -4,7 +4,6 @@ JSON instances. Should they be in Types.hs ?
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# LANGUAGE CPP                 #-}
 --{-# LANGUAGE DataKinds           #-}
 --{-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveGeneric       #-}
@@ -34,9 +33,6 @@ module Hledger.Data.Json (
   ,readJsonFile
 ) where
 
-#if !(MIN_VERSION_base(4,13,0))
-import           Data.Semigroup ((<>))
-#endif
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty (encodePrettyToTextBuilder)
 --import           Data.Aeson.TH

--- a/hledger-lib/Hledger/Data/PeriodicTransaction.hs
+++ b/hledger-lib/Hledger/Data/PeriodicTransaction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-|
@@ -12,9 +11,6 @@ module Hledger.Data.PeriodicTransaction (
 )
 where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Text.Printf

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -9,7 +9,6 @@ look up the date or description there.
 -}
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 module Hledger.Data.Posting (
   -- * Posting
@@ -78,9 +77,6 @@ import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust)
 import Data.MemoUgly (memo)
 import Data.List (foldl')
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)

--- a/hledger-lib/Hledger/Data/Timeclock.hs
+++ b/hledger-lib/Hledger/Data/Timeclock.hs
@@ -6,7 +6,6 @@ converted to 'Transactions' and queried like a ledger.
 
 -}
 
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Hledger.Data.Timeclock (
@@ -16,10 +15,6 @@ module Hledger.Data.Timeclock (
 where
 
 import Data.Maybe (fromMaybe)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
--- import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (addDays)
 import Data.Time.Clock (addUTCTime, getCurrentTime)

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -7,7 +7,6 @@ tags.
 
 -}
 
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -67,9 +66,6 @@ import Data.Foldable (asum)
 import Data.List (intercalate, partition)
 import Data.List.Extra (nubSort)
 import Data.Maybe (fromMaybe, isNothing, mapMaybe)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL

--- a/hledger-lib/Hledger/Data/TransactionModifier.hs
+++ b/hledger-lib/Hledger/Data/TransactionModifier.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
 {-|
 
 A 'TransactionModifier' is a rule that modifies certain 'Transaction's,
@@ -15,9 +14,6 @@ where
 
 import Control.Applicative ((<|>))
 import Data.Maybe
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid ((<>))
-#endif
 import qualified Data.Text as T
 import Data.Time.Calendar
 import Hledger.Data.Types

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -22,7 +22,6 @@ For more detailed documentation on each type, see the corresponding modules.
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 module Hledger.Data.Types
 where

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -16,7 +16,6 @@ For more detailed documentation on each type, see the corresponding modules.
 
 -}
 
-{-# LANGUAGE CPP                  #-}
 -- {-# LANGUAGE DeriveAnyClass #-}  -- https://hackage.haskell.org/package/deepseq-1.4.4.0/docs/Control-DeepSeq.html#v:rnf
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleInstances    #-}
@@ -40,11 +39,7 @@ import Text.Blaze (ToMarkup(..))
 --The stored values don't represent large virtual data structures to be lazily computed.
 import qualified Data.Map as M
 import Data.Ord (comparing)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
--- import qualified Data.Text as T
 import Data.Time.Calendar
 import Data.Time.LocalTime
 import Data.Word (Word8)

--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -5,7 +5,6 @@ transactions..)  by various criteria, and a SimpleTextParser for query expressio
 
 -}
 
-{-# LANGUAGE CPP                #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE ViewPatterns       #-}
@@ -65,9 +64,6 @@ import Data.Default (Default(..))
 import Data.Either (partitionEithers)
 import Data.List (partition)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day, fromGregorian )

--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -11,7 +11,6 @@ to import modules below this one.
 -}
 
 --- ** language
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -54,9 +53,6 @@ import Data.List (group, sort, sortBy)
 import Data.List.NonEmpty (nonEmpty)
 import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -14,13 +14,11 @@ A reader for CSV data, using an extra rules file to help interpret the data.
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE MultiWayIf           #-}
-{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE PackageImports       #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ViewPatterns         #-}
 
 --- ** exports

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -26,7 +26,6 @@ Hledger.Read.Common, to avoid import cycles.
 
 --- ** language
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoMonoLocalBinds #-}
@@ -85,9 +84,6 @@ import Control.Monad.Trans.Class (lift)
 import Data.Char (toLower)
 import Data.Either (isRight)
 import qualified Data.Map.Strict as M
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 import Data.String
 import Data.List

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -26,14 +26,12 @@ Hledger.Read.Common, to avoid import cycles.
 
 --- ** language
 
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NoMonoLocalBinds #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NoMonoLocalBinds    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 
 --- ** exports
 module Hledger.Read.JournalReader (

--- a/hledger-lib/Hledger/Reports.hs
+++ b/hledger-lib/Hledger/Reports.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 {-|
 
 Generate several common kinds of report from a journal, as \"*Report\" -

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 {-|
 
 An account-centric transactions report.

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -4,7 +4,9 @@ Balance report, used by the balance command.
 
 -}
 
-{-# LANGUAGE FlexibleInstances, RecordWildCards, ScopedTypeVariables, OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Hledger.Reports.BalanceReport (
   BalanceReport,

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -1,7 +1,3 @@
-{- |
--}
-
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -34,9 +30,6 @@ import qualified Data.HashMap.Strict as HM
 import Data.List (find, partition, transpose)
 import Data.List.Extra (nubSort)
 import Data.Maybe (fromMaybe)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid ((<>))
-#endif
 import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as S

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 module Hledger.Reports.BudgetReport (
   BudgetGoal,

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -44,9 +43,6 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (Down(..))
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Semigroup (sconcat)
 import Data.Time.Calendar (Day, addDays, fromGregorian)
 import Safe (lastDef, minimumMay)

--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -1,7 +1,6 @@
 {- |
 New common report types, used by the BudgetReport for now, perhaps all reports later.
 -}
-{-# LANGUAGE CPP            #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveFunctor  #-}
 {-# LANGUAGE DeriveGeneric  #-}
@@ -36,9 +35,6 @@ import Data.Aeson (ToJSON(..))
 import Data.Decimal (Decimal)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
 import GHC.Generics (Generic)
 
 import Hledger.Data

--- a/hledger-lib/Hledger/Reports/TransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/TransactionsReport.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 {-|
 
 A transactions report. Like an EntriesReport, but with more

--- a/hledger-lib/Hledger/Utils/Color.hs
+++ b/hledger-lib/Hledger/Utils/Color.hs
@@ -1,6 +1,5 @@
 -- | Basic color helpers for prettifying console output.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Hledger.Utils.Color
@@ -14,9 +13,6 @@ module Hledger.Utils.Color
 )
 where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text.Lazy.Builder as TB
 import System.Console.ANSI
 import Hledger.Utils.Text (WideBuilder(..))

--- a/hledger-lib/Hledger/Utils/Color.hs
+++ b/hledger-lib/Hledger/Utils/Color.hs
@@ -1,7 +1,5 @@
 -- | Basic color helpers for prettifying console output.
 
-{-# LANGUAGE OverloadedStrings #-}
-
 module Hledger.Utils.Color
 (
   color,

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -69,9 +68,6 @@ import Data.Array ((!), elems, indices)
 import Data.Char (isDigit)
 import Data.List (foldl')
 import Data.MemoUgly (memo)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Text.Regex.TDFA (

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
 {-|
 
 Easy regular expression helpers, currently based on regex-tdfa. These should:

--- a/hledger-lib/Hledger/Utils/Test.hs
+++ b/hledger-lib/Hledger/Utils/Test.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -26,10 +25,6 @@ where
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.State.Strict (StateT, evalStateT, execStateT)
 import Data.Default (Default(..))
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
--- import Data.CallStack
 import Data.List (isInfixOf)
 import qualified Data.Text as T
 import Test.Tasty hiding (defaultMain)

--- a/hledger-lib/Hledger/Utils/Text.hs
+++ b/hledger-lib/Hledger/Utils/Text.hs
@@ -2,7 +2,6 @@
 -- There may be better alternatives out there.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 module Hledger.Utils.Text
   (
@@ -54,9 +53,6 @@ where
 
 import Data.Char (digitToInt)
 import Data.Default (def)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL

--- a/hledger-lib/Text/Tabular/AsciiWide.hs
+++ b/hledger-lib/Text/Tabular/AsciiWide.hs
@@ -1,7 +1,6 @@
 -- | Text.Tabular.AsciiArt from tabular-0.2.2.7, modified to treat
 -- wide characters as double width.
 
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Text.Tabular.AsciiWide
@@ -24,9 +23,6 @@ module Text.Tabular.AsciiWide
 import Data.Maybe (fromMaybe)
 import Data.Default (Default(..))
 import Data.List (intersperse, transpose)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Semigroup (stimesMonoid)
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/hledger-lib/Text/WideString.hs
+++ b/hledger-lib/Text/WideString.hs
@@ -1,7 +1,5 @@
 -- | Calculate the width of String and Text, being aware of wide characters.
 
-{-# LANGUAGE CPP #-}
-
 module Text.WideString (
   -- * wide-character-aware layout
   strWidth,
@@ -13,9 +11,6 @@ module Text.WideString (
   wbToText
   ) where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -33,9 +28,6 @@ instance Semigroup WideBuilder where
 
 instance Monoid WideBuilder where
   mempty = WideBuilder mempty 0
-#if !(MIN_VERSION_base(4,11,0))
-  mappend = (<>)
-#endif
 
 -- | Convert a WideBuilder to a strict Text.
 wbToText :: WideBuilder -> Text

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -2,7 +2,6 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE CPP #-}
 
 module Hledger.UI.AccountsScreen
  (accountsScreen
@@ -19,9 +18,6 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.List
 import Data.Maybe
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid ((<>))
-#endif
 import qualified Data.Text as T
 import Data.Time.Calendar (Day, addDays)
 import qualified Data.Vector as V

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -1,7 +1,8 @@
 -- The error screen, showing a current error condition (such as a parse error after reloading the journal)
 
-{-# LANGUAGE OverloadedStrings, FlexibleContexts, RecordWildCards #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Hledger.UI.ErrorScreen
  (errorScreen
@@ -15,9 +16,6 @@ import Brick
 -- import Brick.Widgets.Border ("border")
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import Data.Time.Calendar (Day)
 import Data.Void (Void)
 import Graphics.Vty (Event(..),Key(..),Modifier(..))

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -3,9 +3,8 @@ hledger-ui - a hledger add-on providing a curses-style interface.
 Copyright (c) 2007-2015 Simon Michael <simon@joyful.com>
 Released under GPL version 3 or later.
 -}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 
 module Hledger.UI.Main where
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -3,7 +3,6 @@ hledger-ui - a hledger add-on providing a curses-style interface.
 Copyright (c) 2007-2015 Simon Michael <simon@joyful.com>
 Released under GPL version 3 or later.
 -}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -220,12 +219,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
           d
           -- predicate: ignore changes not involving our files
           (\fev -> case fev of
-#if MIN_VERSION_fsnotify(0,3,0)
-            Modified f _ False
-#else
-            Modified f _
-#endif
-                               -> f `elem` files
+            Modified f _ False -> f `elem` files
             -- Added    f _ -> f `elem` files
             -- Removed  f _ -> f `elem` files
             -- we don't handle adding/removing journal files right now
@@ -242,9 +236,5 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
 
         -- and start the app. Must be inside the withManager block
         let mkvty = mkVty mempty
-#if MIN_VERSION_brick(0,47,0)
         vty0 <- mkvty
         void $ customMain vty0 mkvty (Just eventChan) brickapp ui
-#else
-        void $ customMain mkvty (Just eventChan) brickapp ui
-#endif

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -1,7 +1,8 @@
 -- The account register screen, showing transactions in an account, like hledger-web's register.
 
-{-# LANGUAGE OverloadedStrings, FlexibleContexts, RecordWildCards #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Hledger.UI.RegisterScreen
  (registerScreen
@@ -14,9 +15,6 @@ where
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.List
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid ((<>))
-#endif
 import Data.Maybe
 import qualified Data.Text as T
 import Data.Time.Calendar

--- a/hledger-ui/Hledger/UI/Theme.hs
+++ b/hledger-ui/Hledger/UI/Theme.hs
@@ -7,7 +7,6 @@
 -- http://hackage.haskell.org/package/brick-0.1/docs/Brick-Widgets-Core.html#g:5
 -- http://hackage.haskell.org/package/brick-0.1/docs/Brick-Widgets-Border.html
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Hledger.UI.Theme (
@@ -20,9 +19,6 @@ where
 
 import qualified Data.Map as M
 import Data.Maybe
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import Graphics.Vty
 import Brick
 

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -1,7 +1,8 @@
 -- The transaction screen, showing a single transaction's general journal entry.
 
-{-# LANGUAGE OverloadedStrings, TupleSections, RecordWildCards #-} -- , FlexibleContexts
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TupleSections     #-}
 
 module Hledger.UI.TransactionScreen
  (transactionScreen
@@ -13,9 +14,6 @@ import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.List
 import Data.Maybe
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
 import Graphics.Vty (Event(..),Key(..),Modifier(..))

--- a/hledger-ui/Hledger/UI/UIOptions.hs
+++ b/hledger-ui/Hledger/UI/UIOptions.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
 {-|
 
 -}

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -2,7 +2,6 @@
 
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
 
 module Hledger.UI.UIState
 where

--- a/hledger-ui/Hledger/UI/UIUtils.hs
+++ b/hledger-ui/Hledger/UI/UIUtils.hs
@@ -1,7 +1,7 @@
 {- | Rendering & misc. helpers. -}
 
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 module Hledger.UI.UIUtils (
    borderDepthStr
@@ -35,9 +35,6 @@ import Brick.Widgets.Edit
 import Brick.Widgets.List (List, listSelectedL, listNameL, listItemHeightL)
 import Control.Monad.IO.Class
 import Data.List
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import qualified Data.Text as T
 import Graphics.Vty
   (Event(..),Key(..),Modifier(..),Vty(..),Color,Attr,currentAttr,refresh

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -1,15 +1,15 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE ViewPatterns          #-}
 
 -- | Define the web application's foundation, in the usual Yesod style.
 --   See a default Yesod app's comments for more details of each part.
@@ -22,9 +22,6 @@ import qualified Data.ByteString.Char8 as BC
 import Data.Traversable (for)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
-#if !(MIN_VERSION_base(4,13,0))
-import Data.Monoid ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
@@ -91,11 +88,7 @@ mkYesodData "App" $(parseRoutesFile "config/routes")
 -- | A convenience alias.
 type AppRoute = Route App
 
-#if MIN_VERSION_yesod(1,6,0)
 type Form x = Html -> MForm (HandlerFor App) (FormResult x, Widget)
-#else
-type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
-#endif
 
 -- Please see the documentation for the Yesod typeclass. There are a number
 -- of settings which can be configured by overriding methods here.

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 -- | Define the web application's foundation, in the usual Yesod style.

--- a/hledger-web/Hledger/Web/Import.hs
+++ b/hledger-web/Hledger/Web/Import.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Hledger.Web.Import
   ( module Import
   ) where
@@ -25,7 +24,3 @@ import           Hledger.Web.Foundation           as Import
 import           Hledger.Web.Settings             as Import
 import           Hledger.Web.Settings.StaticFiles as Import
 import           Hledger.Web.WebOptions           as Import (Capability(..))
-
-#if !(MIN_VERSION_base(4,11,0))
-import           Data.Monoid          as Import ((<>))
-#endif

--- a/hledger-web/Hledger/Web/Settings.hs
+++ b/hledger-web/Hledger/Web/Settings.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE CPP, OverloadedStrings, QuasiQuotes #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
 -- | Settings are centralized, as much as possible, into this file. This
 -- includes database connection settings, static file locations, etc.
 -- In addition, you can configure a number of different aspects of Yesod
@@ -7,9 +10,6 @@
 module Hledger.Web.Settings where
 
 import Data.Default (def)
-#if !(MIN_VERSION_base(4,13,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 import Data.Yaml
 import Language.Haskell.TH.Syntax (Q, Exp)

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -16,9 +15,6 @@ import Data.Bifunctor (first)
 import Data.Foldable (toList)
 import Data.List (dropWhileEnd, intercalate, unfoldr)
 import Data.Maybe (isJust)
-#if !(MIN_VERSION_base(4,13,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -33,11 +29,7 @@ import Hledger.Web.Settings (widgetFile)
 addModal ::
      ( MonadWidget m
      , r ~ Route (HandlerSite m)
-#if MIN_VERSION_yesod(1,6,0)
      , m ~ WidgetFor (HandlerSite m)
-#else
-     , m ~ WidgetT (HandlerSite m) IO
-#endif
      , RenderMessage (HandlerSite m) FormMessage
      )
   => r -> Journal -> Day -> m ()
@@ -60,11 +52,7 @@ addForm ::
   => Journal
   -> Day
   -> Markup
-#if MIN_VERSION_yesod(1,6,0)
   -> MForm m (FormResult Transaction, WidgetFor site ())
-#else
-  -> MForm m (FormResult Transaction, WidgetT site IO ())
-#endif
 addForm j today = identifyForm "add" $ \extra -> do
   (dateRes, dateView) <- mreq dateField dateFS Nothing
   (descRes, descView) <- mreq textField descFS Nothing

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -1,9 +1,8 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 module Hledger.Web.Widget.Common
   ( accountQuery
@@ -23,9 +22,6 @@ module Hledger.Web.Widget.Common
 import Data.Default (def)
 import Data.Foldable (find, for_)
 import Data.List (elemIndex)
-#if !(MIN_VERSION_base(4,13,0))
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.FilePath (takeFileName)
@@ -42,11 +38,7 @@ import Hledger.Cli.Utils (writeFileWithBackupIfChanged)
 import Hledger.Web.Settings (manualurl)
 import qualified Hledger.Query as Query
 
-#if MIN_VERSION_yesod(1,6,0)
 journalFile404 :: FilePath -> Journal -> HandlerFor m (FilePath, Text)
-#else
-journalFile404 :: FilePath -> Journal -> HandlerT m IO (FilePath, Text)
-#endif
 journalFile404 f j =
   case find ((== f) . fst) (jfiles j) of
     Just (_, txt) -> pure (takeFileName f, txt)

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -7,8 +7,6 @@ adds some more which are easier to define here.
 
 -}
 
-{-# LANGUAGE OverloadedStrings #-}
-
 module Hledger.Cli (
                      module Hledger.Cli.CliOptions,
                      module Hledger.Cli.Commands,

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -5,7 +5,6 @@ New built-in commands should be added in four places below:
 the export list, the import list, builtinCommands, commandsList.
 -}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -49,9 +48,6 @@ where
 import Data.Char (isSpace)
 import Data.Default
 import Data.List
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid ((<>))
-#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar

--- a/hledger/Hledger/Cli/Commands/Accounts.hs
+++ b/hledger/Hledger/Cli/Commands/Accounts.hs
@@ -14,16 +14,12 @@ The @accounts@ command lists account names:
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE CPP #-}
 
 module Hledger.Cli.Commands.Accounts (
   accountsmode
  ,accounts
 ) where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Monoid
-#endif
 import Data.List
 import qualified Data.Text as T
 import qualified Data.Text.IO as T

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -233,7 +233,6 @@ Currently, empty cells show 0.
 
 -}
 
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE ExtendedDefaultRules #-}
 {-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE OverloadedStrings    #-}
@@ -258,10 +257,6 @@ module Hledger.Cli.Commands.Balance (
 import Data.Default (def)
 import Data.List (intersperse, transpose)
 import Data.Maybe (fromMaybe, maybeToList)
---import qualified Data.Map as Map
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB

--- a/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
@@ -1,13 +1,8 @@
-{-# LANGUAGE CPP #-}
-
 module Hledger.Cli.Commands.Check.Ordereddates (
   journalCheckOrdereddates
 )
 where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import Hledger
 import Hledger.Cli.CliOptions

--- a/hledger/Hledger/Cli/Commands/Check/Uniqueleafnames.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Uniqueleafnames.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -10,9 +9,6 @@ where
 import Data.Function (on)
 import Data.List (groupBy, sortBy)
 import Data.Text (Text)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import Hledger
 import Text.Printf (printf)

--- a/hledger/Hledger/Cli/Commands/Checkdates.hs
+++ b/hledger/Hledger/Cli/Commands/Checkdates.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE NoOverloadedStrings #-} -- prevent trouble if turned on in ghci
 {-# LANGUAGE TemplateHaskell     #-}
 
@@ -7,9 +6,6 @@ module Hledger.Cli.Commands.Checkdates (
  ,checkdates
 ) where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Hledger

--- a/hledger/Hledger/Cli/Commands/Payees.hs
+++ b/hledger/Hledger/Cli/Commands/Payees.hs
@@ -4,7 +4,6 @@ The @payees@ command lists all unique payees (description part before a |) seen 
 
 -}
 
-{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -15,9 +14,6 @@ module Hledger.Cli.Commands.Payees (
  ,payees
 ) where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Set as S
 import qualified Data.Text.IO as T
 import System.Console.CmdArgs.Explicit as C

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -4,7 +4,6 @@ A ledger-compatible @print@ command.
 
 -}
 
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
@@ -19,9 +18,6 @@ where
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.List (intersperse)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -20,10 +20,6 @@ module Hledger.Cli.Commands.Register (
 
 import Data.Default (def)
 import Data.Maybe (fromMaybe, isJust)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
--- import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE OverloadedStrings, LambdaCase, DeriveTraversable, ViewPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Hledger.Cli.Commands.Rewrite (
   rewritemode
@@ -8,9 +10,6 @@ module Hledger.Cli.Commands.Rewrite (
 )
 where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Control.Monad.Writer hiding (Any)
-#endif
 import Data.Functor.Identity
 import Data.List (sortOn, foldl')
 import Data.Text (Text)

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -17,9 +16,6 @@ module Hledger.Cli.CompoundBalanceCommand (
 
 import Data.List (foldl')
 import Data.Maybe (fromMaybe, mapMaybe)
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB

--- a/hledger/Hledger/Cli/Main.hs
+++ b/hledger/Hledger/Cli/Main.hs
@@ -36,8 +36,6 @@ etc.
 
 -}
 
-{-# LANGUAGE QuasiQuotes #-}
-
 module Hledger.Cli.Main where
 
 import Data.Char (isDigit)


### PR DESCRIPTION
Finally, freedom to use `<>` with impunity.