### PR TITLE
web: base64 encode user controlled strings (#1525)

### DIFF
--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -13,14 +13,14 @@ module Hledger.Web.Widget.AddForm
 import Control.Monad.State.Strict (evalStateT)
 import Data.Bifunctor (first)
 import Data.Foldable (toList)
-import Data.List (dropWhileEnd, intercalate, unfoldr)
+import Data.List (dropWhileEnd, unfoldr)
 import Data.Maybe (isJust)
 import qualified Data.Set as S
 import Data.Text (Text)
 import Data.Text.Encoding.Base64 (encodeBase64)
 import qualified Data.Text as T
 import Data.Time (Day)
-import Text.Blaze.Internal (Markup, preEscapedString)
+import Text.Blaze.Internal (Markup, preEscapedText)
 import Text.Megaparsec (bundleErrors, eof, parseErrorTextPretty, runParser)
 import Yesod
 
@@ -91,11 +91,11 @@ addForm j today = identifyForm "add" $ \extra -> do
       -- This used to work, but since 1.16, it seems like something changed.
       -- toJSON ("a"::Text) gives String "a" instead of "a", etc.
       -- preEscapedString . escapeJSSpecialChars . show . toJSON
-      preEscapedString $ concat [
+      preEscapedText $ T.concat [
         "[",
-        intercalate "," $ map (
-          ("{\"value\":" ++).
-          (++"}").
+        T.intercalate "," $ map (
+          ("{\"value\":" <>).
+          (<> "}").
           -- This will convert a value such as ``hledger!`` into
           -- ``atob("aGxlZGdlciE=")``. When this gets evaluated on the client,
           -- the resulting string is ``hledger!`` again. The same data is
@@ -107,8 +107,8 @@ addForm j today = identifyForm "add" $ \extra -> do
         "]"
         ]
       where
-b64wrap :: Text -> String
-b64wrap = ("atob(\""++) . (++"\")") . T.unpack . encodeBase64
+b64wrap :: Text -> Text
+b64wrap = ("atob(\""<>) . (<>"\")") . encodeBase64
 
 validateTransaction ::
      FormResult Day

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -156,6 +156,7 @@ library
       Decimal >=0.5.1
     , aeson >=1
     , base >=4.11 && <4.16
+    , base64
     , blaze-html
     , blaze-markup
     , bytestring

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -103,6 +103,7 @@ library:
   - hledger >=1.22.99 && <1.23
   - aeson >=1
   - base >=4.11 && <4.16
+  - base64
   - blaze-html
   - blaze-markup
   - bytestring

--- a/stack8.6.yaml
+++ b/stack8.6.yaml
@@ -31,6 +31,8 @@ extra-deps:
 - githash-0.1.4.0
 # for hledger-ui:
 # for hledger-web:
+- ghc-byteorder-4.11.0.0.10
+- base64-0.4.2.3
 
 # Workaround for https://github.com/commercialhaskell/stack/issues/3922
 # Try dropping this.. after stack 2 has been out a while ? Or now ? How about now ?

--- a/stack8.8.yaml
+++ b/stack8.8.yaml
@@ -20,6 +20,7 @@ extra-deps:
 # for hledger:
 # for hledger-ui:
 # for hledger-web:
+- ghc-byteorder-4.11.0.0.10
 # for Shake.hs:
 
 # for precise profiling, per https://www.tweag.io/posts/2020-01-30-haskell-profiling.html:


### PR DESCRIPTION
This fixes a reported Stored XSS vulnerability in toBloodhoundJson by
encoding the user-controlled values in this payload into base64 and
parsing them with atob.

In my exploration of the vulnerability with various payloads I and
others crafted, it would appear that this is the only available XSS in
hledger-web in relation to stored accounts and transaction details. If
there is other parts of the UI which may contain user-controlled data,
they should be examined for similar things. In this instance,
protections provided by yesod and other libraries worked fine, but in a
bit of code that hledger-web was generating, the user could insert a
</Script> tag (which is valid HTML and equivalent to </script> but not
caught by the T.Replace that existed in toBloodhoundJson) in order to
switch out of a script context, allowing the parser to be reset, and for
arbitrary JavaScript to run.

The real fix is a bit more involved, but produces much better results:
Content-Security-Policy headers should be introduced, and using
sha256-<hash of script> or a different algorithm, they should be marked
as trusted in the header. This way, if the (in-browser) parser and
hledger-web generator disagree on the source code of the script, the
script won't run. Note that this would still be susceptible to attacks
that involve changing the script by escaping from the string inside it
or something similar to that, which can be avoided additionally by using
either the method used in this commit, or a proper JSON encoder.

Test payload: ``</Script><svg onload=alert(1)//>``

Closes #1525