### PR TITLE
pkg!: Migrate the last of old-time over to time, changing ClockTime to POSIXTime.

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -116,8 +116,8 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Safe (headMay, headDef, maximumMay, minimumMay)
 import Data.Time.Calendar (Day, addDays, fromGregorian)
+import Data.Time.Clock.POSIX (POSIXTime)
 import Data.Tree (Tree, flatten)
-import System.Time (ClockTime(TOD))
 import Text.Printf (printf)
 
 import Hledger.Utils
@@ -234,7 +234,7 @@ nulljournal = Journal {
   ,jtxns                      = []
   ,jfinalcommentlines         = ""
   ,jfiles                     = []
-  ,jlastreadtime              = TOD 0 0
+  ,jlastreadtime              = 0
   }
 
 journalFilePath :: Journal -> FilePath
@@ -697,7 +697,7 @@ journalReverse j =
     }
 
 -- | Set this journal's last read time, ie when its files were last read.
-journalSetLastReadTime :: ClockTime -> Journal -> Journal
+journalSetLastReadTime :: POSIXTime -> Journal -> Journal
 journalSetLastReadTime t j = j{ jlastreadtime = t }
 
 

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -43,7 +43,6 @@ import           Data.Maybe (fromMaybe)
 import qualified Data.Text.Lazy    as TL
 import qualified Data.Text.Lazy.Builder as TB
 import           GHC.Generics (Generic)
-import           System.Time (ClockTime)
 
 import           Hledger.Data.Types
 import           Hledger.Data.Amount (amountsRaw, mixed)
@@ -149,7 +148,6 @@ instance ToJSON PayeeDeclarationInfo
 instance ToJSON Commodity
 instance ToJSON TimeclockCode
 instance ToJSON TimeclockEntry
-instance ToJSON ClockTime
 instance ToJSON Journal
 
 instance ToJSON Account where

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -39,10 +39,10 @@ import Text.Blaze (ToMarkup(..))
 import qualified Data.Map as M
 import Data.Ord (comparing)
 import Data.Text (Text)
-import Data.Time.Calendar
-import Data.Time.LocalTime
+import Data.Time.Calendar (Day)
+import Data.Time.Clock.POSIX (POSIXTime)
+import Data.Time.LocalTime (LocalTime)
 import Data.Word (Word8)
-import System.Time (ClockTime(..))
 
 import Hledger.Utils.Regex
 
@@ -528,10 +528,8 @@ data Journal = Journal {
                                                                     --   followed by any included files in the order encountered.
                                                                     --   TODO: FilePath is a sloppy type here, don't assume it's a
                                                                     --   real file; values like "", "-", "(string)" can be seen
-  ,jlastreadtime          :: ClockTime                              -- ^ when this journal was last read from its file(s)
+  ,jlastreadtime          :: POSIXTime                              -- ^ when this journal was last read from its file(s)
   } deriving (Eq, Generic)
-
-deriving instance Generic ClockTime
 
 -- | A journal in the process of being parsed, not yet finalised.
 -- The data is partial, and list fields are in reverse order.

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -149,9 +149,9 @@ import qualified Data.Semigroup as Sem
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day, addDays, fromGregorianValid, toGregorian)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Time.LocalTime (LocalTime(..), TimeOfDay(..))
 import Data.Word (Word8)
-import System.Time (getClockTime)
 import Text.Megaparsec
 import Text.Megaparsec.Char (char, char', digitChar, newline, string)
 import Text.Megaparsec.Char.Lexer (decimal)
@@ -367,7 +367,7 @@ parseAndFinaliseJournal' parser iopts f txt = do
 --
 journalFinalise :: InputOpts -> FilePath -> Text -> ParsedJournal -> ExceptT String IO Journal
 journalFinalise InputOpts{forecast_,auto_,balancingopts_,strict_} f txt pj = do
-    t <- liftIO getClockTime
+    t <- liftIO getPOSIXTime
     d <- liftIO getCurrentDay
     -- Infer and apply canonical styles for each commodity (or throw an error).
     -- This affects transaction balancing/assertions/assignments, so needs to be done early.

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -119,7 +119,6 @@ library
     , megaparsec >=7.0.0 && <9.2
     , microlens >=0.4
     , mtl >=2.2.1
-    , old-time
     , parser-combinators >=0.4.0
     , pretty-simple >4 && <5
     , regex-tdfa
@@ -170,7 +169,6 @@ test-suite doctest
     , megaparsec >=7.0.0 && <9.2
     , microlens >=0.4
     , mtl >=2.2.1
-    , old-time
     , parser-combinators >=0.4.0
     , pretty-simple >4 && <5
     , regex-tdfa
@@ -223,7 +221,6 @@ test-suite unittest
     , megaparsec >=7.0.0 && <9.2
     , microlens >=0.4
     , mtl >=2.2.1
-    , old-time
     , parser-combinators >=0.4.0
     , pretty-simple >4 && <5
     , regex-tdfa

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -54,7 +54,6 @@ dependencies:
 - megaparsec >=7.0.0 && <9.2
 - microlens >=0.4
 - mtl >=2.2.1
-- old-time
 - parser-combinators >=0.4.0
 - pretty-simple >4 && <5
 - regex-tdfa

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -159,7 +159,6 @@ library
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.2
     , mtl >=2.2.1
-    , old-time
     , process
     , regex-tdfa
     , safe >=0.2
@@ -209,7 +208,6 @@ executable hledger
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.2
     , mtl >=2.2.1
-    , old-time
     , process
     , regex-tdfa
     , safe >=0.2
@@ -260,7 +258,6 @@ test-suite unittest
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.2
     , mtl >=2.2.1
-    , old-time
     , process
     , regex-tdfa
     , safe >=0.2
@@ -310,7 +307,6 @@ benchmark bench
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.2
     , mtl >=2.2.1
-    , old-time
     , process
     , regex-tdfa
     , safe >=0.2

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -113,7 +113,6 @@ dependencies:
 - haskeline >=0.6
 - megaparsec >=7.0.0 && <9.2
 - mtl >=2.2.1
-- old-time
 - process
 - regex-tdfa
 - safe >=0.2


### PR DESCRIPTION
This eliminates old-time, which has been deprecated for a while, from
our dependencies.

This introduces a slight incompatibility, as a small number of functions
now take/return POSIXTime instead of ClockTime. Generally you will be
using the current time, in which case you should use getPOSIXTime from
Data.Time.Clock.POSIX instead of getClockTime.

utcTimeToClockTime has been removed, as it is now equivalent to
utcTimeToPOSIXSeconds from Data.Time.Clock.POSIX.