### PR TITLE
fix: aregister: Make multicommodity amounts are properly aligned in aregister.

### DIFF
--- a/hledger/test/aregister.test
+++ b/hledger/test/aregister.test
@@ -79,3 +79,24 @@ Transactions in a and subaccounts:
 2021-01-03 fifth                a                                5            15
 2021-01-03 sixth, because fo..  a                                6            21
 2021-01-04 seventh, because ..  b                                7            28
+
+<
+2021-01-01
+  a    1 A
+  a   -1 B
+  b    1 B
+  c   -1 A
+
+2021-01-02
+  a    1 C
+  b   -1 C
+
+# 6. aregister correctly aligns amounts when there are multiple commodities (#1656).
+$ hledger -f- areg a
+Transactions in a and subaccounts:
+2021-01-01                      b, c                           1 A           1 A
+                                                              -1 B          -1 B
+2021-01-02                      b                              1 C           1 A
+                                                                            -1 B
+                                                                             1 C
+


### PR DESCRIPTION
Fixes #1656.

This also switches to the renderTable interface for laying out aregister, just as in postingsReport.