### PR TITLE
fix: journal: Disallow parsing years later than 10000. (#1683)

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -698,6 +698,8 @@ Parse a date in any of the formats allowed in Ledger's period expressions, and s
 Assumes any text in the parse stream has been lowercased.
 Returns a SmartDate, to be converted to a full date later (see fixSmartDate).
 
+Years must be exactly four digits long.
+
 Examples:
 
 > 2004                                        (start of year, which must have 4+ digits)
@@ -729,17 +731,17 @@ YYYYMM is parsed as year-month-01 if year and month are valid:
 >>> parsewith (smartdate <* eof) "201804"
 Right (SmartAssumeStart 2018 (Just (4,Nothing)))
 
-With an invalid month, it's parsed as a year:
+With an invalid month it gives an error:
 >>> parsewith (smartdate <* eof) "201813"
-Right (SmartAssumeStart 201813 Nothing)
+Left (...)
 
 A 9+ digit number beginning with valid YYYYMMDD gives an error:
 >>> parsewith (smartdate <* eof) "201801012"
 Left (...)
 
-Big numbers not beginning with a valid YYYYMMDD are parsed as a year:
+Big numbers not beginning with a valid YYYYMMDD give an error:
 >>> parsewith (smartdate <* eof) "201813012"
-Right (SmartAssumeStart 201813012 Nothing)
+Left (...)
 
 -}
 smartdate :: TextParser m SmartDate
@@ -818,7 +820,7 @@ md = do
 yearp :: TextParser m Integer
 yearp = do
   year <- takeWhile1P (Just "year") isDigit
-  unless (T.length year >= 4) . Fail.fail $ "Year must contain at least 4 digits: " <> T.unpack year
+  unless (T.length year == 4) . Fail.fail $ "Year must contain exactly 4 digits: " <> T.unpack year
   return $ readDecimal year
 
 -- These are compared case insensitively, and should all be kept lower case.

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -614,6 +614,9 @@ datep' mYear = do
       when (sep1 /= sep2) $ customFailure $ parseErrorAtRegion startOffset endOffset $
         "invalid date: separators are different, should be the same"
 
+      when (year >= 10000) $ customFailure $ parseErrorAtRegion startOffset endOffset $
+        "invalid date: years must be exactly four digits"
+
       case fromGregorianValid year month day of
         Nothing -> customFailure $ parseErrorAtRegion startOffset endOffset $
                      "well-formed but invalid date: " ++ dateStr

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -995,7 +995,7 @@ tests_JournalReader = testGroup "JournalReader" [
   ,testGroup "defaultyeardirectivep" [
       testCase "1000" $ assertParse defaultyeardirectivep "Y 1000" -- XXX no \n like the others
      -- ,testCase "999" $ assertParseError defaultyeardirectivep "Y 999" "bad year number"
-     ,testCase "12345" $ assertParse defaultyeardirectivep "Y 12345"
+     ,testCase "2345" $ assertParse defaultyeardirectivep "Y 2345"
      ]
 
   ,testCase "ignoredpricecommoditydirectivep" $ do

--- a/hledger/test/close.test
+++ b/hledger/test/close.test
@@ -306,13 +306,13 @@ $ hledger -f- close -p 2019 assets --interleaved -x
 
 # 14. "The default closing date is yesterday, or the journal's end date, whichever is later."
 <
-999999-12-31
+9999-12-31
   (a)  1
 $ hledger -f- close
-> /999999-12-31 closing balances/
+> /9999-12-31 closing balances/
 >=
 
 # 15. "override the closing date ... by specifying a report period, where last day of the report period will be the closing date"
-$ hledger -f- close -e 100000-01-01
-> /99999-12-31 closing balances/
+$ hledger -f- close -e 9999-01-01
+> /9998-12-31 closing balances/
 >=

--- a/hledger/test/journal/dates.test
+++ b/hledger/test/journal/dates.test
@@ -42,3 +42,10 @@ hledger -f- print
    a  0
 >>>2 /unexpected '*'/
 >>>= 1
+# 6. 5-digit years should be rejected. This is to catch fat-finger typos. Y10K be damned!
+hledger -f- print
+<<<
+20151/01/01
+   a  0
+>>>2 /invalid date/
+>>>= 1


### PR DESCRIPTION
Though there is no technical reason for this restriction, it prevents a
user-input error where someone will fat-finger a 5-digit year with daily
reporting intervals, causing their computer to hang for a long time.