### PR TITLE
ref: auto: Add auto postings during the transaction balancing phase,

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -724,8 +724,6 @@ journalModifyTransactions d j =
       Right ts -> Right j{jtxns=ts}
       Left err -> Left err
 
---
-
 -- | Choose and apply a consistent display style to the posting
 -- amounts in each commodity (see journalCommodityStyles).
 -- Can return an error message eg if inconsistent number formats are found.

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -44,7 +44,6 @@ module Hledger.Read.Common (
   journalCheckCommoditiesDeclared,
   journalCheckPayeesDeclared,
   journalAddForecast,
-  journalAddAutoPostings,
   setYear,
   getYear,
   setDefaultCommodityAndStyle,
@@ -216,10 +215,10 @@ rawOptsToInputOpts day rawopts =
       ,pivot_             = stringopt "pivot" rawopts
       ,forecast_          = forecastPeriodFromRawOpts day rawopts
       ,reportspan_        = DateSpan (queryStartDate False datequery) (queryEndDate False datequery)
-      ,auto_              = boolopt "auto" rawopts
       ,balancingopts_     = defbalancingopts{
                                  ignore_assertions_ = boolopt "ignore-assertions" rawopts
                                , infer_transaction_prices_ = not noinferprice
+                               , auto_              = boolopt "auto" rawopts
                                , commodity_styles_  = Just commodity_styles
                                }
       ,strict_            = boolopt "strict" rawopts
@@ -316,7 +315,7 @@ parseAndFinaliseJournal' parser iopts f txt = do
 -- - infer transaction-implied market prices from transaction prices
 --
 journalFinalise :: InputOpts -> FilePath -> Text -> ParsedJournal -> ExceptT String IO Journal
-journalFinalise iopts@InputOpts{auto_,balancingopts_,strict_} f txt pj = do
+journalFinalise iopts@InputOpts{balancingopts_,strict_} f txt pj = do
     t <- liftIO getPOSIXTime
     -- Infer and apply canonical styles for each commodity (or throw an error).
     -- This affects transaction balancing/assertions/assignments, so needs to be done early.
@@ -333,23 +332,17 @@ journalFinalise iopts@InputOpts{auto_,balancingopts_,strict_} f txt pj = do
           -- and using declared commodities
           journalCheckCommoditiesDeclared j
 
+        -- Add auto postings during balancing if requested and there are transaction modifiers
+        modifyTransaction <- transactionModifiersToFunction (journalCommodityStyles j) d (jtxnmodifiers j)
+        let bopts = balancingopts_{ auto_ = auto_ balancingopts_ && not (null $ jtxnmodifiers j)
+                                  , modify_transaction_ = modifyTransaction}
+
         -- Add forecast transactions if enabled
         journalAddForecast (forecastPeriod iopts j) j
-        -- Add auto postings if enabled
-          & (if auto_ && not (null $ jtxnmodifiers j) then journalAddAutoPostings d balancingopts_ else pure)
         -- Balance all transactions and maybe check balance assertions.
-          >>= journalBalanceTransactions balancingopts_
+          & journalBalanceTransactions bopts
         -- infer market prices from commodity-exchanging transactions
           <&> journalInferMarketPricesFromTransactions
-
-journalAddAutoPostings :: Day -> BalancingOpts -> Journal -> Either String Journal
-journalAddAutoPostings d bopts =
-    -- Balance all transactions without checking balance assertions,
-    journalBalanceTransactions bopts{ignore_assertions_=True}
-    -- then add the auto postings
-    -- (Note adding auto postings after balancing means #893b fails;
-    -- adding them before balancing probably means #893a, #928, #938 fail.)
-    >=> journalModifyTransactions d
 
 -- | Generate periodic transactions from all periodic transaction rules in the journal.
 -- These transactions are added to the in-memory Journal (but not the on-disk file).

--- a/hledger-lib/Hledger/Read/InputOptions.hs
+++ b/hledger-lib/Hledger/Read/InputOptions.hs
@@ -35,7 +35,6 @@ data InputOpts = InputOpts {
     ,pivot_             :: String               -- ^ use the given field's value as the account name
     ,forecast_          :: Maybe DateSpan       -- ^ span in which to generate forecast transactions
     ,reportspan_        :: DateSpan             -- ^ a dirty hack keeping the query dates in InputOpts. This rightfully lives in ReportSpec, but is duplicated here.
-    ,auto_              :: Bool                 -- ^ generate automatic postings when journal is parsed
     ,balancingopts_     :: BalancingOpts        -- ^ options for balancing transactions
     ,strict_            :: Bool                 -- ^ do extra error checking (eg, all posted accounts are declared, no prices are inferred)
     ,_ioDay             :: Day                  -- ^ today's date, for use with forecast transactions  XXX this duplicates _rsDay, and should eventually be removed when it's not needed anymore.
@@ -52,7 +51,6 @@ definputopts = InputOpts
     , pivot_             = ""
     , forecast_          = Nothing
     , reportspan_        = nulldatespan
-    , auto_              = False
     , balancingopts_     = defbalancingopts
     , strict_            = False
     , _ioDay             = nulldate


### PR DESCRIPTION
rather than during a second balancing pass during journal finalisation.

Adding some auto postings and forecast transactions to 10000x1000x10.journal.

```
Running 4 tests 3 times with 2 executables at 2021-09-20 22:40:31 AEST:

Best times 1:
+------------------------------------------------------------------------------++--------------------------+------------------------+
|                                                                              || profiling/hledger-master | profiling/hledger-auto |
+==============================================================================++==========================+========================+
| -f examples/10000x1000x10.journal print --auto --forecast -e 2030            ||                     0.90 |                   0.87 |
| -f examples/10000x1000x10.journal register --auto --forecast -e 2030         ||                    18.00 |                  17.22 |
| -f examples/10000x1000x10.journal balance --auto --forecast -e 2030          ||                     0.70 |                   0.67 |
| -f examples/10000x1000x10.journal balance --weekly --auto --forecast -e 2030 ||                     5.96 |                   5.96 |
+------------------------------------------------------------------------------++--------------------------+------------------------+

Best times 2:
+------------------------------------------------------------------------------++--------------------------+------------------------+
|                                                                              || profiling/hledger-master | profiling/hledger-auto |
+==============================================================================++==========================+========================+
| -f examples/10000x1000x10.journal print --auto --forecast -e 2030            ||                     0.87 |                   0.85 |
| -f examples/10000x1000x10.journal register --auto --forecast -e 2030         ||                    17.52 |                  17.14 |
| -f examples/10000x1000x10.journal balance --auto --forecast -e 2030          ||                     0.69 |                   0.67 |
| -f examples/10000x1000x10.journal balance --weekly --auto --forecast -e 2030 ||                     6.11 |                   5.91 |
+------------------------------------------------------------------------------++--------------------------+------------------------+

Best times 3:
+------------------------------------------------------------------------------++--------------------------+------------------------+
|                                                                              || profiling/hledger-master | profiling/hledger-auto |
+==============================================================================++==========================+========================+
| -f examples/10000x1000x10.journal print --auto --forecast -e 2030            ||                     0.87 |                   0.86 |
| -f examples/10000x1000x10.journal register --auto --forecast -e 2030         ||                    17.68 |                  16.85 |
| -f examples/10000x1000x10.journal balance --auto --forecast -e 2030          ||                     0.70 |                   0.67 |
| -f examples/10000x1000x10.journal balance --weekly --auto --forecast -e 2030 ||                     5.65 |                   5.94 |
+------------------------------------------------------------------------------++--------------------------+------------------------+
```