### PR TITLE
Manual: clarify reference from --strict to check

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -440,7 +440,8 @@ With the `-s`/`--strict` flag, additional checks are performed:
   ([Commodity error checking](#commodity-error-checking))
 - Are all commodity conversions declared explicitly ?
 
-You can also use the [check](#check) command to run these and some additional checks.
+You can use the [check](#check) command to run individual checks -- the
+ones listed above and some more.
 
 # TIME PERIODS
 ## Smart dates


### PR DESCRIPTION
Me on the mailing list, after skimming the manual section on `--strict`:

> `--strict` does too much for me, ...

Simon kindly informs me that the check command can run individual checks.

https://groups.google.com/g/hledger/c/l3wPnljbLco/m/BvGYgyBTAwAJ

I went back to the manual and found that `--strict` refers to `check`. I'm not sure how I could miss it. I hope that my small change improves the situation a bit.
