### PR TITLE
check recentassertions

### DIFF
--- a/hledger/Hledger/Cli/Commands/Check.hs
+++ b/hledger/Hledger/Cli/Commands/Check.hs
@@ -65,6 +65,7 @@ data Check =
   -- done on demand by check
   | Ordereddates
   | Payees
+  | Recentassertions
   | Uniqueleafnames
   deriving (Read,Show,Eq,Enum,Bounded)
 
@@ -96,12 +97,14 @@ parseCheckArgument s =
 -- on this journal with these options.
 runCheck :: CliOpts -> Journal -> (Check,[String]) -> IO ()
 runCheck CliOpts{reportspec_=ReportSpec{_rsReportOpts=ropts}} j (check,_) = do
+  d <- getCurrentDay
   let
     results = case check of
       Accounts        -> journalCheckAccounts j
       Commodities     -> journalCheckCommodities j
       Ordereddates    -> journalCheckOrdereddates (whichDate ropts) j
       Payees          -> journalCheckPayees j
+      Recentassertions -> journalCheckRecentAssertions d j
       Uniqueleafnames -> journalCheckUniqueleafnames j
       -- the other checks have been done earlier during withJournalDo
       _               -> Right ()

--- a/hledger/Hledger/Cli/Commands/Check.md
+++ b/hledger/Hledger/Cli/Commands/Check.md
@@ -58,6 +58,9 @@ They are more specialised and not desirable for everyone, therefore optional:
 
 - **payees** - all payees used by transactions [have been declared](#declaring-payees)
 
+- **recentassertions** - all accounts with balance assertions have a
+  (cleared) assertion no more than 7 days before their latest posting
+
 - **uniqueleafnames** - all account leaf names are unique
 
 ### Custom checks

--- a/hledger/Hledger/Cli/Commands/Check.md
+++ b/hledger/Hledger/Cli/Commands/Check.md
@@ -18,6 +18,9 @@ hledger check -s   # basic + strict checks
 hledger check ordereddates payees  # basic + two other checks
 ```
 
+If you are an Emacs user, you can also configure flycheck-hledger to run these checks,
+providing instant feedback as you edit the journal.
+
 Here are the checks currently available:
 
 ### Basic checks
@@ -75,6 +78,17 @@ in <https://github.com/simonmichael/hledger/tree/master/bin>:
 You could make similar scripts to perform your own custom checks.
 See: Cookbook -> [Scripting](scripting.html).
 
+### More about specific checks
+
+`hledger check recentassertions` will complain if any balance-asserted account does not have
+a (cleared) balance assertion within 7 days before its latest posting.
+This aims to prevent the situation where you are regularly updating your journal,
+but forgetting to check your balances against the real world,
+then one day must dig back through months of data to find an error.
+It assumes that adding a balance assertion requires/reminds you to check the real-world balance.
+This won't be true if you auto-generate balance assertions when importing bank data,
+but hopefully your auto-generated transactions are uncleared, and before manually marking them 
+cleared you will remember to check the latest assertions against the real-world balances.
 
 [add-on commands]:    #add-on-commands
 [balance assertions]: #balance-assertions

--- a/hledger/Hledger/Cli/Commands/Check.txt
+++ b/hledger/Hledger/Cli/Commands/Check.txt
@@ -56,6 +56,10 @@ therefore optional:
 
 -   payees - all payees used by transactions have been declared
 
+-   recentassertions - all accounts with balance assertions have a
+    balance assertion, marked cleared, within 7 days of their latest
+    posting
+
 -   uniqueleafnames - all account leaf names are unique
 
 Custom checks

--- a/hledger/test/errors/README.md
+++ b/hledger/test/errors/README.md
@@ -131,6 +131,7 @@ Click error names to see an example. The table headings mean:
 | [parseable-dates](#parseable-dates)                   | ✓          | ✓    | ✓      | ✓✓      | ✓        |
 | [parseable-regexps](#parseable-regexps)               | ✓          | ✓    | ✓      | ✓✓      | ✓        |
 | [payees](#payees)                                     | ✓          | ✓    | ✓      | ✓✓      | ✓        |
+| [recentassertions](#recentassertions)                 | ✓          | ✓    | ✓      | ✓✓      | ✓        |
 | [uniqueleafnames](#uniqueleafnames)                   | ✓          | ✓    | ✓      | ✓✓      | ✓        |
 | [tcclockouttime](#tcclockouttime)                     | ✓          | ✓    | ✓      | ✓✓      |          |
 | [tcorderedactions](#tcorderedactions)                 | ✓          | ✓    | ✓      | ✓✓      |          |
@@ -155,7 +156,7 @@ Click error names to see an example. The table headings mean:
 
 
 <!-- GENERATED: -->
-hledger 1.26.99-ga7b920750-20220715 error messages:
+hledger 1.26.99-g99825d37f-20220731 error messages:
 
 ### accounts
 ```
@@ -183,9 +184,9 @@ hledger: Error: /Users/simon/src/hledger/hledger/test/errors/./assertions.j:4:8:
 This balance assertion failed.
 In account:    a
 and commodity: 
-this balance was asserted: 1
-but the actual balance is: 0
-a difference of:           1
+this balance was asserted:     1
+but the calculated balance is: 0
+a difference of:               1
 
 Consider viewing this account's register to troubleshoot. Eg:
 
@@ -298,6 +299,26 @@ payee "p" has not been declared.
 Consider adding a payee directive. Examples:
 
 payee p
+```
+
+
+### recentassertions
+```
+hledger: Error: /Users/simon/src/hledger/hledger/test/errors/./recentassertions.j:4:8:
+  | 2022-01-01 *
+4 |     a               0 = 0
+  |                       ^^^
+
+The recentassertions check is enabled, so accounts with balance assertions
+must have an assertion no more than 7 days before their latest posting date.
+In account a,
+the last balance assertion (2022-01-01) was 8 days before
+the latest posting (2022-01-09).
+
+Consider adding a more recent balance assertion for this account. Eg:
+
+2022-07-31 *
+    a    $0 = $0  ; <- adjust
 ```
 
 

--- a/hledger/test/errors/assertions.test
+++ b/hledger/test/errors/assertions.test
@@ -10,5 +10,6 @@ and commodity:
 this balance was asserted:     1
 but the calculated balance is: 0
 a difference of:               1
-/
+
+Consider viewing t/
 >>>= 1

--- a/hledger/test/errors/recentassertions.j
+++ b/hledger/test/errors/recentassertions.j
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S hledger check recentassertions -f
+
+2022-01-01 *
+  a  0 = 0
+
+2022-01-09 *
+  a  0

--- a/hledger/test/errors/recentassertions.test
+++ b/hledger/test/errors/recentassertions.test
@@ -1,0 +1,11 @@
+$$$ hledger check recentassertions -f recentassertions.j
+>>>2 /hledger: Error: .*recentassertions.j:4:8:
+  \| 2022-01-01 \*
+4 \|     a               0 = 0
+  \|                       \^\^\^
+
+The recentassertions check is enabled, so accounts with balance assertions
+must have an assertion no more than 7 days before their latest posting date.
+In account a,
+the las/
+>>>= 1


### PR DESCRIPTION
`hledger check recentassertions` (or flycheck-hledger if you configure it
to run this check) will complain if any balance-asserted account does not have a
(cleared) balance assertion within 7 days before its latest posting.  This aims
to prevent the situation where you are regularly updating your
journal, but forgetting to check your balances against the real world,
then one day must dig back through months of data to find an error.

It assumes that adding a balance assertion requires/reminds you to check the real-world balance.
This won't be true if you auto-generate balance assertions when importing bank data.
However it also requires that the assertion posting is marked cleared, so hopefully
you auto-generate uncleared transactions, and before manually marking them cleared
you will remember to check the real-world balance.

The hard-coded behaviour keeps it simple and allows it to run as a standard check. It might not suit all needs. If checks allow arguments, adding some could be a possibility in future. 

- [doc](https://github.com/simonmichael/hledger/blob/efcc2e804137d56189103c24494972c2b98f7fe6/hledger/Hledger/Cli/Commands/Check.md#other-checks)
- [test](https://github.com/simonmichael/hledger/blob/ff1d3c494f5ae832afc02b4201be74845972c5fe/hledger/test/errors/recentassertions.test)
