### PR TITLE
new type: query for easy matching by account type

### DIFF
--- a/hledger-lib/Hledger/Data/AccountName.hs
+++ b/hledger-lib/Hledger/Data/AccountName.hs
@@ -20,6 +20,13 @@ module Hledger.Data.AccountName (
   ,accountNameToAccountRegexCI
   ,accountNameTreeFrom
   ,accountSummarisedName
+  ,accountNameInferType
+  ,assetAccountRegex
+  ,cashAccountRegex
+  ,liabilityAccountRegex
+  ,equityAccountRegex
+  ,revenueAccountRegex
+  ,expenseAccountRegex
   ,acctsep
   ,acctsepchar
   ,clipAccountName
@@ -81,6 +88,27 @@ accountSummarisedName a
     where
       cs = accountNameComponents a
       a' = accountLeafName a
+
+-- | Regular expressions matching common english top-level account names,
+-- used as a fallback when account types are not declared.
+assetAccountRegex     = toRegexCI' "^assets?(:|$)"
+cashAccountRegex      = toRegexCI' "(investment|receivable|:A/R|:fixed)"
+liabilityAccountRegex = toRegexCI' "^(debts?|liabilit(y|ies))(:|$)"
+equityAccountRegex    = toRegexCI' "^equity(:|$)"
+revenueAccountRegex   = toRegexCI' "^(income|revenue)s?(:|$)"
+expenseAccountRegex   = toRegexCI' "^expenses?(:|$)"
+
+-- | Try to guess an account's type from its name,
+-- matching common english top-level account names. 
+accountNameInferType :: AccountName -> Maybe AccountType
+accountNameInferType a
+  | regexMatchText cashAccountRegex      a = Just Cash
+  | regexMatchText assetAccountRegex     a = Just Asset
+  | regexMatchText liabilityAccountRegex a = Just Liability
+  | regexMatchText equityAccountRegex    a = Just Equity
+  | regexMatchText revenueAccountRegex   a = Just Revenue
+  | regexMatchText expenseAccountRegex   a = Just Expense
+  | otherwise                          = Nothing
 
 accountNameLevel :: AccountName -> Int
 accountNameLevel "" = 0

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -514,7 +514,8 @@ data Journal = Journal {
   ,jdeclaredpayees        :: [(Payee,PayeeDeclarationInfo)]         -- ^ Payees declared by payee directives, in parse order (after journal finalisation)
   ,jdeclaredaccounts      :: [(AccountName,AccountDeclarationInfo)] -- ^ Accounts declared by account directives, in parse order (after journal finalisation)
   ,jdeclaredaccounttags   :: M.Map AccountName [Tag]                -- ^ Accounts which have tags declared in their directives, and those tags. (Does not include parents' tags.)
-  ,jdeclaredaccounttypes  :: M.Map AccountType [AccountName]        -- ^ Accounts whose type has been declared in account directives (usually 5 top-level accounts)
+  ,jdeclaredaccounttypes  :: M.Map AccountType [AccountName]        -- ^ Accounts whose type has been explicitly declared in their account directives, grouped by type.
+  ,jaccounttypes          :: M.Map AccountName AccountType          -- ^ All accounts for which a type has been declared or can be inferred from its parent or its name.
   ,jglobalcommoditystyles :: M.Map CommoditySymbol AmountStyle      -- ^ per-commodity display styles declared globally, eg by command line option or import command
   ,jcommodities           :: M.Map CommoditySymbol Commodity        -- ^ commodities and formats declared by commodity directives
   ,jinferredcommodities   :: M.Map CommoditySymbol AmountStyle      -- ^ commodities and formats inferred from journal amounts

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -489,7 +489,7 @@ rawOptsToCliOpts rawopts = do
               Just d  -> fromRight (error' $ "Unable to parse date \"" ++ d ++ "\"") -- PARTIAL:
                          $ fixSmartDateStrEither' currentDay (T.pack d)
   let iopts = rawOptsToInputOpts day rawopts
-  rspec <- either fail pure $ rawOptsToReportSpec day rawopts  -- PARTIAL:
+  rspec <- either error' pure $ rawOptsToReportSpec day rawopts  -- PARTIAL:
   mcolumns <- readMay <$> getEnvSafe "COLUMNS"
   mtermwidth <-
 #ifdef mingw32_HOST_OS

--- a/hledger/Hledger/Cli/Commands/Accounts.hs
+++ b/hledger/Hledger/Cli/Commands/Accounts.hs
@@ -57,7 +57,8 @@ accounts CliOpts{rawopts_=rawopts, reportspec_=ReportSpec{_rsQuery=query,_rsRepo
       depth    = dbg1 "depth" $ queryDepth $ filterQuery queryIsDepth query
       matcheddeclaredaccts =
         dbg1 "matcheddeclaredaccts" $
-        filter (\a -> matchesTaggedAccount nodepthq (a, (journalInheritedAccountTags j a))) $ map fst $ jdeclaredaccounts j
+        filter (\a -> matchesAccountExtra nodepthq (journalAccountType j a) (journalInheritedAccountTags j a) a)
+          $ map fst $ jdeclaredaccounts j
       matchedusedaccts     = dbg5 "matchedusedaccts" $ map paccount $ journalPostings $ filterJournalPostings nodepthq j
       accts                = dbg5 "accts to show" $ -- no need to nub/sort, accountTree will
         if | declared     && not used -> matcheddeclaredaccts

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -69,11 +69,12 @@ aregistermode = hledgerCommandMode
 aregister :: CliOpts -> Journal -> IO ()
 aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
   -- the first argument specifies the account, any remaining arguments are a filter query
+  let help = "aregister needs an ACCTPAT argument to select an account"
   (apat,querystring) <- case listofstringopt "args" rawopts of
-      []     -> fail "aregister needs an account, please provide an account name or pattern"
+      []     -> error' $ help <> ".\nPlease provide an account name or a (case-insensitive, infix, regexp) pattern."
       (a:as) -> return (a, map T.pack as)
   let
-    acct = fromMaybe (error' $ show apat++" did not match any account")   -- PARTIAL:
+    acct = fromMaybe (error' $ help <> ",\nbut " ++ show apat++" did not match any account.")   -- PARTIAL:
            . firstMatch $ journalAccountNamesDeclaredOrImplied j
     firstMatch = case toRegexCI $ T.pack apat of
         Right re -> find (regexMatchText re)

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -847,6 +847,12 @@ Match real or virtual postings respectively.
 **`status:, status:!, status:*`**\
 Match unmarked, pending, or cleared transactions respectively.
 
+**`type:ACCTTYPES`**\
+Match by account type (see [Declaring accounts > Account types](#account-types)).
+`ACCTTYPES` is one or more of the single-letter account type codes
+`ALERXCV`, case insensitive. 
+Eg: `hledger bal type:AL` shows asset and liability balances. 
+
 **`tag:REGEX[=REGEX]`**\
 Match by tag name, and optionally also by tag value.
 (To match only by value, use `tag:.=REGEX`.)
@@ -3065,10 +3071,10 @@ you can declare hledger accounts to be of a certain type:
 Declaring account types is a good idea: they are required by the convenient 
 [balancesheet], [balancesheetequity], [incomestatement] and [cashflow] reports, 
 and probably other things in future. 
-You can also use them with other commands to reliably select accounts by type, 
-without depending on their names. Eg:
+You can also use the [`type:` query](#queries) to easily select accounts by type, 
+regardless of their names. Eg, to select asset and liability accounts:
 ```shell
-hledger balance tag:type=^[AL]
+hledger balance type:AL
 ```
 
 As a convenience, when account types are not declared, 

--- a/hledger/test/query-type.test
+++ b/hledger/test/query-type.test
@@ -1,0 +1,77 @@
+# Matching accounts by type. 
+# Similar to the tag:type tests in query-tags.test.
+<
+account a   ; type:A
+account l   ; type:Liability
+account r   ; type:R
+account o   ; othertag:
+account u
+
+2022-01-01
+  (r)        1
+
+2022-01-02
+  (a)        1
+  (l)        1
+
+# 1. We can match declared accounts by type, using short type codes
+# regardless of whether account's type was declared in short or long form.
+$ hledger -f- accounts --declared type:AL
+a
+l
+
+# 2. Order and case of type codes doesn't matter.
+$ hledger -f- accounts --declared type:la
+a
+l
+
+# 3. Matching used accounts works the same way.
+$ hledger -f- accounts --used type:AL
+a
+l
+
+# 4. We can match postings by their account's type.
+$ hledger -f- register -w80 type:A
+2022-01-02                      (a)                              1             1
+
+# 5. We can match transactions by their accounts' types.
+$ hledger -f- print type:A
+2022-01-02
+    (a)               1
+    (l)               1
+
+>=
+
+# 6. And negatively match them.
+$ hledger -f- print type:a not:type:l
+
+# 7. We can filter balance reports by account type.
+$ hledger -f- bal type:a
+                   1  a
+--------------------
+                   1  
+
+# 8. Postingless declared accounts in balance reports are also filtered.
+<
+account a  ; type:A
+account l  ; type:L
+
+$ hledger -f- bal -N --declared -E type:A
+                   0  a
+
+# 9. type: is aware of account type inheritance.
+<
+account a    ; type:A
+account a:aa
+
+$ hledger -f- accounts type:a
+a
+a:aa
+
+# 10. type: is aware of inferred account types.
+<
+account assets
+account liabilities
+
+$ hledger -f- accounts type:a
+assets


### PR DESCRIPTION
Follow-on from #1817/#1819: because matching account types with `tag:` is inconvenient, this adds the `type:TYPES` query, where `TYPES` is any of the (case insensitive) letters `ALERXCV` (see https://hledger.org/hledger.html#account-types.) This is expected to work appropriately with all commands. It handles types inherited from parents, overridden by children, and inferred from account names, so should be a pretty reliable way to select accounts by type if 1. you have declared account types or 2. you use common english top-level account names. Eg:

    $ hledger -f examples/sample.journal bal type:al
                      $1  assets:bank:saving
                     $-2  assets:cash
                      $1  liabilities:debts
    --------------------
                       0

API changes:

Journal has a new jaccounttypes map.
The journalAccountType lookup function makes it easy to check an account's type.
The journalTags and journalInheritedTags functions look up an account's tags.
Functions like journalFilterPostings and journalFilterTransactions,
and new matching functions matchesAccountExtra, matchesPostingExtra
and matchesTransactionExtra, use these to allow more powerful matching
that is aware of account types and tags.
