### PR TITLE
ui: Do not reset cost and value flags on reload.

### DIFF
--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -171,8 +171,7 @@ tsHandle ui@UIState{aScreen=s@TransactionScreen{tsTransaction=(i,t)
             Right j' -> do
               continue $
                 regenerateScreens j' d $
-                regenerateTransactions rspec j' s acct i $   -- added (inline) 201512 (why ?)
-                clearCostValue $
+                regenerateTransactions rspec j' s acct i  -- added (inline) 201512 (why ?)
                 ui
         VtyEvent (EvKey (KChar 'I') []) -> continue $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
 

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -105,11 +105,6 @@ toggleEmpty ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rsp
   where
     toggleEmpty ropts = ropts{empty_=not $ empty_ ropts}
 
--- | Show primary amounts, not cost or value.
-clearCostValue :: UIState -> UIState
-clearCostValue ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{cost_ = NoCost, value_ = Nothing}}}}}
-
 -- | Toggle between showing the primary amounts or costs.
 toggleCost :: UIState -> UIState
 toggleCost ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =


### PR DESCRIPTION
Discussion in #1577, indicates that cost and valuation flags should not be reset when reloading the data. This implements that.