### PR TITLE
imp: check: Do not check commodities for zero amounts with empty

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -403,9 +403,14 @@ journalCheckCommoditiesDeclared j =
                           (linesPrepend "  " . (<>"\n") . textChomp $ showTransaction t)
       where
         mfirstundeclaredcomm =
-          find (`M.notMember` jcommodities j) . map acommodity $
-          (maybe id ((:) . baamount) pbalanceassertion) . filter (/= missingamt) $ amountsRaw pamount
+          find (`M.notMember` jcommodities j)
+          . map acommodity
+          . (maybe id ((:) . baamount) pbalanceassertion)
+          . filter (not . isIgnorable)
+          $ amountsRaw pamount
 
+    -- Ignore missing amounts and zero amounts without commodity (#1767)
+    isIgnorable a = (T.null (acommodity a) && amountIsZero a) || a == missingamt
 
 setYear :: Year -> JournalParser m ()
 setYear y = modify' (\j -> j{jparsedefaultyear=Just y})

--- a/hledger/test/check-commodities.test
+++ b/hledger/test/check-commodities.test
@@ -1,14 +1,31 @@
-# check commodities succeeds when all commodities are declared
+# 1. check commodities succeeds when all commodities are declared
 <
 commodity $1.
 2020-01-01
   (a)  $1
 $ hledger -f- check commodities
 
-# and otherwise fails
+# 2. and otherwise fails
 <
 2020-01-01
   (a)  $1
+$ hledger -f- check commodities
+>2 /undeclared commodity "\$"/
+>=1
+
+# 3. But commodityless zero amounts will not fail
+<
+2020-01-01
+  (a)  0
+
+$ hledger -f- check commodities
+>=0
+
+# 4. But zero amounts with undeclared commodities still fail
+<
+2020-01-01
+  (a)  $0
+
 $ hledger -f- check commodities
 >2 /undeclared commodity "\$"/
 >=1


### PR DESCRIPTION
commodity. (Fixes #1767)
