### PR TITLE
fix multi-file account display order (#1909)

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -308,7 +308,7 @@ journalFilePaths :: Journal -> [FilePath]
 journalFilePaths = map fst . jfiles
 
 mainfile :: Journal -> (FilePath, Text)
-mainfile = headDef ("", "") . jfiles
+mainfile = headDef ("(unknown)", "") . jfiles
 
 addTransaction :: Transaction -> Journal -> Journal
 addTransaction t j = j { jtxns = t : jtxns j }

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -49,7 +49,7 @@ import Data.Time.Clock.POSIX (POSIXTime)
 import Data.Time.LocalTime (LocalTime)
 import Data.Word (Word8)
 import Text.Blaze (ToMarkup(..))
-import Text.Megaparsec (SourcePos)
+import Text.Megaparsec (SourcePos(SourcePos), mkPos)
 
 import Hledger.Utils.Regex
 
@@ -585,12 +585,14 @@ data AccountDeclarationInfo = AccountDeclarationInfo {
   ,aditags             :: [Tag]  -- ^ tags extracted from the account comment, if any
   ,adideclarationorder :: Int    -- ^ the order in which this account was declared,
                                  --   relative to other account declarations, during parsing (1..)
+  ,adisourcepos        :: SourcePos  -- ^ source file and position
 } deriving (Eq,Show,Generic)
 
 nullaccountdeclarationinfo = AccountDeclarationInfo {
    adicomment          = ""
   ,aditags             = []
   ,adideclarationorder = 0
+  ,adisourcepos        = SourcePos "" (mkPos 1) (mkPos 1)
 }
 
 -- | An account, with its balances, parent/subaccount relationships, etc.

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -148,6 +148,7 @@ import Hledger.Query (Query(..), filterQuery, parseQueryTerm, queryEndDate, quer
 import Hledger.Reports.ReportOptions (ReportOpts(..), queryFromFlags, rawOptsToReportOpts)
 import Hledger.Utils
 import Hledger.Read.InputOptions
+import System.FilePath (takeFileName)
 
 --- ** doctest setup
 -- $setup
@@ -324,6 +325,10 @@ journalFinalise iopts@InputOpts{..} f txt pj = do
       >>= journalBalanceTransactions balancingopts_                         -- Balance all transactions and maybe check balance assertions.
       <&> (if infer_equity_ then journalAddInferredEquityPostings else id)  -- Add inferred equity postings, after balancing and generating auto postings
       <&> journalInferMarketPricesFromTransactions       -- infer market prices from commodity-exchanging transactions
+      <&> traceAt 6 ("journalFinalise: " <> takeFileName f)  -- debug logging
+      <&> dbgJournalAcctDeclOrder ("journalFinalise: " <> takeFileName f <> "   acct decls           : ")
+      <&> journalRenumberAccountDeclarations
+      <&> dbgJournalAcctDeclOrder ("journalFinalise: " <> takeFileName f <> "   acct decls renumbered: ")
     when strict_ $ do
       journalCheckAccounts j                     -- If in strict mode, check all postings are to declared accounts
       journalCheckCommodities j                  -- and using declared commodities

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -328,7 +328,7 @@ includedirectivep = do
 
           where
             childfilename = takeFileName filepath
-            parentfilename = maybe "" takeFileName $ headMay $ jincludefilestack parentj  -- more accurate than journalFilePath parentj somehow
+            parentfilename = maybe "(unknown)" takeFileName $ headMay $ jincludefilestack parentj  -- XXX more accurate than journalFilePath for some reason
 
       -- Update the parse state.
       put parentj'

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -513,10 +513,10 @@ formatdirectivep expectedsym = do
          printf "commodity directive symbol \"%s\" and format directive symbol \"%s\" should be the same" expectedsym acommodity
 
 keywordp :: String -> JournalParser m ()
-keywordp = (() <$) . string . fromString
+keywordp = void . string . fromString
 
 spacesp :: JournalParser m ()
-spacesp = () <$ lift skipNonNewlineSpaces1
+spacesp = void $ lift skipNonNewlineSpaces1
 
 -- | Backtracking parser similar to string, but allows varying amount of space between words
 keywordsp :: String -> JournalParser m ()
@@ -816,8 +816,8 @@ tests_JournalReader = testGroup "JournalReader" [
     ]
   ,testCase "datetimep" $ do
      let
-       good = assertParse datetimep
-       bad  = (\t -> assertParseError datetimep t "")
+       good  = assertParse datetimep
+       bad t = assertParseError datetimep t ""
      good "2011/1/1 00:00"
      good "2011/1/1 23:59:59"
      bad "2011/1/1"

--- a/hledger-lib/Hledger/Utils/Debug.hs
+++ b/hledger-lib/Hledger/Utils/Debug.hs
@@ -287,7 +287,7 @@ ptraceAt level
     | otherwise = \s a -> let p = pshow a
                               ls = lines p
                               nlorspace | length ls > 1 = "\n"
-                                        | otherwise     = replicate (11 - length s) ' '
+                                        | otherwise     = replicate (max 1 $ 11 - length s) ' '
                               ls' | length ls > 1 = map (' ':) ls
                                   | otherwise     = ls
                           in trace (s++":"++nlorspace++intercalate "\n" ls') a

--- a/hledger/Hledger/Cli/Commands/Accounts.md
+++ b/hledger/Hledger/Cli/Commands/Accounts.md
@@ -15,6 +15,10 @@ Account names can be depth-clipped with `depth:N` or `--depth N` or `-N`.
 With `--types`, it also shows each account's type, if it's known.
 (See Declaring accounts > Account types.)
 
+With `--declarations`, it also shows the file and line number of each
+account's declaration, if any, and the account's overall declaration order;
+these may be useful when troubleshooting account display order.
+
 Examples:
 
 ```shell

--- a/hledger/test/journal/account-display-order/1/a.j
+++ b/hledger/test/journal/account-display-order/1/a.j
@@ -1,0 +1,3 @@
+account A1
+account A2
+include aa.j

--- a/hledger/test/journal/account-display-order/1/aa.j
+++ b/hledger/test/journal/account-display-order/1/aa.j
@@ -1,0 +1,2 @@
+account AA3
+account AA4

--- a/hledger/test/journal/account-display-order/1/b.j
+++ b/hledger/test/journal/account-display-order/1/b.j
@@ -1,0 +1,2 @@
+account B5
+account B6

--- a/hledger/test/journal/account-display-order/account-display-order.test
+++ b/hledger/test/journal/account-display-order/account-display-order.test
@@ -1,0 +1,15 @@
+# 1. Accounts declared in this parent file and included child file are displayed in correct order.
+$ hledger -f 1/a.j accounts
+A1
+A2
+AA3
+AA4
+
+# 2. And with another sibling file, display order is still correct.
+$ hledger -f 1/a.j -f 1/b.j accounts
+A1
+A2
+AA3
+AA4
+B5
+B6


### PR DESCRIPTION
This PR fixes #1909 (by renumbering account directives after merging or finalising Journals), and adds some useful debug logging (at levels 2, 5 and 6) of file reading/including and account declaration order. 

- lib: save account directive positions, for troubleshooting (1909)
- imp: at --debug 5, log account declarations info while parsing (1909)
- imp: accounts: at --debug 2, show account declaration positions (1909)
- dev: tests for multi-file account display order (1909)
- fix: fix multi-file account display order; improve file read logging (1909)
- dev: journalFilePath, include: show (unknown) instead of nothing
- dev: lib: hlint improvements
- imp: add a missing space after colon in some debug output
