### PR TITLE
Clean up valuation functions, and make clear which to use where.

### DIFF
--- a/bin/hledger-swap-dates.hs
+++ b/bin/hledger-swap-dates.hs
@@ -34,7 +34,7 @@ main = do
     d <- getCurrentDay
     let
       q = rsQuery rspec
-      ts = filter (q `matchesTransaction`) $ jtxns $ journalSelectingAmountFromOpts (rsOpts rspec) j
+      ts = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
       ts' = map transactionSwapDates ts
     mapM_ (T.putStrLn . showTransaction) ts'
 

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -64,7 +64,6 @@ module Hledger.Data.Posting (
   -- * misc.
   showComment,
   postingTransformAmount,
-  postingApplyCostValuation,
   postingApplyValuation,
   postingToCost,
   tests_Posting
@@ -331,14 +330,6 @@ aliasReplace (BasicAlias old new) a
   | otherwise = Right a
 aliasReplace (RegexAlias re repl) a =
   fmap T.pack . regexReplace re repl $ T.unpack a -- XXX
-
--- | Apply a specified costing and valuation to this posting's amount,
--- using the provided price oracle, commodity styles, and reference dates.
--- Costing is done first if requested, and after that any valuation.
--- See amountApplyValuation and amountCost.
-postingApplyCostValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> Costing -> Maybe ValuationType -> Posting -> Posting
-postingApplyCostValuation priceoracle styles periodlast today cost v p =
-    postingTransformAmount (mixedAmountApplyCostValuation priceoracle styles periodlast today (postingDate p) cost v) p
 
 -- | Apply a specified valuation to this posting's amount, using the
 -- provided price oracle, commodity styles, and reference dates.

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -33,7 +33,6 @@ module Hledger.Data.Transaction (
   balanceTransaction,
   balanceTransactionHelper,
   transactionTransformPostings,
-  transactionApplyCostValuation,
   transactionApplyValuation,
   transactionToCost,
   transactionApplyAliases,
@@ -615,13 +614,6 @@ postingSetTransaction t p = p{ptransaction=Just t}
 transactionTransformPostings :: (Posting -> Posting) -> Transaction -> Transaction
 transactionTransformPostings f t@Transaction{tpostings=ps} = t{tpostings=map f ps}
 
--- | Apply a specified costing and valuation to this transaction's amounts,
--- using the provided price oracle, commodity styles, and reference dates.
--- See amountApplyValuation and amountCost.
-transactionApplyCostValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day -> Day -> Costing -> Maybe ValuationType -> Transaction -> Transaction
-transactionApplyCostValuation priceoracle styles periodlast today cost v =
-  transactionTransformPostings (postingApplyCostValuation priceoracle styles periodlast today cost v)
-
 -- | Apply a specified valuation to this transaction's amounts, using
 -- the provided price oracle, commodity styles, and reference dates.
 -- See amountApplyValuation.
@@ -631,7 +623,7 @@ transactionApplyValuation priceoracle styles periodlast today v =
 
 -- | Convert this transaction's amounts to cost, and apply the appropriate amount styles.
 transactionToCost :: M.Map CommoditySymbol AmountStyle -> Transaction -> Transaction
-transactionToCost styles t@Transaction{tpostings=ps} = t{tpostings=map (postingToCost styles) ps}
+transactionToCost styles = transactionTransformPostings (postingToCost styles)
 
 -- | Apply some account aliases to all posting account names in the transaction, as described by accountNameApplyAliases.
 -- This can fail due to a bad replacement pattern in a regular expression alias.

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -95,9 +95,7 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
         ptraceAtWith 5 (("ts5:\n"++).pshowTransactions)
       . sortBy (comparing (transactionRegisterDate reportq' thisacctq))
       . jtxns
-      -- maybe convert these transactions to cost or value
       . ptraceAtWith 5 (("ts4:\n"++).pshowTransactions.jtxns)
-      . journalSelectingAmountFromOpts ropts
       -- keep just the transactions affecting this account (via possibly realness or status-filtered postings)
       . traceAt 3 ("thisacctq: "++show thisacctq)
       . ptraceAtWith 5 (("ts3:\n"++).pshowTransactions.jtxns)
@@ -106,6 +104,7 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
       -- apply any cur:SYM filters in reportq'
       . ptraceAtWith 5 (("ts2:\n"++).pshowTransactions.jtxns)
       . (if queryIsNull symq then id else filterJournalAmounts symq)
+      -- maybe convert these transactions to cost or value
       $ journalApplyValuationFromOpts rspec j
 
     startbal

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -84,45 +84,35 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
   where
     -- a depth limit should not affect the account transactions report
     -- seems unnecessary for some reason XXX
-    reportq' = -- filterQuery (not . queryIsDepth)
-               reportq
-
-    -- get all transactions
-    ts1 =
-      -- ptraceAtWith 5 (("ts1:\n"++).pshowTransactions) $
-      jtxns j
-
-    -- apply any cur:SYM filters in reportq'
-    symq  = filterQuery queryIsSym reportq'
-    ts2 =
-      ptraceAtWith 5 (("ts2:\n"++).pshowTransactions) $
-      (if queryIsNull symq then id else map (filterTransactionAmounts symq)) ts1
-
-    -- keep just the transactions affecting this account (via possibly realness or status-filtered postings)
-    realq = filterQuery queryIsReal reportq'
-    statusq = filterQuery queryIsStatus reportq'
-    ts3 =
-      traceAt 3 ("thisacctq: "++show thisacctq) $
-      ptraceAtWith 5 (("ts3:\n"++).pshowTransactions) $
-      filter (matchesTransaction thisacctq . filterTransactionPostings (And [realq, statusq])) ts2
-
-    -- maybe convert these transactions to cost or value
-    -- PARTIAL:
-    prices = journalPriceOracle (infer_value_ ropts) j
-    styles = journalCommodityStyles j
+    reportq'   = reportq -- filterQuery (not . queryIsDepth)
+    symq       = filterQuery queryIsSym reportq'
+    realq      = filterQuery queryIsReal reportq'
+    statusq    = filterQuery queryIsStatus reportq'
+    prices     = journalPriceOracle (infer_value_ ropts) j
+    styles     = journalCommodityStyles j
     periodlast =
       fromMaybe (error' "journalApplyValuation: expected a non-empty journal") $ -- XXX shouldn't happen
       reportPeriodOrJournalLastDay rspec j
-    tval = transactionApplyCostValuation prices styles periodlast (rsToday rspec) (cost_ ropts) $ value_ ropts
-    ts4 =
-      ptraceAtWith 5 (("ts4:\n"++).pshowTransactions) $
-      map tval ts3
+    pvalue = maybe id (postingApplyValuation prices styles periodlast (rsToday rspec)) $ value_ ropts
 
     -- sort by the transaction's register date, for accurate starting balance
     -- these are not yet filtered by tdate, we want to search them all for priorps
-    ts5 =
-      ptraceAtWith 5 (("ts5:\n"++).pshowTransactions) $
-      sortBy (comparing (transactionRegisterDate reportq' thisacctq)) ts4
+    transactions =
+        ptraceAtWith 5 (("ts5:\n"++).pshowTransactions)
+      . sortBy (comparing (transactionRegisterDate reportq' thisacctq))
+      . jtxns
+      -- maybe convert these transactions to cost or value
+      . ptraceAtWith 5 (("ts4:\n"++).pshowTransactions.jtxns)
+      . journalMapPostings pvalue
+      . journalSelectingAmountFromOpts ropts
+      -- keep just the transactions affecting this account (via possibly realness or status-filtered postings)
+      . traceAt 3 ("thisacctq: "++show thisacctq)
+      . ptraceAtWith 5 (("ts3:\n"++).pshowTransactions.jtxns)
+      . filterJournalTransactions thisacctq
+      . filterJournalPostings (And [realq, statusq])
+      -- apply any cur:SYM filters in reportq'
+      . ptraceAtWith 5 (("ts2:\n"++).pshowTransactions.jtxns)
+      $ (if queryIsNull symq then id else filterJournalAmounts symq) j
 
     startbal
       | balancetype_ ropts == HistoricalBalance = sumPostings priorps
@@ -132,7 +122,7 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
                   filter (matchesPosting
                           (dbg5 "priorq" $
                            And [thisacctq, tostartdateq, datelessreportq]))
-                         $ transactionsPostings ts5
+                         $ transactionsPostings transactions
         tostartdateq =
           case mstartdate of
             Just _  -> Date (DateSpan Nothing mstartdate)
@@ -149,7 +139,7 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
     items = reverse $
             accountTransactionsReportItems reportq' thisacctq startbal maNegate $
             (if filtertxns then filter (reportq' `matchesTransaction`) else id) $
-            ts5
+            transactions
 
 pshowTransactions :: [Transaction] -> String
 pshowTransactions = pshow . map (\t -> unwords [show $ tdate t, T.unpack $ tdescription t])

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -76,9 +76,7 @@ postingsReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j = items
       (precedingps, reportps) = matchedPostingsBeforeAndDuring rspec j reportspan
 
       -- We may be converting posting amounts to value, per hledger_options.m4.md "Effect of --value on reports".
-      -- Strip prices from postings if we won't need them.
-      pvalue periodlast = maybeStripPrices . postingApplyCostValuation priceoracle styles periodlast (rsToday rspec) cost_ value_
-        where maybeStripPrices = if show_costs_ then id else postingStripPrices
+      pvalue periodlast = maybe id (postingApplyValuation priceoracle styles periodlast (rsToday rspec)) value_
 
       -- Postings, or summary postings with their subperiod's end date, to be displayed.
       displayps :: [(Posting, Maybe Day)]

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -488,13 +488,14 @@ flat_ = not . tree_
 -- depthFromOpts :: ReportOpts -> Int
 -- depthFromOpts opts = min (fromMaybe 99999 $ depth_ opts) (queryDepth $ queryFromOpts nulldate opts)
 
--- | Convert this journal's postings' amounts to cost using their
--- transaction prices, if specified by options (-B/--cost).
--- Maybe soon superseded by newer valuation code.
+-- | Convert this journal's postings' amounts to cost using their transaction prices,
+-- if specified by options (-B/--cost). Strip prices if not needed.
 journalSelectingAmountFromOpts :: ReportOpts -> Journal -> Journal
-journalSelectingAmountFromOpts opts = case cost_ opts of
+journalSelectingAmountFromOpts ropts = maybeStripPrices . case cost_ ropts of
     Cost   -> journalToCost
     NoCost -> id
+  where
+    maybeStripPrices = if show_costs_ ropts then id else journalMapPostingAmounts mixedAmountStripPrices
 
 -- | Convert report options to a query, ignoring any non-flag command line arguments.
 queryFromFlags :: ReportOpts -> Query

--- a/hledger-lib/Hledger/Reports/TransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/TransactionsReport.hs
@@ -62,13 +62,13 @@ triCommodityBalance c = filterMixedAmountByCommodity c  . triBalance
 -- "postingsReport" except with transaction-based report items which
 -- are ordered most recent first. XXX Or an EntriesReport - use that instead ?
 -- This is used by hledger-web's journal view.
-transactionsReport :: ReportOpts -> Journal -> Query -> TransactionsReport
-transactionsReport opts j q = items
+transactionsReport :: ReportSpec -> Journal -> Query -> TransactionsReport
+transactionsReport rspec j q = items
    where
      -- XXX items' first element should be the full transaction with all postings
      items = reverse $ accountTransactionsReportItems q None nullmixedamt id ts
-     ts    = sortBy (comparing date) $ filter (q `matchesTransaction`) $ jtxns $ journalSelectingAmountFromOpts opts j
-     date  = transactionDateFn opts
+     ts    = sortBy (comparing date) $ filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
+     date = transactionDateFn $ rsOpts rspec
 
 -- | Split a transactions report whose items may involve several commodities,
 -- into one or more single-commodity transactions reports.

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -83,7 +83,10 @@ tsDraw UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{
 
       render . defaultLayout toplabel bottomlabel . str
         . T.unpack . showTransactionOneLineAmounts
-        $ transactionApplyCostValuation prices styles periodlast (rsToday rspec) (cost_ ropts) (value_ ropts) t
+        . maybe id (transactionApplyValuation prices styles periodlast (rsToday rspec)) (value_ ropts)
+        $ case cost_ ropts of
+               Cost   -> transactionToCost styles t
+               NoCost -> t
         -- (if real_ ropts then filterTransactionPostings (Real True) else id) -- filter postings by --real
       where
         toplabel =

--- a/hledger-web/Hledger/Web/Handler/JournalR.hs
+++ b/hledger-web/Hledger/Web/Handler/JournalR.hs
@@ -27,7 +27,7 @@ getJournalR = do
         Just (a, inclsubs) -> "Transactions in " <> a <> if inclsubs then "" else " (excluding subaccounts)"
       title' = title <> if m /= Any then ", filtered" else ""
       acctlink a = (RegisterR, [("q", replaceInacct q $ accountQuery a)])
-      items = transactionsReport (rsOpts . reportspec_ $ cliopts_ opts) j m
+      items = transactionsReport (reportspec_ $ cliopts_ opts) j m
       transactionFrag = transactionFragment j
 
   defaultLayout $ do

--- a/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
@@ -22,7 +22,7 @@ journalCheckOrdereddates CliOpts{reportspec_=rspec} j = do
     filets = 
       groupBy (\t1 t2 -> transactionFile t1 == transactionFile t2) $
       filter (rsQuery rspec `matchesTransaction`) $
-      jtxns $ journalSelectingAmountFromOpts ropts j
+      jtxns $ journalApplyValuationFromOpts rspec j
     checkunique = False -- boolopt "unique" rawopts  XXX was supported by checkdates command
     compare a b = if checkunique then getdate a < getdate b else getdate a <= getdate b
       where getdate = transactionDateFn ropts

--- a/hledger/Hledger/Cli/Commands/Checkdates.hs
+++ b/hledger/Hledger/Cli/Commands/Checkdates.hs
@@ -29,7 +29,7 @@ checkdates :: CliOpts -> Journal -> IO ()
 checkdates CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
   let ropts = (rsOpts rspec){accountlistmode_=ALFlat}
   let ts = filter (rsQuery rspec `matchesTransaction`) $
-           jtxns $ journalSelectingAmountFromOpts ropts j
+           jtxns $ journalApplyValuationFromOpts rspec{rsOpts=ropts} j
   -- pprint rawopts
   let unique = boolopt "--unique" rawopts  -- TEMP: it's this for hledger check dates
             || boolopt "unique" rawopts    -- and this for hledger check-dates (for some reason)

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -63,7 +63,10 @@ roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{rsOpts=ReportOpts{..}
     priceOracle = journalPriceOracle infer_value_ j
     styles = journalCommodityStyles j
     today = rsToday rspec
-    mixedAmountValue periodlast date = mixedAmountApplyCostValuation priceOracle styles periodlast today date cost_ value_
+    mixedAmountValue periodlast date =
+        maybe id (mixedAmountApplyValuation priceOracle styles periodlast today date) value_
+        . mixedAmountToCost cost_ styles
+
   let
     ropts = rsOpts rspec
     showCashFlow = boolopt "cashflow" rawopts

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -39,7 +39,7 @@ tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
   argsquery <- either usageError (return . fst) $ parseQueryList d querystring
   let
     q = simplifyQuery $ And [queryFromFlags $ rsOpts rspec, argsquery]
-    txns = filter (q `matchesTransaction`) $ jtxns $ journalSelectingAmountFromOpts (rsOpts rspec) j
+    txns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
     tagsorvalues =
       (if parsed then id else nubSort)
       [ r


### PR DESCRIPTION
Doing costing and valuation for amounts is a bit confusing; every report handles it differently. This was fine when valuation was simpler, but now that we have `--value=then`, `--value=end`, `--valuechange`, and soon `--gain`, this means a lot of duplicated code handling special cases.

This PR simplifies things by defining one master valuation function which should be used in most cases: `journalApplyValuationFromOpts`. It does the following based on the `ReportSpec`:
- Convert to cost
- Strip prices if able
- Apply valuation

The only place this function is not sufficient is when performing `--value=end` valuation on balance reports that require you to sum amounts, such as the historical balance report. To handle these cases, we introduce `mixedAmountApplyValuationFromOptsWith`, which returns the valuation function to be used in those cases by `multiBalanceReport`. It also defines the function `valuationAfterSum`, which tests a `ReportOpts` to see if we need to do this second kind of valuation.

I have then pruned a bunch of helper functions which are no longer so helpful.