### PR TITLE
ref: bal: rename some report types to clarify/sync with docs

### DIFF
--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -107,8 +107,8 @@ accountTransactionsReport rspec@ReportSpec{rsOpts=ropts} j reportq thisacctq = i
       $ journalApplyValuationFromOpts rspec j
 
     startbal
-      | balancetype_ ropts == HistoricalBalance = sumPostings priorps
-      | otherwise                               = nullmixedamt
+      | balanceaccum_ ropts == Historical = sumPostings priorps
+      | otherwise                                = nullmixedamt
       where
         priorps = dbg5 "priorps" $
                   filter (matchesPosting

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -280,7 +280,7 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
 -- | Build a 'Table' from a multi-column balance report.
 budgetReportAsTable :: ReportOpts -> BudgetReport -> Table Text Text (Maybe MixedAmount, Maybe MixedAmount)
 budgetReportAsTable
-  ropts@ReportOpts{balancetype_}
+  ropts@ReportOpts{balanceaccum_}
   (PeriodicReport spans rows (PeriodicReportRow _ coltots grandtot grandavg)) =
     addtotalrow $
     Table
@@ -288,7 +288,7 @@ budgetReportAsTable
       (Tab.Group NoLine $ map Header colheadings)
       (map rowvals rows)
   where
-    colheadings = map (reportPeriodName balancetype_ spans) spans
+    colheadings = map (reportPeriodName balanceaccum_ spans) spans
                   ++ ["  Total" | row_total_ ropts]
                   ++ ["Average" | average_ ropts]
 

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -90,7 +90,7 @@ postingsReport rspec@ReportSpec{rsOpts=ropts@ReportOpts{..}} j = items
           -- may be converting to value per hledger_options.m4.md "Effect
           -- of --value on reports".
           -- XXX balance report doesn't value starting balance.. should this ?
-          historical = balancetype_ == HistoricalBalance
+          historical = balanceaccum_ == Historical
           startbal | average_  = if historical then precedingavg else nullmixedamt
                    | otherwise = if historical then precedingsum else nullmixedamt
             where

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -11,8 +11,8 @@ Options common to most hledger reports.
 module Hledger.Reports.ReportOptions (
   ReportOpts(..),
   ReportSpec(..),
-  ReportType(..),
-  BalanceType(..),
+  BalanceCalculation(..),
+  BalanceAccumulation(..),
   AccountListMode(..),
   ValuationType(..),
   defreportopts,
@@ -22,7 +22,7 @@ module Hledger.Reports.ReportOptions (
   updateReportSpec,
   updateReportSpecWith,
   rawOptsToReportSpec,
-  balanceTypeOverride,
+  balanceAccumulationOverride,
   flat_,
   tree_,
   reportOptsToggleStatus,
@@ -65,23 +65,26 @@ import Hledger.Query
 import Hledger.Utils
 
 
--- | What is calculated and shown in each cell in a balance report.
-data ReportType = ChangeReport       -- ^ The sum of posting amounts.
-                | BudgetReport       -- ^ The sum of posting amounts and the goal.
-                | ValueChangeReport  -- ^ The change of value of period-end historical values.
+-- | What to calculate for each cell in a balance report.
+-- "Balance report types -> Calculation type" in the hledger manual.
+data BalanceCalculation = 
+    CalcChange      -- ^ Sum of posting amounts in the period.
+  | CalcBudget      -- ^ Sum of posting amounts and the goal for the period.
+  | CalcValueChange -- ^ Change from previous period's historical end value to this period's historical end value.
   deriving (Eq, Show)
 
-instance Default ReportType where def = ChangeReport
+instance Default BalanceCalculation where def = CalcChange
 
--- | Which "accumulation method" is being shown in a balance report.
-data BalanceType = PeriodChange      -- ^ The accumulate change over a single period.
-                 | CumulativeChange  -- ^ The accumulated change across multiple periods.
-                 | HistoricalBalance -- ^ The historical ending balance, including the effect of
-                                     --   all postings before the report period. Unless altered by,
-                                     --   a query, this is what you would see on a bank statement.
+-- | How to accumulate calculated values across periods (columns) in a balance report.
+-- "Balance report types -> Accumulation type" in the hledger manual.
+data BalanceAccumulation =
+    PerPeriod   -- ^ No accumulation. Eg, shows the change of balance in each period.
+  | Cumulative  -- ^ Accumulate changes across periods, starting from zero at report start.
+  | Historical  -- ^ Accumulate changes across periods, including any from before report start.
+                --   Eg, shows the historical end balance of each period.
   deriving (Eq,Show)
 
-instance Default BalanceType where def = PeriodChange
+instance Default BalanceAccumulation where def = PerPeriod
 
 -- | Should accounts be displayed: in the command's default style, hierarchically, or as a flat list ?
 data AccountListMode = ALFlat | ALTree deriving (Eq, Show)
@@ -114,8 +117,8 @@ data ReportOpts = ReportOpts {
     -- for account transactions reports (aregister)
     ,txn_dates_      :: Bool
     -- for balance reports (bal, bs, cf, is)
-    ,reporttype_     :: ReportType
-    ,balancetype_    :: BalanceType
+    ,balancecalc_    :: BalanceCalculation
+    ,balanceaccum_   :: BalanceAccumulation
     ,accountlistmode_ :: AccountListMode
     ,drop_           :: Int
     ,row_total_      :: Bool
@@ -162,8 +165,8 @@ defreportopts = ReportOpts
     , average_         = False
     , related_         = False
     , txn_dates_       = False
-    , reporttype_      = def
-    , balancetype_     = def
+    , balancecalc_     = def
+    , balanceaccum_    = def
     , accountlistmode_ = ALFlat
     , drop_            = 0
     , row_total_       = False
@@ -209,8 +212,8 @@ rawOptsToReportOpts rawopts = do
           ,average_     = boolopt "average" rawopts
           ,related_     = boolopt "related" rawopts
           ,txn_dates_   = boolopt "txn-dates" rawopts
-          ,reporttype_  = reporttypeopt rawopts
-          ,balancetype_ = balancetypeopt rawopts
+          ,balancecalc_  = balancecalcopt rawopts
+          ,balanceaccum_ = balanceaccumulationopt rawopts
           ,accountlistmode_ = accountlistmodeopt rawopts
           ,drop_        = posintopt "drop" rawopts
           ,row_total_   = boolopt "row-total" rawopts
@@ -286,28 +289,28 @@ accountlistmodeopt =
       "flat" -> Just ALFlat
       _      -> Nothing
 
-reporttypeopt :: RawOpts -> ReportType
-reporttypeopt =
-  fromMaybe ChangeReport . choiceopt parse where
+balancecalcopt :: RawOpts -> BalanceCalculation
+balancecalcopt =
+  fromMaybe CalcChange . choiceopt parse where
     parse = \case
-      "sum"         -> Just ChangeReport
-      "valuechange" -> Just ValueChangeReport
-      "budget"      -> Just BudgetReport
+      "sum"         -> Just CalcChange
+      "valuechange" -> Just CalcValueChange
+      "budget"      -> Just CalcBudget
       _             -> Nothing
 
-balancetypeopt :: RawOpts -> BalanceType
-balancetypeopt = fromMaybe PeriodChange . balanceTypeOverride
+balanceaccumulationopt :: RawOpts -> BalanceAccumulation
+balanceaccumulationopt = fromMaybe PerPeriod . balanceAccumulationOverride
 
-balanceTypeOverride :: RawOpts -> Maybe BalanceType
-balanceTypeOverride rawopts = choiceopt parse rawopts <|> reportbal
+balanceAccumulationOverride :: RawOpts -> Maybe BalanceAccumulation
+balanceAccumulationOverride rawopts = choiceopt parse rawopts <|> reportbal
   where
     parse = \case
-      "historical" -> Just HistoricalBalance
-      "cumulative" -> Just CumulativeChange
-      "change"     -> Just PeriodChange
+      "historical" -> Just Historical
+      "cumulative" -> Just Cumulative
+      "change"     -> Just PerPeriod
       _            -> Nothing
-    reportbal = case reporttypeopt rawopts of
-      ValueChangeReport -> Just PeriodChange
+    reportbal = case balancecalcopt rawopts of
+      CalcValueChange -> Just PerPeriod
       _                 -> Nothing
 
 -- Get the period specified by any -b/--begin, -e/--end and/or -p/--period
@@ -439,8 +442,8 @@ valuationTypeFromRawOpts :: RawOpts -> (Costing, Maybe ValuationType)
 valuationTypeFromRawOpts rawopts = (costing, valuation)
   where
     costing   = if (any ((Cost==) . fst) valuationopts) then Cost else NoCost
-    valuation = case reporttypeopt rawopts of
-        ValueChangeReport -> case directval of
+    valuation = case balancecalcopt rawopts of
+        CalcValueChange -> case directval of
             Nothing        -> Just $ AtEnd Nothing  -- If no valuation requested for valuechange, use AtEnd
             Just (AtEnd _) -> directval             -- If AtEnd valuation requested, use it
             Just _         -> usageError "--valuechange only produces sensible results with --value=end"
@@ -544,8 +547,8 @@ valuationAfterSum :: ReportOpts -> Maybe (Maybe CommoditySymbol)
 valuationAfterSum ropts = case value_ ropts of
     Just (AtEnd mc) | valueAfterSum -> Just mc
     _                               -> Nothing
-  where valueAfterSum = reporttype_  ropts == ValueChangeReport
-                     || balancetype_ ropts /= PeriodChange
+  where valueAfterSum = balancecalc_  ropts == CalcValueChange
+                     || balanceaccum_ ropts /= PerPeriod
 
 
 -- | Convert report options to a query, ignoring any non-flag command line arguments.
@@ -652,10 +655,10 @@ reportPeriodOrJournalLastDay rspec j = reportPeriodLastDay rspec <|> journalOrPr
 --
 -- - all other balance change reports: a description of the datespan,
 --   abbreviated to compact form if possible (see showDateSpan).
-reportPeriodName :: BalanceType -> [DateSpan] -> DateSpan -> T.Text
-reportPeriodName balancetype spans =
-  case balancetype of
-    PeriodChange -> if multiyear then showDateSpan else showDateSpanMonthAbbrev
+reportPeriodName :: BalanceAccumulation -> [DateSpan] -> DateSpan -> T.Text
+reportPeriodName balanceaccumulation spans =
+  case balanceaccumulation of
+    PerPeriod -> if multiyear then showDateSpan else showDateSpanMonthAbbrev
       where
         multiyear = (>1) $ length $ nubSort $ map spanStartYear spans
     _ -> maybe "" (showDate . prevday) . spanEnd

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -213,7 +213,7 @@ rawOptsToReportOpts rawopts = do
           ,related_     = boolopt "related" rawopts
           ,txn_dates_   = boolopt "txn-dates" rawopts
           ,balancecalc_  = balancecalcopt rawopts
-          ,balanceaccum_ = balanceaccumulationopt rawopts
+          ,balanceaccum_ = balanceaccumopt rawopts
           ,accountlistmode_ = accountlistmodeopt rawopts
           ,drop_        = posintopt "drop" rawopts
           ,row_total_   = boolopt "row-total" rawopts
@@ -298,8 +298,8 @@ balancecalcopt =
       "budget"      -> Just CalcBudget
       _             -> Nothing
 
-balanceaccumulationopt :: RawOpts -> BalanceAccumulation
-balanceaccumulationopt = fromMaybe PerPeriod . balanceAccumulationOverride
+balanceaccumopt :: RawOpts -> BalanceAccumulation
+balanceaccumopt = fromMaybe PerPeriod . balanceAccumulationOverride
 
 balanceAccumulationOverride :: RawOpts -> Maybe BalanceAccumulation
 balanceAccumulationOverride rawopts = choiceopt parse rawopts <|> reportbal
@@ -311,7 +311,7 @@ balanceAccumulationOverride rawopts = choiceopt parse rawopts <|> reportbal
       _            -> Nothing
     reportbal = case balancecalcopt rawopts of
       CalcValueChange -> Just PerPeriod
-      _                 -> Nothing
+      _               -> Nothing
 
 -- Get the period specified by any -b/--begin, -e/--end and/or -p/--period
 -- options appearing in the command line.
@@ -324,8 +324,7 @@ periodFromRawOpts d rawopts =
     (Nothing, Nothing) -> PeriodAll
     (Just b, Nothing)  -> PeriodFrom b
     (Nothing, Just e)  -> PeriodTo e
-    (Just b, Just e)   -> simplifyPeriod $
-                          PeriodBetween b e
+    (Just b, Just e)   -> simplifyPeriod $ PeriodBetween b e
   where
     mlastb = case beginDatesFromRawOpts d rawopts of
                    [] -> Nothing

--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -64,7 +64,7 @@ type Average = MixedAmount  -- ^ The average of 'Change's or 'Balance's in a rep
 --
 --   * A list of amounts, one for each column. Depending on the value type,
 --     these can represent balance changes, ending balances, budget
---     performance, etc. (for example, see 'BalanceType' and
+--     performance, etc. (for example, see 'BalanceAccumulation' and
 --     "Hledger.Cli.Commands.Balance").
 --
 --   * the total of the row's amounts for a periodic report,

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -153,7 +153,7 @@ asDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
 
       where
         ropts = rsOpts rspec
-        ishistorical = balancetype_ ropts == HistoricalBalance
+        ishistorical = balanceaccum_ ropts == Historical
 
         toplabel =
               withAttr ("border" <> "filename") files

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -109,7 +109,7 @@ runBrickUi uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rsp
                period_=periodfromoptsandargs,       -- query's date part
                no_elide_=True,  -- avoid squashing boring account names, for a more regular tree (unlike hledger)
                empty_=not $ empty_ ropts,  -- show zero items by default, hide them with -E (unlike hledger)
-               balancetype_=HistoricalBalance  -- show historical balances by default (unlike hledger)
+               balanceaccum_=Historical  -- show historical balances by default (unlike hledger)
                }
             }
          }

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -70,7 +70,7 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{cliopts_=CliOpts{reportspec_=rspec
         depth_=Nothing
       -- XXX aregister also has this, needed ?
         -- always show historical balance
-      -- , balancetype_= HistoricalBalance
+      -- , balanceaccum_= Historical
       }
     rspec' =
       either (error "rsInit: adjusting the query for register, should not have failed") id $ -- PARTIAL:
@@ -201,7 +201,7 @@ rsDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
 
       where
         ropts = rsOpts rspec
-        ishistorical = balancetype_ ropts == HistoricalBalance
+        ishistorical = balanceaccum_ ropts == Historical
         -- inclusive = tree_ ropts || rsForceInclusive
 
         toplabel =

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -146,10 +146,10 @@ toggleTree ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspe
 -- | Toggle between historical balances and period balances.
 toggleHistorical :: UIState -> UIState
 toggleHistorical ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{rsOpts=ropts}}}} =
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{balancetype_=b}}}}}
+  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{rsOpts=ropts{balanceaccum_=b}}}}}
   where
