### PR TITLE
dev: reg: areg: Speed up reg and areg by only aligning to first 1000 items.

### DIFF
--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -130,8 +130,8 @@ accountTransactionsReportAsText copts reportq thisacctq items = TB.toLazyText $
     title <> TB.singleton '\n' <> lines
   where
     lines = foldMap (accountTransactionsReportItemAsText copts reportq thisacctq amtwidth balwidth) items
-    amtwidth = maximumStrict $ 12 : widths (map itemamt items)
-    balwidth = maximumStrict $ 12 : widths (map itembal items)
+    amtwidth = maximumStrict $ 12 : widths (map itemamt $ take 1000 items)
+    balwidth = maximumStrict $ 12 : widths (map itembal $ take 1000 items)
     widths = map wbWidth . concatMap (showMixedAmountLinesB oneLine)
     itemamt (_,_,_,_,a,_) = a
     itembal (_,_,_,_,_,a) = a

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -96,8 +96,8 @@ postingsReportAsText :: CliOpts -> PostingsReport -> TL.Text
 postingsReportAsText opts items = TB.toLazyText lines
   where
     lines = foldMap (postingsReportItemAsText opts amtwidth balwidth) items
-    amtwidth = maximumStrict $ 12 : widths (map itemamt items)
-    balwidth = maximumStrict $ 12 : widths (map itembal items)
+    amtwidth = maximumStrict $ 12 : widths (map itemamt $ take 1000 items)
+    balwidth = maximumStrict $ 12 : widths (map itembal $ take 1000 items)
     widths = map wbWidth . concatMap (showMixedAmountLinesB oneLine)
     itemamt (_,_,_,Posting{pamount=a},_) = a
     itembal (_,_,_,_,a) = a


### PR DESCRIPTION
register is still very slow for large reports, but this at least improves it a bit.

`hledger -f examples/100000x1000x10.journal reg`
master -> this branch
```
 794,803,740,896 bytes allocated in the heap						   493,117,386,064 bytes allocated in the heap
  80,017,131,248 bytes copied during GC							    74,343,432,976 bytes copied during GC
     846,933,760 bytes maximum residency (68 sample(s))					       694,092,872 bytes maximum residency (69 sample(s))
      31,580,760 bytes maximum slop							  	31,580,760 bytes maximum slop
	    2430 MiB total memory in use (0 MB lost due to fragmentation)		  	      1973 MiB total memory in use (0 MB lost due to fragmentation)
											  
				     Tot time (elapsed)	 Avg pause  Max pause		  				       Tot time (elapsed)  Avg pause  Max pause
  Gen  0     770481 colls,     0 par   25.081s	25.266s	    0.0000s    0.0015s		    Gen	 0     477743 colls,	 0 par	 21.720s  21.850s     0.0000s	 0.0016s
  Gen  1	68 colls,     0 par   15.234s  15.237s	   0.2241s    0.4519s		    Gen	 1	  69 colls,	0 par	15.667s	 15.668s     0.2271s	0.4504s
											  
  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)				    TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)
											  
  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)			    SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)
											  
  INIT	  time	  0.002s  (  0.002s elapsed)						    INIT    time    0.001s  (  0.001s elapsed)
  MUT	  time	218.142s  (217.315s elapsed)						    MUT	    time  149.555s  (149.086s elapsed)
  GC	  time	 40.316s  ( 40.503s elapsed)						    GC	    time   37.388s  ( 37.517s elapsed)
  RP	  time	  0.000s  (  0.000s elapsed)						    RP	    time    0.000s  (  0.000s elapsed)
  PROF	  time	  0.000s  (  0.000s elapsed)						    PROF    time    0.000s  (  0.000s elapsed)
  EXIT	  time	  0.001s  (  0.000s elapsed)						    EXIT    time    0.000s  (  0.001s elapsed)
  Total	  time	258.460s  (257.820s elapsed)						    Total   time  186.944s  (186.605s elapsed)
											  
  Alloc rate	3,643,517,874 bytes per MUT second					    Alloc rate	  3,297,236,278 bytes per MUT second
											  
  Productivity	84.4% of total user, 84.3% of total elapsed				    Productivity  80.0% of total user, 79.9% of total elapsed
```