### PR TITLE
Fix the link to the developer workdflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,7 +239,7 @@ Marketing and market understanding is vital.
 
 ### Developer
 
-See [Developer workflows](#developer-workflows).
+See [Developer workflows](WORKFLOWS.md#developer-workflows).
 
 
 


### PR DESCRIPTION
The "Developer workflows" was moved to the `WORKFLOWS.md` file