### PR TITLE
ref: performance: Improve performance for some high-use functions.

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -639,13 +639,13 @@ isNegativeMixedAmount m =
 -- i.e. does it have zero quantity with no price, zero quantity with a total price (which is also zero),
 -- and zero quantity for each unit price?
 mixedAmountLooksZero :: MixedAmount -> Bool
-mixedAmountLooksZero = all amountLooksZero . amounts . normaliseMixedAmount
+mixedAmountLooksZero (Mixed ma) = all amountLooksZero ma
 
 -- | Is this mixed amount exactly zero, ignoring its display precision?
 -- i.e. does it have zero quantity with no price, zero quantity with a total price (which is also zero),
 -- and zero quantity for each unit price?
 mixedAmountIsZero :: MixedAmount -> Bool
-mixedAmountIsZero = all amountIsZero . amounts . normaliseMixedAmount
+mixedAmountIsZero (Mixed ma) = all amountIsZero ma
 
 -- | Is this mixed amount exactly zero, ignoring its display precision?
 --
@@ -759,7 +759,9 @@ mapMixedAmountUnsafe f (Mixed ma) = Mixed $ M.map f ma  -- Use M.map instead of 
 -- | Convert all component amounts to cost/selling price where
 -- possible (see amountCost).
 mixedAmountCost :: MixedAmount -> MixedAmount
-mixedAmountCost = mapMixedAmount amountCost
+mixedAmountCost (Mixed ma) =
+    foldl' (\m a -> maAddAmount m (amountCost a)) (Mixed noPrices) withPrices
+  where (noPrices, withPrices) = M.partition (isNothing . aprice) ma
 
 -- -- | MixedAmount derived Eq instance in Types.hs doesn't know that we
 -- -- want $0 = EUR0 = 0. Yet we don't want to drag all this code over there.

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -72,11 +72,11 @@ where
 
 import Control.Monad (foldM)
 import Data.Foldable (asum)
-import Data.List.Extra (nubSort)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust)
 import Data.MemoUgly (memo)
 import Data.List (foldl')
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
@@ -191,7 +191,7 @@ hasBalanceAssignment p = not (hasAmount p) && isJust (pbalanceassertion p)
 
 -- | Sorted unique account names referenced by these postings.
 accountNamesFromPostings :: [Posting] -> [AccountName]
-accountNamesFromPostings = nubSort . map paccount
+accountNamesFromPostings = S.toList . S.fromList . map paccount
 
 -- | Sum all amounts from a list of postings.
 sumPostings :: [Posting] -> MixedAmount


### PR DESCRIPTION
mixedAmount(Looks|Is)Zero now operate directly on the MixedAmount,
rather than converting them to a list of amounts first.

mixedAmountCost no longer reconstructs the entire MixedAmount when there
are amounts with no cost.

transactionCheckBalanced only checks if signs are okay if sums are not
okay. It also only traverses the list of postings once when picking real
and balanced virtual postings.

accountNamesFromPostings now uses a Set instead of nubSort.