### PR TITLE
csv: convert datetimes with time zones to local date, mostly (WIP)

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3865,11 +3865,9 @@ date-format %-m/%-d/%Y %l:%M %p some other junk
 For the supported strptime syntax, see:\
 <https://hackage.haskell.org/package/time/docs/Data-Time-Format.html#v:formatTime>
 
-Note that although you can parse date-times which include a time zone, 
-that time zone is ignored; it will not change the date that is parsed.
-This means when reading CSV data with times not in your local time zone,
-dates can be "off by one".
-
+Note: date-times which include a time zone, different from your own local time zone,
+will usually be parsed as the correct date in your time zone; but in certain situations 
+with daylight savings, it's possible for the parsed date to be "off by one".
 
 ### `decimal-mark`
 


### PR DESCRIPTION
Just sharing this.. it's an attempt to fix this CSV limitation I just noticed, dates from other timezones can be off by one:

fc364cd8c origin/master ;doc: csv: note a limitation with datetimes in other zones

I have abandoned it for now, because (in a non-UTC timezone) dates with no time/timezone all get adjusted, as they are parsed as 00:00:00 UTC. Perhaps with a bit more work this could be useful (somehow use local timezone as the default when parsing ? Convert to local date only when timezone-related strptime codes (%z, %ez, %Z, %eZ) appear in date-format  ?

Related: https://github.com/haskell/time/issues/172. ~This PR doesn't handle the daylight-savings inaccuracy mentioned there, but I think it would still improve the date in most cases (off by one errors would still be possible, but rather rare for most people). Adding the `tz` package as a dependency could allow "perfect" accuracy, but only for past dates, as far as I understand it.~ <- a mistake ? Hopefully.
