### PR TITLE
Fix cmdline example typo, f- should be -f-

### DIFF
--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -1339,7 +1339,7 @@ Eg: how much of food expenses was paid with cash ?
 .IP
 .nf
 \f[C]
-$ hledger print assets:cash | hledger f- -I balance expenses:food
+$ hledger print assets:cash | hledger -f- -I balance expenses:food
 \f[R]
 .fi
 .PP

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -1037,7 +1037,7 @@ Most commands select things which match:
 running a first query with 'print', and piping the result into a second
 hledger command.  Eg: how much of food expenses was paid with cash ?
 
-$ hledger print assets:cash | hledger f- -I balance expenses:food
+$ hledger print assets:cash | hledger -f- -I balance expenses:food
 
    If you are interested in full boolean expressions for queries, see
 #203.

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -872,7 +872,7 @@ and piping the result into a second hledger command.
 Eg: how much of food expenses was paid with cash ?
 
 ```shell
-$ hledger print assets:cash | hledger f- -I balance expenses:food
+$ hledger print assets:cash | hledger -f- -I balance expenses:food
 ```
 
 If you are interested in full boolean expressions for queries,

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -879,7 +879,7 @@ QUERIES
        running  a  first query with print, and piping the result into a second
        hledger command.  Eg: how much of food expenses was paid with cash ?
 
-              $ hledger print assets:cash | hledger f- -I balance expenses:food
+              $ hledger print assets:cash | hledger -f- -I balance expenses:food
 
        If you are interested in full  boolean  expressions  for  queries,  see
        #203.


### PR DESCRIPTION
Just a quick typo fix,

```
hledger: command f- is not recognized, run with no command to see a list
```
is obviously not what the example is supposed to print :)
