### PR TITLE
; cabal.project: Drop compatibility comment

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,11 +3,6 @@ packages: hledger-lib
           hledger-ui
           hledger-web
 
--- syntax error with cabal 3.4, seems no longer needed
--- allow-newer:
---   brick:base
---   config-ini:containers
-
 -- generate a ghc environment file, needed by doctest 
 -- (eg: ./.ghc.environment.x86_64-darwin-8.8.3). 
 -- cabal 3 doesn't write these by default.


### PR DESCRIPTION
The offending syntax is no longer used so the comment can be removed
too. Ideally `allow-newer` isn't used in the project's setup. The
problem should rather be fixed by adjusting constraints, though these
adjustments may need to be made in dependencies upstream.

Fixes #1365

[ci skip]