### PR TITLE
timedot: support ranges

### DIFF
--- a/examples/sample.timedot
+++ b/examples/sample.timedot
@@ -19,4 +19,5 @@ fos:hledger   .... .... ....
 fos:ledger    0.25
 fos:haskell   .5
 inc:client1   2
+inc:client2   14-16
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4948,7 +4948,7 @@ time transaction lines, consisting of:
 - **two or more spaces** - a field separator, 
   required if there is an amount (as in journal format).
 - a **timedot amount** - dots representing quarter hours, 
-  or a number representing hours.
+  a number representing hours, or a range calculating hours.
 - an optional **comment** beginning with semicolon. This is ignored.
 
 In more detail, timedot amounts can be:
@@ -4958,6 +4958,9 @@ In more detail, timedot amounts can be:
   Eg: `.... ..`
 
 - a **number**, representing hours. Eg: `1.5`
+
+- a **range**, representing hours between two times. Eg: `12.5-13.5` to denote
+  the 1.0 hr from 12:30pm to 1:30pm
 
 - a **number immediately followed by a unit symbol**
   `s`, `m`, `h`, `d`, `w`, `mo`, or `y`, 
@@ -5003,6 +5006,7 @@ biz:research  .
 ```timedot
 2016/2/3
 inc:client1   4
+inc:client2   13-15
 fos:hledger   3
 biz:research  1
 ```


### PR DESCRIPTION
This is a follow-up to a thread I created here: https://groups.google.com/g/hledger/c/FaEBpC8JYus

This change allows the following to parse correctly in a timedot file:

```
2022-06-28 description
Time:ABC:Task1  8.2-8.9 ; comment 1
Time:ABC:Task1  9-10.3 ; comment 2
```

Using this syntax, the duration associated with each line is computed by subtracting the two numbers (8.9 - 8.2 = 0.7 or 10.3 - 9 = 1.3). The default time unit is applied just as if the hour count itself (0.7 or 1.3) had been written instead. The primary advantage is that I can use a 24-hour timestamp for start and end times, and I can leave a "hanging entry" while I'm working. It also makes a 6-minute rule very easy to observe by using zero or one decimal place everywhere, and is also less verbose than the timeclock format for this use case.