### PR TITLE
fix: bal: Allow cumulative gain and valuechange reports

### DIFF
--- a/hledger/test/journal/gain.test
+++ b/hledger/test/journal/gain.test
@@ -49,7 +49,17 @@ Historical gain in 2000-01-01..2000-02-29, valued at period ends:
  assets:new ||       -1 A           0 
  assets:old ||          0         2 A 
 
-# 4. use a different valuation strategy
+# 4. cumulative gain report
+$ hledger -f- bal -M --gain -b 2000 --no-total --cumulative
+Cumulative gain in 2000-01-01..2000-02-29, valued at period ends:
+
+            || 2000-01-31  2000-02-29 
+============++========================
+ assets:b   ||      -13 A       -15 A 
+ assets:new ||       -1 A           0 
+ assets:old ||        2 A         4 A 
+
+# 5. use a different valuation strategy
 $ hledger -f- bal -M --gain --no-total --value=2000-02-01
 Incremental gain in 1999-12-01..2000-01-31, valued at 2000-02-01:
 
@@ -58,7 +68,7 @@ Incremental gain in 1999-12-01..2000-01-31, valued at 2000-02-01:
  assets:b   ||       0    -15 A 
  assets:old ||     2 A        0 
 
-# 5. use a different valuation strategy for historical
+# 6. use a different valuation strategy for historical
 $ hledger -f- bal -M --gain --no-total --value=2000-02-01 -b 2000 --historical
 Historical gain in 2000-01, valued at 2000-02-01:
 
@@ -67,7 +77,7 @@ Historical gain in 2000-01, valued at 2000-02-01:
  assets:b   ||      -15 A 
  assets:old ||        2 A 
 
-# 6. also works in balancesheet
+# 7. also works in balancesheet
 $ hledger -f- bs -M --gain --no-total
 Balance Sheet 1999-12-31..2000-02-29 (Historical Gain), valued at period ends
 


### PR DESCRIPTION
Previously, --cumulative with --gain or --valuechange would produce an
empty report. This fixes this issue to produce a reasonable report.