### PR TITLE
fix: price: Make sure inferred market prices have the correct sign with

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -66,6 +66,7 @@ module Hledger.Data.Posting (
   postingApplyValuation,
   postingToCost,
   postingAddInferredEquityPostings,
+  postingPriceDirectivesFromCost,
   tests_Posting
 )
 where
@@ -73,7 +74,7 @@ where
 import Data.Default (def)
 import Data.Foldable (asum)
 import qualified Data.Map as M
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.List (foldl', sort, union)
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -455,6 +456,12 @@ postingAddInferredEquityPostings equityAcct p = taggedPosting : concatMap conver
 
     priceTag = ("cost", T.strip . wbToText $ foldMap showAmountPrice priceAmounts)
     priceAmounts = filter (isJust . aprice) . amountsRaw $ pamount p
+
+-- | Make a market price equivalent to this posting's amount's unit
+-- price, if any.
+postingPriceDirectivesFromCost :: Posting -> [PriceDirective]
+postingPriceDirectivesFromCost p@Posting{pamount} =
+    mapMaybe (amountPriceDirectiveFromCost $ postingDate p) $ amountsRaw pamount
 
 -- | Apply a transform function to this posting's amount.
 postingTransformAmount :: (MixedAmount -> MixedAmount) -> Posting -> Posting

--- a/hledger-lib/Hledger/Utils.hs
+++ b/hledger-lib/Hledger/Utils.hs
@@ -234,6 +234,22 @@ sequence' ms = do
 mapM' :: Monad f => (a -> f b) -> [a] -> f [b]
 mapM' f = sequence' . map f
 
+-- | Find the number of digits of an 'Int'.
+numDigitsInt :: Integral a => Int -> a
+numDigitsInt n
+    | n == minBound = 19  -- negate minBound is out of the range of Int
+    | n < 0         = go (negate n)
+    | otherwise     = go n
+  where
+    go a | a < 10                 = 1
+         | a < 100                = 2
+         | a < 1000               = 3
+         | a < 10000              = 4
+         | a >= 10000000000000000 = 16 + go (a `quot` 10000000000000000)
+         | a >= 100000000         = 8  + go (a `quot` 100000000)
+         | otherwise              = 4  + go (a `quot` 10000)
+{-# INLINE numDigitsInt #-}
+
 -- | Simpler alias for errorWithoutStackTrace
 error' :: String -> a
 error' = errorWithoutStackTrace

--- a/hledger/test/prices.test
+++ b/hledger/test/prices.test
@@ -32,10 +32,15 @@ P 2016/2/1 EUR $1.05
 2016/1/3 spend
     expenses             20 EUR @@ $21.45
     assets:bank
+
+2016/1/4 spend
+    expenses            -20 EUR @@ $21.45
+    assets:bank
 $ hledger prices -f- --infer-market-prices
 P 2016-01-01 EUR $1.06
 P 2016-01-02 EUR $1.07
 P 2016-01-03 EUR $1.0725
+P 2016-01-04 EUR $1.0725
 P 2016-02-01 EUR $1.05
 
 # 3. inverted prices can be calculated


### PR DESCRIPTION
total prices. (Fixes #1813)

Also reduce duplication for inferring market prices (previously it was
done separately in both Hledger.Data.Journal and
Hledger.Cli.Commands.Prices), and remove *TotalPriceToUnitPrice
functions, since unit prices cannot represent all total prices.