### PR TITLE
imp: reg: areg: Align to first 1000 postings by default, rather than 100.

### DIFF
--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -48,7 +48,7 @@ Each `aregister` line item shows:
 Transactions making a net change of zero are not shown by default;
 add the `-E/--empty` flag to show them.
 
-For performance reasons, column widths are chosen based on the first 100 lines;
+For performance reasons, column widths are chosen based on the first 1000 lines;
 this means unusually wide values in later lines can cause visual discontinuities
 as column widths are adjusted. If you want to ensure perfect alignment, 
 at the cost of more time and memory, use the `--align-all` flag.

--- a/hledger/Hledger/Cli/Commands/Register.md
+++ b/hledger/Hledger/Cli/Commands/Register.md
@@ -25,7 +25,7 @@ $ hledger register checking
 
 With --date2, it shows and sorts by secondary date instead.
 
-For performance reasons, column widths are chosen based on the first 100 lines;
+For performance reasons, column widths are chosen based on the first 1000 lines;
 this means unusually wide values in later lines can cause visual discontinuities
 as column widths are adjusted. If you want to ensure perfect alignment, 
 at the cost of more time and memory, use the `--align-all` flag.

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -268,7 +268,7 @@ postingsOrTransactionsReportAsText alignAll opts itemAsText itemamt itembal repo
     mconcat . snd $ mapAccumL renderItem (startWidth amt, startWidth bal) itemsWithAmounts
   where
     minWidth  = 12
-    chunkSize = 100
+    chunkSize = 1000
 
     renderItem (amtWidth, balWidth) item@(_, amt, bal) = ((amtWidth', balWidth'), itemBuilder)
       where


### PR DESCRIPTION
This has the same performance characteristics for a big decrease in alignment
issues. 1000 postings seems to still put it under the memory bottleneck.