### PR TITLE
lib!: Remove GenericSourcePos, and replace it with SourcePos

### DIFF
--- a/hledger-lib/Hledger/Data/Balancing.hs
+++ b/hledger-lib/Hledger/Data/Balancing.hs
@@ -169,7 +169,7 @@ transactionBalanceError t errs =
 
 annotateErrorWithTransaction :: Transaction -> String -> String
 annotateErrorWithTransaction t s =
-  unlines [ showGenericSourcePos $ tsourcepos t, s
+  unlines [ showSourcePosPair $ tsourcepos t, s
           , T.unpack . T.stripEnd $ showTransaction t
           ]
 
@@ -586,7 +586,7 @@ checkBalanceAssertionOneCommodityB p@Posting{paccount=assertedacct} assertedamt 
       (case ptransaction p of
          Nothing -> "?" -- shouldn't happen
          Just t ->  printf "%s\ntransaction:\n%s"
-                      (showGenericSourcePos pos)
+                      (showSourcePos pos)
                       (textChomp $ showTransaction t)
                       :: String
                       where

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -24,6 +24,7 @@ import           Data.Decimal (DecimalRaw(..), roundTo)
 import           Data.Maybe (fromMaybe)
 import qualified Data.Text.Lazy    as TL
 import qualified Data.Text.Lazy.Builder as TB
+import           Text.Megaparsec (Pos, SourcePos, mkPos, unPos)
 
 import           Hledger.Data.Types
 import           Hledger.Data.Amount (amountsRaw, mixed)
@@ -31,7 +32,12 @@ import           Hledger.Data.Amount (amountsRaw, mixed)
 -- To JSON
 
 instance ToJSON Status
-instance ToJSON GenericSourcePos
+instance ToJSON SourcePos
+
+-- Use the same encoding as the underlying Int
+instance ToJSON Pos where
+  toJSON = toJSON . unPos
+  toEncoding = toEncoding . unPos
 
 -- https://github.com/simonmichael/hledger/issues/1195
 
@@ -159,7 +165,11 @@ instance ToJSON Ledger
 -- From JSON
 
 instance FromJSON Status
-instance FromJSON GenericSourcePos
+instance FromJSON SourcePos
+-- Use the same encoding as the underlying Int
+instance FromJSON Pos where
+  parseJSON = fmap mkPos . parseJSON
+
 instance FromJSON Amount
 instance FromJSON AmountStyle
 

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -125,15 +125,15 @@ post' acc amt ass = posting {paccount=acc, pamount=mixedAmount amt, pbalanceasse
 vpost' :: AccountName -> Amount -> Maybe BalanceAssertion -> Posting
 vpost' acc amt ass = (post' acc amt ass){ptype=VirtualPosting, pbalanceassertion=ass}
 
-nullsourcepos :: GenericSourcePos
-nullsourcepos = JournalSourcePos "" (1,1)
+nullsourcepos :: (SourcePos, SourcePos)
+nullsourcepos = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
 
 nullassertion :: BalanceAssertion
 nullassertion = BalanceAssertion
                   {baamount=nullamt
                   ,batotal=False
                   ,bainclusive=False
-                  ,baposition=nullsourcepos
+                  ,baposition=initialPos ""
                   }
 
 -- | Make a partial, exclusive balance assertion.

--- a/hledger-lib/Hledger/Data/Timeclock.hs
+++ b/hledger-lib/Hledger/Data/Timeclock.hs
@@ -77,10 +77,7 @@ timeclockEntriesToTransactions now (i:o:rest)
 {- HLINT ignore timeclockEntriesToTransactions -}
 
 errorExpectedCodeButGot expected actual = errorWithSourceLine line $ "expected timeclock code " ++ (show expected) ++ " but got " ++ show (tlcode actual)
-    where
-        line = case tlsourcepos actual of
-                  GenericSourcePos _ l _ -> l
-                  JournalSourcePos _ (l, _) -> l
+    where line = unPos . sourceLine $ tlsourcepos actual
 
 errorWithSourceLine line msg = error $ "line " ++ show line ++ ": " ++ msg
 
@@ -95,7 +92,7 @@ entryFromTimeclockInOut i o
     where
       t = Transaction {
             tindex       = 0,
-            tsourcepos   = tlsourcepos i,
+            tsourcepos   = (tlsourcepos i, tlsourcepos i),
             tdate        = idate,
             tdate2       = Nothing,
             tstatus      = Cleared,
@@ -135,7 +132,7 @@ tests_Timeclock = testGroup "Timeclock" [
       let now = utcToLocalTime tz now'
           nowstr = showtime now
           yesterday = prevday today
-          clockin = TimeclockEntry nullsourcepos In
+          clockin = TimeclockEntry (initialPos "") In
           mktime d = LocalTime d . fromMaybe midnight .
                      parseTimeM True defaultTimeLocale "%H:%M:%S"
           showtime = formatTime defaultTimeLocale "%H:%M"

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -7,7 +7,6 @@ tags.
 
 -}
 
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -44,10 +43,6 @@ module Hledger.Data.Transaction
 , showTransactionOneLineAmounts
   -- showPostingLine
 , showPostingLines
-  -- * GenericSourcePos
-, sourceFilePath
-, sourceFirstLine
-, showGenericSourcePos
 , transactionFile
   -- * tests
 , tests_Transaction
@@ -71,22 +66,6 @@ import Hledger.Data.Amount
 import Hledger.Data.Valuation
 import Text.Tabular.AsciiWide
 
-sourceFilePath :: GenericSourcePos -> FilePath
-sourceFilePath = \case
-    GenericSourcePos fp _ _ -> fp
-    JournalSourcePos fp _ -> fp
-
-sourceFirstLine :: GenericSourcePos -> Int
-sourceFirstLine = \case
-    GenericSourcePos _ line _ -> line
-    JournalSourcePos _ (line, _) -> line
-
--- | Render source position in human-readable form.
--- Keep in sync with Hledger.UI.ErrorScreen.hledgerparseerrorpositionp (temporary). XXX
-showGenericSourcePos :: GenericSourcePos -> String
-showGenericSourcePos = \case
-    GenericSourcePos fp line column -> show fp ++ " (line " ++ show line ++ ", column " ++ show column ++ ")"
-    JournalSourcePos fp (line, line') -> show fp ++ " (lines " ++ show line ++ "-" ++ show line' ++ ")"
 
 nulltransaction :: Transaction
 nulltransaction = Transaction {
@@ -393,10 +372,7 @@ transactionMapPostingAmounts f  = transactionMapPostings (postingTransformAmount
 
 -- | The file path from which this transaction was parsed.
 transactionFile :: Transaction -> FilePath
-transactionFile Transaction{tsourcepos} =
-  case tsourcepos of
-    GenericSourcePos f _ _ -> f
-    JournalSourcePos f _   -> f
+transactionFile Transaction{tsourcepos} = sourceName $ fst tsourcepos
 
 -- tests
 

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -44,7 +44,6 @@ module Hledger.Read.JournalReader (
   reader,
 
   -- * Parsing utils
-  genericSourcePos,
   parseAndFinaliseJournal,
   runJournalParser,
   rjp,
@@ -696,7 +695,7 @@ transactionp = do
   let year = first3 $ toGregorian date
   postings <- postingsp (Just year)
   endpos <- getSourcePos
-  let sourcepos = journalSourcePos startpos endpos
+  let sourcepos = (startpos, endpos)
   return $ txnTieKnot $ Transaction 0 "" sourcepos date edate status code description comment tags postings
 
 --- *** postings
@@ -921,7 +920,7 @@ tests_JournalReader = testGroup "JournalReader" [
         "    ; ptag2: val2"
         ])
       nulltransaction{
-        tsourcepos=JournalSourcePos "" (1,7),  -- XXX why 7 here ?
+        tsourcepos=(SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 8) (mkPos 1)),  -- 8 because there are 7 lines
         tprecedingcomment="",
         tdate=fromGregorian 2012 5 14,
         tdate2=Just $ fromGregorian 2012 5 15,

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -119,7 +119,7 @@ timeclockfilep = do many timeclockitemp
 -- | Parse a timeclock entry.
 timeclockentryp :: JournalParser m TimeclockEntry
 timeclockentryp = do
-  sourcepos <- genericSourcePos <$> lift getSourcePos
+  sourcepos <- getSourcePos
   code <- oneOf ("bhioO" :: [Char])
   lift skipNonNewlineSpaces1
   datetime <- datetimep

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -168,7 +168,7 @@ orgheadingprefixp = do
 entryp :: JournalParser m Transaction
 entryp = do
   lift $ traceparse "entryp"
-  pos <- genericSourcePos <$> getSourcePos
+  pos <- getSourcePos
   notFollowedBy datelinep
   lift $ optional $ choice [orgheadingprefixp, skipNonNewlineSpaces1]
   a <- modifiedaccountnamep
@@ -178,7 +178,7 @@ entryp = do
     <|> (durationp <*
          (try (lift followingcommentp) <|> (newline >> return "")))
   let t = nulltransaction{
-        tsourcepos = pos,
+        tsourcepos = (pos, pos),
         tstatus    = Cleared,
         tpostings  = [
           nullposting{paccount=a

--- a/hledger-lib/Hledger/Utils/Parse.hs
+++ b/hledger-lib/Hledger/Utils/Parse.hs
@@ -6,6 +6,15 @@ module Hledger.Utils.Parse (
   SimpleTextParser,
   TextParser,
 
+  SourcePos(..),
+  mkPos,
+  unPos,
+  initialPos,
+
+  -- * SourcePos
+  showSourcePosPair,
+  showSourcePos,
+
   choice',
   choiceInState,
   surroundedBy,
@@ -53,6 +62,17 @@ type SimpleTextParser = Parsec CustomErr Text  -- XXX an "a" argument breaks the
 
 -- | A parser of text that runs in some monad.
 type TextParser m a = ParsecT CustomErr Text m a
+
+-- | Render source position in human-readable form.
+showSourcePos :: SourcePos -> String
+showSourcePos (SourcePos fp l c) =
+    show fp ++ " (line " ++ show (unPos l) ++ ", column " ++ show (unPos c) ++ ")"
+
+-- | Render a pair of source position in human-readable form.
+showSourcePosPair :: (SourcePos, SourcePos) -> String
+showSourcePosPair (SourcePos fp l1 _, SourcePos _ l2 c2) =
+    show fp ++ " (lines " ++ show (unPos l1) ++ "-" ++ show l2' ++ ")"
+  where l2' = if unPos c2 == 1 then unPos l2 - 1 else unPos l2  -- might be at end of file withat last new-line
 
 -- | Backtracking choice, use this when alternatives share a prefix.
 -- Consumes no input if all choices fail.

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -326,9 +326,7 @@ rsHandle ui@UIState{
             (pos,f) = case listSelectedElement rsList of
                         Nothing -> (endPosition, journalFilePath j)
                         Just (_, RegisterScreenItem{
-                          rsItemTransaction=Transaction{tsourcepos=GenericSourcePos f l c}}) -> (Just (l, Just c),f)
-                        Just (_, RegisterScreenItem{
-                          rsItemTransaction=Transaction{tsourcepos=JournalSourcePos f (l,_)}}) -> (Just (l, Nothing),f)
+                          rsItemTransaction=Transaction{tsourcepos=(SourcePos f l c,_)}}) -> (Just (unPos l, Just $ unPos c),f)
 
         -- display mode/query toggles
         VtyEvent (EvKey (KChar 'B') []) -> rsCenterAndContinue $ regenerateScreens j d $ toggleCost ui

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -158,8 +158,7 @@ tsHandle ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransaction
         VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor pos f) >> uiReloadJournalIfChanged copts d j ui
           where
             (pos,f) = case tsourcepos t of
-                        GenericSourcePos f l c    -> (Just (l, Just c),f)
-                        JournalSourcePos f (l1,_) -> (Just (l1, Nothing),f)
+                        (SourcePos f l1 c1,_) -> (Just (unPos l1, Just $ unPos c1),f)
         AppEvent (DateChange old _) | isStandardPeriod p && p `periodContainsDate` old ->
           continue $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
           where

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -112,7 +112,7 @@ transactionFragment j Transaction{tindex, tsourcepos} =
   where
     -- the numeric index of this txn's file within all the journal files,
     -- or 0 if this txn has no known file (eg a forecasted txn)
-    tfileindex = maybe 0 (+1) $ elemIndex (sourceFilePath tsourcepos) (journalFilePaths j)
+    tfileindex = maybe 0 (+1) $ elemIndex (sourceName $ fst tsourcepos) (journalFilePaths j)
 
 removeDates :: Text -> [Text]
 removeDates =

--- a/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Ordereddates.hs
@@ -30,7 +30,7 @@ journalCheckOrdereddates CliOpts{reportspec_=rspec} j = do
         let
           datestr = if date2_ ropts then "2" else ""
           uniquestr = if checkunique then " and/or not unique" else ""
-          positionstr = showGenericSourcePos $ tsourcepos error
+          positionstr = showSourcePosPair $ tsourcepos error
           txn1str = T.unpack . linesPrepend  (T.pack "  ")               $ showTransaction previous
           txn2str = T.unpack . linesPrepend2 (T.pack "> ") (T.pack "  ") $ showTransaction error
         Left $

--- a/hledger/Hledger/Cli/Commands/Check/Uniqueleafnames.hs
+++ b/hledger/Hledger/Cli/Commands/Check/Uniqueleafnames.hs
@@ -49,5 +49,5 @@ checkposting leafandfullnames Posting{paccount,ptransaction} =
         Nothing -> ""
         Just t  -> printf "\nseen in \"%s\" in transaction at: %s\n\n%s"
                     paccount
-                    (showGenericSourcePos $ tsourcepos t)
+                    (showSourcePosPair $ tsourcepos t)
                     (linesPrepend "> " . (<>"\n") . textChomp $ showTransaction t) :: String)


### PR DESCRIPTION
or (SourcePos, SourcePos).

This has been marked for possible removal for a while. We are keeping
strictly more information. Possible edge cases arise with Timeclock and
CsvReader, but I think these are covered.

The particular motivation for getting rid of this is that
GenericSourcePos is creating some awkward import considerations for
little gain. Removing this enables some flattening of the module
dependency tree.