### PR TITLE
Don't write debug.log when reloading the journal in hledger-ui's transaction screen

### DIFF
--- a/hledger-lib/Hledger/Utils/Debug.hs
+++ b/hledger-lib/Hledger/Utils/Debug.hs
@@ -87,9 +87,6 @@ module Hledger.Utils.Debug (
   ,dbg7IO
   ,dbg8IO
   ,dbg9IO
-  -- ** Trace to a file
-  ,plog
-  ,plogAt
   -- ** Trace the state of hledger parsers
   ,traceParse
   ,dbgparse
@@ -421,37 +418,6 @@ dbg8IO = ptraceAtIO 8
 
 dbg9IO :: (MonadIO m, Show a) => String -> a -> m ()
 dbg9IO = ptraceAtIO 9
-
--- | Log a label and a pretty-printed showable value to ./debug.log, then return it.
--- Can fail, see plogAt.
-plog :: Show a => String -> a -> a
-plog = plogAt 0
-
--- | Log a label and a pretty-printed showable value to ./debug.log,
--- if the global debug level is at or above the specified level.
--- At level 0, always logs. Otherwise, uses unsafePerformIO.
--- Tends to fail if called more than once too quickly, at least when built with -threaded
--- ("Exception: debug.log: openFile: resource busy (file is locked)").
-plogAt :: Show a => Int -> String -> a -> a
-plogAt lvl
-    | lvl > 0 && debugLevel < lvl = flip const
-    | otherwise = \s a ->
-        let p = pshow a
-            ls = lines p
-            nlorspace | length ls > 1 = "\n"
-                      | otherwise     = " " ++ take (10 - length s) (repeat ' ')
-            ls' | length ls > 1 = map (" "++) ls
-                | otherwise     = ls
-            output = s++":"++nlorspace++intercalate "\n" ls'++"\n"
-        in unsafePerformIO $ appendFile "debug.log" output >> return a
-
--- XXX redundant ? More/less robust than plogAt ?
--- -- | Like dbg, but writes the output to "debug.log" in the current directory.
--- dbglog :: Show a => String -> a -> a
--- dbglog label a =
---   (unsafePerformIO $
---     appendFile "debug.log" $ label ++ ": " ++ ppShow a ++ "\n")
---   `seq` a
 
 -- | Print the provided label (if non-null) and current parser state
 -- (position and next input) to the console. See also megaparsec's dbg.

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -108,7 +108,7 @@ toggleEmpty ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rsp
 -- | Show primary amounts, not cost or value.
 clearCostValue :: UIState -> UIState
 clearCostValue ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{value_ = plog "clearing value mode" Nothing}}}}}
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{cost_ = NoCost, value_ = Nothing}}}}}
 
 -- | Toggle between showing the primary amounts or costs.
 toggleCost :: UIState -> UIState


### PR DESCRIPTION
[Another instance of #1556.]

A couple of issues raised from this.

1. `plog` is no longer used anywhere in the code base. It's not clear to me what purpose it is supposed to server over `dbg`, and every instance of its use in the code caused some sort of bug. Should we just remove it?
2. `clearCostValue` is only used in one place: when reloading the journal file in the transaction screen. Why that code is implemented the way it is is very confusing to me (and I'm not the only one judging by the code comments), but there are some strange things in there likely to be bugs. In particular, `regenerateTransactions` uses the old `rspec`, not the new one that results from `clearCostValue`. If anybody knows more about what should happen here and what I should be looking for, it would help with debugging.
https://github.com/simonmichael/hledger/blob/61a3fbc0192d19348746e77850b4e3b3866e30f5/hledger-ui/Hledger/UI/TransactionScreen.hs#L165-L176