-    b | balancetype_ ropts == HistoricalBalance = PeriodChange
-      | otherwise                               = HistoricalBalance
+    b | balanceaccum_ ropts == Historical = PerPeriod
+      | otherwise                         = Historical
 
 -- | Toggle hledger-ui's "forecast/future mode". When this mode is enabled,
 -- hledger-shows regular transactions which have future dates, and

--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -46,7 +46,7 @@ getRegisterR = do
           tail $ (", "<$xs) ++ [""]
       items = accountTransactionsReport rspec j m acctQuery
       balancelabel
-        | isJust (inAccount qopts), balancetype_ (rsOpts rspec) == HistoricalBalance = "Historical Total"
+        | isJust (inAccount qopts), balanceaccum_ (rsOpts rspec) == Historical = "Historical Total"
         | isJust (inAccount qopts) = "Period Total"
         | otherwise                = "Total"
       transactionFrag = transactionFragment j

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -86,7 +86,7 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
         -- ignore any depth limit, as in postingsReport; allows register's total to match balance reports (cf #1468)
         depth_=Nothing
         -- always show historical balance
-      , balancetype_= HistoricalBalance
+      , balanceaccum_= Historical
       }
     -- and regenerate the ReportSpec, making sure to use the above
     rspec' = rspec{ rsQuery=simplifyQuery $ And [queryFromFlags ropts', argsquery]

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -274,35 +274,35 @@ import Hledger.Read.CsvReader (CSV, printCSV)
 -- | Command line options for this command.
 balancemode = hledgerCommandMode
   $(embedFileRelative "Hledger/Cli/Commands/Balance.txt")
