### PR TITLE
fix: aliases: Make sure we can escape forward slashes in account

### DIFF
--- a/hledger/test/account-aliases.test
+++ b/hledger/test/account-aliases.test
@@ -267,3 +267,33 @@ $ hledger -f- print
     b
 
 >=0
+
+# 19. Make sure you can escape special regexp characters.
+<
+alias /\./ = :
+
+2021-01-01
+  hi.there    1
+  b
+
+$ hledger -f- print
+2021-01-01
+    hi:there               1
+    b
+
+>=0
+
+# 20. Including backslashes
+<
+alias /\\/ = :
+
+2021-01-01
+  hi\there    1
+  b
+
+$ hledger -f- print
+2021-01-01
+    hi:there               1
+    b
+
+>=0


### PR DESCRIPTION
aliases, but otherwise the regular expression handler handles escapes.
