### PR TITLE
fix: csv: Allow unicode in field references for csv. (#1809)

### DIFF
--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -45,7 +45,7 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.IO.Class     (MonadIO, liftIO)
 import Control.Monad.State.Strict (StateT, get, modify', evalStateT)
 import Control.Monad.Trans.Class  (lift)
-import Data.Char                  (toLower, isDigit, isSpace, isAlphaNum, isAscii, ord)
+import Data.Char                  (toLower, isDigit, isSpace, isAlphaNum, ord)
 import Data.Bifunctor             (first)
 import Data.List (elemIndex, foldl', intersperse, mapAccumL, nub, sortBy)
 import Data.Maybe (catMaybes, fromMaybe, isJust)
@@ -1245,7 +1245,7 @@ renderTemplate rules record t = maybe t mconcat $ parseMaybe
     t
   where
     referencep = liftA2 T.cons (char '%') (takeWhile1P (Just "reference") isFieldNameChar) :: Parsec CustomErr Text Text
-    isFieldNameChar c = isAscii c && (isAlphaNum c || c == '_' || c == '-')
+    isFieldNameChar c = isAlphaNum c || c == '_' || c == '-'
 
 -- | Replace something that looks like a reference to a csv field ("%date" or "%1)
 -- with that field's value. If it doesn't look like a field reference, or if we

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -1014,6 +1014,24 @@ $  ./csvtest.sh
 
 >=0
 
+# 50. Allow unicode field references (#1809)
+<
+Date, Description, Id, Amount
+12/11/2019, Foo, 123, 10.23
+
+RULES
+skip         1
+fields       date, description, unicöde, amount
+date-format  %d/%m/%Y
+code         %unicöde
+
+$  ./csvtest.sh
+2019-11-12 (123) Foo
+    expenses:unknown           10.23
+    income:unknown            -10.23
+
+>=0
+
 ## . 
 #<
 #$  ./csvtest.sh


### PR DESCRIPTION
Fixes #1809.