### PR TITLE
hledger: bump lower bounds for Diff and githash

### DIFF
--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -137,7 +137,7 @@ library
   cpp-options: -DVERSION="1.26.99"
   build-depends:
       Decimal >=0.5.1
-    , Diff
+    , Diff >= 0.2
     , aeson >=1
     , ansi-terminal >=0.9
     , base >=4.11 && <4.17
@@ -148,7 +148,7 @@ library
     , directory
     , extra >=1.6.3
     , filepath
-    , githash >=0.1.4
+    , githash >=0.1.6.1
     , hashable >=1.2.4
     , haskeline >=0.6
     , hledger-lib >=1.26.99 && <1.27


### PR DESCRIPTION
For earlier versions `cabal build -w ghc-9.2` fails with 
```
Hledger/Cli/Commands/Rewrite.hs:144:12: error:
    Not in scope: type constructor or class ‘D.Diff’
    Module ‘Data.Algorithm.Diff’ does not export ‘Diff’.
    |
144 | mapDiff :: D.Diff a -> DiffLine a
    |            ^^^^^^
```
and
```
Hledger/Cli.hs:49:37: error:
    • Couldn't match expected type: template-haskell-2.18.0.0:Language.Haskell.TH.Syntax.Code
                                      template-haskell-2.18.0.0:Language.Haskell.TH.Syntax.Q
                                      (Either String GitHash.GitInfo)
                  with actual type: template-haskell-2.18.0.0:Language.Haskell.TH.Syntax.Q
                                      (template-haskell-2.18.0.0:Language.Haskell.TH.Syntax.TExp
                                         (Either String GitHash.GitInfo))
    • In the expression: tGitInfoCwdTry
      In the Template Haskell splice $$tGitInfoCwdTry
      In the first argument of ‘versionStringWith’, namely
        ‘$$tGitInfoCwdTry’
   |
49 | versionString = versionStringWith $$tGitInfoCwdTry
   |
```

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and learn how to get hledger PRs accepted swiftly, 
please check the latest guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
-->
