### PR TITLE
imp: performance: Add strictness annotations for some mixed amount

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -40,6 +40,7 @@ exchange rates.
 
 -}
 
+{-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
 
@@ -589,11 +590,11 @@ mixed = maAddAmounts nullmixedamt
 
 -- | Create a MixedAmount from a single Amount.
 mixedAmount :: Amount -> MixedAmount
-mixedAmount a = Mixed $ M.singleton (amountKey a) a
+mixedAmount !a = Mixed $ M.singleton (amountKey a) a
 
 -- | Add an Amount to a MixedAmount, normalising the result.
 maAddAmount :: MixedAmount -> Amount -> MixedAmount
-maAddAmount (Mixed ma) a = Mixed $ M.insertWith sumSimilarAmountsUsingFirstPrice (amountKey a) a ma
+maAddAmount (Mixed ma) !a = Mixed $ M.insertWith sumSimilarAmountsUsingFirstPrice (amountKey a) a ma
 
 -- | Add a collection of Amounts to a MixedAmount, normalising the result.
 maAddAmounts :: Foldable t => MixedAmount -> t Amount -> MixedAmount
@@ -609,7 +610,7 @@ maPlus (Mixed as) (Mixed bs) = Mixed $ M.unionWith sumSimilarAmountsUsingFirstPr
 
 -- | Subtract a MixedAmount from another.
 maMinus :: MixedAmount -> MixedAmount -> MixedAmount
-maMinus a = maPlus a . maNegate
+maMinus !a = maPlus a . maNegate
 
 -- | Sum a collection of MixedAmounts.
 maSum :: Foldable t => t MixedAmount -> MixedAmount
@@ -725,7 +726,7 @@ unifyMixedAmount = foldM combine 0 . amounts
 -- price to the result and discarding any other prices. Only used as a
 -- rendering helper.
 sumSimilarAmountsUsingFirstPrice :: Amount -> Amount -> Amount
-sumSimilarAmountsUsingFirstPrice a b = (a + b){aprice=p}
+sumSimilarAmountsUsingFirstPrice !a !b = (a + b){aprice=p}
   where
     p = case (aprice a, aprice b) of
         (Just (TotalPrice ap), Just (TotalPrice bp))
@@ -976,7 +977,7 @@ mixedAmountSetFullPrecision = mapMixedAmountUnsafe amountSetFullPrecision
 -- | Remove all prices from a MixedAmount.
 mixedAmountStripPrices :: MixedAmount -> MixedAmount
 mixedAmountStripPrices (Mixed ma) =
-    foldl' (\m a -> maAddAmount m a{aprice=Nothing}) (Mixed noPrices) withPrices
+    foldl' (\(!m) (!a) -> maAddAmount m a{aprice=Nothing}) (Mixed noPrices) withPrices
   where (noPrices, withPrices) = M.partition (isNothing . aprice) ma
 
 -- | Canonicalise a mixed amount's display styles using the provided commodity style map.


### PR DESCRIPTION
arithmetic.

This seems to result in an approximately 5-10% speedup for reports
involving a lot of arithmetic (register reports, balance reports).

```
run quick performance benchmarks in bench.sh (approximate, can be skewed):
Running 5 tests 1 times with 2 executables at 2021-09-20 11:39:20 AEST:

Best times:
+----------------------------------------------------++----------------------------+-------------------------------+
|                                                    || profiling/hledger-masterNP | profiling/hledger-strictamtNP |
+====================================================++============================+===============================+
| -f examples/10000x1000x10.journal print            ||                       0.61 |                          0.59 |
| -f examples/10000x1000x10.journal register         ||                       9.06 |                          8.52 |
| -f examples/10000x1000x10.journal balance          ||                       0.52 |                          0.54 |
| -f examples/1000x1000x10.journal balance --weekly  ||                       0.52 |                          0.45 |
| -f examples/10000x1000x10.journal balance --weekly ||                       6.00 |                          5.64 |
+----------------------------------------------------++----------------------------+-------------------------------+
```
