### PR TITLE
test: cli: Add --today option to explicitly set the current date. (#1674)

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -228,21 +228,20 @@ parseCommodity optStr =
       Left _ -> Left optStr 
       Right (Amount acommodity _ astyle _) -> Right (acommodity, astyle)
 
--- | Parse an InputOpts from a RawOpts and the current date.
+-- | Parse an InputOpts from a RawOpts and a provided date.
 -- This will fail with a usage error if the forecast period expression cannot be parsed.
-rawOptsToInputOpts :: RawOpts -> IO InputOpts
-rawOptsToInputOpts rawopts = do
-    d <- getCurrentDay
+rawOptsToInputOpts :: Day -> RawOpts -> InputOpts
+rawOptsToInputOpts day rawopts =
 
     let noinferprice = boolopt "strict" rawopts || stringopt "args" rawopts == "balancednoautoconversion"
 
         -- Do we really need to do all this work just to get the requested end date? This is duplicating
         -- much of reportOptsToSpec.
-        ropts = rawOptsToReportOpts d rawopts
-        argsquery = lefts . rights . map (parseQueryTerm d) $ querystring_ ropts
+        ropts = rawOptsToReportOpts day rawopts
+        argsquery = lefts . rights . map (parseQueryTerm day) $ querystring_ ropts
         datequery = simplifyQuery . filterQuery queryIsDate . And $ queryFromFlags ropts : argsquery
 
-    return InputOpts{
+    in InputOpts{
        -- files_             = listofstringopt "file" rawopts
        mformat_           = Nothing
       ,mrules_file_       = maybestringopt "rules-file" rawopts
@@ -251,7 +250,7 @@ rawOptsToInputOpts rawopts = do
       ,new_               = boolopt "new" rawopts
       ,new_save_          = True
       ,pivot_             = stringopt "pivot" rawopts
-      ,forecast_          = forecastPeriodFromRawOpts d rawopts
+      ,forecast_          = forecastPeriodFromRawOpts day rawopts
       ,reportspan_        = DateSpan (queryStartDate False datequery) (queryEndDate False datequery)
       ,auto_              = boolopt "auto" rawopts
       ,balancingopts_     = defbalancingopts{

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -777,9 +777,7 @@ updateReportSpec = setEither reportOpts
 updateReportSpecWith :: (ReportOpts -> ReportOpts) -> ReportSpec -> Either String ReportSpec
 updateReportSpecWith = overEither reportOpts
 
--- | Generate a ReportSpec from RawOpts and the current date.
-rawOptsToReportSpec :: RawOpts -> IO ReportSpec
-rawOptsToReportSpec rawopts = do
-    d <- getCurrentDay
-    let ropts = rawOptsToReportOpts d rawopts
-    either fail return $ reportOptsToSpec d ropts
+-- | Generate a ReportSpec from RawOpts and a provided day, or return an error
+-- string if there are regular expression errors.
+rawOptsToReportSpec :: Day -> RawOpts -> Either String ReportSpec
+rawOptsToReportSpec day = reportOptsToSpec day . rawOptsToReportOpts day

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -227,8 +227,8 @@ asHandle ui0@UIState{
   ,ajournal=j
   ,aMode=mode
   } ev = do
-  d <- liftIO getCurrentDay
   let
+    d = copts^.rsDay
     nonblanks = V.takeWhile (not . T.null . asItemAccountName) $ _asList^.listElementsL
     lastnonblankidx = max 0 (length nonblanks - 1)
 

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -19,9 +19,9 @@ import Control.Monad.IO.Class (liftIO)
 import Data.Time.Calendar (Day)
 import Data.Void (Void)
 import Graphics.Vty (Event(..),Key(..),Modifier(..))
+import Lens.Micro ((^.))
 import Text.Megaparsec
 import Text.Megaparsec.Char
-import Lens.Micro ((^.))
 
 import Hledger.Cli hiding (progname,prognameandversion)
 import Hledger.UI.UIOptions
@@ -90,7 +90,7 @@ esHandle ui@UIState{aScreen=ErrorScreen{..}
         _                    -> helpHandle ui ev
 
     _ -> do
-      d <- liftIO getCurrentDay
+      let d = copts^.rsDay
       case ev of
         VtyEvent (EvKey (KChar 'q') []) -> halt ui
         VtyEvent (EvKey KEsc        []) -> continue $ uiCheckBalanceAssertions d $ resetScreens d ui

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -279,8 +279,8 @@ rsHandle ui@UIState{
   ,ajournal=j
   ,aMode=mode
   } ev = do
-  d <- liftIO getCurrentDay
   let
+    d = copts^.rsDay
     journalspan = journalDateSpan False j
     nonblanks = V.takeWhile (not . T.null . rsItemDate) $ rsList^.listElementsL
     lastnonblankidx = max 0 (length nonblanks - 1)

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -147,8 +147,8 @@ tsHandle ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransaction
         _                    -> helpHandle ui ev
 
     _ -> do
-      d <- liftIO getCurrentDay
       let
+        d = copts^.rsDay
         (iprev,tprev) = maybe (i,t) ((i-1),) $ lookup (i-1) nts
         (inext,tnext) = maybe (i,t) ((i+1),) $ lookup (i+1) nts
       case ev of
@@ -166,7 +166,6 @@ tsHandle ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransaction
             p = reportPeriod ui
         e | e `elem` [VtyEvent (EvKey (KChar 'g') []), AppEvent FileChange] -> do
           -- plog (if e == AppEvent FileChange then "file change" else "manual reload") "" `seq` return ()
-          d <- liftIO getCurrentDay
           ej <- liftIO $ journalReload copts
           case ej of
             Left err -> continue $ screenEnter d errorScreen{esError=err} ui

--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -199,7 +199,7 @@ instance Show Text.Blaze.Markup where show _ = "<blaze markup>"
 getViewData :: Handler ViewData
 getViewData = do
   App{appOpts=opts@WebOpts{cliopts_=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts}}}, appJournal} <- getYesod
-  today <- liftIO getCurrentDay
+  let today = _rsDay rspec
 
   -- try to read the latest journal content, keeping the old content
   -- if there's an error

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -33,6 +33,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
 import Data.Time.Calendar (Day)
 import Data.Time.Format (formatTime, defaultTimeLocale, iso8601DateFormat)
+import Lens.Micro ((^.))
 import Safe (headDef, headMay, atMay)
 import System.Console.CmdArgs.Explicit (flagNone)
 import System.Console.Haskeline (runInputT, defaultSettings, setComplete)
@@ -93,8 +94,8 @@ add opts j
     | otherwise = do
         hPutStrLn stderr $ "Adding transactions to journal file " <> journalFilePath j
         showHelp
-        today <- getCurrentDay
-        let es = defEntryState{esOpts=opts
+        let today = opts^.rsDay
+            es = defEntryState{esOpts=opts
                               ,esArgs=listofstringopt "args" $ rawopts_ opts
                               ,esToday=today
                               ,esDefDate=today

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -49,8 +49,8 @@ closemode = hledgerCommandMode
 -- debugger, beware: close is incredibly devious. simple rules combine to make a horrid maze.
 -- tests are in hledger/test/close.test.
 close CliOpts{rawopts_=rawopts, reportspec_=rspec} j = do
-  today <- getCurrentDay
   let
+    today = _rsDay rspec
     -- show opening entry, closing entry, or (default) both ?
     (opening, closing) =
       case (boolopt "open" rawopts, boolopt "close" rawopts) of

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -39,9 +39,9 @@ rewritemode = hledgerCommandMode
 
 rewrite opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j@Journal{jtxns=ts} = do
   -- rewrite matched transactions
-  d <- getCurrentDay
+  let today = _rsDay rspec
   let modifiers = transactionModifierFromOpts opts : jtxnmodifiers j
-  let j' = j{jtxns=either error' id $ modifyTransactions mempty d modifiers ts}  -- PARTIAL:
+  let j' = j{jtxns=either error' id $ modifyTransactions mempty today modifiers ts}  -- PARTIAL:
   -- run the print command, showing all transactions, or show diffs
   printOrDiff rawopts opts{reportspec_=rspec{_rsQuery=Any}} j j'
 

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -59,12 +59,11 @@ data OneSpan = OneSpan
 
 roi ::  CliOpts -> Journal -> IO ()
 roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsReportOpts=ReportOpts{..}}} j = do
-  d <- getCurrentDay
   -- We may be converting posting amounts to value, per hledger_options.m4.md "Effect of --value on reports".
   let
+    today = _rsDay rspec
     priceOracle = journalPriceOracle infer_value_ j
     styles = journalCommodityStyles j
-    today = _rsDay rspec
     mixedAmountValue periodlast date =
         maybe id (mixedAmountApplyValuation priceOracle styles periodlast today date) value_
         . mixedAmountToCost cost_ styles
@@ -74,7 +73,7 @@ roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsReportOpts=ReportO
     showCashFlow = boolopt "cashflow" rawopts
     prettyTables = pretty_tables_
     makeQuery flag = do
-        q <- either usageError (return . fst) . parseQuery d . T.pack $ stringopt flag rawopts
+        q <- either usageError (return . fst) . parseQuery today . T.pack $ stringopt flag rawopts
         return . simplifyQuery $ And [queryFromFlags ropts{period_=PeriodAll}, q]
 
   investmentsQuery <- makeQuery "investment"

--- a/hledger/Hledger/Cli/Commands/Stats.hs
+++ b/hledger/Hledger/Cli/Commands/Stats.hs
@@ -43,12 +43,12 @@ statsmode = hledgerCommandMode
 -- | Print various statistics for the journal.
 stats :: CliOpts -> Journal -> IO ()
 stats opts@CliOpts{reportspec_=rspec} j = do
-  d <- getCurrentDay
-  let q = _rsQuery rspec
+  let today = _rsDay rspec
+      q = _rsQuery rspec
       l = ledgerFromJournal q j
       reportspan = ledgerDateSpan l `spanDefaultsFrom` queryDateSpan False q
       intervalspans = splitSpan (interval_ $ _rsReportOpts rspec) reportspan
-      showstats = showLedgerStats l d
+      showstats = showLedgerStats l today
       s = unlinesB $ map showstats intervalspans
   writeOutputLazyText opts $ TB.toLazyText s
 

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -27,8 +27,8 @@ tagsmode = hledgerCommandMode
 
 tags :: CliOpts -> Journal -> IO ()
 tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
-  d <- getCurrentDay
-  let args = listofstringopt "args" rawopts
+  let today = _rsDay rspec
+      args = listofstringopt "args" rawopts
   mtagpat <- mapM (either Fail.fail pure . toRegexCI . T.pack) $ headMay args
   let
     querystring = map T.pack $ drop 1 args
@@ -36,7 +36,7 @@ tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     parsed      = boolopt "parsed" rawopts
     empty       = empty_ $ _rsReportOpts rspec
 
-  argsquery <- either usageError (return . fst) $ parseQueryList d querystring
+  argsquery <- either usageError (return . fst) $ parseQueryList today querystring
   let
     q = simplifyQuery $ And [queryFromFlags $ _rsReportOpts rspec, argsquery]
     txns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -473,6 +473,10 @@ Counterexamples - malformed digit sequences might give surprising results:
 | `20181232`  | 8 digits with an invalid day gives an error                       |
 | `201801012` | 9+ digits beginning with a valid YYYYMMDD gives an error          |
 
+Note "today's date" can be overridden with the `--today` option, in case it's
+needed for testing or for recreating old reports. (Except for periodic
+transaction rules; those are not affected by `--today`.)
+
 <a name="report-period"></a>
 
 ## Report start & end date


### PR DESCRIPTION
Fixes #1674.

This is so that we can run tests containing future transactions that
won't fail as soon as ‘the future’ actually arrives.