### PR TITLE
dev: reg: areg: Strip prices early on in PostingsReport and AccountTransactionsReport, when possible.

### DIFF
--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -120,6 +120,11 @@ matchedPostingsBeforeAndDuring rspec@ReportSpec{_rsReportOpts=ropts,_rsQuery=q} 
         sortOn (postingDateOrDate2 (whichDate ropts))            -- sort postings by date or date2
       . (if invert_ ropts then map negatePostingAmount else id)  -- with --invert, invert amounts
       . journalPostings
+      -- With most calls we will not require transaction prices past this point, and can get a big
+      -- speed improvement by stripping them early. In some cases, such as in hledger-ui, we still
+      -- want to keep prices around, so we can toggle between cost and no cost quickly. We can use
+      -- the show_costs_ flag to be efficient when we can, and detailed when we have to.
+      . (if show_costs_ ropts then id else journalMapPostingAmounts mixedAmountStripPrices)
       $ journalValueAndFilterPostings rspec{_rsQuery=beforeandduringq} j
 
     -- filter postings by the query, with no start date or depth limit

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -69,6 +69,8 @@ rsInit d reset ui@UIState{aopts=_uopts@UIOpts{uoCliOpts=copts@CliOpts{reportspec
     ropts' = ropts {
         -- ignore any depth limit, as in postingsReport; allows register's total to match accounts screen
         depth_=Nothing
+        -- do not strip prices so we can toggle costs within the ui
+      , show_costs_=True
       -- XXX aregister also has this, needed ?
         -- always show historical balance
       -- , balanceaccum_= Historical


### PR DESCRIPTION
This results in big speedups in cases when we have many transaction prices, like in examples/10000x1000x10.journal. This can be disabled with the show_costs_ option in ReportOpts.

We tried something like this earlier, and ended up causing problems in hledger-ui (see #1577). I think this avoids that issue, but we should be careful nonetheless.