-  ([flagNone ["sum"] (setboolopt "sum")
+  (
+    [flagNone ["sum"] (setboolopt "sum")
       "show sum of posting amounts (default)"
-   ,flagNone ["budget"] (setboolopt "budget")
+    ,flagNone ["budget"] (setboolopt "budget")
       "show sum of posting amounts compared to budget goals defined by periodic transactions\n "
-   ,flagNone ["valuechange"] (setboolopt "valuechange")
+    ,flagNone ["valuechange"] (setboolopt "valuechange")
       "show change of value of period-end historical balances"
-
-   ,flagNone ["change"] (setboolopt "change")
+    ,flagNone ["change"] (setboolopt "change")
       "accumulate amounts from column start to column end (in multicolumn reports, default)"
-   ,flagNone ["cumulative"] (setboolopt "cumulative")
+    ,flagNone ["cumulative"] (setboolopt "cumulative")
       "accumulate amounts from report start (specified by e.g. -b/--begin) to column end"
-   ,flagNone ["historical","H"] (setboolopt "historical")
+    ,flagNone ["historical","H"] (setboolopt "historical")
       "accumulate amounts from journal start to column end (includes postings before report start date)\n "
-   ]
-   ++ flattreeflags True ++
-   [flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "omit N leading account name parts (in flat mode)"
-   ,flagNone ["average","A"] (setboolopt "average") "show a row average column (in multicolumn reports)"
-   ,flagNone ["row-total","T"] (setboolopt "row-total") "show a row total column (in multicolumn reports)"
-   ,flagNone ["no-total","N"] (setboolopt "no-total") "omit the final total row"
-   ,flagNone ["no-elide"] (setboolopt "no-elide") "don't squash boring parent accounts (in tree mode); don't show only 2 commodities per amount"
-   ,flagReq  ["format"] (\s opts -> Right $ setopt "format" s opts) "FORMATSTR" "use this custom line format (in simple reports)"
-   ,flagNone ["pretty-tables"] (setboolopt "pretty-tables") "use unicode to display prettier tables"
-   ,flagNone ["sort-amount","S"] (setboolopt "sort-amount") "sort by amount instead of account code/name (in flat mode). With multiple columns, sorts by the row total, or by row average if that is displayed."
-   ,flagNone ["percent", "%"] (setboolopt "percent") "express values in percentage of each column's total"
-   ,flagNone ["invert"] (setboolopt "invert") "display all amounts with reversed sign"
-   ,flagNone ["transpose"] (setboolopt "transpose") "transpose rows and columns"
-   ,outputFormatFlag ["txt","html","csv","json"]
-   ,outputFileFlag
-   ]
+    ]
+    ++ flattreeflags True ++
+    [flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "omit N leading account name parts (in flat mode)"
+    ,flagNone ["average","A"] (setboolopt "average") "show a row average column (in multicolumn reports)"
+    ,flagNone ["row-total","T"] (setboolopt "row-total") "show a row total column (in multicolumn reports)"
+    ,flagNone ["no-total","N"] (setboolopt "no-total") "omit the final total row"
+    ,flagNone ["no-elide"] (setboolopt "no-elide") "don't squash boring parent accounts (in tree mode); don't show only 2 commodities per amount"
+    ,flagReq  ["format"] (\s opts -> Right $ setopt "format" s opts) "FORMATSTR" "use this custom line format (in simple reports)"
+    ,flagNone ["pretty-tables"] (setboolopt "pretty-tables") "use unicode to display prettier tables"
+    ,flagNone ["sort-amount","S"] (setboolopt "sort-amount") "sort by amount instead of account code/name (in flat mode). With multiple columns, sorts by the row total, or by row average if that is displayed."
+    ,flagNone ["percent", "%"] (setboolopt "percent") "express values in percentage of each column's total"
+    ,flagNone ["invert"] (setboolopt "invert") "display all amounts with reversed sign"
+    ,flagNone ["transpose"] (setboolopt "transpose") "transpose rows and columns"
+    ,outputFormatFlag ["txt","html","csv","json"]
+    ,outputFileFlag
+    ]
   )
   [generalflagsgroup1]
   hiddenflags

--- a/hledger/Hledger/Cli/Commands/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Commands/Balancesheet.hs
@@ -37,7 +37,7 @@ balancesheetSpec = CompoundBalanceCommandSpec {
      ,cbcsubreportincreasestotal=False
      }
     ],
