### PR TITLE
Make sure aregister correctly identifies historical postings (#1634)

### DIFF
--- a/hledger/test/aregister.test
+++ b/hledger/test/aregister.test
@@ -1,5 +1,18 @@
 <
 2021-01-01
+  (b)  1
+
+2021-01-02
+  a   1
+  b  -1
+
+# 1. aregister only shows transactions matching the account query, and displays other accounts involved
+$ hledger -f- areg a
+Transactions in a and subaccounts:
+2021-01-02                      b                                1             1
+
+<
+2021-01-01
   (a)  1
 
 2021-01-02
@@ -8,8 +21,8 @@
 2021-01-03
   (a:aa:aaa)  100
 
-# aregister ignores a depth limit, always showing transactions in subaccounts. #1448
-$ hledger -f- areg -w80 a depth:1
+# 2. aregister ignores a depth limit, always showing transactions in subaccounts. #1448
+$ hledger -f- areg a depth:1
 Transactions in a and subaccounts:
 2021-01-01                      a                                1             1
 2021-01-02                      a:aa                            10            11
@@ -17,14 +30,14 @@ Transactions in a and subaccounts:
 
 #1634:
 
-# # aregister is always in historical mode, showing balance from prior transactions.
-# $ hledger -f- areg -w80 a -b 2021-01-02
-# Transactions in a and subaccounts:
-# 2021-01-02                      a:aa                            10            11
-# 2021-01-03                      a:aa:aaa                       100           111
+# 3. aregister is always in historical mode, showing balance from prior transactions.
+$ hledger -f- areg a -b 2021-01-02
+Transactions in a and subaccounts:
+2021-01-02                      a:aa                            10            11
+2021-01-03                      a:aa:aaa                       100           111
 
-# # Any additional arguments are a query, filtering the transactions. This may
-# # cause the running balance to diverge from the real-world running balance.
-# $ hledger -f- areg -w80 a aaa
-# Transactions in a and subaccounts:
-# 2021-01-03                      a:aa:aaa                       100           100
+# 4. Any additional arguments are a query, filtering the transactions. This may
+# cause the running balance to diverge from the real-world running balance.
+$ hledger -f- areg a aaa
+Transactions in a and subaccounts:
+2021-01-03                      a:aa:aaa                       100           100

--- a/hledger/test/journal/amounts-and-commodities.test
+++ b/hledger/test/journal/amounts-and-commodities.test
@@ -324,10 +324,8 @@ $ hledger -f- register -V -B cur:A "amt:<5"
 2021-01-01                      (a)                         1000 B        1000 B
 >=
 
-# 24. aregister report cur: and amt: query matches currency before
-# valuation/cost (note that aregister currently only tests queries other than
-# "cur:" and the account query when given the --txn-dates option. Who knows why.
-$ hledger -f- aregister a -V -B cur:A "amt:<5" --txn-dates
+# 24. aregister report cur: and amt: query matches currency before valuation/cost
+$ hledger -f- aregister a -V -B cur:A "amt:<5"
 Transactions in a and subaccounts:
 2021-01-01                      a                           1000 B        1000 B
 >=


### PR DESCRIPTION
<s>Explicitly avoid filtering by depth queries, perform valuation after all reportq filtering is done (in both the historical and recent postings), and make sure filtering is done at the correct point based on whether --txn-dates is set.</s> (#1634)

Make sure the reportq properly excludes depth, currency, and amount queries. Do not transform transactions (except as documented) unless we keep the original transaction.