### PR TITLE
bal: Show commodity symbol as a subaccount / in a column

### DIFF
--- a/hledger-lib/Hledger/Data/StringFormat.hs
+++ b/hledger-lib/Hledger/Data/StringFormat.hs
@@ -136,7 +136,7 @@ formatfieldp = do
     char '('
     f <- fieldp
     char ')'
-    return $ FormatField (isJust leftJustified) (parseDec minWidth) (parseDec maxWidth) f
+    return $ FormatField (isJust leftJustified) (parseDec minWidth <|> Just 0) (parseDec maxWidth) f
     where
       parseDec s = case s of
         Just text -> Just m where ((m,_):_) = readDec text
@@ -175,20 +175,20 @@ tests_StringFormat = tests "StringFormat" [
    in tests "parseStringFormat" [
       ""                           `gives` (defaultStringFormatStyle [])
     , "D"                          `gives` (defaultStringFormatStyle [FormatLiteral "D"])
-    , "%(date)"                    `gives` (defaultStringFormatStyle [FormatField False Nothing Nothing DescriptionField])
-    , "%(total)"                   `gives` (defaultStringFormatStyle [FormatField False Nothing Nothing TotalField])
+    , "%(date)"                    `gives` (defaultStringFormatStyle [FormatField False (Just 0) Nothing DescriptionField])
+    , "%(total)"                   `gives` (defaultStringFormatStyle [FormatField False (Just 0) Nothing TotalField])
     -- TODO
     -- , "^%(total)"                  `gives` (TopAligned [FormatField False Nothing Nothing TotalField])
     -- , "_%(total)"                  `gives` (BottomAligned [FormatField False Nothing Nothing TotalField])
     -- , ",%(total)"                  `gives` (OneLine [FormatField False Nothing Nothing TotalField])
-    , "Hello %(date)!"             `gives` (defaultStringFormatStyle [FormatLiteral "Hello ", FormatField False Nothing Nothing DescriptionField, FormatLiteral "!"])
-    , "%-(date)"                   `gives` (defaultStringFormatStyle [FormatField True Nothing Nothing DescriptionField])
+    , "Hello %(date)!"             `gives` (defaultStringFormatStyle [FormatLiteral "Hello ", FormatField False (Just 0) Nothing DescriptionField, FormatLiteral "!"])
+    , "%-(date)"                   `gives` (defaultStringFormatStyle [FormatField True (Just 0) Nothing DescriptionField])
     , "%20(date)"                  `gives` (defaultStringFormatStyle [FormatField False (Just 20) Nothing DescriptionField])
-    , "%.10(date)"                 `gives` (defaultStringFormatStyle [FormatField False Nothing (Just 10) DescriptionField])
+    , "%.10(date)"                 `gives` (defaultStringFormatStyle [FormatField False (Just 0) (Just 10) DescriptionField])
     , "%20.10(date)"               `gives` (defaultStringFormatStyle [FormatField False (Just 20) (Just 10) DescriptionField])
     , "%20(account) %.10(total)"   `gives` (defaultStringFormatStyle [FormatField False (Just 20) Nothing AccountField
                                                                      ,FormatLiteral " "
-                                                                     ,FormatField False Nothing (Just 10) TotalField
+                                                                     ,FormatField False (Just 0) (Just 10) TotalField
                                                                      ])
     , test "newline not parsed" $ assertLeft $ parseStringFormat "\n"
     ]

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -202,14 +202,14 @@ combineBudgetAndActual ropts j
         mbrsorted = map prrFullName . sortRows ropts j . map (fmap $ fromMaybe nullmixedamt . fst)
         rows = rows1 ++ rows2
 
-    -- TODO: grand total & average shows 0% when there are no actual amounts, inconsistent with other cells
     totalrow = PeriodicReportRow ()
         [ (Map.lookup p totActualByPeriod, Map.lookup p totBudgetByPeriod) | p <- periods ]
-        ( Just actualgrandtot, Just budgetgrandtot )
-        ( Just actualgrandavg, Just budgetgrandavg )
+        ( Just actualgrandtot, budget budgetgrandtot )
+        ( Just actualgrandavg, budget budgetgrandavg )
       where
         totBudgetByPeriod = Map.fromList $ zip budgetperiods budgettots :: Map DateSpan BudgetTotal
         totActualByPeriod = Map.fromList $ zip actualperiods actualtots :: Map DateSpan Change
+        budget b = if mixedAmountLooksZero b then Nothing else Just b
 
 -- | Render a budget report as plain text suitable for console output.
 budgetReportAsText :: ReportOpts -> BudgetReport -> TL.Text

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -156,6 +156,7 @@ data ReportOpts = ReportOpts {
       --   whether stdout is an interactive terminal, and the value of
       --   TERM and existence of NO_COLOR environment variables.
     ,transpose_      :: Bool
+    ,commodity_column_:: Bool
  } deriving (Show)
 
 instance Default ReportOpts where def = defreportopts
@@ -193,6 +194,7 @@ defreportopts = ReportOpts
     , normalbalance_   = Nothing
     , color_           = False
     , transpose_       = False
+    , commodity_column_ = False
     }
 
 -- | Generate a ReportOpts from raw command-line input, given a day.
