### PR TITLE
Add forecast transactions at journal finalisation, rather than as a post-processing step.

### DIFF
--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -20,6 +20,7 @@ module Hledger.Query (
   -- * parsing
   parseQuery,
   parseQueryList,
+  parseQueryTerm,
   simplifyQuery,
   filterQuery,
   -- * accessors

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -29,7 +29,7 @@ import Data.Maybe (catMaybes)
 import Data.Ord (Down(..), comparing)
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Time.Calendar (Day, addDays)
+import Data.Time.Calendar (Day)
 
 import Hledger.Data
 import Hledger.Query
@@ -97,16 +97,10 @@ accountTransactionsReport rspec@ReportSpec{_rsReportOpts=ropts} j thisacctq = it
   where
     -- A depth limit should not affect the account transactions report; it should show all transactions in/below this account.
     -- Queries on currency or amount are also ignored at this stage; they are handled earlier, before valuation.
-    reportq = simplifyQuery $ And [aregisterq, periodq, excludeforecastq (forecast_ ropts)]
+    reportq = simplifyQuery $ And [aregisterq, periodq]
       where
         aregisterq = filterQuery (not . queryIsCurOrAmt) . filterQuery (not . queryIsDepth) $ _rsQuery rspec
         periodq = Date . periodAsDateSpan $ period_ ropts
-        -- Except in forecast mode, exclude future/forecast transactions.
-        excludeforecastq (Just _) = Any
-        excludeforecastq Nothing  =  -- not:date:tomorrow- not:tag:generated-transaction
-          And [ Not . Date $ DateSpan (Just . addDays 1 $ _rsDay rspec) Nothing
-              , Not generatedTransactionTag
-              ]
     amtq = filterQuery queryIsCurOrAmt $ _rsQuery rspec
     queryIsCurOrAmt q = queryIsSym q || queryIsAmt q
 

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -49,7 +49,7 @@ accountsScreen = AccountsScreen{
 
 asInit :: Day -> Bool -> UIState -> UIState
 asInit d reset ui@UIState{
-  aopts=UIOpts{cliopts_=CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}},
+  aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}},
   ajournal=j,
   aScreen=s@AccountsScreen{}
   } =
@@ -77,7 +77,7 @@ asInit d reset ui@UIState{
                         as = map asItemAccountName displayitems
 
     -- Further restrict the query based on the current period and future/forecast mode.
-    rspec' = rspec{_rsQuery=simplifyQuery $ And [_rsQuery rspec, periodq, excludeforecastq (forecast_ ropts)]}
+    rspec' = rspec{_rsQuery=simplifyQuery $ And [_rsQuery rspec, periodq, excludeforecastq (forecast_ $ inputopts_ copts)]}
       where
         periodq = Date $ periodAsDateSpan $ period_ ropts
         -- Except in forecast mode, exclude future/forecast transactions.
@@ -198,7 +198,7 @@ asDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
               -- ,("l", str "list")
               ,("-+", str "depth")
               ,("H", renderToggle (not ishistorical) "end-bals" "changes")
-              ,("F", renderToggle1 (isJust $ forecast_ ropts) "forecast")
+              ,("F", renderToggle1 (isJust . forecast_ $ inputopts_ copts) "forecast")
               --,("/", "filter")
               --,("DEL", "unfilter")
               --,("ESC", "cancel/top")

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -182,13 +182,13 @@ uiReloadJournalIfChanged copts d j ui = do
 -- or in the provided UIState's startup options,
 -- it is preserved.
 enableForecastPreservingPeriod :: UIState -> CliOpts -> CliOpts
-enableForecastPreservingPeriod ui copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}} =
-  copts{reportspec_=rspec{_rsReportOpts=ropts{forecast_=mforecast}}}
+enableForecastPreservingPeriod ui copts@CliOpts{inputopts_=iopts} =
+    copts{inputopts_=iopts{forecast_=mforecast}}
   where
     mforecast = asum [mprovidedforecastperiod, mstartupforecastperiod, mdefaultforecastperiod]
       where
