### PR TITLE
imp!: journal: Remove deprecated account type code syntax from account directives.

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3037,7 +3037,7 @@ account assets:bank:checking
 
 Here is the full syntax of account directives:
 ```journal
-account ACCTNAME  [ACCTTYPE] [;COMMENT]
+account ACCTNAME  [;type:ACCTTYPE] [COMMENT]
   [;COMMENTS]
   [LEDGER-STYLE SUBDIRECTIVES, IGNORED]
 ```

--- a/hledger/test/journal/directive-account.test
+++ b/hledger/test/journal/directive-account.test
@@ -13,11 +13,11 @@ b
 # "b" is a liability. "b:bb" is an asset.
 <
 ; a liability
-account asset  L
+account asset  ; type:L
 ; an asset
-account b:bb   A
+account b:bb   ; type:A
 ; a liability
-account b      L
+account b      ; type:L
 
 2018/1/1
   (asset:a)  1

--- a/hledger/test/journal/transaction-prices.test
+++ b/hledger/test/journal/transaction-prices.test
@@ -329,7 +329,7 @@ hledger -f - balance --no-total -E -B
 # 27. The equity account used by --infer-equity can be customised
 hledger -f- print --infer-equity
 <<<
-account  equity:trades   V
+account  equity:trades   ; type:V
 
 2011/01/01
     expenses:foreign currency       €100 @ $1.35


### PR DESCRIPTION
Previously, you declare an account type with the following format:
account assets  A
This has been deprecated since 1.13, and should now be declared with oneof:
account assets  ; type:A
account assets  ; type:asset