@@ -243,6 +245,7 @@ rawOptsToReportOpts d rawopts =
           ,pretty_tables_ = boolopt "pretty-tables" rawopts
           ,color_       = useColorOnStdout -- a lower-level helper
           ,transpose_   = boolopt "transpose" rawopts
+          ,commodity_column_= boolopt "commodity-column" rawopts
           }
 
 -- | The result of successfully parsing a ReportOpts on a particular

--- a/hledger-lib/Hledger/Utils/Text.hs
+++ b/hledger-lib/Hledger/Utils/Text.hs
@@ -41,6 +41,7 @@ module Hledger.Utils.Text
   -- * wide-character-aware layout
   WideBuilder(..),
   wbToText,
+  wbFromText,
   wbUnpack,
   textWidth,
   textTakeWidth,
@@ -61,7 +62,7 @@ import qualified Data.Text.Lazy.Builder as TB
 import Hledger.Utils.Test ((@?=), test, tests)
 import Text.Tabular.AsciiWide
   (Align(..), Header(..), Properties(..), TableOpts(..), renderRow, textCell)
-import Text.WideString (WideBuilder(..), wbToText, wbUnpack, charWidth, textWidth)
+import Text.WideString (WideBuilder(..), wbToText, wbFromText, wbUnpack, charWidth, textWidth)
 
 
 -- lowercase, uppercase :: String -> String

--- a/hledger-lib/Text/WideString.hs
+++ b/hledger-lib/Text/WideString.hs
@@ -34,7 +34,7 @@ instance Monoid WideBuilder where
 wbToText :: WideBuilder -> Text
 wbToText = TL.toStrict . TB.toLazyText . wbBuilder
 
--- | Convert a WideBuilder to a strict Text.
+-- | Convert a strict Text to a WideBuilder.
 wbFromText :: Text -> WideBuilder
 wbFromText t = WideBuilder (TB.fromText t) (textWidth t)
 

--- a/hledger-lib/Text/WideString.hs
+++ b/hledger-lib/Text/WideString.hs
@@ -8,7 +8,8 @@ module Text.WideString (
   -- * Text Builders which keep track of length
   WideBuilder(..),
   wbUnpack,
-  wbToText
+  wbToText,
+  wbFromText
   ) where
 
 import Data.Text (Text)
@@ -32,6 +33,10 @@ instance Monoid WideBuilder where
 -- | Convert a WideBuilder to a strict Text.
 wbToText :: WideBuilder -> Text
 wbToText = TL.toStrict . TB.toLazyText . wbBuilder
+
+-- | Convert a WideBuilder to a strict Text.
+wbFromText :: Text -> WideBuilder
+wbFromText t = WideBuilder (TB.fromText t) (textWidth t)
 
 -- | Convert a WideBuilder to a String.
 wbUnpack :: WideBuilder -> String

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -311,7 +311,7 @@ balancemode = hledgerCommandMode
     ,flagNone ["invert"] (setboolopt "invert") "display all amounts with reversed sign"
     ,flagNone ["transpose"] (setboolopt "transpose") "transpose rows and columns"
     ,flagNone ["commodity-column"] (setboolopt "commodity-column")
