### PR TITLE
[WIP] tab-separated text as --output-format

### DIFF
--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -50,7 +50,7 @@ registermode = hledgerCommandMode
 #endif
       ++ " or $COLUMNS). -wN,M sets description width as well."
      )
-  ,outputFormatFlag ["txt","csv","json"]
+  ,outputFormatFlag ["txt","csv","json","txt-tab-separated"]
   ,outputFileFlag
   ])
   [generalflagsgroup1]
@@ -66,6 +66,7 @@ register opts@CliOpts{reportspec_=rspec} j =
     render | fmt=="txt"  = postingsReportAsText opts
            | fmt=="csv"  = printCSV . postingsReportAsCsv
            | fmt=="json" = toJsonText
+           | fmt=="txt-tab-separated" = postingsReportAsTextTabSeparated opts
            | otherwise   = error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
 
 postingsReportAsCsv :: PostingsReport -> CSV
@@ -90,6 +91,10 @@ postingsReportItemAsCsvRecord (_, _, _, p, b) = [idx,date,code,desc,acct,amt,bal
     -- Since postingsReport strips prices from all Amounts when not used, we can display prices.
     amt = wbToText . showMixedAmountB oneLine $ pamount p
     bal = wbToText $ showMixedAmountB oneLine b
+
+-- | Render a register report as tab-separated plain text suitable for console output.
+postingsReportAsTextTabSeparated :: CliOpts -> PostingsReport -> TL.Text
+postingsReportAsTextTabSeparated opts items = TB.toLazyText ""
 
 -- | Render a register report as plain text suitable for console output.
 postingsReportAsText :: CliOpts -> PostingsReport -> TL.Text


### PR DESCRIPTION
I'd like to add a new output format, especially for the `register` command: tab-separated text

**Use-case:**
I often use hledger to generate register reports which must be formatted nicely. For that, I use a text processing software (e.g. LibreOffice). To get a nice format, I have to adapt the font size, the output width (`-w`) to match the correct page width and avoid line breaks. Also, only mono-space fonts are possible with the text format. To remove the account column, I have to apply an ugly sed script.

**Suggestion:**
I suggest a tab-separated text format that puts tab characters between date, description, account, amount, total/average as column separater. The output could also directly pasted and used into table calculation software.

**Alternatives considered:**
CSV output format would be a alternative for my use-case but it's much easier to do

```
hledger register -Otxt-tab-separated | xclip -i
```

… and then paste it directly into a LibreOffice Writer template.

Would maintainers accept such an PR?