### PR TITLE
Interval-related refactorings and cleanups

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -968,18 +968,14 @@ reportingintervalp = choice'
                                               (toPermutation $ nth <* skipNonNewlineSpaces)
 
     -- Parse any of several variants of a basic interval, eg "daily", "every day", "every N days".
-    tryinterval :: String -> String -> (Int -> Interval) -> TextParser m Interval
+    tryinterval :: Text -> Text -> (Int -> Interval) -> TextParser m Interval
     tryinterval singular compact intcons = intcons <$> choice'
-        [ 1 <$ string' compact'
+        [ 1 <$ string' compact
         , string' "every" *> skipNonNewlineSpaces *> choice
-            [ 1 <$ string' singular'
-            , decimal <* skipNonNewlineSpaces <* string' plural'
+            [ 1 <$ string' singular
+            , decimal <* skipNonNewlineSpaces <* string' (singular <> "s")
             ]
         ]
-      where
-        compact'  = T.pack compact
-        singular' = T.pack singular
-        plural'   = T.pack $ singular ++ "s"
 
 periodexprdatespanp :: Day -> TextParser m DateSpan
 periodexprdatespanp rdate = choice $ map try [

--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -66,6 +66,7 @@ module Hledger.Data.Dates (
   latestSpanContaining,
   smartdate,
   splitSpan,
+  spansFromBoundaries,
   groupByDateSpan,
   fixSmartDate,
   fixSmartDateStr,
@@ -206,51 +207,47 @@ spansSpan spans = DateSpan (spanStart =<< headMay spans) (spanEnd =<< lastMay sp
 --
 splitSpan :: Interval -> DateSpan -> [DateSpan]
 splitSpan _ (DateSpan Nothing Nothing) = [DateSpan Nothing Nothing]
-splitSpan _ s | isEmptySpan s = []
-splitSpan NoInterval     s = [s]
-splitSpan (Days n)       s = splitspan startofday     (applyN n nextday)     s
-splitSpan (Weeks n)      s = splitspan startofweek    (applyN n nextweek)    s
-splitSpan (Months n)     s = splitspan startofmonth   (applyN n nextmonth)   s
-splitSpan (Quarters n)   s = splitspan startofquarter (applyN n nextquarter) s
-splitSpan (Years n)      s = splitspan startofyear    (applyN n nextyear)    s
-splitSpan (DayOfMonth n) s = splitspan (nthdayofmonthcontaining n) (nthdayofmonth n . nextmonth) s
-splitSpan (WeekdayOfMonth n wd) s = splitspan (nthweekdayofmonthcontaining n wd) (advancetonthweekday n wd . nextmonth) s
-splitSpan (DaysOfWeek []) s = [s]  -- shouldn't happen in parser but for completeness
-splitSpan (DaysOfWeek days@(n:_)) ds
-  | DateSpan Nothing  (Just e)  <- ds = split (DateSpan (Just $ start e) (Just $ nextday $ start e))
-  | DateSpan (Just s) Nothing  <- ds = split (DateSpan (Just $ start s) (Just $ nextday $ start s))
-  | DateSpan (Just s) (Just e) <- ds =
-      if s == e then [ds] else split (DateSpan (Just $ start s) (Just e))
+splitSpan _ ds | isEmptySpan ds = []
+splitSpan _ ds@(DateSpan (Just s) (Just e)) | s == e = [ds]
+splitSpan NoInterval      ds = [ds]
+splitSpan (Days n)        ds = splitspan startofday     addDays n                    ds
+splitSpan (Weeks n)       ds = splitspan startofweek    addDays (7*n)                ds
+splitSpan (Months n)      ds = splitspan startofmonth   addGregorianMonthsClip n     ds
+splitSpan (Quarters n)    ds = splitspan startofquarter addGregorianMonthsClip (3*n) ds
+splitSpan (Years n)       ds = splitspan startofyear    addGregorianYearsClip n      ds
+splitSpan (DayOfMonth n)  ds = splitspan (nthdayofmonthcontaining n)  addGregorianMonthsClip 1 ds
+splitSpan (DayOfYear m n) ds = splitspan (nthdayofyearcontaining m n) addGregorianYearsClip 1 ds
+splitSpan (WeekdayOfMonth n wd) ds = splitspan (nthweekdayofmonthcontaining n wd) advancemonths 1 ds
   where
-    start = nthdayofweekcontaining n
-
-    wheel = (\x -> zipWith (-) (tail x) x) . concat . zipWith fmap (fmap (+) [0,7..]) . repeat $ days
-
-    split = splitspan' (repeat startofday) (fmap (`applyN` nextday) wheel)
-
-splitSpan (DayOfYear m n) s = splitspan (nthdayofyearcontaining m n) (applyN (n-1) nextday . applyN (m-1) nextmonth . nextyear) s
--- splitSpan (WeekOfYear n)    s = splitspan startofweek    (applyN n nextweek)    s
--- splitSpan (MonthOfYear n)   s = splitspan startofmonth   (applyN n nextmonth)   s
--- splitSpan (QuarterOfYear n) s = splitspan startofquarter (applyN n nextquarter) s
+    advancemonths 0 = id
+    advancemonths w = advancetonthweekday n wd . startofmonth . addGregorianMonthsClip w
+splitSpan (DaysOfWeek [])         ds = [ds]
+splitSpan (DaysOfWeek days@(n:_)) ds = spansFromBoundaries e bdrys
+  where
+    (s, e) = dateSpanSplitLimits (nthdayofweekcontaining n) nextday ds
+    bdrys = concatMap (flip map starts . addDays) [0,7..]
+    -- The first representative of each weekday
+    starts = map (\d -> addDays (toInteger $ d - n) $ nthdayofweekcontaining n s) days
 
 -- Split the given span using the provided helper functions:
 -- start is applied to the span's start date to get the first sub-span's start date
--- next is applied to a sub-span's start date to get the next sub-span's start date
-splitspan :: (Day -> Day) -> (Day -> Day) -> DateSpan -> [DateSpan]
-splitspan _ _ (DateSpan Nothing Nothing) = []
-splitspan start next (DateSpan Nothing (Just e)) = splitspan start next (DateSpan (Just $ start e) (Just $ next $ start e))
-splitspan start next (DateSpan (Just s) Nothing) = splitspan start next (DateSpan (Just $ start s) (Just $ next $ start s))
-splitspan start next span@(DateSpan (Just s) (Just e))
-    | s == e = [span]
-    | otherwise = splitspan' (repeat start) (repeat next) span
+-- addInterval is applied to an integer n (multiplying it by mult) and the span's start date to get the nth sub-span's start date
+splitspan :: (Day -> Day) -> (Integer -> Day -> Day) -> Int -> DateSpan -> [DateSpan]
+splitspan start addInterval mult ds = spansFromBoundaries e bdrys
+  where
+    (s, e) = dateSpanSplitLimits start (addInterval $ toInteger mult) ds
+    bdrys = mapM (addInterval . toInteger) [0,mult..] $ start s
 
-splitspan' :: [Day -> Day] -> [Day -> Day] -> DateSpan -> [DateSpan]
-splitspan' (start:ss) (next:ns) (DateSpan (Just s) (Just e))
-    | s >= e = []
-    | otherwise = DateSpan (Just subs) (Just sube) : splitspan' ss ns (DateSpan (Just sube) (Just e))
-    where subs = start s
-          sube = next subs
-splitspan' _ _ _ = error' "won't happen, avoids warnings"  -- PARTIAL:
+-- | Fill in missing endpoints for calculating 'splitSpan'.
+dateSpanSplitLimits :: (Day -> Day) -> (Day -> Day) -> DateSpan -> (Day, Day)
+dateSpanSplitLimits start _    (DateSpan (Just s) (Just e)) = (start s, e)
+dateSpanSplitLimits start next (DateSpan (Just s) Nothing)  = (start s, next $ start s)
+dateSpanSplitLimits start next (DateSpan Nothing  (Just e)) = (start e, next $ start e)
+dateSpanSplitLimits _     _    (DateSpan Nothing   Nothing) = error "dateSpanSplitLimits: Should not be nulldatespan"  -- PARTIAL: This case should have been handled in splitSpan
+
+-- | Construct a list of 'DateSpan's from a list of boundaries, which fit within a given range.
+spansFromBoundaries :: Day -> [Day] -> [DateSpan]
+spansFromBoundaries e bdrys = zipWith (DateSpan `on` Just) (takeWhile (< e) bdrys) $ drop 1 bdrys
 
 -- | Count the days in a DateSpan, or if it is open-ended return Nothing.
 daysInSpan :: DateSpan -> Maybe Integer
@@ -1070,8 +1067,8 @@ tests_Dates = testGroup "Dates"
             ]
 
   , testCase "match dayOfWeek" $ do
-      let dayofweek n s = splitspan (nthdayofweekcontaining n) (applyN (n-1) nextday . nextweek) s
-          match ds day = dayofweek day ds == splitSpan (DaysOfWeek [day]) ds @?= True
+      let dayofweek n s = splitspan (nthdayofweekcontaining n) (\w -> (if w == 0 then id else applyN (n-1) nextday . applyN (fromInteger w) nextweek)) 1 s
+          match ds day = splitSpan (DaysOfWeek [day]) ds @?= dayofweek day ds
           ys2021 = fromGregorian 2021 01 01
           ye2021 = fromGregorian 2021 12 31
           ys2022 = fromGregorian 2022 01 01

--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -73,7 +73,6 @@ module Hledger.Data.Dates (
   fixSmartDateStrEither',
   yearp,
   daysInSpan,
-  maybePeriod,
 
   tests_Dates
 )
@@ -372,9 +371,6 @@ parsePeriodExpr' :: Day -> Text -> (Interval, DateSpan)
 parsePeriodExpr' refdate s =
   either (error' . ("failed to parse:" ++) . customErrorBundlePretty) id $  -- PARTIAL:
   parsePeriodExpr refdate s
-
-maybePeriod :: Day -> Text -> Maybe (Interval,DateSpan)
-maybePeriod refdate = either (const Nothing) Just . parsePeriodExpr refdate
 
 -- | Show a DateSpan as a human-readable pseudo-period-expression string.
 -- dateSpanAsText :: DateSpan -> String

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -114,11 +114,11 @@ multiBalanceReportWith :: ReportSpec -> Journal -> PriceOracle -> MultiBalanceRe
 multiBalanceReportWith rspec' j priceoracle = report
   where
     -- Queries, report/column dates.
-    reportspan = dbg3 "reportspan" $ reportSpan j rspec'
-    rspec      = dbg3 "reportopts" $ makeReportQuery rspec' reportspan
+    (reportspan, colspans) = reportSpan j rspec'
+    rspec = dbg3 "reportopts" $ makeReportQuery rspec' reportspan
 
     -- Group postings into their columns.
-    colps = dbg5 "colps" $ getPostingsByColumn rspec j priceoracle reportspan
+    colps = dbg5 "colps" $ getPostingsByColumn rspec j priceoracle colspans
 
     -- The matched accounts with a starting balance. All of these should appear
     -- in the report, even if they have no postings during the report period.
@@ -143,11 +143,11 @@ compoundBalanceReportWith :: ReportSpec -> Journal -> PriceOracle
 compoundBalanceReportWith rspec' j priceoracle subreportspecs = cbr
   where
     -- Queries, report/column dates.
-    reportspan = dbg3 "reportspan" $ reportSpan j rspec'
-    rspec      = dbg3 "reportopts" $ makeReportQuery rspec' reportspan
+    (reportspan, colspans) = reportSpan j rspec'
+    rspec = dbg3 "reportopts" $ makeReportQuery rspec' reportspan
 
     -- Group postings into their columns.
-    colps = dbg5 "colps" $ getPostingsByColumn rspec j priceoracle reportspan
+    colps = dbg5 "colps" $ getPostingsByColumn rspec j priceoracle colspans
 
     -- The matched postings with a starting balance. All of these should appear
     -- in the report, even if they have no postings during the report period.
@@ -240,14 +240,13 @@ makeReportQuery rspec reportspan
     dateqcons        = if date2_ (_rsReportOpts rspec) then Date2 else Date
 
 -- | Group postings, grouped by their column
-getPostingsByColumn :: ReportSpec -> Journal -> PriceOracle -> DateSpan -> [(DateSpan, [Posting])]
-getPostingsByColumn rspec j priceoracle reportspan =
+getPostingsByColumn :: ReportSpec -> Journal -> PriceOracle -> [DateSpan] -> [(DateSpan, [Posting])]
+getPostingsByColumn rspec j priceoracle colspans =
     groupByDateSpan True getDate colspans ps
   where
     -- Postings matching the query within the report period.
     ps = dbg5 "getPostingsByColumn" $ getPostings rspec j priceoracle
     -- The date spans to be included as report columns.
-    colspans = dbg3 "colspans" $ splitSpan (interval_ $ _rsReportOpts rspec) reportspan
     getDate = postingDateOrDate2 (whichDate (_rsReportOpts rspec))
 
 -- | Gather postings matching the query within the report period.

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -332,14 +332,14 @@ tests_PostingsReport = testGroup "PostingsReport" [
         let periodexpr `gives` dates = do
               j' <- samplejournal
               registerdates (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j') `is` dates
-                  where opts = defreportopts{period_=maybePeriod date1 periodexpr}
+                  where opts = defreportopts{period_=Just $ parsePeriodExpr' date1 periodexpr}
         ""     `gives` ["2008/01/01","2008/06/01","2008/06/02","2008/06/03","2008/12/31"]
         "2008" `gives` ["2008/01/01","2008/06/01","2008/06/02","2008/06/03","2008/12/31"]
         "2007" `gives` []
         "june" `gives` ["2008/06/01","2008/06/02","2008/06/03"]
         "monthly" `gives` ["2008/01/01","2008/06/01","2008/12/01"]
         "quarterly" `gives` ["2008/01/01","2008/04/01","2008/10/01"]
-        let opts = defreportopts{period_=maybePeriod date1 "yearly"}
+        let opts = defreportopts{period_=Just $ parsePeriodExpr' date1 "yearly"}
         (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` unlines
          ["2008/01/01 - 2008/12/31         assets:bank:saving               $1           $1"
          ,"                                assets:cash                     $-2          $-1"
@@ -349,9 +349,9 @@ tests_PostingsReport = testGroup "PostingsReport" [
          ,"                                income:salary                   $-1          $-1"
          ,"                                liabilities:debts                $1            0"
          ]
-        let opts = defreportopts{period_=maybePeriod date1 "quarterly"}
+        let opts = defreportopts{period_=Just $ parsePeriodExpr' date1 "quarterly"}
         registerdates (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` ["2008/01/01","2008/04/01","2008/10/01"]
-        let opts = defreportopts{period_=maybePeriod date1 "quarterly",empty_=True}
+        let opts = defreportopts{period_=Just $ parsePeriodExpr' date1 "quarterly",empty_=True}
         registerdates (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` ["2008/01/01","2008/04/01","2008/07/01","2008/10/01"]
 
       ]

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -597,10 +597,10 @@ journalApplyValuationFromOptsWith rspec@ReportSpec{_rsReportOpts=ropts} j priceo
     -- Find the end of the period containing this posting
     periodEnd  = addDays (-1) . fromMaybe err . mPeriodEnd . postingDate
     mPeriodEnd = case interval_ ropts of
-        NoInterval -> const . spanEnd $ reportSpan j rspec
+        NoInterval -> const . spanEnd . fst $ reportSpan j rspec
         _          -> spanEnd <=< latestSpanContaining (historical : spans)
     historical = DateSpan Nothing $ spanStart =<< headMay spans
-    spans = splitSpan (interval_ ropts) $ reportSpanBothDates j rspec
+    spans = snd $ reportSpanBothDates j rspec
     styles = journalCommodityStyles j
     err = error "journalApplyValuationFromOpts: expected all spans to have an end date"
 
@@ -655,18 +655,20 @@ queryFromFlags ReportOpts{..} = simplifyQuery $ And flagsq
 -- options or queries, or otherwise the earliest and latest transaction or
 -- posting dates in the journal. If no dates are specified by options/queries
 -- and the journal is empty, returns the null date span.
-reportSpan :: Journal -> ReportSpec -> DateSpan
+-- Also return the intervals if they are requested.
+reportSpan :: Journal -> ReportSpec -> (DateSpan, [DateSpan])
 reportSpan = reportSpanHelper False
 
 -- | Like reportSpan, but uses both primary and secondary dates when calculating
 -- the span.
-reportSpanBothDates :: Journal -> ReportSpec -> DateSpan
+reportSpanBothDates :: Journal -> ReportSpec -> (DateSpan, [DateSpan])
 reportSpanBothDates = reportSpanHelper True
 
 -- | A helper for reportSpan, which takes a Bool indicating whether to use both
 -- primary and secondary dates.
-reportSpanHelper :: Bool -> Journal -> ReportSpec -> DateSpan
-reportSpanHelper bothdates j ReportSpec{_rsQuery=query, _rsReportOpts=ropts} = reportspan
+reportSpanHelper :: Bool -> Journal -> ReportSpec -> (DateSpan, [DateSpan])
+reportSpanHelper bothdates j ReportSpec{_rsQuery=query, _rsReportOpts=ropts} =
+    (reportspan, intervalspans)
   where
     -- The date span specified by -b/-e/-p options and query args if any.
     requestedspan  = dbg3 "requestedspan" $ if bothdates then queryDateSpan' query else queryDateSpan (date2_ ropts) query
@@ -690,10 +692,10 @@ reportSpanHelper bothdates j ReportSpec{_rsQuery=query, _rsReportOpts=ropts} = r
                                               (spanEnd =<< lastMay intervalspans)
 
 reportStartDate :: Journal -> ReportSpec -> Maybe Day
-reportStartDate j = spanStart . reportSpan j
+reportStartDate j = spanStart . fst . reportSpan j
 
 reportEndDate :: Journal -> ReportSpec -> Maybe Day
-reportEndDate j = spanEnd . reportSpan j
+reportEndDate j = spanEnd . fst . reportSpan j
 
 -- Some pure alternatives to the above. XXX review/clean up
 

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -340,7 +340,7 @@ balancemode = hledgerCommandMode
 balance :: CliOpts -> Journal -> IO ()
 balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ of
     CalcBudget -> do  -- single or multi period budget report
-      let reportspan = reportSpan j rspec
+      let reportspan = fst $ reportSpan j rspec
           budgetreport = budgetReport rspec (balancingopts_ $ inputopts_ opts) reportspan j
           render = case fmt of
             "txt"  -> budgetReportAsText ropts

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -81,25 +81,14 @@ roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsReportOpts=ReportO
   pnlQuery         <- makeQuery "pnl"
 
   let
-    trans = dbg3 "investments" $ jtxns $ filterJournalTransactions investmentsQuery j
-
-    journalSpan =
-        let dates = map (transactionDateOrDate2 wd) trans in
-        DateSpan (Just $ minimum dates) (Just $ addDays 1 $ maximum dates)
-
-    requestedSpan = periodAsDateSpan period_
-    requestedInterval = interval_
-
-    wholeSpan = dbg3 "wholeSpan" $ spanDefaultsFrom requestedSpan journalSpan
+    filteredj = filterJournalTransactions investmentsQuery j
+    trans = dbg3 "investments" $ jtxns filteredj
 
   when (null trans) $ do
     putStrLn "No relevant transactions found. Check your investments query"
     exitFailure
 
-  let spans = case requestedInterval of
-        NoInterval -> [wholeSpan]
-        interval ->
-            splitSpan interval wholeSpan
+  let spans = snd $ reportSpan filteredj rspec
 
   let priceDirectiveDates = dbg3 "priceDirectiveDates" $ map pddate $ jpricedirectives j
 

--- a/hledger/Hledger/Cli/Commands/Stats.hs
+++ b/hledger/Hledger/Cli/Commands/Stats.hs
@@ -48,8 +48,7 @@ stats opts@CliOpts{reportspec_=rspec, progstarttime_} j = do
   let today = _rsDay rspec
       q = _rsQuery rspec
       l = ledgerFromJournal q j
-      reportspan = ledgerDateSpan l `spanDefaultsFrom` queryDateSpan False q
-      intervalspans = splitSpan (interval_ $ _rsReportOpts rspec) reportspan
+      intervalspans = snd $ reportSpanBothDates j rspec
       showstats = showLedgerStats l today
       (ls, txncounts) = unzip $ map showstats intervalspans
       numtxns = sum txncounts

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -136,7 +136,7 @@ compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=r
             _          -> showDateSpan requestedspan
           where
             enddates = map (addDays (-1)) . mapMaybe spanEnd $ cbrDates cbr  -- these spans will always have a definite end date
-            requestedspan = reportSpan j rspec
+            requestedspan = fst $ reportSpan j rspec
 
         -- when user overrides, add an indication to the report title
         -- Do we need to deal with overridden BalanceCalculation?


### PR DESCRIPTION
In particular, `splitSpan` is refactored to make it easier to reason about.