-  cbctype     = HistoricalBalance
+  cbcaccum     = Historical
 }
 
 balancesheetmode :: Mode RawOpts

--- a/hledger/Hledger/Cli/Commands/Balancesheetequity.hs
+++ b/hledger/Hledger/Cli/Commands/Balancesheetequity.hs
@@ -45,7 +45,7 @@ balancesheetequitySpec = CompoundBalanceCommandSpec {
      ,cbcsubreportincreasestotal=False
      }
     ],
-  cbctype     = HistoricalBalance
+  cbcaccum     = Historical
 }
 
 balancesheetequitymode :: Mode RawOpts

--- a/hledger/Hledger/Cli/Commands/Cashflow.hs
+++ b/hledger/Hledger/Cli/Commands/Cashflow.hs
@@ -34,7 +34,7 @@ cashflowSpec = CompoundBalanceCommandSpec {
      ,cbcsubreportincreasestotal=True
      }
     ],
-  cbctype     = PeriodChange
+  cbcaccum     = PerPeriod
 }
 
 cashflowmode :: Mode RawOpts

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -102,7 +102,7 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec} j = do
     explicit = boolopt "explicit" rawopts
 
     -- the balances to close
-    ropts = (rsOpts rspec){balancetype_=HistoricalBalance, accountlistmode_=ALFlat}
+    ropts = (rsOpts rspec){balanceaccum_=Historical, accountlistmode_=ALFlat}
     rspec_ = rspec{rsOpts=ropts}
     (acctbals',_) = balanceReport rspec_ j
     acctbals = map (\(a,_,_,b) -> (a, if show_costs_ ropts then b else mixedAmountStripPrices b)) acctbals'

--- a/hledger/Hledger/Cli/Commands/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Commands/Incomestatement.hs
@@ -35,7 +35,7 @@ incomestatementSpec = CompoundBalanceCommandSpec {
      ,cbcsubreportincreasestotal=False
      }
     ],
