### PR TITLE
feat: queries can now match account tags (#1817)

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -39,6 +39,7 @@ module Hledger.Data.Posting (
   postingStripPrices,
   postingApplyAliases,
   postingApplyCommodityStyles,
+  postingAddTags,
   -- * date operations
   postingDate,
   postingDate2,
@@ -82,7 +83,7 @@ import Data.Foldable (asum)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust)
 import Data.MemoUgly (memo)
-import Data.List (foldl', sort)
+import Data.List (foldl', sort, union)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -444,6 +445,10 @@ postingApplyCommodityStyles styles p = p{pamount=styleMixedAmount styles $ pamou
                                         ,pbalanceassertion=fixbalanceassertion <$> pbalanceassertion p}
   where
     fixbalanceassertion ba = ba{baamount=styleAmountExceptPrecision styles $ baamount ba}
+
+-- | Add tags to a posting, discarding any for which the posting already has a value.
+postingAddTags :: Posting -> [Tag] -> Posting
+postingAddTags p@Posting{ptags} tags = p{ptags=ptags `union` tags}
 
 -- | Rewrite an account name using all matching aliases from the given list, in sequence.
 -- Each alias sees the result of applying the previous aliases.

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -530,6 +530,8 @@ data Journal = Journal {
                                                                     --   TODO: FilePath is a sloppy type here, don't assume it's a
                                                                     --   real file; values like "", "-", "(string)" can be seen
   ,jlastreadtime          :: POSIXTime                              -- ^ when this journal was last read from its file(s)
+  -- NOTE: after adding new fields, eg involving account names, consider updating
+  -- the Anon instance in Hleger.Cli.Anon
   } deriving (Eq, Generic)
 
 -- | A journal in the process of being parsed, not yet finalised.

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -362,7 +362,8 @@ data Posting = Posting {
       pamount           :: MixedAmount,
       pcomment          :: Text,              -- ^ this posting's comment lines, as a single non-indented multi-line string
       ptype             :: PostingType,
-      ptags             :: [Tag],                   -- ^ tag names and values, extracted from the comment
+      ptags             :: [Tag],                   -- ^ tag names and values, extracted from the posting comment 
+                                                    --   and (after finalisation) the posting account's directive if any
       pbalanceassertion :: Maybe BalanceAssertion,  -- ^ an expected balance in the account after this posting,
                                                     --   in a single commodity, excluding subaccounts.
       ptransaction      :: Maybe Transaction,       -- ^ this posting's parent transaction (co-recursive types).
@@ -512,6 +513,7 @@ data Journal = Journal {
   -- principal data
   ,jdeclaredpayees        :: [(Payee,PayeeDeclarationInfo)]         -- ^ Payees declared by payee directives, in parse order (after journal finalisation)
   ,jdeclaredaccounts      :: [(AccountName,AccountDeclarationInfo)] -- ^ Accounts declared by account directives, in parse order (after journal finalisation)
+  ,jdeclaredaccounttags   :: M.Map AccountName [Tag]                -- ^ Accounts which have tags declared in their directives, and those tags. (Does not include parents' tags.)
   ,jdeclaredaccounttypes  :: M.Map AccountType [AccountName]        -- ^ Accounts whose type has been declared in account directives (usually 5 top-level accounts)
   ,jglobalcommoditystyles :: M.Map CommoditySymbol AmountStyle      -- ^ per-commodity display styles declared globally, eg by command line option or import command
   ,jcommodities           :: M.Map CommoditySymbol Commodity        -- ^ commodities and formats declared by commodity directives

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -288,19 +288,27 @@ parseAndFinaliseJournal' parser iopts f txt = do
 
 -- | Post-process a Journal that has just been parsed or generated, in this order:
 --
--- - apply canonical amount styles,
+-- - add misc info (file path, read time) 
 --
--- - save misc info and reverse transactions into their original parse order,
+-- - reverse transactions into their original parse order
 --
--- - add forecast transactions,
+-- - apply canonical commodity styles
 --
--- - evaluate balance assignments and balance each transaction,
+-- - add forecast transactions if enabled
 --
--- - apply transaction modifiers (auto postings) if enabled,
+-- - add auto postings if enabled
 --
--- - check balance assertions if enabled.
+-- - evaluate balance assignments and balance each transaction
 --
--- - infer transaction-implied market prices from transaction prices
+-- - check balance assertions if enabled
+--
+-- - infer equity postings in conversion transactions if enabled
+--
+-- - infer market prices from costs if enabled
+--
+-- - check all accounts have been declared if in strict mode
+--
+-- - check all commodities have been declared if in strict mode
 --
 journalFinalise :: InputOpts -> FilePath -> Text -> ParsedJournal -> ExceptT String IO Journal
 journalFinalise iopts@InputOpts{auto_,infer_equity_,balancingopts_,strict_} f txt pj = do

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -73,7 +73,7 @@ where
 --- ** imports
 import qualified Control.Monad.Fail as Fail (fail)
 import qualified Control.Exception as C
-import Control.Monad (forM_, when, void)
+import Control.Monad (forM_, when, void, unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Except (ExceptT(..), runExceptT)
 import Control.Monad.State.Strict (evalStateT,get,modify',put)
@@ -360,6 +360,7 @@ accountdirectivep = do
 
   -- update the journal
   addAccountDeclaration (acct, cmt, tags)
+  unless (null tags) $ addDeclaredAccountTags acct tags
   case metype of
     Nothing         -> return ()
     Just (Right t)  -> addDeclaredAccountType acct t

--- a/hledger/Hledger/Cli/Anon.hs
+++ b/hledger/Hledger/Cli/Anon.hs
@@ -19,6 +19,7 @@ import Numeric (showHex)
 import qualified Data.Text as T
 
 import Hledger.Data
+import Data.Map (mapKeys)
 
 class Anon a where
     -- | Consistent converter to structure with sensitive data anonymized
@@ -27,9 +28,11 @@ class Anon a where
 instance Anon Journal where
     -- Apply the anonymisation transformation on a journal after finalisation
     anon j = j { jtxns = map anon . jtxns $ j
-               , jparseparentaccounts = map anonAccount $ jparseparentaccounts j
-               , jparsealiases = []  -- already applied
-               , jdeclaredaccounts = map (first anon) $ jdeclaredaccounts j
+               , jparseparentaccounts  = map anonAccount $ jparseparentaccounts j
+               , jparsealiases         = []  -- already applied
+               , jdeclaredaccounts     = map (first anon) $ jdeclaredaccounts j
+               , jdeclaredaccounttags  = mapKeys anon $ jdeclaredaccounttags j
+               , jdeclaredaccounttypes = (map anon) <$> jdeclaredaccounttypes j
                }
 
 instance Anon Posting where

--- a/hledger/Hledger/Cli/Commands/Accounts.hs
+++ b/hledger/Hledger/Cli/Commands/Accounts.hs
@@ -55,7 +55,9 @@ accounts CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{_rsQuery=query,_rsRepo
       -- just the acct: part of the query will be reapplied later, after clipping
       acctq    = dbg1 "acctq" $ filterQuery queryIsAcct query
       depth    = dbg1 "depth" $ queryDepth $ filterQuery queryIsDepth query
-      matcheddeclaredaccts = dbg1 "matcheddeclaredaccts" $ filter (matchesAccount nodepthq) $ map fst $ jdeclaredaccounts j
+      matcheddeclaredaccts =
+        dbg1 "matcheddeclaredaccts" $
+        filter (\a -> matchesTaggedAccount nodepthq (a, (journalInheritedAccountTags j a))) $ map fst $ jdeclaredaccounts j
       matchedusedaccts     = dbg5 "matchedusedaccts" $ map paccount $ journalPostings $ filterJournalPostings nodepthq j
       accts                = dbg5 "accts to show" $ -- no need to nub/sort, accountTree will
         if | declared     && not used -> matcheddeclaredaccts

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -850,9 +850,12 @@ Match unmarked, pending, or cleared transactions respectively.
 **`tag:REGEX[=REGEX]`**\
 Match by tag name, and optionally also by tag value.
 (To match only by value, use `tag:.=REGEX`.)
-Note that postings also inherit tags from their transaction,
-and transactions also acquire tags from their postings,
-when querying.
+
+When querying by tag, note that:
+
+- Accounts also inherit the tags of their parent accounts
+- Postings also inherit the tags of their account and their transaction 
+- Transactions also acquire the tags of their postings.
 
 (**`inacct:ACCTNAME`**\
 A special query term used automatically in hledger-web only:
@@ -2977,15 +2980,11 @@ in another commodity. See [Valuation](#valuation).
 Though not required, these declarations can provide several benefits:
 
 - They can document your intended chart of accounts, providing a reference.
-- They can help hledger know your accounts' types (asset, liability, equity, revenue, expense),
-  useful for reports like balancesheet and incomestatement.
-- They control account display order in reports, allowing non-alphabetic sorting
-  (eg Revenues to appear above Expenses).
-- They can store extra information about accounts (account numbers, notes, etc.)
-- They help with account name completion
-  in the add command, hledger-iadd, hledger-web, ledger-mode etc.
-- In [strict mode], they restrict which accounts may be posted to by transactions,
-  which helps detect typos.
+- They control account display order in reports, allowing non-alphabetic sorting (eg Revenues to appear above Expenses).
+- They can help hledger know your accounts' types (asset, liability, equity, revenue, expense), useful for reports like balancesheet and incomestatement.
+- They can store other account information, as comments or as tags which can be used to filter reports.
+- They help with account name completion (in hledger add, hledger-web, hledger-iadd, ledger-mode, etc.)
+- In [strict mode], they restrict which accounts may be posted to by transactions, which helps detect typos.
 
 The simplest form is just the word `account` followed by a hledger-style
 [account name](#account-names), eg this account directive declares the `assets:bank:checking` account: 
@@ -3018,12 +3017,12 @@ In [strict mode], enabled with the `-s`/`--strict` flag, hledger will report an 
 
 An example of both:
 ```journal
-account assets:bank:checking  ; same-line comment, note 2+ spaces before ;
+account assets:bank:checking    ; same-line comment, note 2+ spaces required before ;
   ; next-line comment
-  ; another with tag, acctno:12345 (not used yet)
+  ; some tags, type:A, acctnum:12345
 ```
 
-Same-line comments are not supported by Ledger, or hledger <1.13.
+Compatibility note: same-line comments are not supported by Ledger or hledger <1.13.
 
 <!-- Account comments may include [tags](#tags), though we don't yet use them for anything. -->
 
@@ -3063,25 +3062,33 @@ you can declare hledger accounts to be of a certain type:
 - **conversion**\
   a subtype of equity, used for [conversion postings](#costing)
 
-Declaring account types is a good idea, since it helps enable the easy 
+Declaring account types is a good idea: they are required by the convenient 
 [balancesheet], [balancesheetequity], [incomestatement] and [cashflow] reports, 
 and probably other things in future. 
+You can also use them with other commands to reliably select accounts by type, 
+without depending on their names. Eg:
+```shell
+hledger balance tag:type=^[AL]
+```
+
 As a convenience, when account types are not declared, 
 hledger will try to guess them based on english-language account names.
 
 Here is a typical set of top-level account declarations 
-(because of the aforementioned, with these account names the type tags are not strictly needed,
-but with non-english or non-standard account names, they will be):
+(with these account names the type tags are not strictly needed,
+but with non-english or non-standard account names, they would be):
 
 ```journal
-account assets       ; type: A
-account liabilities  ; type: L
-account equity       ; type: E
-account revenues     ; type: R
-account expenses     ; type: X
+account assets             ; type: A
+account liabilities        ; type: L
+account equity             ; type: E
+account revenues           ; type: R
+account expenses           ; type: X
 
-account assets:bank  ; type: C
-account assets:cash  ; type: C
+account assets:bank        ; type: C
+account assets:cash        ; type: C
+
+account equity:conversion  ; type: V
 ```
 
 It's not necessary to declare the type of subaccounts.

--- a/hledger/test/journal/anon.test
+++ b/hledger/test/journal/anon.test
@@ -13,28 +13,28 @@ alias tips=expenses:tips
     (tips)  3
 
 # Basic tests on accounts
-
+# 1.
 $ hledger -f- print --anon
 > !/assets|liabilities|expenses|tips/
-
+# 2.
 $ hledger -f- reg --anon
 > !/assets|liabilities|expenses|tips/
-
+# 3.
 $ hledger -f- bal --anon
 > !/assets|liabilities|expenses|tips/
-
+# 4.
 $ hledger -f- accounts --anon
 > !/assets|liabilities|expenses|tips/
 
 # Basic tests on descriptions and comments
-
+# 5.
 $ hledger -f- print --anon
 > !/borrow|signed/
-
+# 6.
 $ hledger -f- reg --anon
 > !/borrow/
 
 # Basic tests on transaction code
-
+# 7.
 $ hledger -f- print --anon
 > !/receipt/

--- a/hledger/test/query-tag.test
+++ b/hledger/test/query-tag.test
@@ -120,3 +120,97 @@ $ hledger -f - print not:tag:.
 # 6. query is not affected by implicit tags (XXX ?)
 $ hledger -f ../../examples/sample.journal reg tag:d
 
+# Querying accounts by tag.
+<
+account a   ; type:A
+account l   ; type:Liability
+account r   ; type:R
+account o   ; othertag:
+account u
+
+2022-01-01
+  (r)        1
+
+2022-01-02
+  (a)        1
+  (l)        1
+
+# 7. We can match declared accounts by having a tag,
+$ hledger -f- accounts --declared tag:.
+a
+l
+r
+o
+
+# 8. not having a tag,
+$ hledger -f- accounts --declared not:tag:.
+u
+
+# 9. or a tag and it's value. Tag values are matched infix.
+$ hledger -f- accounts --declared tag:type=a
+a
+l
+
+# 10. So we must anchor the regex to match single-letter account types.
+$ hledger -f- accounts --declared tag:type=^a$
+a
+
+# 11. But if account type was declared in the long form, matching just one letter fails
+$ hledger -f- accounts --declared tag:type=^l$
+
+# 12. so we need to match more loosely
+$ hledger -f- accounts --declared tag:type=^l
+l
+
+# 13. In the same way, we can match used accounts by tag.
+$ hledger -f- accounts --used tag:type=r
+r
+
+# 14. We can match postings by their account's tags.
+$ hledger -f- register -w80 tag:type=^a
+2022-01-02                      (a)                              1             1
+
+# 15. We can match transactions by their accounts' tags.
+$ hledger -f- print tag:type=^a
+2022-01-02
+    (a)               1
+    (l)               1
+
+>=
+
+# 16. And negatively match them by tag.
+$ hledger -f- print tag:type=^a not:tag:type=^l
+
+# 17. We can filter balance reports by account tags.
+$ hledger -f- bal tag:type=^a
+                   1  a
+--------------------
+                   1  
+
+# 18. Postingless declared accounts in balance reports are also filtered.
+$ hledger -f- bal -N --declared -E o u tag:othertag
+                   0  o
+
+# 19. Accounts inherit the tags of their parents.
+<
+account a    ; type:A
+account a:aa
+
+$ hledger -f- accounts tag:type=a
+a
+a:aa
+
+# 20.
+<
+account a    ; type:A
+account a:aa
+
+2022-01-01
+  (a:aa)    1
+
+$ hledger -f- bal -N tag:type=a
+                   1  a:aa
+
+# 21.
+$ hledger -f- reg -w80 tag:type=a
+2022-01-01                      (a:aa)                           1             1

--- a/hledger/test/query-tag.test
+++ b/hledger/test/query-tag.test
@@ -1,8 +1,7 @@
 # 1. we parse metadata tags in transaction and posting comments. Currently,
 # - they can be on the same line and/or separate lines
 # - they are always printed on separate lines
-hledger -f - print
-<<<
+<
 2010/01/01  ; txntag1: txn val 1
   ; txntag2: txn val 2
   a             1
@@ -11,7 +10,7 @@ hledger -f - print
   b            -1   ; posting-2-tag-1: posting 2 val 1
   ; posting-2-tag-2:
 ; non-metadata:
->>>
+$ hledger -f - print
 2010-01-01  ; txntag1: txn val 1
     ; txntag2: txn val 2
     a               1
@@ -20,12 +19,10 @@ hledger -f - print
     b              -1  ; posting-2-tag-1: posting 2 val 1
     ; posting-2-tag-2:
 
->>>2
->>>=0
+>=
 
 # 2. reports can filter by tag existence
-hledger -f - print tag:foo
-<<<
+<
 2010/01/01  ; foo:bar
   a             1
   b            -1
@@ -37,7 +34,7 @@ hledger -f - print tag:foo
 2010/01/03
     e             1
     f            -1
->>>
+$ hledger -f - print tag:foo
 2010-01-01  ; foo:bar
     a               1
     b              -1
@@ -46,12 +43,10 @@ hledger -f - print tag:foo
     c               1
     d              -1
 
->>>2
->>>=0
+>=
 
 # 3. or tag value
-hledger -f - print tag:foo=bar
-<<<
+<
 2010/01/01  ; foo:bar
   a             1
   b            -1
@@ -64,17 +59,15 @@ hledger -f - print tag:foo=bar
 2010/01/03
     e             1
     f            -1
->>>
+$ hledger -f - print tag:foo=bar
 2010-01-01  ; foo:bar
     a               1
     b              -1
 
->>>2
->>>=0
+>=
 
 # 4. postings inherit their transaction's tags
-hledger -f - register tag:foo=bar
-<<<
+<
 2010/01/01
   a             1  ; foo:bar
   b            -1
@@ -86,16 +79,13 @@ hledger -f - register tag:foo=bar
 2010/01/03  ; foo:bar
   e             1
   f            -1
->>>
+$ hledger -f - register tag:foo=bar
 2010-01-01                      a                                1             1
 2010-01-03                      e                                1             2
                                 f                               -1             1
->>>2
->>>=0
 
 # 5. look for transactions without tags
-hledger -f - print not:tag:.
-<<<
+<
 2010/01/01 desc
   a             1
   b            -1
@@ -112,7 +102,7 @@ hledger -f - print not:tag:.
 2010/01/04 (code)
     g             4
     h            -4
->>>
+$ hledger -f - print not:tag:.
 2010-01-01 desc
     a               1
     b              -1
@@ -125,10 +115,8 @@ hledger -f - print not:tag:.
     g               4
     h              -4
 
->>>=0
+>=
 
-# 6. query is not affected by implicit tags
-hledger -f ../../examples/sample.journal reg tag:d
->>>
->>>2
->>>=0
+# 6. query is not affected by implicit tags (XXX ?)
+$ hledger -f ../../examples/sample.journal reg tag:d
+


### PR DESCRIPTION
For #1817:

Accounts, postings, and transactions can now all be filtered by the
tags in an account's declaration. In particular it's now possible to
more reliably select accounts by type, using their type: tag rather
than their name:

```
account myasset       ; type:Asset
account myliability   ; type:Liability

$ hledger accounts tag:type=^a
myasset
```

API changes:
A finalised Journal has a new jdeclaredaccounttags field
for easy lookup of account tags.
Query.matchesTaggedAccount is a tag-aware version of matchesAccount.

The current tests, to show how it behaves:
```shell
# Querying accounts by tag.
<
account a   ; type:A
account l   ; type:Liability
account r   ; type:R
account o   ; othertag:
account u

2022-01-01
  (r)        1

2022-01-02
  (a)        1
  (l)        1

# 7. We can match declared accounts by having a tag,
$ hledger -f- accounts --declared tag:.
a
l
r
o

# 8. not having a tag,
$ hledger -f- accounts --declared not:tag:.
u

# 9. or a tag and it's value. Tag values are matched infix.
$ hledger -f- accounts --declared tag:type=a
a
l

# 10. So we must anchor the regex to match single-letter account types.
$ hledger -f- accounts --declared tag:type=^a$
a

# 11. But if account type was declared in the long form, matching just one letter fails
$ hledger -f- accounts --declared tag:type=^l$

# 12. so we need to match more loosely
$ hledger -f- accounts --declared tag:type=^l
l

# 13. In the same way, we can match used accounts by tag.
$ hledger -f- accounts --used tag:type=r
r

# 14. We can match postings by their account's tags.
$ hledger -f- register -w80 tag:type=^a
2022-01-02                      (a)                              1             1

# 15. We can match transactions by their accounts' tags.
$ hledger -f- print tag:type=^a
2022-01-02
    (a)               1
    (l)               1

>=

# 16. And negatively match them by tag.
$ hledger -f- print tag:type=^a not:tag:type=^l

# 17. We can filter balance reports by account tags.
$ hledger -f- bal tag:type=^a
                   1  a
--------------------
                   1  

# 18. Postingless declared accounts in balance reports are also filtered.
$ hledger -f- bal -N --declared -E o u tag:othertag
                   0  o

```