### PR TITLE
imp: smartdates: Simplify and generalise the SmartDate constructor and

### DIFF
--- a/hledger-lib/Hledger/Data/PeriodicTransaction.hs
+++ b/hledger-lib/Hledger/Data/PeriodicTransaction.hs
@@ -263,7 +263,7 @@ checkPeriodicTransactionStartDate i s periodexpr =
     _                    -> Nothing
     where
       checkStart d x =
-        let firstDate = fixSmartDate d $ SmartRelative This x
+        let firstDate = fixSmartDate d $ SmartRelative 0 x
         in
          if d == firstDate
          then Nothing

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -84,10 +84,9 @@ data SmartDate
   = SmartAssumeStart Year (Maybe (Month, Maybe MonthDay))
   | SmartFromReference (Maybe Month) MonthDay
   | SmartMonth Month
-  | SmartRelative SmartSequence SmartInterval
+  | SmartRelative Integer SmartInterval
   deriving (Show)
 
-data SmartSequence = Last | This | Next deriving (Show)
 data SmartInterval = Day | Week | Month | Quarter | Year deriving (Show)
 
 data WhichDate = PrimaryDate | SecondaryDate deriving (Eq,Show)

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -461,6 +461,9 @@ Examples:
 | `october, oct`                               | start of month in current year                                                        |
 | `yesterday, today, tomorrow`                 | -1, 0, 1 days from today                                                              |
 | `last/this/next day/week/month/quarter/year` | -1, 0, 1 periods from the current period                                              |
+| `in n days/weeks/months/quarters/years`      | n periods from the current period                                                     |
+| `n days/weeks/months/quarters/years ahead`   | n periods from the current period                                                     |
+| `n days/weeks/months/quarters/years ago`     | -n periods from the current period                                                    |
 | `20181201`                                   | 8 digit YYYYMMDD with valid year month and day                                        |
 | `201812`                                     | 6 digit YYYYMM with valid year and month                                              |
 


### PR DESCRIPTION
parsers to allow for arbitrary numbers of periods in relative dates.

We now accept smart dates like “in 5 days, in -6 months, 2 quarters ago”.