### PR TITLE
fix: bal: fix commodity-column interaction with transpose and empty commodities

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -100,6 +100,7 @@ module Hledger.Data.Amount (
   maAddAmounts,
   amounts,
   amountsRaw,
+  maCommodities,
   filterMixedAmount,
   filterMixedAmountByCommodity,
   mapMixedAmount,
@@ -152,6 +153,7 @@ import Data.Foldable (toList)
 import Data.List (find, foldl', intercalate, intersperse, mapAccumL, partition)
 import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
 import qualified Data.Map.Strict as M
+import qualified Data.Set as S
 import Data.Maybe (fromMaybe, isNothing, isJust)
 import Data.Semigroup (Semigroup(..))
 import qualified Data.Text as T
@@ -661,6 +663,11 @@ amounts (Mixed ma)
 -- unit price from most negative to most positive.
 amountsRaw :: MixedAmount -> [Amount]
 amountsRaw (Mixed ma) = toList ma
+
+-- | Get the set of mixed amount commodities. Returns an empty set of no amounts
+maCommodities :: MixedAmount -> S.Set CommoditySymbol
+maCommodities = S.fromList . fmap acommodity . amounts'
+  where amounts' ma@(Mixed m) = if M.null m then [] else amounts ma
 
 normaliseMixedAmount :: MixedAmount -> MixedAmount
 normaliseMixedAmount = id  -- XXX Remove

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -231,10 +231,6 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
                  Nothing             -> "")
            <> ":"
 
--- | Add the second table below the first, discarding its column headings.
-concatTables (Table hLeft hTop dat) (Table hLeft' _ dat') =
-    Table (Tab.Group SingleLine [hLeft, hLeft']) hTop (dat ++ dat')
-
 -- | Build a 'Table' from a multi-column balance report.
 budgetReportAsTable :: ReportOpts -> BudgetReport -> Table Text Text WideBuilder
 budgetReportAsTable
@@ -263,7 +259,7 @@ budgetReportAsTable
       | no_total_ = id
       | otherwise = let rh = Tab.Group NoLine $ map Header (replicate (length totalrows) "")
                         ch = Header [] -- ignored
-                     in (`concatTables` Table rh ch totalrows)
+                     in (flip (concatTables SingleLine) $ Table rh ch totalrows)
 
     maybetranspose
       | transpose_ = transpose

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -241,12 +241,12 @@ budgetReportAsText ropts@ReportOpts{..} budgetr = TB.toLazyText $
           ( textCell TopLeft rh
           , textsCell TopLeft cs : fmap (uncurry (showcell' cs)) cells)
       where
-        cs = filter (not . T.null) . S.toList . foldl' S.union mempty
+        cs = S.toList . foldl' S.union mempty
             . fmap (budgetCellCommodities . fst . snd) $ cells
 
     budgetCellCommodities :: BudgetCell -> S.Set CommoditySymbol
     budgetCellCommodities (am, bm) = f am `S.union` f bm
-      where f = S.fromList . fmap acommodity . amounts . fromMaybe nullmixedamt
+      where f = maybe mempty maCommodities
 
     displayTableWithWidths :: Table Text Text ((Int, Int, Int), BudgetDisplayCell)
     displayTableWithWidths = Table rh ch $ map (zipWith (,) widths) displaycells
@@ -436,10 +436,7 @@ budgetReportAsCsv
           . fmap (fromMaybe nullmixedamt)
           $ all
       where
-        cs = commodities $ catMaybes all
-        commodities = filter (not . T.null) . S.toList
-            . foldl' S.union mempty
-            . fmap (S.fromList . fmap acommodity . amounts)
+        cs = S.toList . foldl' S.union mempty . fmap maCommodities $ catMaybes all
         all = flattentuples as
             ++ concat [[rowtot, budgettot] | row_total_]
             ++ concat [[rowavg, budgetavg] | average_]

--- a/hledger-lib/Text/Tabular/AsciiWide.hs
+++ b/hledger-lib/Text/Tabular/AsciiWide.hs
@@ -21,6 +21,7 @@ module Text.Tabular.AsciiWide
 , textCell
 , textsCell
 , cellWidth
+, concatTables
 ) where
 
 import Data.Maybe (fromMaybe)
@@ -295,3 +296,9 @@ lineart SingleLine SingleLine DoubleLine DoubleLine = pick "╪" "+"
 lineart DoubleLine DoubleLine SingleLine SingleLine = pick "╫" "++"
 
 lineart _          _          _          _          = const mempty
+
+
+-- | Add the second table below the first, discarding its column headings.
+concatTables :: Properties -> Table rh ch a -> Table rh ch2 a -> Table rh ch a
+concatTables prop (Table hLeft hTop dat) (Table hLeft' _ dat') =
+    Table (Group prop [hLeft, hLeft']) hTop (dat ++ dat')

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -678,25 +678,6 @@ balanceReportAsTable opts@ReportOpts{average_, row_total_, balanceaccum_}
     maybetranspose | transpose_ opts = \(Table rh ch vals) -> Table ch rh (transpose vals)
                    | otherwise       = id
 
--- | Given a table representing a multi-column balance report (for example,
--- made using 'balanceReportAsTable'), render it in a format suitable for
--- console output. Amounts with more than two commodities will be elided
--- unless --no-elide is used.
-balanceReportTableAsText :: ReportOpts -> Table T.Text T.Text WideBuilder -> TB.Builder
-balanceReportTableAsText ReportOpts{..} =
-    Tab.renderTableByRowsB def{tableBorders=False, prettyTable=pretty_tables_} renderCh renderRow
-  where
-    renderCh
-      | not commodity_column_ || transpose_ = fmap (Tab.textCell TopRight)
-      | otherwise = zipWith ($) (Tab.textCell TopLeft : repeat (Tab.textCell TopRight))
-
-    renderRow :: (T.Text, [WideBuilder]) -> (Cell, [Cell])
-    renderRow (rh, row)
-      | not commodity_column_ || transpose_ =
-          (Tab.textCell TopLeft rh, fmap (Cell TopRight . pure) row)
-      | otherwise =
-          (Tab.textCell TopLeft rh, zipWith ($) (Cell TopLeft : repeat (Cell TopRight)) (fmap pure row))
-
 multiBalanceRowAsWbs :: AmountDisplayOpts -> ReportOpts -> PeriodicReportRow a MixedAmount -> [[WideBuilder]]
 multiBalanceRowAsWbs bopts ReportOpts{..} (PeriodicReportRow _ as rowtot rowavg)
   | not commodity_column_ = [fmap (showMixedAmountB bopts) all]

--- a/hledger/test/balance/commodity-column.test
+++ b/hledger/test/balance/commodity-column.test
@@ -1,6 +1,7 @@
 # Record a complicated real-life example. Layout is not perfect, but any
 # changes should be noted and evaluated whether they improve things.
 
+# 1. Balance report csv output with no commodity columns.
 $ hledger -f bcexample.hledger bal assets.*etrade -3 -O csv
 >
 "account","balance"
@@ -8,6 +9,7 @@ $ hledger -f bcexample.hledger bal assets.*etrade -3 -O csv
 "total","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
 >=0
 
+# 2. Balance report csv output with one line per commodity (--commodity-columns).
 $ hledger -f bcexample.hledger bal assets.*etrade -3 -O csv --commodity-column
 >
 "account","commodity","balance"
@@ -23,6 +25,7 @@ $ hledger -f bcexample.hledger bal assets.*etrade -3 -O csv --commodity-column
 "total","VHT","294.00"
 >=0
 
+# 3. Balance report output with no commodity column.
 $ hledger -f bcexample.hledger bal assets.*etrade -3
 >
            70.00 GLD
@@ -38,6 +41,7 @@ $ hledger -f bcexample.hledger bal assets.*etrade -3
           294.00 VHT  
 >=0
 
+# 4. Balance report with commodity column.
 $ hledger -f bcexample.hledger bal assets.*etrade -3 --commodity-column
 >
    70.00  GLD                    
@@ -53,6 +57,7 @@ $ hledger -f bcexample.hledger bal assets.*etrade -3 --commodity-column
   294.00  VHT                    
 >=0
 
+# 5. Multicolumn balance report csv output with no commodity columns.
 $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv
 >
 "account","2012","2013","2014","total"
@@ -60,6 +65,7 @@ $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv
 "total","10.00 ITOT, 337.18 USD, 12.00 VEA, 106.00 VHT","70.00 GLD, 18.00 ITOT, -98.12 USD, 10.00 VEA, 18.00 VHT","-11.00 ITOT, 4881.44 USD, 14.00 VEA, 170.00 VHT","70.00 GLD, 17.00 ITOT, 5120.50 USD, 36.00 VEA, 294.00 VHT"
 >=0
 
+# 6. Multicolumn balance report csv output with --commodity-columns.
 $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv --commodity-column
 >
 "account","commodity","2012","2013","2014","total"
@@ -75,6 +81,7 @@ $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv --commodity-co
 "total","VHT","106.00","18.00","170.00","294.00"
 >=0
 
+# 7. Multicolumn balance report with --commodity-column.
 $ hledger -f bcexample.hledger bal -Y assets.*etrade -3 --average --commodity-column --no-total
 >
 Balance changes in 2012-01-01..2014-12-31:
@@ -88,6 +95,7 @@ Balance changes in 2012-01-01..2014-12-31:
  Assets:US:ETrade || VHT        106.00   18.00   170.00    98.00 
 >=0
 
+# 8. Multicolumn budget report csv output with --commodity-columns.
 $ hledger -f bcexample.hledger bal -Y assets.*etrade -3 -O csv --commodity-column --budget
 >
 "Account","Commodity","2012","budget","2013","budget","2014","budget"

--- a/hledger/test/balance/commodity-column.test
+++ b/hledger/test/balance/commodity-column.test
@@ -110,3 +110,128 @@ $ hledger -f bcexample.hledger bal -Y assets.*etrade -3 -O csv --commodity-colum
 "Total:","VEA","12.00","0","10.00","0","14.00","0"
 "Total:","VHT","106.00","0","18.00","0","170.00","0"
 >=0
+
+# 9. Multicolumn balance report with --commodity-column and null commodity
+<
+2018/1/1
+  (a)          1
+  (a:b:c)      1
+
+2018/1/2
+  (a)          1 EUR
+
+$ hledger -f- bal -Y --commodity-column
+Balance changes in 2018:
+
+       || Commodity  2018 
+=======++=================
+ a     ||               1 
+ a     || EUR           1 
+ a:b:c ||               1 
+-------++-----------------
+       ||               2 
+       || EUR           1 
+
+
+# 10. Multicolumn balance report with --commodity-column --transpose.
+$ hledger -f bcexample.hledger bal -Y assets.*etrade -1 --average --commodity-column --transpose
+>
+Balance changes in 2012-01-01..2014-12-31:
+
+           || Assets  Assets   Assets  Assets  Assets |                                       
+===========++=========================================+=======================================
+ Commodity ||    GLD    ITOT      USD     VEA     VHT |   GLD    ITOT      USD    VEA     VHT 
+ 2012      ||      0   10.00   337.18   12.00  106.00 |     0   10.00   337.18  12.00  106.00 
+ 2013      ||  70.00   18.00   -98.12   10.00   18.00 | 70.00   18.00   -98.12  10.00   18.00 
+ 2014      ||      0  -11.00  4881.44   14.00  170.00 |     0  -11.00  4881.44  14.00  170.00 
+ Average   ||  23.33    5.67  1706.83   12.00   98.00 | 23.33    5.67  1706.83  12.00   98.00 
+>=0
+
+# 11. Multicolumn balance report with --commodity-column --transpose.
+<
+~ daily from 2016/1/1
+    expenses:food     $10
+    expenses:leisure  $15
+    assets:cash
+
+2016/12/01
+    expenses:food  $10
+    assets:cash
+
+2016/12/02
+    expenses:food  $9
+    assets:cash
+
+2016/12/03
+    expenses:food  $11
+    assets:cash
+
+2016/12/02
+    expenses:leisure  $5
+    assets:cash
+
+2016/12/03
+    expenses:movies  $25
+    assets:cash
+
+2016/12/03
+    expenses:cab  $15
+    assets:cash
+
+$ hledger -f- bal --budget --commodity-column --transpose -DTN
+>
+Budget performance in 2016-12-01..2016-12-03:
+
+            ||       assets:cash         expenses    expenses:food  expenses:leisure 
+============++=======================================================================
+ Commodity  ||                 $                $                $                 $ 
+ 2016-12-01 || -10 [ 40% of -25]  10 [ 40% of 25]  10 [100% of 10]     0 [       15] 
+ 2016-12-02 || -14 [ 56% of -25]  14 [ 56% of 25]   9 [ 90% of 10]     5 [33% of 15] 
+ 2016-12-03 || -51 [204% of -25]  51 [204% of 25]  11 [110% of 10]     0 [       15] 
+   Total    || -75 [100% of -75]  75 [100% of 75]  30 [100% of 30]     5 [11% of 45] 
+>=0
+
+# 12. Compound balance report output with --commodity-column.
+$ hledger -f bcexample.hledger bs -3 --commodity-column
+>
+Balance Sheet 2014-10-11
+
+                      || Commodity        2014-10-11 
+======================++=============================
+ Assets               ||                             
+----------------------++-----------------------------
+ Assets:US:BofA       || USD                  596.05 
+ Assets:US:ETrade     || GLD                   70.00 
+ Assets:US:ETrade     || ITOT                  17.00 
+ Assets:US:ETrade     || USD                 5120.50 
+ Assets:US:ETrade     || VEA                   36.00 
+ Assets:US:ETrade     || VHT                  294.00 
+ Assets:US:Hoogle     || VACHR                337.26 
+ Assets:US:Vanguard   || RGAGX      489.957000000000 
+ Assets:US:Vanguard   || USD                   -0.02 
+ Assets:US:Vanguard   || VBMPX      309.950000000000 
+----------------------++-----------------------------
+                      || GLD                   70.00 
+                      || ITOT                  17.00 
+                      || RGAGX      489.957000000000 
+                      || USD                 5716.53 
+                      || VACHR                337.26 
+                      || VBMPX      309.950000000000 
+                      || VEA                   36.00 
+                      || VHT                  294.00 
+======================++=============================
+ Liabilities          ||                             
+----------------------++-----------------------------
+ Liabilities:US:Chase || USD                 2891.85 
+----------------------++-----------------------------
+                      || USD                 2891.85 
+======================++=============================
+ Net:                 || GLD                   70.00 
+                      || ITOT                  17.00 
+                      || RGAGX      489.957000000000 
+                      || USD                 2824.68 
+                      || VACHR                337.26 
+                      || VBMPX      309.950000000000 
+                      || VEA                   36.00 
+                      || VHT                  294.00 
+>=0


### PR DESCRIPTION
I was introducing `--commodity-column` into my personal reports and realized that the textual output didn't correctly handle `--transpose`  when both flags are set. While fixing that, I also realized that empty commodities were being silently filtered out (e.g https://github.com/simonmichael/hledger/blob/master/hledger/Hledger/Cli/Commands/Balance.hs#L717). This wasn't a regression per-se but obviously undesirable behavior.

There is some overlap with https://github.com/simonmichael/hledger/pull/1649 since handling transposition unfortunately involved some reworking of the compound call-site.

Perhaps the suite of flag interactions should be more formally considered?