### PR TITLE
fix!: register: Tighten up spacing around the date in register reports. (#1655)

### DIFF
--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -141,6 +141,7 @@ instance ToJSON PeriodicTransaction
 instance ToJSON PriceDirective
 instance ToJSON DateSpan
 instance ToJSON Interval
+instance ToJSON Period
 instance ToJSON AccountAlias
 instance ToJSON AccountType
 instance ToJSONKey AccountType
@@ -250,6 +251,7 @@ instance FromJSON (DecimalRaw Integer)
 -- instance FromJSON Commodity
 -- instance FromJSON DateSpan
 -- instance FromJSON Interval
+-- instance FromJSON Period
 -- instance FromJSON PeriodicTransaction
 -- instance FromJSON PriceDirective
 -- instance FromJSON TimeclockCode

--- a/hledger-lib/Hledger/Data/Period.hs
+++ b/hledger-lib/Hledger/Data/Period.hs
@@ -13,6 +13,7 @@ module Hledger.Data.Period (
   ,simplifyPeriod
   ,isLastDayOfMonth
   ,isStandardPeriod
+  ,periodTextWidth
   ,showPeriod
   ,showPeriodMonthAbbrev
   ,periodStart
@@ -154,6 +155,20 @@ isStandardPeriod = isStandardPeriod' . simplifyPeriod
     isStandardPeriod' (QuarterPeriod _ _) = True
     isStandardPeriod' (YearPeriod _) = True
     isStandardPeriod' _ = False
+
+-- | The width of a period of this type when displayed.
+periodTextWidth :: Period -> Int
+periodTextWidth = periodTextWidth' . simplifyPeriod
+  where
+    periodTextWidth' DayPeriod{}     = 10  -- 2021-01-01
+    periodTextWidth' WeekPeriod{}    = 13  -- 2021-01-01W52
+    periodTextWidth' MonthPeriod{}   = 7   -- 2021-01
+    periodTextWidth' QuarterPeriod{} = 6   -- 2021Q1
+    periodTextWidth' YearPeriod{}    = 4   -- 2021
+    periodTextWidth' PeriodBetween{} = 22  -- 2021-01-01..2021-01-07
+    periodTextWidth' PeriodFrom{}    = 12  -- 2021-01-01..
+    periodTextWidth' PeriodTo{}      = 12  -- ..2021-01-01
+    periodTextWidth' PeriodAll       = 2   -- ..
 
 -- | Render a period as a compact display string suitable for user output.
 --

--- a/hledger/test/cli/report-interval.test
+++ b/hledger/test/cli/report-interval.test
@@ -13,22 +13,22 @@
 # The last report interval option takes precedence.
 
 $ hledger -f- register --weekly --monthly
-2019-01                 a                                        2             2
-2019-02                 a                                        1             3
+2019-01   a                                                      2             2
+2019-02   a                                                      1             3
 
 $ hledger -f- register --monthly --weekly
-2018-12-31W01           a                                        2             2
-2019-01-28W05           a                                        1             3
+2018-12-31W01   a                                                2             2
+2019-01-28W05   a                                                1             3
 
 # The last report interval option takes precedence.
 # The --period expression is no exception.
 $ hledger -f- register -p 'monthly in 2019' --weekly
-2018-12-31W01           a                                        2             2
-2019-01-28W05           a                                        1             3
+2018-12-31W01   a                                                2             2
+2019-01-28W05   a                                                1             3
 
 $ hledger -f- register --weekly -p 'monthly in 2019'
-2019-01                 a                                        2             2
-2019-02                 a                                        1             3
+2019-01   a                                                      2             2
+2019-02   a                                                      1             3
 
 
 
@@ -41,13 +41,13 @@ $ hledger -f- register --weekly -p 'monthly in 2019'
 # -p 'monthly in 2019'
 
 $ hledger -f- register --monthly -p 2019
-2019-01                 a                                        2             2
-2019-02                 a                                        1             3
+2019-01   a                                                      2             2
+2019-02   a                                                      1             3
 
 $ hledger -f- register -p 2019 --monthly
-2019-01                 a                                        2             2
-2019-02                 a                                        1             3
+2019-01   a                                                      2             2
+2019-02   a                                                      1             3
 
 $ hledger -f- register -p 'monthly in 2019'
-2019-01                 a                                        2             2
-2019-02                 a                                        1             3
+2019-01   a                                                      2             2
+2019-02   a                                                      1             3

--- a/hledger/test/journal/valuation.test
+++ b/hledger/test/journal/valuation.test
@@ -302,9 +302,9 @@ P 2000/04/01 A  4 B
   (a)      1 A @ 9 B
 
 $ hledger -f- reg --value=cost -M
-2000-01                 a                                     13 B          13 B
-2000-02                 a                                      8 B          21 B
-2000-03                 a                                      9 B          30 B
+2000-01   a                                                   13 B          13 B
+2000-02   a                                                    8 B          21 B
+2000-03   a                                                    9 B          30 B
 
 # back to the original test journal:
 <
@@ -326,27 +326,27 @@ P 2000/04/01 B  1 C
 
 # 26. periodic register report valued at period end
 $ hledger -f- reg --value=end -M -b 2000
-2000-01                 a                                      5 B           5 B
-2000-02                 a                                      2 B           7 B
-2000-03                 a                                      3 B          10 B
+2000-01   a                                                    5 B           5 B
+2000-02   a                                                    2 B           7 B
+2000-03   a                                                    3 B          10 B
 
 # 27. periodic register report valued at specified date
 $ hledger -f- reg --value=2000-01-15 -M -b 2000
-2000-01                 a                                      5 B           5 B
-2000-02                 a                                      5 B          10 B
-2000-03                 a                                      5 B          15 B
+2000-01   a                                                    5 B           5 B
+2000-02   a                                                    5 B          10 B
+2000-03   a                                                    5 B          15 B
 
 # 28. periodic register report valued today
 $ hledger -f- reg --value=now -M -b 2000
-2000-01                 a                                      4 B           4 B
-2000-02                 a                                      4 B           8 B
-2000-03                 a                                      4 B          12 B
+2000-01   a                                                    4 B           4 B
+2000-02   a                                                    4 B           8 B
+2000-03   a                                                    4 B          12 B
 
 # 29. periodic register report valued at default date (same as --value=end)
 $ hledger -f- reg -V -M -b 2000
-2000-01                 a                                      5 B           5 B
-2000-02                 a                                      2 B           7 B
-2000-03                 a                                      3 B          10 B
+2000-01   a                                                    5 B           5 B
+2000-02   a                                                    2 B           7 B
+2000-03   a                                                    3 B          10 B
 
 # balance
 
@@ -621,8 +621,8 @@ P 2020-04-01 A 4 B
    (a)  1 A
 
 $ hledger -f- reg --value=then -Q
-2020Q1                  a                                      6 B           6 B
-2020Q2                  a                                      4 B          10 B
+2020Q1   a                                                     6 B           6 B
+2020Q2   a                                                     4 B          10 B
 >=0
 
 # 53. print --value should affect all postings, including when there's an implicit transaction price

--- a/hledger/test/pivot.test
+++ b/hledger/test/pivot.test
@@ -75,8 +75,8 @@ hledger -f- --pivot description reg -M
     assets:bank account                                   2 EUR  ; date:03/01
     income:donations                                  -2 EUR
 >>>
-2016-02                 Freifunk                            -2 EUR        -2 EUR
-2016-03                 Freifunk                             2 EUR             0
+2016-02   Freifunk                                          -2 EUR        -2 EUR
+2016-03   Freifunk                                           2 EUR             0
 >>>=0
 
 # pivot for implicit tag code (technical sample)
@@ -86,8 +86,8 @@ hledger -f- --pivot code reg -M
     assets:bank account                                   2 EUR  ; date:03/01
     income:donations                                  -2 EUR
 >>>
-2016-02                 Freifunk                            -2 EUR        -2 EUR
-2016-03                 Freifunk                             2 EUR             0
+2016-02   Freifunk                                          -2 EUR        -2 EUR
+2016-03   Freifunk                                           2 EUR             0
 >>>=0
 
 # use of pivot with code-based budgeting
@@ -132,7 +132,7 @@ hledger -f- --pivot payee reg -D ^expense
     assets:bank account
     expense:grocery                    30 EUR
 >>>
-2016-02-16              Auchan                              22 EUR        22 EUR
-                        StarBars                             5 EUR        27 EUR
-2016-02-17              Auchan                              30 EUR        57 EUR
+2016-02-16   Auchan                                         22 EUR        22 EUR
+             StarBars                                        5 EUR        27 EUR
+2016-02-17   Auchan                                         30 EUR        57 EUR
 >>>=0

--- a/hledger/test/register/depth.test
+++ b/hledger/test/register/depth.test
@@ -43,8 +43,8 @@ hledger -f - register aa --depth 1 --daily
   a:aa      1
   b:bb:bbb
 >>>
-2010-01-01              a                                        2             2
-2010-01-02              a                                        1             3
+2010-01-01   a                                                   2             2
+2010-01-02   a                                                   1             3
 >>>=0
 
 # 4. with --cleared
@@ -75,7 +75,7 @@ hledger -f - register --depth 0 --daily a b
   b:bb      2
   c:cc
 >>>
-2010-01-01              ...                                      6             6
-2010-01-02              ...                                      3             9
+2010-01-01   ...                                                 6             6
+2010-01-02   ...                                                 3             9
 >>>=0
 

--- a/hledger/test/register/intervals.test
+++ b/hledger/test/register/intervals.test
@@ -5,8 +5,8 @@
   (a:b)  1
 
 $ hledger -f- register --period 'monthly'
-2011-02                 a                                        1             1
-                        a:b                                      1             2
+2011-02   a                                                      1             1
+          a:b                                                    1             2
 
 # 2. or with a query pattern, just the intervals with matched data:
 <
@@ -17,7 +17,7 @@ $ hledger -f- register --period 'monthly'
   (b)  1
 
 $ hledger -f- register --period 'monthly' b
-2011-02                 b                                        1             1
+2011-02   b                                                      1             1
 
 <
 2011/1/1
@@ -33,13 +33,13 @@ $ hledger -f- register --period 'monthly' b
 # (unlike current ledger, but more useful)
 $ hledger -f- register --period 'monthly' b --empty
 2011-01                                                          0             0
-2011-02                 b                                        1             1
+2011-02   b                                                      1             1
 2011-03                                                          0             1
 
 # 4. any specified begin/end dates limit the intervals reported
 $ hledger -f- register --period 'monthly to 2011/3/1' b --empty
 2011-01                                                          0             0
-2011-02                 b                                        1             1
+2011-02   b                                                      1             1
 
 # 5. --date2 should work with intervals
 <
@@ -50,8 +50,8 @@ $ hledger -f- register --period 'monthly to 2011/3/1' b --empty
   (b)  1
 
 $ hledger -f- register --monthly --date2
-2014-01                 a                                        1             1
-                        b                                        1             2
+2014-01   a                                                      1             1
+          b                                                      1             2
 
 # 6. All matched postings in the displayed intervals should be reported on.
 <
@@ -65,7 +65,14 @@ $ hledger -f- register --monthly --date2
  (after)  1
 
 $ hledger -f- register -p 'monthly 2014/1/10-2014/2/20'
-2014-01                 before                                   1             1
-2014-02                 after                                    1             2
-                        within                                   1             3
+2014-01   before                                                 1             1
+2014-02   after                                                  1             2
+          within                                                 1             3
+
+
+# 7. Custom ranges should display fully.
+$ hledger -f- register -p 'every tue'
+2013-12-31..2014-01-06   before                                  1             1
+2014-01-28..2014-02-03   within                                  1             2
+2014-02-25..2014-03-03   after                                   1             3
 


### PR DESCRIPTION
Fixes #1655.

As a side effect, this changes the Json representation of the PostingsReport. The maybe report end date is now replaced with a maybe period.

I think this will provide strictly more information, and so is a desirable change, but if it will break too much we can change it back.
