### PR TITLE
fix: colour: NO_COLOR flag no longer overrides an explicit --color op…

### DIFF
--- a/hledger-lib/Hledger/Utils/Debug.hs
+++ b/hledger-lib/Hledger/Utils/Debug.hs
@@ -167,14 +167,14 @@ debugLevel = case dropWhile (/="--debug") args of
 
 -- Avoid using dbg*, pshow etc. in this function (infinite loop).
 -- | Check the IO environment to see if ANSI colour codes should be used on stdout.
--- This is done using unsafePerformIO so it can be used anywhere, eg in 
+-- This is done using unsafePerformIO so it can be used anywhere, eg in
 -- low-level debug utilities, which should be ok since we are just reading.
--- The logic is: use color if 
--- a NO_COLOR environment variable is not defined
--- and the program was not started with --color=no|never
--- and (
---   the program was started with --color=yes|always
---   or stdout supports ANSI color and -o/--output-file was not used or is "-"
+-- The logic is: use color if
+-- the program was started with --color=yes|always
+-- or (
+--   the program was not started with --color=no|never
+--   and a NO_COLOR environment variable is not defined
+--   and stdout supports ANSI color and -o/--output-file was not used or is "-"
 -- ).
 -- Caveats:
 -- When running code in GHCI, this module must be reloaded to see a change.
@@ -200,9 +200,8 @@ useColorOnHandle h = unsafePerformIO $ do
   no_color       <- isJust <$> lookupEnv "NO_COLOR"
   supports_color <- hSupportsANSIColor h
   let coloroption = colorOption
-  return $ not no_color
-        && coloroption `notElem` ["never","no"]
-        && (coloroption `elem` ["always","yes"] || supports_color)
+  return $ coloroption `elem` ["always","yes"]
+       || (coloroption `notElem` ["never","no"] && not no_color && supports_color)
 
 -- Keep synced with color/colour flag definition in hledger:CliOptions.
 -- Avoid using dbg*, pshow etc. in this function (infinite loop).

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -351,7 +351,7 @@ Default: the full terminal width.
 **NO_COLOR**
 If this variable exists with any value, 
 hledger will not use ANSI color codes in terminal output.
-This overrides the --color/--colour option.
+This is overriden by the --color/--colour option.
 
 # DATA FILES
 
@@ -1387,9 +1387,9 @@ If you need to capture it, use shell redirects, eg: `hledger bal --debug=3 >file
 
 hledger commands can produce colour output when the terminal supports it.
 This is controlled by the `--color/--colour` option:
-- if the `NO_COLOR` environment variable is set, colour will not be used;
-- otherwise, if the `--color/--colour` option is given a value of `yes` or `always`
+- if the `--color/--colour` option is given a value of `yes` or `always`
   (or `no` or `never`), colour will (or will not) be used;
+- otherwise, if the `NO_COLOR` environment variable is set, colour will not be used;
 - otherwise, colour will be used if the output (terminal or file) supports it.
 
 hledger commands can also use unicode box-drawing characters to produce prettier tables and output.


### PR DESCRIPTION
…tion. (Fixes #1710)

http://no-color.org/ specifies that command line arguments should
override a NO_COLOR flag.