-  cbctype     = PeriodChange
+  cbcaccum     = PerPeriod
 }
 
 incomestatementmode :: Mode RawOpts

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -47,8 +47,8 @@ data CompoundBalanceCommandSpec = CompoundBalanceCommandSpec {
   cbcdoc      :: CommandDoc,                      -- ^ the command's name(s) and documentation
   cbctitle    :: String,                          -- ^ overall report title
   cbcqueries  :: [CBCSubreportSpec DisplayName],  -- ^ subreport details
-  cbctype     :: BalanceType                      -- ^ the "balance" type (change, cumulative, historical)
-                                                  --   this report shows (overrides command line flags)
+  cbcaccum    :: BalanceAccumulation              -- ^ how to accumulate balances (per-period, cumulative, historical)
+                                                  --   (overrides command line flags)
 }
 
 -- | Generate a cmdargs option-parsing mode from a compound balance command
@@ -66,13 +66,13 @@ compoundBalanceCommandMode CompoundBalanceCommandSpec{..} =
 
    ,flagNone ["change"] (setboolopt "change")
        ("accumulate amounts from column start to column end (in multicolumn reports)"
-           ++ defType PeriodChange)
+           ++ defaultMarker PerPeriod)
     ,flagNone ["cumulative"] (setboolopt "cumulative")
        ("accumulate amounts from report start (specified by e.g. -b/--begin) to column end"
-           ++ defType CumulativeChange)
+           ++ defaultMarker Cumulative)
     ,flagNone ["historical","H"] (setboolopt "historical")
        ("accumulate amounts from journal start to column end (includes postings before report start date)"
-           ++ defType HistoricalBalance ++ "\n ")
+           ++ defaultMarker Historical ++ "\n ")
     ]
     ++ flattreeflags True ++
     [flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "flat mode: omit N leading account name parts"
@@ -91,9 +91,9 @@ compoundBalanceCommandMode CompoundBalanceCommandSpec{..} =
     hiddenflags
     ([], Just $ argsFlag "[QUERY]")
  where
-   defType :: BalanceType -> String
-   defType bt | bt == cbctype = " (default)"
-              | otherwise    = ""
+   defaultMarker :: BalanceAccumulation -> String
+   defaultMarker bacc | bacc == cbcaccum = " (default)"
+                      | otherwise        = ""
 
 -- | Generate a runnable command from a compound balance command specification.
 compoundBalanceCommand :: CompoundBalanceCommandSpec -> (CliOpts -> Journal -> IO ())
@@ -102,10 +102,10 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
   where
     ropts@ReportOpts{..} = rsOpts rspec
     -- use the default balance type for this report, unless the user overrides
-    mBalanceTypeOverride = balanceTypeOverride rawopts
-    balancetype = fromMaybe cbctype mBalanceTypeOverride
+    mbalanceAccumulationOverride = balanceAccumulationOverride rawopts
+    balanceaccumulation = fromMaybe cbcaccum mbalanceAccumulationOverride
     -- Set balance type in the report options.
-    ropts' = ropts{balancetype_=balancetype}
+    ropts' = ropts{balanceaccum_=balanceaccumulation}
 
     title =
       T.pack cbctitle
@@ -116,24 +116,24 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
       where
 
         -- XXX #1078 the title of ending balance reports
-        -- (HistoricalBalance) should mention the end date(s) shown as
+        -- (Historical) should mention the end date(s) shown as
         -- column heading(s) (not the date span of the transactions).
         -- Also the dates should not be simplified (it should show
         -- "2008/01/01-2008/12/31", not "2008").
-        titledatestr = case balancetype of
-            HistoricalBalance -> showEndDates enddates
+        titledatestr = case balanceaccumulation of
+            Historical -> showEndDates enddates
             _                 -> showDateSpan requestedspan
           where
             enddates = map (addDays (-1)) . mapMaybe spanEnd $ cbrDates cbr  -- these spans will always have a definite end date
             requestedspan = reportSpan j rspec
 
         -- when user overrides, add an indication to the report title
-        -- Do we need to deal with overridden ReportType?
-        mtitleclarification = flip fmap mBalanceTypeOverride $ \case
-            PeriodChange | changingValuation -> "(Period-End Value Changes)"
-            PeriodChange                     -> "(Balance Changes)"
-            CumulativeChange                 -> "(Cumulative Ending Balances)"
-            HistoricalBalance                -> "(Historical Ending Balances)"
+        -- Do we need to deal with overridden BalanceCalculation?
+        mtitleclarification = flip fmap mbalanceAccumulationOverride $ \case
+            PerPeriod | changingValuation -> "(Period-End Value Changes)"
+            PerPeriod                     -> "(Balance Changes)"
+            Cumulative                 -> "(Cumulative Ending Balances)"
+            Historical                -> "(Historical Ending Balances)"
 
         valuationdesc =
           (case cost_ of
@@ -147,9 +147,9 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
                Just (AtDate today _mc) -> ", valued at " <> showDate today
                Nothing                 -> "")
 
-        changingValuation = case (reporttype_, balancetype_) of
-            (ValueChangeReport, PeriodChange)     -> True
-            (ValueChangeReport, CumulativeChange) -> True
+        changingValuation = case (balancecalc_, balanceaccum_) of
+            (CalcValueChange, PerPeriod)     -> True
+            (CalcValueChange, Cumulative) -> True
             _                                     -> False
 
     -- make a CompoundBalanceReport.
@@ -239,7 +239,7 @@ compoundBalanceReportAsCsv ropts (CompoundPeriodicReport title colspans subrepor
     addtotals $
       padRow title
       : ( "Account"
-        : map (reportPeriodName (balancetype_ ropts) colspans) colspans
+        : map (reportPeriodName (balanceaccum_ ropts) colspans) colspans
         ++ (if row_total_ ropts then ["Total"] else [])
         ++ (if average_ ropts then ["Average"] else [])
         )
@@ -284,7 +284,7 @@ compoundBalanceReportAsHtml ropts cbr =
          [tr_ $ th_ [colspanattr, leftattr] $ h2_ $ toHtml title]
       ++ [thRow $
           "" :
-          map (reportPeriodName (balancetype_ ropts) colspans) colspans
+          map (reportPeriodName (balanceaccum_ ropts) colspans) colspans
           ++ (if row_total_ ropts then ["Total"] else [])
           ++ (if average_ ropts then ["Average"] else [])
           ]

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -132,8 +132,8 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
         mtitleclarification = flip fmap mbalanceAccumulationOverride $ \case
             PerPeriod | changingValuation -> "(Period-End Value Changes)"
             PerPeriod                     -> "(Balance Changes)"
-            Cumulative                 -> "(Cumulative Ending Balances)"
-            Historical                -> "(Historical Ending Balances)"
+            Cumulative                    -> "(Cumulative Ending Balances)"
+            Historical                    -> "(Historical Ending Balances)"
 
         valuationdesc =
           (case cost_ of


### PR DESCRIPTION
Some renaming that seemed helpful as I contemplated working on something (named budgets). Types now match the terminology at https://hledger.org/hledger.html#balance-report-types, constructors are shorter, and there's no longer a constructor with the same name as the unrelated `BudgetReport` type. Any feedback welcome.