-        mprovidedforecastperiod = forecast_ ropts
-        mstartupforecastperiod  = forecast_ $ _rsReportOpts $ reportspec_ $ cliopts_ $ astartupopts ui
+        mprovidedforecastperiod = forecast_ $ inputopts_ copts
+        mstartupforecastperiod  = forecast_ $ inputopts_ $ cliopts_ $ astartupopts ui
         mdefaultforecastperiod  = Just nulldatespan
 
 -- Re-check any balance assertions in the current journal, and if any

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -8,6 +8,7 @@ Released under GPL version 3 or later.
 
 module Hledger.UI.Main where
 
+import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync)
 import Control.Monad (forM_, void, when)
@@ -43,11 +44,11 @@ writeChan = BC.writeBChan
 
 main :: IO ()
 main = do
-  opts@UIOpts{cliopts_=copts@CliOpts{inputopts_=_iopts,reportspec_=rspec@ReportSpec{_rsReportOpts=ropts},rawopts_=rawopts}} <- getHledgerUIOpts
+  opts@UIOpts{cliopts_=copts@CliOpts{inputopts_=iopts,rawopts_=rawopts}} <- getHledgerUIOpts
   -- when (debug_ $ cliopts_ opts) $ printf "%s\n" prognameandversion >> printf "opts: %s\n" (show opts)
 
   -- always generate forecasted periodic transactions; their visibility will be toggled by the UI.
-  let copts' = copts{reportspec_=rspec{_rsReportOpts=ropts{forecast_=Just $ fromMaybe nulldatespan (forecast_ ropts)}}}
+  let copts' = copts{inputopts_=iopts{forecast_=forecast_ iopts <|> Just nulldatespan}}
 
   case True of
     _ | "help"            `inRawOpts` rawopts -> putStr (showModeUsage uimode)

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -239,7 +239,7 @@ rsDraw UIState{aopts=_uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec}}
               -- ,("l", str "list(-subs)")
 
               ,("H", renderToggle (not ishistorical) "historical" "period")
-              ,("F", renderToggle1 (isJust $ forecast_ ropts) "forecast")
+              ,("F", renderToggle1 (isJust . forecast_ . inputopts_ $ copts) "forecast")
 --               ,("a", "add")
 --               ,("g", "reload")
 --               ,("q", "quit")

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -7,8 +7,8 @@ module Hledger.UI.UIState
 where
 
 import Brick.Widgets.Edit
+import Control.Applicative ((<|>))
 import Data.List ((\\), foldl', sort)
-import Data.Maybe (fromMaybe)
 import Data.Semigroup (Max(..))
 import qualified Data.Text as T
 import Data.Text.Zipper (gotoEOL)
@@ -157,19 +157,19 @@ toggleHistorical ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec
 -- (which are usually but not necessarily future-dated).
 -- In normal mode, both of these are hidden.
 toggleForecast :: Day -> UIState -> UIState
-toggleForecast d ui@UIState{aopts=UIOpts{cliopts_=copts@CliOpts{reportspec_=ReportSpec{_rsReportOpts=ropts}}}} =
+toggleForecast d ui@UIState{aopts=UIOpts{cliopts_=copts@CliOpts{inputopts_=iopts}}} =
   uiSetForecast ui $
-    case forecast_ ropts of
+    case forecast_ iopts of
       Just _  -> Nothing
-      Nothing -> Just $ fromMaybe nulldatespan $ forecastPeriodFromRawOpts d $ rawopts_ copts
+      Nothing -> forecastPeriodFromRawOpts d (rawopts_ copts) <|> Just nulldatespan
 
 -- | Helper: set forecast mode (with the given forecast period) on or off in the UI state.
 uiSetForecast :: UIState -> Maybe DateSpan -> UIState
 uiSetForecast
-  ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}}}
+  ui@UIState{aopts=uopts@UIOpts{cliopts_=copts@CliOpts{inputopts_=iopts}}}
   mforecast =
   -- we assume forecast mode has no effect on ReportSpec's derived fields
-  ui{aopts=uopts{cliopts_=copts{reportspec_=rspec{_rsReportOpts=ropts{forecast_=mforecast}}}}}
+  ui{aopts=uopts{cliopts_=copts{inputopts_=iopts{forecast_=mforecast}}}}
 
 -- | Toggle between showing all and showing only real (non-virtual) items.
 toggleReal :: UIState -> UIState

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -79,14 +79,8 @@ hledgerWebTest = do
 
       -- yit "can add transactions" $ do
 
