### PR TITLE
Add balancing amounts in periodic transactions before applying auto postings

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -711,9 +711,9 @@ journalUntieTransactions t@Transaction{tpostings=ps} = t{tpostings=map (\p -> p{
 -- relative dates in transaction modifier queries.
 journalModifyTransactions :: Day -> Journal -> Either String Journal
 journalModifyTransactions d j =
-  case modifyTransactions d (jtxnmodifiers j) (jtxns j) of
-    Right ts -> Right j{jtxns=ts}
-    Left err -> Left err
+    case modifyTransactions (journalCommodityStyles j) d (jtxnmodifiers j) (jtxns j) of
+      Right ts -> Right j{jtxns=ts}
+      Left err -> Left err
 
 -- | Check any balance assertions in the journal and return an error message
 -- if any of them fail (or if the transaction balancing they require fails).
@@ -1054,20 +1054,12 @@ checkBalanceAssignmentUnassignableAccountB p = do
 -- amounts in each commodity (see journalCommodityStyles).
 -- Can return an error message eg if inconsistent number formats are found.
 journalApplyCommodityStyles :: Journal -> Either String Journal
-journalApplyCommodityStyles j@Journal{jtxns=ts, jpricedirectives=pds} =
-  case journalInferCommodityStyles j of
-    Left e   -> Left e
-    Right j' -> Right j''
+journalApplyCommodityStyles = fmap fixjournal . journalInferCommodityStyles
+  where
+    fixjournal j@Journal{jpricedirectives=pds} =
+        journalMapPostings (postingApplyCommodityStyles styles) j{jpricedirectives=map fixpricedirective pds}
       where
-        styles = journalCommodityStyles j'
-        j'' = j'{jtxns=map fixtransaction ts
-                ,jpricedirectives=map fixpricedirective pds
-                }
-        fixtransaction t@Transaction{tpostings=ps} = t{tpostings=map fixposting ps}
-        fixposting p = p{pamount=styleMixedAmount styles $ pamount p
-                        ,pbalanceassertion=fixbalanceassertion <$> pbalanceassertion p}
-        -- balance assertion amounts are always displayed (by print) at full precision, per docs
-        fixbalanceassertion ba = ba{baamount=styleAmountExceptPrecision styles $ baamount ba}
+        styles = journalCommodityStyles j
         fixpricedirective pd@PriceDirective{pdamount=a} = pd{pdamount=styleAmountExceptPrecision styles a}
 
 -- | Get the canonical amount styles for this journal, whether (in order of precedence):

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -38,6 +38,7 @@ module Hledger.Data.Posting (
   relatedPostings,
   postingStripPrices,
   postingApplyAliases,
+  postingApplyCommodityStyles,
   -- * date operations
   postingDate,
   postingDate2,
@@ -297,6 +298,14 @@ postingApplyAliases aliases p@Posting{paccount} =
       where
         err = "problem while applying account aliases:\n" ++ pshow aliases 
           ++ "\n to account name: "++T.unpack paccount++"\n "++e
+
+-- | Choose and apply a consistent display style to the posting
+-- amounts in each commodity (see journalCommodityStyles).
+postingApplyCommodityStyles :: M.Map CommoditySymbol AmountStyle -> Posting -> Posting
+postingApplyCommodityStyles styles p = p{pamount=styleMixedAmount styles $ pamount p
+                                        ,pbalanceassertion=fixbalanceassertion <$> pbalanceassertion p}
+  where
+    fixbalanceassertion ba = ba{baamount=styleAmountExceptPrecision styles $ baamount ba}
 
 -- | Rewrite an account name using all matching aliases from the given list, in sequence.
 -- Each alias sees the result of applying the previous aliases.

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -362,8 +362,6 @@ journalFinalise InputOpts{auto_,balancingopts_,strict_} f txt pj' = do
           -- (Note adding auto postings after balancing means #893b fails;
           -- adding them before balancing probably means #893a, #928, #938 fail.)
           >>= journalModifyTransactions d
-          -- then apply commodity styles once more, to style the auto posting amounts. (XXX inefficient ?)
-          >>= journalApplyCommodityStyles
           -- then check balance assertions.
           >>= journalBalanceTransactions balancingopts_
 

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -88,7 +88,7 @@ hledgerWebTest = do
             Right rs -> rs
     copts = defcliopts{reportspec_=rspec, file_=[""]}  -- non-empty, see file_ note above
     wopts = defwebopts{cliopts_=copts}
-  j <- fmap (journalTransform copts) $ readJournal' (T.pack $ unlines  -- PARTIAL: readJournal' should not fail
+  j <- fmap (either error id . journalTransform copts) $ readJournal' (T.pack $ unlines  -- PARTIAL: readJournal' should not fail
     ["~ monthly"
     ,"    assets    10"
     ,"    income"

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -41,7 +41,7 @@ rewrite opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j@Journal{jtxns=ts} = d
   -- rewrite matched transactions
   d <- getCurrentDay
   let modifiers = transactionModifierFromOpts opts : jtxnmodifiers j
-  let j' = j{jtxns=either error' id $ modifyTransactions d modifiers ts}  -- PARTIAL:
+  let j' = j{jtxns=either error' id $ modifyTransactions mempty d modifiers ts}  -- PARTIAL:
   -- run the print command, showing all transactions, or show diffs
   printOrDiff rawopts opts{reportspec_=rspec{_rsQuery=Any}} j j'
 

--- a/hledger/test/journal/auto-postings.test
+++ b/hledger/test/journal/auto-postings.test
@@ -384,3 +384,30 @@ $ hledger -f- print --auto
     (b)                 100 EUR  ; generated-posting: = assets amt:>50
 
 >=0
+
+# 20. Auto-generated postings apply on auto-balanced periodic postings.
+<
+2021-01-01   Fixed
+    Checking            -10
+    Costs
+
+~ 2021-01-02   Periodic
+    Checking            -10
+    Costs
+
+= acct:Costs
+    (Auto)     *1
+
+$ hledger -f- print --forecast --auto --explicit
+2021-01-01 Fixed  ; modified:
+    Checking             -10
+    Costs                 10
+    (Auto)                10  ; generated-posting: = acct:Costs
+
+2021-01-02 Periodic
+    ; generated-transaction: ~ 2021-01-02, modified: 
+    Checking             -10
+    Costs                 10
+    (Auto)                10  ; generated-posting: = acct:Costs
+
+>=0


### PR DESCRIPTION
Addresses #1412.

The second commit here is a minimal fix for the problem. The first was work I did while trying to understand where the problem is.

<s>I actually think that generating the forecast transactions should happen in journal finalisation, not as a separate step after the journal has already been finalised.</s> This would avoid having to re-balance the whole journal several times.