### PR TITLE
lib: Remove aismultiplier from Amount.

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -218,7 +218,7 @@ instance Num Amount where
 
 -- | The empty simple amount.
 amount, nullamt :: Amount
-amount = Amount{acommodity="", aquantity=0, aprice=Nothing, astyle=amountstyle, aismultiplier=False}
+amount = Amount{acommodity="", aquantity=0, aprice=Nothing, astyle=amountstyle}
 nullamt = amount
 
 -- | A temporary value for parsed transactions which had no amount specified.

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -827,7 +827,7 @@ journalBalanceTransactions bopts' j' =
     styles = Just $ journalCommodityStyles j
     bopts = bopts'{commodity_styles_=styles}
     -- balance assignments will not be allowed on these
-    txnmodifieraccts = S.fromList $ map paccount $ concatMap tmpostingrules $ jtxnmodifiers j
+    txnmodifieraccts = S.fromList . map (paccount . tmprPosting) . concatMap tmpostingrules $ jtxnmodifiers j
   in
     runST $ do
       -- We'll update a mutable array of transactions as we balance them,

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -136,6 +136,7 @@ postingKV Posting{..} =
 
 instance ToJSON Transaction
 instance ToJSON TransactionModifier
+instance ToJSON TMPostingRule
 instance ToJSON PeriodicTransaction
 instance ToJSON PriceDirective
 instance ToJSON DateSpan

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -224,8 +224,6 @@ data Commodity = Commodity {
 data Amount = Amount {
       acommodity  :: !CommoditySymbol,     -- commodity symbol, or special value "AUTO"
       aquantity   :: !Quantity,            -- numeric quantity, or zero in case of "AUTO"
-      aismultiplier :: !Bool,              -- ^ kludge: a flag marking this amount and posting as a multiplier
-                                           --   in a TMPostingRule. In a regular Posting, should always be false.
       astyle      :: !AmountStyle,
       aprice      :: !(Maybe AmountPrice)  -- ^ the (fixed, transaction-specific) price for this amount, if any
     } deriving (Eq,Ord,Generic,Show)
@@ -429,7 +427,10 @@ nulltransactionmodifier = TransactionModifier{
 -- to the matched posting's transaction.
 -- Can be like a regular posting, or the amount can have the aismultiplier flag set,
 -- indicating that it's a multiplier for the matched posting's amount.
-type TMPostingRule = Posting
+data TMPostingRule = TMPostingRule
+  { tmprPosting :: Posting
+  , tmprIsMultiplier :: Bool
+  } deriving (Eq,Generic,Show)
 
 -- | A periodic transaction rule, describing a transaction that recurs.
 data PeriodicTransaction = PeriodicTransaction {

--- a/hledger-lib/Hledger/Read.hs
+++ b/hledger-lib/Hledger/Read.hs
@@ -32,7 +32,7 @@ module Hledger.Read (
   readJournal',
 
   -- * Re-exported
-  JournalReader.postingp,
+  JournalReader.tmpostingrulep,
   findReader,
   splitReaderPrefix,
   module Hledger.Read.Common,

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -559,7 +559,7 @@ cumulativeSum value start = snd . M.mapAccumWithKey accumValued start
 tests_MultiBalanceReport = tests "MultiBalanceReport" [
 
   let
-    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = Precision 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}, aismultiplier=False}
+    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = Precision 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}}
     (rspec,journal) `gives` r = do
       let rspec' = rspec{rsQuery=And [queryFromFlags $ rsOpts rspec, rsQuery rspec]}
           (eitems, etotal) = r

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -55,7 +55,7 @@ transactionModifierFromOpts CliOpts{rawopts_=rawopts} =
     ps = map (parseposting . T.pack) $ listofstringopt "add-posting" rawopts
     parseposting t = either (error' . errorBundlePretty) id ep  -- PARTIAL:
       where
-        ep = runIdentity (runJournalParser (postingp Nothing <* eof) t')
+        ep = runIdentity (runJournalParser (tmpostingrulep Nothing <* eof) t')
         t' = " " <> t <> "\n" -- inject space and newline for proper parsing
 
 printOrDiff :: RawOpts -> (CliOpts -> Journal -> Journal -> IO ())

--- a/hledger/test/journal/parse-errors.test
+++ b/hledger/test/journal/parse-errors.test
@@ -155,3 +155,11 @@ $ hledger -f- print
     equity:opening/closing balances
 
 >=0
+
+# 13. Adding a multiplier in a normal posting gives a parse error.
+<
+2020-01-01
+  (a)  *1
+$ hledger -f- print
+>2 /unexpected '\*'/
+>=1

--- a/hledger/test/json.test
+++ b/hledger/test/json.test
@@ -14,7 +14,6 @@ $ hledger -f- reg --output-format=json
       "pamount": [
         {
           "acommodity": "AAA",
-          "aismultiplier": false,
           "aprice": null,
           "aquantity": {
             "decimalMantissa": 10,
@@ -43,7 +42,6 @@ $ hledger -f- reg --output-format=json
     [
       {
         "acommodity": "AAA",
-        "aismultiplier": false,
         "aprice": null,
         "aquantity": {
           "decimalMantissa": 10,
@@ -73,7 +71,6 @@ $ hledger -f- bal --output-format=json
       [
         {
           "acommodity": "AAA",
-          "aismultiplier": false,
           "aprice": null,
           "aquantity": {
             "decimalMantissa": 10,
@@ -94,7 +91,6 @@ $ hledger -f- bal --output-format=json
   [
     {
       "acommodity": "AAA",
-      "aismultiplier": false,
       "aprice": null,
       "aquantity": {
         "decimalMantissa": 10,


### PR DESCRIPTION
In Amount, aismultiplier is a boolean flag that will always be False,
except for in TMPostingRules, where it indicates whether the posting
rule is a multiplier. It is therefore unnecessary in the vast majority
of cases. This PR pulls this flag out of Amount and puts it into
TMPostingRule, so it is only kept around when necessary.

This changes the parsing of journals somewhat. Previously you could
include an `*` before an amount anywhere in a Journal, and it would
happily parse and set the aismultiplier flag true. This will now fail
with a parse error: `*` is now only acceptable before an amount within an
auto posting rule.

This changes the JSON output of Amount, as it will no longer include
aismultiplier.