-  -- test with forecasted transactions
-  d <- getCurrentDay
   let
-    ropts = defreportopts{forecast_=Just nulldatespan}
-    rspec = case reportOptsToSpec d ropts of
-            Left e   -> error $ "failed to set up report options for tests, shouldn't happen: " ++ show e
-            Right rs -> rs
-    copts = defcliopts{reportspec_=rspec, file_=[""]}  -- non-empty, see file_ note above
+    copts = defcliopts{reportspec_=defreportspec, file_=[""]}  -- non-empty, see file_ note above
     wopts = defwebopts{cliopts_=copts}
   j <- fmap (either error id . journalTransform copts) $ readJournal' (T.pack $ unlines  -- PARTIAL: readJournal' should not fail
     ["~ monthly"

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -454,7 +454,7 @@ replaceNumericFlags = map replace
 -- Also records the terminal width, if supported.
 rawOptsToCliOpts :: RawOpts -> IO CliOpts
 rawOptsToCliOpts rawopts = do
-  let iopts = rawOptsToInputOpts rawopts
+  iopts <- rawOptsToInputOpts rawopts
   rspec <- rawOptsToReportSpec rawopts
   mcolumns <- readMay <$> getEnvSafe "COLUMNS"
   mtermwidth <-

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -123,7 +123,7 @@ anonymiseByOpts opts =
 --
 journalAddForecast :: CliOpts -> Journal -> Either String Journal
 journalAddForecast CliOpts{inputopts_=iopts, reportspec_=rspec} j =
-    case forecast_ ropts of
+    case forecast_ iopts of
         Nothing -> return j
         Just _  -> do
             forecasttxns <- addAutoTxns =<< mapM (balanceTransaction (balancingopts_ iopts))
@@ -135,7 +135,6 @@ journalAddForecast CliOpts{inputopts_=iopts, reportspec_=rspec} j =
             journalBalanceTransactions (balancingopts_ iopts) j{ jtxns = concat [jtxns j, forecasttxns] }
   where
     today = _rsDay rspec
-    ropts = _rsReportOpts rspec
     styles = journalCommodityStyles j
 
     -- "They can start no earlier than: the day following the latest normal transaction in the journal (or today if there are none)."
@@ -148,7 +147,7 @@ journalAddForecast CliOpts{inputopts_=iopts, reportspec_=rspec} j =
 
     forecastspan = dbg2 "forecastspan" $
       spanDefaultsFrom
-        (fromMaybe nulldatespan $ dbg2 "forecastspan flag" $ forecast_ ropts)
+        (fromMaybe nulldatespan $ dbg2 "forecastspan flag" $ forecast_ iopts)
         (DateSpan (Just forecastbeginDefault) (Just forecastendDefault))
 
     addAutoTxns = if auto_ iopts then modifyTransactions styles today (jtxnmodifiers j) else return

--- a/hledger/test/forecast.test
+++ b/hledger/test/forecast.test
@@ -235,3 +235,36 @@ hledger -f - reg -b 2021-01-01 -e 2021-01-05 --forecast
 2021-01-04                      (a)                              1          1003
 >>>2
 >>>=0
+
+# 12. Forecast transactions work with balance assignments
+hledger -f - print -x --forecast -e 2021-11
+<<<
+2021-09-01  Normal Balance Assertion Works
+    Checking   = -60
+    Costs
+
+~ 2021-10-01  explicit forecasted assertion
+    Checking      = -100
+    Costs             40
+
+~ 2021-10-02  auto-deduced forecasted assertion
+    Checking      = -120
+    Costs
+
+>>>
+2021-09-01 Normal Balance Assertion Works
+    Checking             -60 = -60
+    Costs                 60
+
+2021-10-01 explicit forecasted assertion
+    ; generated-transaction: ~ 2021-10-01
+    Checking             -40 = -100
+    Costs                 40
+
+2021-10-02 auto-deduced forecasted assertion
+    ; generated-transaction: ~ 2021-10-02
+    Checking             -20 = -120
+    Costs                 20
+
+>>>2
+>>>=0


### PR DESCRIPTION
Fixes #1638.