### PR TITLE
fix: alias: Allow escaped characters in regular expression aliases.

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -1515,11 +1515,12 @@ basicaliasp = do
 regexaliasp :: TextParser m AccountAlias
 regexaliasp = do
   -- dbgparse 0 "regexaliasp"
-  char '/'
-  off1 <- getOffset
-  re <- some $ noneOf ("/\n\r" :: [Char]) -- paranoid: don't try to read past line end
-  off2 <- getOffset
-  char '/'
+  (off1, off2, re) <- between (char '/') (char '/') $ do
+    off1 <- getOffset
+    re <- some $ noneOf ("/\\\n\r" :: [Char])  -- paranoid: don't try to read past line end
+             <|> (char '\\' *> anySingle)      -- allow escaping any character
+    off2 <- getOffset
+    return (off1, off2, re)
   skipNonNewlineSpaces
   char '='
   skipNonNewlineSpaces

--- a/hledger/test/account-aliases.test
+++ b/hledger/test/account-aliases.test
@@ -252,3 +252,18 @@ $ hledger -f- --alias old="new  USD" print | hledger -f- print
     other
 
 >=0
+
+# 18. Make sure you can match forward slashes in regexps by escaping them. (#982)
+<
+alias /\// = :
+
+2021-01-01
+  hi/there    1
+  b
+
+$ hledger -f- print
+2021-01-01
+    hi:there               1
+    b
+
+>=0


### PR DESCRIPTION
Fixes #982
