### PR TITLE
; imp: use megaparsec's prettyprinter for assertion parse errors

### DIFF
--- a/bin/hledger-check-fancyassertions.hs
+++ b/bin/hledger-check-fancyassertions.hs
@@ -420,7 +420,7 @@ args = info (helper <*> parser) $ mconcat
       parsed <- P.runParserT (runStateT p H.nulljournal) "" s
       case parsed of
         Right (a, _) -> pure (s, a)
-        Left err -> fail ("failed to parse input '" ++ unpack s ++ "': " ++ show err)
+        Left err -> fail ("failed to parse input '" ++ unpack s ++ "': " ++ P.errorBundlePretty err)
 
     readParsec' :: H.SimpleTextParser a -> ReadM (String, a)
     readParsec' p = do
@@ -428,7 +428,7 @@ args = info (helper <*> parser) $ mconcat
       let parsed = runIdentity $ P.runParserT p "" (pack s)
       case parsed of
         Right a -> pure (s, a)
-        Left err -> fail ("failed to parse input '" ++ s ++ "': " ++ show err)
+        Left err -> fail ("failed to parse input '" ++ s ++ "': " ++ P.errorBundlePretty err)
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The `Show` instance for the error bundle is not human-readable, `megaparsec` provides a prettyprinter.