### PR TITLE
fix: csv: Successfully parse empty csv file. (#1183)

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -786,7 +786,7 @@ parseCsv :: Char -> FilePath -> Text -> IO (Either String CSV)
 parseCsv separator filePath csvdata =
   case filePath of
     "-" -> parseCassava separator "(stdin)" <$> T.getContents
-    _   -> return $ parseCassava separator filePath csvdata
+    _   -> return $ if T.null csvdata then Right mempty else parseCassava separator filePath csvdata
 
 parseCassava :: Char -> FilePath -> Text -> Either String CSV
 parseCassava separator path content =


### PR DESCRIPTION
Fixes #1183.

This fix is due to @la-wu, but hasn't been submitted. If you want to submit your own PR then I'll happily withdraw this.