### PR TITLE
imp: csv: Give an error if unable to substitute csv templates. (#1803)

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -1249,10 +1249,10 @@ renderTemplate rules record t = maybe t mconcat $ parseMaybe
 
 -- | Replace something that looks like a reference to a csv field ("%date" or "%1)
 -- with that field's value. If it doesn't look like a field reference, or if we
--- can't find such a field, leave it unchanged.
+-- can't find such a field, replace it with the empty string.
 replaceCsvFieldReference :: CsvRules -> CsvRecord -> CsvFieldReference -> Text
 replaceCsvFieldReference rules record s = case T.uncons s of
-    Just ('%', fieldname) -> fromMaybe s $ csvFieldValue rules record fieldname
+    Just ('%', fieldname) -> fromMaybe "" $ csvFieldValue rules record fieldname
     _                     -> s
 
 -- | Get the (whitespace-stripped) value of a CSV field, identified by its name or

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -1032,6 +1032,19 @@ $  ./csvtest.sh
 
 >=0
 
+# 51. Throw an error when unable to substitute csv templates
+<
+"2021-12-23","caffe_siciliaexpenses:cibo:dolce","-10.5"
+
+RULES file
+
+account1 assets:bank:checking
+fields date, description, account2, amount
+
+$  ./csvtest.sh
+>2 /could not balance this transaction/
+>=1
+
 ## . 
 #<
 #$  ./csvtest.sh


### PR DESCRIPTION
Fixes #1803.