### PR TITLE
fix: extend application of commodity style to prices (except precision)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,11 @@ old
 hledger/test/addons/hledger-*
 tools/generatejournal
 tools/simplebench
-/examples/10*.journal
+/examples/[1-9]0*.journal
 *.webmanual.md
 *.m4-e
 stack*.yaml.lock
+bench
 
 # hledger-web stuff
 /config

--- a/doc/common.m4
+++ b/doc/common.m4
@@ -173,6 +173,9 @@ m4_define({{_reportingoptions_}}, {{
 : generate future transactions from [periodic transaction](hledger.html#periodic-transactions) rules, for the next 6 months or till report end date.
 In hledger-ui, also make ordinary future transactions visible.
 
+`--commodity-style`
+: Override the commodity style in the output for the specified commodity. For example 'EUR1.000,00'.
+
 `--color=WHEN (or --colour=WHEN)`
 : Should color-supporting commands use ANSI color codes in text output.
 : 'auto' (default): whenever stdout seems to be a color-supporting terminal.

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -424,11 +424,18 @@ showAmountPriceDebug (Just (TotalPrice pa)) = " @@ " ++ showAmountDebug pa
 -- | Given a map of standard commodity display styles, apply the
 -- appropriate one to this amount. If there's no standard style for
 -- this amount's commodity, return the amount unchanged.
+-- Also apply the style to the price (except for precision)
 styleAmount :: M.Map CommoditySymbol AmountStyle -> Amount -> Amount
-styleAmount styles a =
-  case M.lookup (acommodity a) styles of
-    Just s  -> a{astyle=s}
-    Nothing -> a
+styleAmount styles a = styledAmount{aprice = stylePrice styles (aprice styledAmount)}
+  where
+    styledAmount = case M.lookup (acommodity a) styles of
+      Just s -> a{astyle=s}
+      Nothing -> a
+
+stylePrice :: M.Map CommoditySymbol AmountStyle -> Maybe AmountPrice -> Maybe AmountPrice
+stylePrice styles (Just (UnitPrice a)) = Just (UnitPrice $ styleAmountExceptPrecision styles a)
+stylePrice styles (Just (TotalPrice a)) = Just (TotalPrice $ styleAmountExceptPrecision styles a)
+stylePrice _ _  = Nothing
 
 -- | Like styleAmount, but keep the number of decimal places unchanged.
 styleAmountExceptPrecision :: M.Map CommoditySymbol AmountStyle -> Amount -> Amount

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -24,7 +24,6 @@ module Hledger.Cli.CliOptions (
   reportflags,
   -- outputflags,
   outputFormatFlag,
-  commodityStyleFlag,
   outputFileFlag,
   generalflagsgroup1,
   generalflagsgroup2,
@@ -198,6 +197,8 @@ reportflags = [
    ])
 
   -- general output-related
+ ,flagReq ["commodity-style", "c"] (\s opts -> Right $ setopt "commodity-style" s opts) "COMM"
+    "Override the commodity style in the output for the specified commodity. For example 'EUR1.000,00'."
   
   -- This has special support in hledger-lib:colorOption, keep synced
  ,flagReq  ["color","colour"] (\s opts -> Right $ setopt "color" s opts) "WHEN"
@@ -242,11 +243,6 @@ outputFileFlag :: Flag RawOpts
 outputFileFlag = flagReq
   ["output-file","o"] (\s opts -> Right $ setopt "output-file" s opts) "FILE"
   "write output to FILE. A file extension matching one of the above formats selects that format."
-
-commodityStyleFlag :: Flag RawOpts
-commodityStyleFlag = flagReq
-    ["commodity-style", "c"] (\s opts -> Right $ setopt "commodity-style" s opts) "COMM"
-    ("Override the commodity style in the output for the specified commodity. For example 'EUR1.000,00'.")
 
 argsFlag :: FlagHelp -> Arg RawOpts
 argsFlag = flagArg (\s opts -> Right $ setopt "args" s opts)

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -58,7 +58,6 @@ aregistermode = hledgerCommandMode
      )
   ,outputFormatFlag ["txt","csv","json"]
   ,outputFileFlag
-  ,commodityStyleFlag
   ])
   [generalflagsgroup1]
   hiddenflags

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -319,7 +319,6 @@ balancemode = hledgerCommandMode
       "show commodity symbols in a separate column, amounts as bare numbers, one row per commodity"
     ,outputFormatFlag ["txt","html","csv","json"]
     ,outputFileFlag
-    ,commodityStyleFlag
     ]
   )
   [generalflagsgroup1]

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -41,7 +41,6 @@ printmode = hledgerCommandMode
     "show only newer-dated transactions added in each file since last run"
   ,outputFormatFlag ["txt","csv","json","sql"]
   ,outputFileFlag
-  ,commodityStyleFlag
   ])
   [generalflagsgroup1]
   hiddenflags

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -52,7 +52,6 @@ registermode = hledgerCommandMode
      )
   ,outputFormatFlag ["txt","csv","json"]
   ,outputFileFlag
-  ,commodityStyleFlag
   ])
   [generalflagsgroup1]
   hiddenflags

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -89,7 +89,6 @@ compoundBalanceCommandMode CompoundBalanceCommandSpec{..} =
       "show commodity symbols in a separate column, amounts as bare numbers, one row per commodity"
     ,outputFormatFlag ["txt","html","csv","json"]
     ,outputFileFlag
-    ,commodityStyleFlag
     ])
     [generalflagsgroup1]
     hiddenflags

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -1447,10 +1447,14 @@ real-world feedback.
 
 ## Commodity styles
 
-The display style of a commodity/currence is inferred according to the rules
+The display style of a commodity/currency is inferred according to the rules
 described in [Commodity display style](#commodity-display-style). The
-inferred display style can be overriden by an optional `-c/--commodity-style` 
-option. For example, the following will override the display style for dollars.
+inferred display style can be overridden by an optional `-c/--commodity-style` 
+option (Exceptions: as is the case for inferred styles, 
+[price amounts](#transaction-prices), and all amounts displayed by the 
+[`print`](#print) command, will be displayed with all of their decimal digits 
+visible, regardless of the specified precision). For example, the following will 
+override the display style for dollars.
 ```shell
 $ hledger print -c '$1.000,0'
 ```

--- a/hledger/test/cli/commodity-style.test
+++ b/hledger/test/cli/commodity-style.test
@@ -47,3 +47,13 @@ $ hledger -f- print -c 'EUR 1.000,00' -c 'EUR 1,000.00'
     (a)    EUR 1,234.00
 
 >= 0
+# Commodity styles are applied to quantity and price of a commodity (except for precision)
+<
+2021-09-12 buy A
+    (a)    1,234 A @ $ 1234,56
+$ hledger -f- print -c '1,000.0 $' -c 'A 1000.0'
+>
+2021-09-12 buy A
+    (a)    A 1.234 @ 1,234.56 $
+
+>= 0


### PR DESCRIPTION
This PR:
- Changes the behavior of applying commodity styles (such as those set by the  the -c/--commodity-style option) to include applying it to amount prices (except for precision, which is not affected). 
- Changes -c/--commodity-style into a general (reporting) option.