### PR TITLE
Fix PR template comment syntax

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,11 @@
-# Thanks for your pull request! We appreciate it. 
-# If you're a new developer, FOSS contributor, or hledger contributor, welcome.
-# 
-# Much of our best design work and knowledge sharing happens during code review,
-# so be prepared for more work ahead, especially if your PR is large.
-# To minimise waste, and learn how to get hledger PRs accepted swiftly, 
-# please check the latest guidelines in the developer docs:
-# 
-# https://hledger.org/PULLREQUESTS.html
+<!--
+Thanks for your pull request! We appreciate it. 
+If you're a new developer, FOSS contributor, or hledger contributor, welcome.
+
+Much of our best design work and knowledge sharing happens during code review,
+so be prepared for more work ahead, especially if your PR is large.
+To minimise waste, and learn how to get hledger PRs accepted swiftly, 
+please check the latest guidelines in the developer docs:
+
+https://hledger.org/PULLREQUESTS.html
+-->


### PR DESCRIPTION
The # syntax for comments results in all the lines being rendered as
separate headers because it's markdown syntax for titles. I believe the
markdown custom is to use `<!-- HTML comments -->`.

Using the comment syntax customarily used in many other languages here meant I accidentally included a bunch of strange section headers in my last PR : )
I figured I might as well save other contributors those few seconds for every PR.

The URL in the PR template redirects to a general contributing guide,
which is useful, but it's hard to see the trees for the forest when just
looking for PR and commit guidelines.

I updated it with the URL for the PR page in the developer docs, as was the original intention AFAICT. Maybe we want to include the URL to the general contributor guide as well?
