### PR TITLE
Mention expansion of report start and end dates in report intevals documentation.

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -477,6 +477,9 @@ selected with one of `-D/--daily`, `-W/--weekly`, `-M/--monthly`,
 specified with a [period expression](#period-expressions).
 Report intervals can not be specified with a [query](#queries).
 
+Note that the requested start and end dates may be extended when specifying a report
+interval (see [period expression](#period-expressions)).
+
 ## Period expressions
 
 The `-p/--period` option accepts period expressions, a shorthand way


### PR DESCRIPTION
Somebody in the Google group expressed surprise that their quarterly report ended at the end of the quarter, even though they specified an explicit end date in the middle of the of the quarter. It seems that the manual on report intervals does not mention this fact: it is left to later in the period expressions section. I've added a note about this.