### PR TITLE
feat: bal: with --declared, include all declared accounts

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -148,12 +148,13 @@ data ReportOpts = ReportOpts {
                                         --   (Not a regexp, nor a full hledger query, for now.)
     ,accountlistmode_  :: AccountListMode
     ,drop_             :: Int
+    ,declared_         :: Bool  -- ^ Include accounts declared but not yet posted to ?
     ,row_total_        :: Bool
     ,no_total_         :: Bool
-    ,show_costs_       :: Bool  -- ^ Whether to show costs for reports which normally don't show them
+    ,show_costs_       :: Bool  -- ^ Show costs for reports which normally don't show them ?
     ,sort_amount_      :: Bool
     ,percent_          :: Bool
-    ,invert_           :: Bool  -- ^ if true, flip all amount signs in reports
+    ,invert_           :: Bool  -- ^ Flip all amount signs in reports ?
     ,normalbalance_    :: Maybe NormalSign
       -- ^ This can be set when running balance reports on a set of accounts
       --   with the same normal balance type (eg all assets, or all incomes).
@@ -197,6 +198,7 @@ defreportopts = ReportOpts
     , budgetpat_        = Nothing
     , accountlistmode_  = ALFlat
     , drop_             = 0
+    , declared_         = False
     , row_total_        = False
     , no_total_         = False
     , show_costs_       = False
@@ -250,6 +252,7 @@ rawOptsToReportOpts d rawopts =
           ,budgetpat_        = maybebudgetpatternopt rawopts
           ,accountlistmode_  = accountlistmodeopt rawopts
           ,drop_             = posintopt "drop" rawopts
+          ,declared_         = boolopt "declared" rawopts
           ,row_total_        = boolopt "row-total" rawopts
           ,no_total_         = boolopt "no-total" rawopts
           ,show_costs_       = boolopt "show-costs" rawopts

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -308,6 +308,7 @@ balancemode = hledgerCommandMode
     ]
     ++ flattreeflags True ++
     [flagReq  ["drop"] (\s opts -> Right $ setopt "drop" s opts) "N" "omit N leading account name parts (in flat mode)"
+    ,flagNone ["declared"] (setboolopt "declared") "include accounts which have been declared but not yet used"
     ,flagNone ["average","A"] (setboolopt "average") "show a row average column (in multicolumn reports)"
     ,flagNone ["related","r"] (setboolopt "related") "show postings' siblings instead"
     ,flagNone ["row-total","T"] (setboolopt "row-total") "show a row total column (in multicolumn reports)"

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -267,6 +267,12 @@ Here are some ways to handle that:
 [csv-mode]: https://elpa.gnu.org/packages/csv-mode.html
 [visidata]: https://www.visidata.org
 
+### Showing declared accounts
+
+With `--declared`, accounts which have been declared with an [account directive](#declaring-accounts), 
+even if they have no transactions yet, will be included in the balance report with a zero balance,
+and will be visible with `-E/--empty`.
+
 ### Commodity layout
 
 With `--layout`, you can control how amounts with more than one commodity are displayed:

--- a/hledger/test/balance/balance.test
+++ b/hledger/test/balance/balance.test
@@ -168,3 +168,10 @@ hledger -f - balance -N --output-format=csv --tree
 "Assets:Cash","$-1"
 >>>= 0
 
+# 9. --declared includes all declared accounts, with a zero balance if they have no postings.
+hledger -f - balance -N --declared -E
+<<<
+account a
+>>>
+                   0  a
+>>>= 0


### PR DESCRIPTION
Together with -E, this allows showing a balance for all accounts, both
used and declared. I mainly want this for hledger-ui, but there's no
harm in exposing it in the balance command as well. This is somewhat
consistent with the accounts and payees commands.