-      "shows each commodity in its own automatically-generated subaccount, for tidier reports"
+      "shows one row per commodity and puts the commodity symbol in its own column, leaving amounts as bare numbers"
     ,outputFormatFlag ["txt","html","csv","json"]
     ,outputFileFlag
     ]

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -64,6 +64,7 @@ Many of these work with the higher-level commands as well.
 - rows and columns swapped ([`--transpose`](#multi-period-balance-report))
 - another field used as account name ([`--pivot`](#multi-period-balance-report))
 - custom-formatted line items (single-period reports only) ([`--format`](#customising-single-period-balance-reports))
+- commodities shown in a separate column, one per row ([`--commodity-column`](#commodity-column))
 
 This command supports the
 [output destination](#output-destination) and
@@ -254,6 +255,63 @@ Here are some ways to handle that:
 
 [csv-mode]: https://elpa.gnu.org/packages/csv-mode.html
 [visidata]: https://www.visidata.org
+
+#### commodity column
+
+With `--commodity-column`, each commodity of an account is displayed as a
+separate row item row will only include the quantity. The commodity itself is
+shown as a separate column, one per row. This can be useful for a cleaner
+display of multi-period reports with many commodities
+
+```shell
+$ hledger bal -T -Y
+Balance changes in 2012-01-01..2014-12-31:
+
+                  ||                               2012                             2013                   2014                            Total
+==================++=============================================================================================================================
+ Assets:US:ETrade ||   10.00 ITOT, 337.18 USD, 2 more..  70.00 GLD, 18.00 ITOT, 3 more..  -11.00 ITOT, 3 more..  70.00 GLD, 17.00 ITOT, 3 more..
+------------------++-----------------------------------------------------------------------------------------------------------------------------
+ total            ||   10.00 ITOT, 337.18 USD, 2 more..  70.00 GLD, 18.00 ITOT, 3 more..  -11.00 ITOT, 3 more..  70.00 GLD, 17.00 ITOT, 3 more..
+
+$ hledger bal -T -Y --commodity-column
+Balance changes in 2012-01-01..2014-12-31:
+
+                   || Commodity    2012    2013     2014    Total
+==================++=============================================
+ Assets:US:ETrade || GLD             0   70.00        0    70.00
+ Assets:US:ETrade || ITOT        10.00   18.00   -11.00    17.00
+ Assets:US:ETrade || USD        337.18  -98.12  4881.44  5120.50
+ Assets:US:ETrade || VEA         12.00   10.00    14.00    36.00
+ Assets:US:ETrade || VHT        106.00   18.00   170.00   294.00
+------------------++---------------------------------------------
+                  || GLD             0   70.00        0    70.00
+                  || ITOT        10.00   18.00   -11.00    17.00
+                  || USD        337.18  -98.12  4881.44  5120.50
+                  || VEA         12.00   10.00    14.00    36.00
+                  || VHT        106.00   18.00   170.00   294.00
+```
+
+Single-period CSV balance reports also follow this new convention.
+
+```shell
+$ hledger bal -T -O csv
+"account","balance"
+"Assets:US:ETrade","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
+"total","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
+
+$ hledger bal -T -O csv --commodity-column
+"account","commodity","balance"
+"Assets:US:ETrade","GLD","70.00"
+"Assets:US:ETrade","ITOT","17.00"
+"Assets:US:ETrade","USD","5120.50"
+"Assets:US:ETrade","VEA","36.00"
+"Assets:US:ETrade","VHT","294.00"
+"total","GLD","70.00"
+"total","ITOT","17.00"
+"total","USD","5120.50"
+"total","VEA","36.00"
+"total","VHT","294.00"
+```
 
 ### Sorting by amount
 

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -297,11 +297,11 @@ compoundBalanceReportAsHtml ropts cbr =
     subreportrows :: (T.Text, MultiBalanceReport, Bool) -> [Html ()]
     subreportrows (subreporttitle, mbr, _increasestotal) =
       let
-        (_,bodyrows,mtotalsrow) = multiBalanceReportHtmlRows ropts mbr
+        (_,bodyrows,mtotalsrows) = multiBalanceReportHtmlRows ropts mbr
       in
            [tr_ $ th_ [colspanattr, leftattr] $ toHtml subreporttitle]
         ++ bodyrows
-        ++ maybe [] (:[]) mtotalsrow
+        ++ mtotalsrows
         ++ [blankrow]
 
     totalrows | no_total_ ropts || length subreports == 1 = []

--- a/hledger/test/balance/commodity-account.test
+++ b/hledger/test/balance/commodity-account.test
@@ -1,0 +1,104 @@
+# Record a complicated real-life example. Layout is not perfect, but any
+# changes should be noted and evaluated whether they improve things.
+
+$ hledger -f bcexample.hledger bal assets.*etrade -3 -O csv
+>
+"account","balance"
+"Assets:US:ETrade","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
+"total","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
+>=0
+
+$ hledger -f bcexample.hledger bal assets.*etrade -3 -O csv --commodity-column
+>
+"account","commodity","balance"
+"Assets:US:ETrade","GLD","70.00"
+"Assets:US:ETrade","ITOT","17.00"
+"Assets:US:ETrade","USD","5120.50"
+"Assets:US:ETrade","VEA","36.00"
+"Assets:US:ETrade","VHT","294.00"
+"total","GLD","70.00"
+"total","ITOT","17.00"
+"total","USD","5120.50"
+"total","VEA","36.00"
+"total","VHT","294.00"
+>=0
+
+$ hledger -f bcexample.hledger bal assets.*etrade -3
+>
+           70.00 GLD
+          17.00 ITOT
+         5120.50 USD
+           36.00 VEA
+          294.00 VHT  Assets:US:ETrade
+--------------------
+           70.00 GLD
+          17.00 ITOT
+         5120.50 USD
+           36.00 VEA
+          294.00 VHT  
+>=0
+
+$ hledger -f bcexample.hledger bal assets.*etrade -3 --commodity-column
+>
+   70.00  GLD                    
+   17.00  ITOT                   
+ 5120.50  USD                    
+   36.00  VEA                    
+  294.00  VHT   Assets:US:ETrade 
+ ------- 
+   70.00  GLD                    
+   17.00  ITOT                   
+ 5120.50  USD                    
+   36.00  VEA                    
+  294.00  VHT                    
+>=0
+
+$ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv
+>
+"account","2012","2013","2014","total"
+"Assets:US:ETrade","10.00 ITOT, 337.18 USD, 12.00 VEA, 106.00 VHT","70.00 GLD, 18.00 ITOT, -98.12 USD, 10.00 VEA, 18.00 VHT","-11.00 ITOT, 4881.44 USD, 14.00 VEA, 170.00 VHT","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
+"total","10.00 ITOT, 337.18 USD, 12.00 VEA, 106.00 VHT","70.00 GLD, 18.00 ITOT, -98.12 USD, 10.00 VEA, 18.00 VHT","-11.00 ITOT, 4881.44 USD, 14.00 VEA, 170.00 VHT","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
+>=0
+
+$ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv --commodity-column
+>
+"account","commodity","2012","2013","2014","total"
+"Assets:US:ETrade","GLD","0","70.00","0","70.00"
+"Assets:US:ETrade","ITOT","10.00","18.00","-11.00","17.00"
+"Assets:US:ETrade","USD","337.18","-98.12","4881.44","5120.50"
+"Assets:US:ETrade","VEA","12.00","10.00","14.00","36.00"
+"Assets:US:ETrade","VHT","106.00","18.00","170.00","294.00"
+"total","GLD","0","70.00","0","70.00"
+"total","ITOT","10.00","18.00","-11.00","17.00"
+"total","USD","337.18","-98.12","4881.44","5120.50"
+"total","VEA","12.00","10.00","14.00","36.00"
+"total","VHT","106.00","18.00","170.00","294.00"
+>=0
+
+$ hledger -f bcexample.hledger bal -Y assets.*etrade -3 --average --commodity-column --no-total
+>
+Balance changes in 2012-01-01..2014-12-31:
+
+                  || Commodity    2012    2013     2014  Average 
+==================++=============================================
+ Assets:US:ETrade || GLD             0   70.00        0    23.33 
+ Assets:US:ETrade || ITOT        10.00   18.00   -11.00     5.67 
+ Assets:US:ETrade || USD        337.18  -98.12  4881.44  1706.83 
+ Assets:US:ETrade || VEA         12.00   10.00    14.00    12.00 
+ Assets:US:ETrade || VHT        106.00   18.00   170.00    98.00 
+>=0
+
+$ hledger -f bcexample.hledger bal -Y assets.*etrade -3 -O csv --commodity-column --budget
+>
+"Account","Commodity","2012","budget","2013","budget","2014","budget"
+"<unbudgeted>","GLD","0","0","70.00","0","0","0"
+"<unbudgeted>","ITOT","10.00","0","18.00","0","-11.00","0"
+"<unbudgeted>","USD","337.18","0","-98.12","0","4881.44","0"
+"<unbudgeted>","VEA","12.00","0","10.00","0","14.00","0"
+"<unbudgeted>","VHT","106.00","0","18.00","0","170.00","0"
+"Total:","GLD","0","0","70.00","0","0","0"
+"Total:","ITOT","10.00","0","18.00","0","-11.00","0"
+"Total:","USD","337.18","0","-98.12","0","4881.44","0"
+"Total:","VEA","12.00","0","10.00","0","14.00","0"
+"Total:","VHT","106.00","0","18.00","0","170.00","0"
+>=0


### PR DESCRIPTION
This is a potential implementation of proposals (6) and (10) from https://github.com/simonmichael/hledger/issues/1559. These commits handle the `balance` family of commands but should be extendable to `compound-balance` family as well.