### PR TITLE
fix: handle relative paths for haskell-language-server

### DIFF
--- a/hledger-web/Hledger/Web/Foundation.hs
+++ b/hledger-web/Hledger/Web/Foundation.hs
@@ -19,6 +19,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (join, when)
 import qualified Data.ByteString.Char8 as BC
 import Data.Traversable (for)
+import Data.FileEmbed (makeRelativeToProject)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -82,7 +83,7 @@ data App = App
 -- for our application to be in scope. However, the handler functions
 -- usually require access to the AppRoute datatype. Therefore, we
 -- split these actions into two functions and place them in separate files.
-mkYesodData "App" $(parseRoutesFile "config/routes")
+mkYesodData "App" $(makeRelativeToProject "config/routes" >>= parseRoutesFile)
 
 -- | A convenience alias.
 type AppRoute = Route App
@@ -164,7 +165,7 @@ instance Yesod App where
       addScript $ StaticR hledger_js
       $(widgetFile "default-layout")
 
-    withUrlRenderer $(hamletFile "templates/default-layout-wrapper.hamlet")
+    withUrlRenderer $(makeRelativeToProject "templates/default-layout-wrapper.hamlet" >>= hamletFile)
 
 #ifndef DEVELOPMENT
   -- This function creates static content files in the static folder

--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -21,6 +21,7 @@ import Hledger.Web.Widget.AddForm (addModal)
 import Hledger.Web.Widget.Common
              (accountQuery, mixedAmountAsHtml,
               transactionFragment, removeDates, removeInacct, replaceInacct)
+import Data.FileEmbed (makeRelativeToProject)
 
 -- | The main journal/account register view, with accounts sidebar.
 getRegisterR :: Handler Html
@@ -99,7 +100,7 @@ decorateLinks = concatMap $ \(acct, (name, comma)) ->
 -- | Generate javascript/html for a register balance line chart based on
 -- the provided "AccountTransactionsReportItem"s.
 registerChartHtml :: Text -> String -> [(CommoditySymbol, [AccountTransactionsReportItem])] -> HtmlUrl AppRoute
-registerChartHtml q title percommoditytxnreports = $(hamletFile "templates/chart.hamlet")
+registerChartHtml q title percommoditytxnreports = $(makeRelativeToProject "templates/chart.hamlet" >>= hamletFile)
  -- have to make sure plot is not called when our container (maincontent)
  -- is hidden, eg with add form toggled
  where

--- a/hledger-web/Hledger/Web/Settings/StaticFiles.hs
+++ b/hledger-web/Hledger/Web/Settings/StaticFiles.hs
@@ -5,6 +5,7 @@ import System.IO (stdout, hFlush)
 import Yesod.Static (Static, embed, publicFiles, staticDevel)
 
 import Hledger.Web.Settings (staticDir, development)
+import Data.FileEmbed (makeRelativeToProject)
 
 -- | use this to create your static file serving site
 -- staticSite :: IO Static.Static
@@ -26,6 +27,6 @@ staticSite =
             staticDevel staticDir)
    else (do
             -- putStrLn "Using built-in web files" >> hFlush stdout
-            return $(embed staticDir))
+            return $(makeRelativeToProject staticDir >>= embed))
 
-$(publicFiles staticDir)
+$(makeRelativeToProject staticDir >>= publicFiles)

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -19,6 +19,7 @@ module Hledger.Web.Widget.Common
   , replaceInacct
   ) where
 
+import Data.FileEmbed (makeRelativeToProject)
 import Data.Foldable (find, for_)
 import Data.List (elemIndex)
 import Data.Text (Text)
@@ -79,7 +80,7 @@ helplink topic label _ = H.a ! A.href u ! A.target "hledgerhelp" $ toHtml label
 -- | Render a "BalanceReport" as html.
 balanceReportAsHtml :: Eq r => (r, r) -> r -> Bool -> Journal -> Text -> [QueryOpt] -> BalanceReport -> HtmlUrl r
 balanceReportAsHtml (journalR, registerR) here hideEmpty j q qopts (items, total) =
-  $(hamletFile "templates/balance-report.hamlet")
+  $(makeRelativeToProject "templates/balance-report.hamlet" >>= hamletFile)
   where
     l = ledgerFromJournal Any j
     indent a = preEscapedString $ concat $ replicate (2 + 2 * a) "&nbsp;"

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -169,6 +169,7 @@ library
     , data-default
     , directory >=1.2.3.0
     , extra >=1.6.3
+    , file-embed >=0.0.10
     , filepath
     , hjsmin
     , hledger >=1.24.99 && <1.25

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -117,6 +117,7 @@ library:
   - Decimal >=0.5.1
   - directory >=1.2.3.0
   - extra >=1.6.3
+  - file-embed >=0.0.10
   - filepath
   - hjsmin
   - http-conduit


### PR DESCRIPTION
This is needed for both `cabal build hledger-web` and
`haskell-language-server` to succeed. This was already done in the
heldger-cli package for example but not in the heldger-web package. In
essence, hls and stack/cabal uses different roots when embedding files
in template haskell in sub-packages.

Reference: https://github.com/haskell/haskell-language-server/issues/481#issuecomment-737775878

Example of error:
```
2021-12-12 22:33:08.881739011 [ThreadId 71316] INFO hls:        File:     /home/timi/Projects/hledger-official/hledger-web/Hledger/Web/Handler/RegisterR.hs
Hidden:   no
Range:    102:52-102:90
Source:   typecheck
Severity: DsError
Message: 
  • Exception when trying to run compile-time code:
  templates/chart.hamlet: openFile: does not exist (No such file or directory)
  Code: hamletFile "templates/chart.hamlet"
  • In the untyped splice: $(hamletFile "templates/chart.hamlet")
```