### PR TITLE
fix: Ensure date2 is used for journal valuation if requested. (#1851)

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -594,7 +594,7 @@ journalApplyValuationFromOptsWith rspec@ReportSpec{_rsReportOpts=ropts} j priceo
     costing     = journalToCost (fromMaybe NoConversionOp $ conversionop_ ropts)
 
     -- Find the end of the period containing this posting
-    periodEnd  = addDays (-1) . fromMaybe err . mPeriodEnd . postingDate
+    periodEnd  = addDays (-1) . fromMaybe err . mPeriodEnd . postingDateOrDate2 (whichDate ropts)
     mPeriodEnd = case interval_ ropts of
         NoInterval -> const . spanEnd . fst $ reportSpan j rspec
         _          -> spanEnd <=< latestSpanContaining (historical : spans)

--- a/hledger/test/journal/valuation2.test
+++ b/hledger/test/journal/valuation2.test
@@ -340,3 +340,21 @@ P 2020-01-01 P 100Z
 
 $ hledger -f- bal -N -X Z
                 100Z  a
+
+# 32. #1851 It should use posting date 2 if requested.
+<
+2019-12-31 FOO
+    Assets:A        $1.00
+    Income:B
+
+2020-01-01=2019-12-30 BAR
+    Assets:A        $1.00
+    Income:B
+
+$ hledger -f- bal -Y --date2 -V -N
+Balance changes in 2019, valued at period ends:
+
+          ||   2019 
+==========++========
+ Assets:A ||  $2.00 
+ Income:B || $-2.00 


### PR DESCRIPTION
Fixes #1851.