### PR TITLE
lib,cli: No longer strip prices in journalApplyValuationFromOptsWith …

### DIFF
--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -407,8 +407,9 @@ displayedAccounts ReportSpec{rsQuery=query,rsOpts=ropts} valuedaccts
            || not (isZeroRow balance amts))            -- Throw out anything with zero balance
       where
         d = accountNameLevel name
-        balance | ALTree <- accountlistmode_ ropts, d == depth = aibalance
-                | otherwise = aebalance
+        balance | ALTree <- accountlistmode_ ropts, d == depth = maybeStripPrices . aibalance
+                | otherwise = maybeStripPrices . aebalance
+          where maybeStripPrices = if show_costs_ ropts then id else mixedAmountStripPrices
 
     -- Accounts interesting because they are a fork for interesting subaccounts
     interestingParents = dbg5 "interestingParents" $ case accountlistmode_ ropts of

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -654,8 +654,6 @@ balanceOpts :: Bool -> ReportOpts -> AmountDisplayOpts
 balanceOpts isTable ReportOpts{..} = oneLine
     { displayColour   = isTable && color_
     , displayMaxWidth = if isTable && not no_elide_ then Just 32 else Nothing
-    , displayPrice    = True  -- multiBalanceReport strips prices from Amounts if they are not being used,
-                              -- so we can display prices here without fear.
     }
 
 tests_Balance = tests "Balance" [

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -89,8 +89,8 @@ postingsReportItemAsCsvRecord (_, _, _, p, b) = [idx,date,code,desc,acct,amt,bal
                              VirtualPosting -> wrap "(" ")"
                              _ -> id
     -- Since postingsReport strips prices from all Amounts when not used, we can display prices.
-    amt = wbToText . showMixedAmountB oneLine{displayPrice=True} $ pamount p
-    bal = wbToText $ showMixedAmountB oneLine{displayPrice=True} b
+    amt = wbToText . showMixedAmountB oneLine $ pamount p
+    bal = wbToText $ showMixedAmountB oneLine b
 
 -- | Render a register report as plain text suitable for console output.
 postingsReportAsText :: CliOpts -> PostingsReport -> TL.Text
@@ -104,7 +104,7 @@ postingsReportAsText opts items = TB.toLazyText $ foldMap first3 linesWithWidths
     amtwidth = maximumStrict $ 12 : widths (map itemamt items)
     balwidth = maximumStrict $ 12 : widths (map itembal items)
     -- Since postingsReport strips prices from all Amounts when not used, we can display prices.
-    widths = map wbWidth . concatMap (showMixedAmountLinesB oneLine{displayPrice=True})
+    widths = map wbWidth . concatMap (showMixedAmountLinesB oneLine)
     itemamt (_,_,_,Posting{pamount=a},_) = a
     itembal (_,_,_,_,a) = a
 
@@ -187,9 +187,7 @@ postingsReportItemAsText opts preferredamtwidth preferredbalwidth (mdate, mendda
             _                      -> (id,acctwidth)
     amt = showamt $ pamount p
     bal = showamt b
-    -- Since postingsReport strips prices from all Amounts when not used, we can display prices.
-    showamt = showMixedAmountLinesB oneLine{displayColour=color_, displayPrice=True}
-      where ReportOpts{..} = rsOpts $ reportspec_ opts
+    showamt = showMixedAmountLinesB oneLine{displayColour=color_ . rsOpts $ reportspec_ opts}
     -- Since this will usually be called with the knot tied between this(amt|bal)width and
     -- preferred(amt|bal)width, make sure the former do not depend on the latter to avoid loops.
     thisamtwidth = maximumDef 0 $ map wbWidth amt


### PR DESCRIPTION
…and mixedAmountApplyValuationAfterSumFromOptsWith (#1577).

These were theoretically an efficiency improvement, but have been
error-prone. We instead handle stripping prices at the point of
consumption.
