### PR TITLE
Fix tables of contents in developer documentation

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,7 @@
 # Benchmarks
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,6 +1,7 @@
 # Changelogs
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/CODE.md
+++ b/CODE.md
@@ -1,6 +1,7 @@
 # Code
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,6 +1,7 @@
 # COMMITS
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributor Guide
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,6 +1,7 @@
 # Docs
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/FINANCE.md
+++ b/FINANCE.md
@@ -1,6 +1,7 @@
 # Finance
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,6 +1,7 @@
 # Issues
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/PULLREQUESTS.md
+++ b/PULLREQUESTS.md
@@ -1,6 +1,7 @@
 # Pull requests
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 # Releasing
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,6 +1,7 @@
 # Tests
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -1,6 +1,7 @@
 # Developer workflows
 
 <div class=pagetoc>
+
 <!-- toc -->
 </div>
 


### PR DESCRIPTION
Currently, several pages on the website don't render their tables of contents properly. For instance:

![image](https://user-images.githubusercontent.com/324152/178418202-7dadba30-c9b2-4b4d-a4dc-fa8ff298d2b9.png)

This PR addresses all instances I identified, correcting to:

![image](https://user-images.githubusercontent.com/324152/178418341-d7e24af3-92eb-46fe-b049-d7b9337237c5.png)
