### PR TITLE
ui: add mouse support

### DIFF
--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -323,11 +323,15 @@ asHandle ui0@UIState{
         VtyEvent e | e `elem` moveRightEvents
                    , not $ isBlankElement $ listSelectedElement _asList -> asEnterRegister d selacct ui
 
+        -- MouseDown is sometimes duplicated, https://github.com/jtdaugherty/brick/issues/347
+        -- just use it to move the selection
         MouseDown _n BLeft _mods Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
-          let list' = listMoveTo y _asList
-          asEnterRegister d clickedacct ui{aScreen=scr{_asList=list'}}
-          where 
-            clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
+          continue ui{aScreen=scr{_asList=listMoveTo y _asList}}
+          where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
+        -- and on MouseUp, enter the subscreen
+        MouseUp _n (Just BLeft) Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
+          asEnterRegister d clickedacct ui
+          where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
 
         -- prevent moving down over blank padding items;
         -- instead scroll down by one, until maximally scrolled - shows the end has been reached

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -2,6 +2,7 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Hledger.UI.AccountsScreen
  (accountsScreen
@@ -12,7 +13,7 @@ where
 
 import Brick
 import Brick.Widgets.List
-  (handleListEvent, list, listElementsL, listMoveDown, listMoveTo, listNameL, listSelectedElement, listSelectedL, renderList, listElements)
+  (handleListEvent, list, listElementsL, listMoveDown, listMoveTo, listNameL, listSelectedElement, listSelectedL, renderList, listElements, listSelected, listMoveUp)
 import Brick.Widgets.Edit
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
@@ -21,7 +22,7 @@ import Data.Maybe
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
 import qualified Data.Vector as V
-import Graphics.Vty (Event(..),Key(..),Modifier(..), Button (BLeft))
+import Graphics.Vty (Event(..),Key(..),Modifier(..), Button (BLeft, BScrollDown, BScrollUp))
 import Lens.Micro.Platform
 import Safe
 import System.Console.ANSI
@@ -331,10 +332,39 @@ asHandle ui0@UIState{
         -- prevent moving down over blank padding items;
         -- instead scroll down by one, until maximally scrolled - shows the end has been reached
         VtyEvent (EvKey (KDown)     []) | isBlankElement mnextelement -> do
-          vScrollBy (viewportScroll $ _asList^.listNameL) 1
-          continue ui
-          where
-            mnextelement = listSelectedElement $ listMoveDown _asList
+          vScrollBy (viewportScroll $ _asList^.listNameL) 1 >> continue ui
+          where mnextelement = listSelectedElement $ listMoveDown _asList
+
+        -- mouse scroll wheel scrolls the viewport up or down to its maximum extent.
+        -- The selection will be moved when necessary to keep it visible and allow the scroll.
+        MouseDown name BScrollDown _mods _loc -> do
+          mvp <- lookupViewport name
+          let mselidx = listSelected _asList
+          case (mvp, mselidx) of
+            (Just VP{_vpTop}, Just selidx) -> do
+              let
+                listheight = asListSize _asList
+                pushsel | selidx <= _vpTop && selidx < (listheight-1) = listMoveDown
+                        | otherwise = id
+                ui' = ui{aScreen=scr{_asList=pushsel _asList}}
+              viewportScroll name `vScrollBy` 1
+              continue ui'
+
+            _ -> continue ui
+
+        MouseDown name BScrollUp _mods _loc -> do
+          mvp <- lookupViewport name
+          let mselidx = listSelected _asList
+          case (mvp, mselidx) of
+            (Just VP{_vpTop, _vpSize=(_,vpheight)}, Just selidx) -> do
+              let
+                pushsel | selidx >= _vpTop + vpheight - 1 && selidx > 0 = listMoveUp
+                        | otherwise = id
+                ui'   = ui{aScreen=scr{_asList=pushsel _asList}}
+              viewportScroll name `vScrollBy` (-1)
+              continue ui'
+
+            _ -> continue ui
 
         -- if page down or end leads to a blank padding item, stop at last non-blank
         VtyEvent e@(EvKey k           []) | k `elem` [KPageDown, KEnd] -> do
@@ -382,3 +412,5 @@ isBlankElement mel = ((asItemAccountName . snd) <$> mel) == Just ""
 asCenterAndContinue ui = do
   scrollSelectionToMiddle $ _asList $ aScreen ui
   continue ui
+
+asListSize = V.length . V.takeWhile ((/="").asItemAccountName) . listElements

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -332,9 +332,8 @@ asHandle ui0@UIState{
           asEnterRegister d clickedacct ui
           where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
 
-        -- prevent moving down over blank padding items;
-        -- instead scroll down by one, until maximally scrolled - shows the end has been reached
-        VtyEvent (EvKey (KDown)     []) | isBlankElement mnextelement -> do
+        -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
+        VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
           vScrollBy (viewportScroll $ _asList^.listNameL) 1 >> continue ui
           where mnextelement = listSelectedElement $ listMoveDown _asList
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -229,6 +229,6 @@ runBrickUi uopts@UIOpts{uoCliOpts=copts@CliOpts{inputopts_=_iopts,reportspec_=rs
             )
 
         -- and start the app. Must be inside the withManager block
-        let mkvty = mkVty mempty
-        vty0 <- mkvty
-        void $ customMain vty0 mkvty (Just eventChan) brickapp ui
+        let vtyhandle = mkVty mempty
+        vty <- vtyhandle
+        void $ customMain vty vtyhandle (Just eventChan) brickapp ui

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -372,7 +372,7 @@ rsHandle ui@UIState{
           continue $ screenEnter d transactionScreen{tsAccount=rsAccount} ui
           where clickeddate = maybe "" rsItemDate $ listElements rsList !? y
 
-        -- when at the last item, instead of moving down, scroll down by one, until maximally scrolled
+        -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
         VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
           vScrollBy (viewportScroll $ rsList ^. listNameL) 1 >> continue ui
           where mnextelement = listSelectedElement $ listMoveDown rsList

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -15,7 +15,7 @@ import Data.Maybe
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
 import qualified Data.Vector as V
-import Graphics.Vty (Event(..),Key(..),Modifier(..))
+import Graphics.Vty (Event(..),Key(..),Modifier(..), Button (BLeft))
 import Lens.Micro ((^.))
 import Brick
 import Brick.Widgets.List (listElementsL, listMoveTo, listSelectedElement)
@@ -181,7 +181,12 @@ tsHandle ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransaction
 
         VtyEvent e | e `elem` moveUpEvents   -> continue $ tsSelect iprev tprev ui
         VtyEvent e | e `elem` moveDownEvents -> continue $ tsSelect inext tnext ui
+
+        -- exit screen on LEFT
         VtyEvent e | e `elem` moveLeftEvents -> continue . popScreen $ tsSelect i t ui  -- Probably not necessary to tsSelect here, but it's safe.
+        -- or on a click in the app's left or top margin. This is a VtyEvent since not in a clickable widget.
+        VtyEvent (EvMouseUp x y (Just BLeft)) | x==0 || y==0 -> continue . popScreen $ tsSelect i t ui
+
         VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
         _ -> continue ui


### PR DESCRIPTION
This PR adds mouse support to hledger-ui. These should work:

- left click on an account should enter its register
- left click on a register transaction should enter the transaction screen
- mouse wheel/trackpad swipe should scroll the accounts and register screens
- left click on the left-most column or top-most row should return to the previous screen (like the LEFT key)
- if mouse support doesn't work on some terminal/platform, it should at least be harmless (unnoticeable)

Known issues:
- ~There seems to be a bounce issue - sometimes one click has the effect of two.~
- ~I would like to left click on the top or left border to navigate back, but these areas seem unclickable.~
