### PR TITLE
Support (and require) brick 1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ ghcid: $(call def-help,ghcid, start ghcid autobuilder on hledger-lib + hledger)
 	ghcid -c 'make ghci'
 
 ghcid-ui: $(call def-help,ghcid-ui, start ghcid autobuilder on hledger-lib + hledger + hledger-ui)
-	ghcid -c 'make ui'
+	ghcid -c 'make ghci-ui'
 
 ghcid-web: $(call def-help,ghcid-web, start ghcid autobuilder on hledger-lib + hledger + hledger-web)
 	ghcid -c 'make ghci-web'
@@ -407,9 +407,7 @@ ghci-dev: $(call def-help,ghci-dev, start ghci REPL on hledger-lib + hledger + d
 	$(STACKGHCI) exec -- $(GHCI) $(BUILDFLAGS) -fno-warn-unused-imports -fno-warn-unused-binds dev.hs
 
 ghci-ui: $(call def-help,ghci-ui, start ghci REPL on hledger-lib + hledger + hledger-ui)
-	stack --stack-yaml=stack8.10.yaml exec -- $(GHCI) $(BUILDFLAGS) hledger-ui/Hledger/UI/Main.hs
-# XXX run older GHCI because ghci-ui fails most of the time with 9.0
-#	$(STACKGHCI) exec -- $(GHCI) $(BUILDFLAGS) hledger-ui/Hledger/UI/Main.hs
+	$(STACKGHCI) exec -- $(GHCI) $(BUILDFLAGS) hledger-ui/Hledger/UI/Main.hs
 
 ghci-web: webdirs $(call def-help,ghci-web, start ghci REPL on hledger-lib + hledger + hledger-web)
 	$(STACKGHCI) exec -- $(GHCI) $(BUILDFLAGS) hledger-web/app/main.hs

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -152,7 +152,7 @@ asDraw UIState{aopts=_uopts@UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec}}
         ishistorical = balanceaccum_ ropts == Historical
 
         toplabel =
-              withAttr ("border" <> "filename") files
+              withAttr (attrName "border" <> attrName "filename") files
           <+> toggles
           <+> str (" account " ++ if ishistorical then "balances" else "changes")
           <+> borderPeriodStr (if ishistorical then "at end of" else "in") (period_ ropts)
@@ -160,7 +160,7 @@ asDraw UIState{aopts=_uopts@UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec}}
           <+> borderDepthStr mdepth
           <+> str (" ("++curidx++"/"++totidx++")")
           <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts
-               then withAttr ("border" <> "query") (str " ignoring balance assertions")
+               then withAttr (attrName "border" <> attrName "query") (str " ignoring balance assertions")
                else str "")
           where
             files = case journalFilePaths j of
@@ -168,7 +168,7 @@ asDraw UIState{aopts=_uopts@UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec}}
                            f:_ -> str $ takeFileName f
                            -- [f,_:[]] -> (withAttr ("border" <> "bold") $ str $ takeFileName f) <+> str " (& 1 included file)"
                            -- f:fs  -> (withAttr ("border" <> "bold") $ str $ takeFileName f) <+> str (" (& " ++ show (length fs) ++ " included files)")
-            toggles = withAttr ("border" <> "query") $ str $ unwords $ concat [
+            toggles = withAttr (attrName "border" <> attrName "query") $ str $ unwords $ concat [
                [""]
               ,if empty_ ropts then [] else ["nonzero"]
               ,uiShowStatus copts $ statuses_ ropts
@@ -220,22 +220,24 @@ asDrawItem (acctwidth, balwidth) selected AccountsScreenItem{..} =
         balspace = T.replicate (2 + balwidth - wbWidth balBuilder) " "
         splitAmounts = foldr1 (<+>) . intersperse (str ", ") . map renderamt . T.splitOn ", " . wbToText
         renderamt :: T.Text -> Widget Name
-        renderamt a | T.any (=='-') a = withAttr (sel $ "list" <> "balance" <> "negative") $ txt a
-                    | otherwise       = withAttr (sel $ "list" <> "balance" <> "positive") $ txt a
-        sel | selected  = (<> "selected")
+        renderamt a | T.any (=='-') a = withAttr (sel $ attrName "list" <> attrName "balance" <> attrName "negative") $ txt a
+                    | otherwise       = withAttr (sel $ attrName "list" <> attrName "balance" <> attrName "positive") $ txt a
+        sel | selected  = (<> attrName "selected")
             | otherwise = id
 
-asHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
-asHandle ui0@UIState{
+asHandle :: BrickEvent Name AppEvent -> EventM Name UIState ()
+asHandle ev = do
+  ui0@UIState{
    aScreen=scr@AccountsScreen{..}
   ,aopts=UIOpts{uoCliOpts=copts}
   ,ajournal=j
   ,aMode=mode
-  } ev = do
+  } <- get  -- PARTIAL: should not fail
   let
     d = copts^.rsDay
     nonblanks = V.takeWhile (not . T.null . asItemAccountName) $ _asList^.listElementsL
     lastnonblankidx = max 0 (length nonblanks - 1)
+    journalspan = journalDateSpan False j
 
   -- save the currently selected account, in case we leave this screen and lose the selection
   let
@@ -247,87 +249,81 @@ asHandle ui0@UIState{
   case mode of
     Minibuffer _ ed ->
       case ev of
-        VtyEvent (EvKey KEsc   []) -> continue $ closeMinibuffer ui
-        VtyEvent (EvKey KEnter []) -> continue $ regenerateScreens j d $
+        VtyEvent (EvKey KEsc   []) -> put $ closeMinibuffer ui
+        VtyEvent (EvKey KEnter []) -> put $ regenerateScreens j d $
             case setFilter s $ closeMinibuffer ui of
               Left bad -> showMinibuffer "Cannot compile regular expression" (Just bad) ui
               Right ui' -> ui'
           where s = chomp $ unlines $ map strip $ getEditContents ed
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        VtyEvent ev        -> do
-          ed' <- handleEditorEvent 
-#if MIN_VERSION_brick(0,72,0)
-            (VtyEvent ev)
-#else
-            ev
-#endif
-            ed
-          continue $ ui{aMode=Minibuffer "filter" ed'}
-        AppEvent _        -> continue ui
-        MouseDown{}       -> continue ui
-        MouseUp{}         -> continue ui
+        VtyEvent ev -> do
+          ed' <- nestEventM' ed $ handleEditorEvent (VtyEvent ev)
+          put ui{aMode=Minibuffer "filter" ed'}
+        AppEvent _  -> return ()
+        MouseDown{} -> return ()
+        MouseUp{}   -> return ()
 
     Help ->
       case ev of
-        -- VtyEvent (EvKey (KChar 'q') []) -> halt ui
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
+        -- VtyEvent (EvKey (KChar 'q') []) -> halt
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        _                    -> helpHandle ui ev
+        _                    -> helpHandle ev
 
     Normal ->
       case ev of
-        VtyEvent (EvKey (KChar 'q') []) -> halt ui
+        VtyEvent (EvKey (KChar 'q') []) -> halt
         -- EvKey (KChar 'l') [MCtrl] -> do
-        VtyEvent (EvKey KEsc        []) -> continue $ resetScreens d ui
-        VtyEvent (EvKey (KChar c)   []) | c == '?' -> continue $ setMode Help ui
+        VtyEvent (EvKey KEsc        []) -> put $ resetScreens d ui
+        VtyEvent (EvKey (KChar c)   []) | c == '?' -> put $ setMode Help ui
         -- XXX AppEvents currently handled only in Normal mode
         -- XXX be sure we don't leave unconsumed events piling up
         AppEvent (DateChange old _) | isStandardPeriod p && p `periodContainsDate` old ->
-          continue $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
+          put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
           where
             p = reportPeriod ui
         e | e `elem` [VtyEvent (EvKey (KChar 'g') []), AppEvent FileChange] ->
-          liftIO (uiReloadJournal copts d ui) >>= continue
-        VtyEvent (EvKey (KChar 'I') []) -> continue $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
+          liftIO (uiReloadJournal copts d ui) >>= put
+        VtyEvent (EvKey (KChar 'I') []) -> put $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
         VtyEvent (EvKey (KChar 'a') []) -> suspendAndResume $ clearScreen >> setCursorPosition 0 0 >> add copts j >> uiReloadJournalIfChanged copts d j ui
         VtyEvent (EvKey (KChar 'A') []) -> suspendAndResume $ void (runIadd (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
         VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor endPosition (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
-        VtyEvent (EvKey (KChar 'B') []) -> continue $ regenerateScreens j d $ toggleConversionOp ui
-        VtyEvent (EvKey (KChar 'V') []) -> continue $ regenerateScreens j d $ toggleValue ui
-        VtyEvent (EvKey (KChar '0') []) -> continue $ regenerateScreens j d $ setDepth (Just 0) ui
-        VtyEvent (EvKey (KChar '1') []) -> continue $ regenerateScreens j d $ setDepth (Just 1) ui
-        VtyEvent (EvKey (KChar '2') []) -> continue $ regenerateScreens j d $ setDepth (Just 2) ui
-        VtyEvent (EvKey (KChar '3') []) -> continue $ regenerateScreens j d $ setDepth (Just 3) ui
-        VtyEvent (EvKey (KChar '4') []) -> continue $ regenerateScreens j d $ setDepth (Just 4) ui
-        VtyEvent (EvKey (KChar '5') []) -> continue $ regenerateScreens j d $ setDepth (Just 5) ui
-        VtyEvent (EvKey (KChar '6') []) -> continue $ regenerateScreens j d $ setDepth (Just 6) ui
-        VtyEvent (EvKey (KChar '7') []) -> continue $ regenerateScreens j d $ setDepth (Just 7) ui
-        VtyEvent (EvKey (KChar '8') []) -> continue $ regenerateScreens j d $ setDepth (Just 8) ui
-        VtyEvent (EvKey (KChar '9') []) -> continue $ regenerateScreens j d $ setDepth (Just 9) ui
-        VtyEvent (EvKey (KChar '-') []) -> continue $ regenerateScreens j d $ decDepth ui
-        VtyEvent (EvKey (KChar '_') []) -> continue $ regenerateScreens j d $ decDepth ui
-        VtyEvent (EvKey (KChar c)   []) | c `elem` ['+','='] -> continue $ regenerateScreens j d $ incDepth ui
-        VtyEvent (EvKey (KChar 'T') []) -> continue $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
+        VtyEvent (EvKey (KChar 'B') []) -> put $ regenerateScreens j d $ toggleConversionOp ui
+        VtyEvent (EvKey (KChar 'V') []) -> put $ regenerateScreens j d $ toggleValue ui
+        VtyEvent (EvKey (KChar '0') []) -> put $ regenerateScreens j d $ setDepth (Just 0) ui
+        VtyEvent (EvKey (KChar '1') []) -> put $ regenerateScreens j d $ setDepth (Just 1) ui
+        VtyEvent (EvKey (KChar '2') []) -> put $ regenerateScreens j d $ setDepth (Just 2) ui
+        VtyEvent (EvKey (KChar '3') []) -> put $ regenerateScreens j d $ setDepth (Just 3) ui
+        VtyEvent (EvKey (KChar '4') []) -> put $ regenerateScreens j d $ setDepth (Just 4) ui
+        VtyEvent (EvKey (KChar '5') []) -> put $ regenerateScreens j d $ setDepth (Just 5) ui
+        VtyEvent (EvKey (KChar '6') []) -> put $ regenerateScreens j d $ setDepth (Just 6) ui
+        VtyEvent (EvKey (KChar '7') []) -> put $ regenerateScreens j d $ setDepth (Just 7) ui
+        VtyEvent (EvKey (KChar '8') []) -> put $ regenerateScreens j d $ setDepth (Just 8) ui
+        VtyEvent (EvKey (KChar '9') []) -> put $ regenerateScreens j d $ setDepth (Just 9) ui
+        VtyEvent (EvKey (KChar '-') []) -> put $ regenerateScreens j d $ decDepth ui
+        VtyEvent (EvKey (KChar '_') []) -> put $ regenerateScreens j d $ decDepth ui
+        VtyEvent (EvKey (KChar c)   []) | c `elem` ['+','='] -> put $ regenerateScreens j d $ incDepth ui
+        VtyEvent (EvKey (KChar 'T') []) -> put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
 
         -- display mode/query toggles
-        VtyEvent (EvKey (KChar 'H') []) -> asCenterAndContinue $ regenerateScreens j d $ toggleHistorical ui
-        VtyEvent (EvKey (KChar 't') []) -> asCenterAndContinue $ regenerateScreens j d $ toggleTree ui
-        VtyEvent (EvKey (KChar c) []) | c `elem` ['z','Z'] -> asCenterAndContinue $ regenerateScreens j d $ toggleEmpty ui
-        VtyEvent (EvKey (KChar 'R') []) -> asCenterAndContinue $ regenerateScreens j d $ toggleReal ui
-        VtyEvent (EvKey (KChar 'U') []) -> asCenterAndContinue $ regenerateScreens j d $ toggleUnmarked ui
-        VtyEvent (EvKey (KChar 'P') []) -> asCenterAndContinue $ regenerateScreens j d $ togglePending ui
-        VtyEvent (EvKey (KChar 'C') []) -> asCenterAndContinue $ regenerateScreens j d $ toggleCleared ui
-        VtyEvent (EvKey (KChar 'F') []) -> continue $ regenerateScreens j d $ toggleForecast d ui
+        VtyEvent (EvKey (KChar 'H') []) -> modify (regenerateScreens j d . toggleHistorical) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar 't') []) -> modify (regenerateScreens j d . toggleTree) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar c) []) | c `elem` ['z','Z'] -> modify (regenerateScreens j d . toggleEmpty) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar 'R') []) -> modify (regenerateScreens j d . toggleReal) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar 'U') []) -> modify (regenerateScreens j d . toggleUnmarked) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar 'P') []) -> modify (regenerateScreens j d . togglePending) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar 'C') []) -> modify (regenerateScreens j d . toggleCleared) >> asCenterAndContinue
+        VtyEvent (EvKey (KChar 'F') []) -> modify (regenerateScreens j d . toggleForecast d)
 
-        VtyEvent (EvKey (KDown)     [MShift]) -> continue $ regenerateScreens j d $ shrinkReportPeriod d ui
-        VtyEvent (EvKey (KUp)       [MShift]) -> continue $ regenerateScreens j d $ growReportPeriod d ui
-        VtyEvent (EvKey (KRight)    [MShift]) -> continue $ regenerateScreens j d $ nextReportPeriod journalspan ui
-        VtyEvent (EvKey (KLeft)     [MShift]) -> continue $ regenerateScreens j d $ previousReportPeriod journalspan ui
-        VtyEvent (EvKey (KChar '/') []) -> continue $ regenerateScreens j d $ showMinibuffer "filter" Nothing ui
-        VtyEvent (EvKey k           []) | k `elem` [KBS, KDel] -> (continue $ regenerateScreens j d $ resetFilter ui)
-        VtyEvent e | e `elem` moveLeftEvents -> continue $ popScreen ui
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle _asList >> redraw ui
+        VtyEvent (EvKey (KDown)     [MShift]) -> put $ regenerateScreens j d $ shrinkReportPeriod d ui
+        VtyEvent (EvKey (KUp)       [MShift]) -> put $ regenerateScreens j d $ growReportPeriod d ui
+        VtyEvent (EvKey (KRight)    [MShift]) -> put $ regenerateScreens j d $ nextReportPeriod journalspan ui
+        VtyEvent (EvKey (KLeft)     [MShift]) -> put $ regenerateScreens j d $ previousReportPeriod journalspan ui
+        VtyEvent (EvKey (KChar '/') []) -> put $ regenerateScreens j d $ showMinibuffer "filter" Nothing ui
+        VtyEvent (EvKey k           []) | k `elem` [KBS, KDel] -> (put $ regenerateScreens j d $ resetFilter ui)
+        VtyEvent e | e `elem` moveLeftEvents -> put $ popScreen ui
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle _asList >> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
 
         -- enter register screen for selected account (if there is one),
@@ -338,7 +334,7 @@ asHandle ui0@UIState{
         -- MouseDown is sometimes duplicated, https://github.com/jtdaugherty/brick/issues/347
         -- just use it to move the selection
         MouseDown _n BLeft _mods Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
-          continue ui{aScreen=scr{_asList=listMoveTo y _asList}}
+          case scr of AccountsScreen{} -> put ui{aScreen=scr}; _ -> fail ""  -- PARTIAL: should not happen
           where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
         -- and on MouseUp, enter the subscreen
         MouseUp _n (Just BLeft) Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
@@ -347,42 +343,35 @@ asHandle ui0@UIState{
 
         -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
         VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
-          vScrollBy (viewportScroll $ _asList^.listNameL) 1 >> continue ui
+          vScrollBy (viewportScroll $ _asList^.listNameL) 1 >> put ui
           where mnextelement = listSelectedElement $ listMoveDown _asList
 
         -- mouse scroll wheel scrolls the viewport up or down to its maximum extent,
         -- pushing the selection when necessary.
         MouseDown name btn _mods _loc | btn `elem` [BScrollUp, BScrollDown] -> do
           let scrollamt = if btn==BScrollUp then -1 else 1
-          list' <- listScrollPushingSelection name _asList (asListSize _asList) scrollamt
-          continue ui{aScreen=scr{_asList=list'}}
+          list' <- nestEventM' _asList $ listScrollPushingSelection name (asListSize _asList) scrollamt
+          case scr of AccountsScreen{} -> put ui{aScreen=scr{_asList=list'}}; _ -> fail ""  -- PARTIAL: should not fail
 
         -- if page down or end leads to a blank padding item, stop at last non-blank
         VtyEvent e@(EvKey k           []) | k `elem` [KPageDown, KEnd] -> do
-          list <- handleListEvent e _asList
+          list <- nestEventM' _asList $ handleListEvent e
           if isBlankElement $ listSelectedElement list
           then do
             let list' = listMoveTo lastnonblankidx list
             scrollSelectionToMiddle list'
-            continue ui{aScreen=scr{_asList=list'}}
+            case scr of AccountsScreen{} -> put ui{aScreen=scr{_asList=list'}}; _ -> fail ""  -- PARTIAL: should not fail
           else
-            continue ui{aScreen=scr{_asList=list}}
+            case scr of AccountsScreen{} -> put ui{aScreen=scr{_asList=list}}; _ -> fail ""  -- PARTIAL: should not fail
 
         -- fall through to the list's event handler (handles up/down)
         VtyEvent ev -> do
-          newitems <- handleListEvent (normaliseMovementKeys ev) _asList
-          continue $ ui{aScreen=scr & asList .~ newitems
-                                    & asSelectedAccount .~ selacct
-                                    }
+          list' <- nestEventM' _asList $ handleListEvent (normaliseMovementKeys ev)
+          put $ ui{aScreen=scr & asList .~ list' & asSelectedAccount .~ selacct }
 
-        MouseDown{} -> continue ui
-        MouseUp{}   -> continue ui
-        AppEvent _  -> continue ui
-
-  where
-    journalspan = journalDateSpan False j
-
-asHandle _ _ = error "event handler called with wrong screen type, should not happen"  -- PARTIAL:
+        MouseDown{} -> put ui
+        MouseUp{}   -> put ui
+        AppEvent _  -> put ui
 
 asEnterRegister d selacct ui = do
   rsCenterAndContinue $
@@ -399,8 +388,9 @@ asSetSelectedAccount _ s = s
 
 isBlankElement mel = ((asItemAccountName . snd) <$> mel) == Just ""
 
-asCenterAndContinue ui = do
-  scrollSelectionToMiddle $ _asList $ aScreen ui
-  continue ui
+asCenterAndContinue :: EventM Name UIState ()
+asCenterAndContinue = do
+  ui <- get
+  scrollSelectionToMiddle (_asList $ aScreen ui)
 
 asListSize = V.length . V.takeWhile ((/="").asItemAccountName) . listElements

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -227,151 +227,154 @@ asDrawItem (acctwidth, balwidth) selected AccountsScreenItem{..} =
 
 asHandle :: BrickEvent Name AppEvent -> EventM Name UIState ()
 asHandle ev = do
-  ui0@UIState{
-   aScreen=scr@AccountsScreen{..}
-  ,aopts=UIOpts{uoCliOpts=copts}
-  ,ajournal=j
-  ,aMode=mode
-  } <- get  -- PARTIAL: should not fail
-  let
-    d = copts^.rsDay
-    nonblanks = V.takeWhile (not . T.null . asItemAccountName) $ _asList^.listElementsL
-    lastnonblankidx = max 0 (length nonblanks - 1)
-    journalspan = journalDateSpan False j
+  ui0 <- get
+  case ui0 of
+    ui1@UIState{
+      aScreen=scr@AccountsScreen{..}
+      ,aopts=UIOpts{uoCliOpts=copts}
+      ,ajournal=j
+      ,aMode=mode
+      } -> do
 
-  -- save the currently selected account, in case we leave this screen and lose the selection
-  let
-    selacct = case listSelectedElement _asList of
-                Just (_, AccountsScreenItem{..}) -> asItemAccountName
-                Nothing -> scr ^. asSelectedAccount
-    ui = ui0{aScreen=scr & asSelectedAccount .~ selacct}
+      let
+        -- save the currently selected account, in case we leave this screen and lose the selection
+        selacct = case listSelectedElement _asList of
+                    Just (_, AccountsScreenItem{..}) -> asItemAccountName
+                    Nothing -> scr ^. asSelectedAccount
+        ui = ui1{aScreen=scr & asSelectedAccount .~ selacct}
+        nonblanks = V.takeWhile (not . T.null . asItemAccountName) $ _asList^.listElementsL
+        lastnonblankidx = max 0 (length nonblanks - 1)
+        journalspan = journalDateSpan False j
+        d = copts^.rsDay
 
-  case mode of
-    Minibuffer _ ed ->
-      case ev of
-        VtyEvent (EvKey KEsc   []) -> put $ closeMinibuffer ui
-        VtyEvent (EvKey KEnter []) -> put $ regenerateScreens j d $
-            case setFilter s $ closeMinibuffer ui of
-              Left bad -> showMinibuffer "Cannot compile regular expression" (Just bad) ui
-              Right ui' -> ui'
-          where s = chomp $ unlines $ map strip $ getEditContents ed
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
-        VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        VtyEvent ev -> do
-          ed' <- nestEventM' ed $ handleEditorEvent (VtyEvent ev)
-          put ui{aMode=Minibuffer "filter" ed'}
-        AppEvent _  -> return ()
-        MouseDown{} -> return ()
-        MouseUp{}   -> return ()
+      case mode of
+        Minibuffer _ ed ->
+          case ev of
+            VtyEvent (EvKey KEsc   []) -> put $ closeMinibuffer ui
+            VtyEvent (EvKey KEnter []) -> put $ regenerateScreens j d $
+                case setFilter s $ closeMinibuffer ui of
+                  Left bad -> showMinibuffer "Cannot compile regular expression" (Just bad) ui
+                  Right ui' -> ui'
+              where s = chomp $ unlines $ map strip $ getEditContents ed
+            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
+            VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
+            VtyEvent ev -> do
+              ed' <- nestEventM' ed $ handleEditorEvent (VtyEvent ev)
+              put ui{aMode=Minibuffer "filter" ed'}
+            AppEvent _  -> return ()
+            MouseDown{} -> return ()
+            MouseUp{}   -> return ()
 
-    Help ->
-      case ev of
-        -- VtyEvent (EvKey (KChar 'q') []) -> halt
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
-        VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        _                    -> helpHandle ev
+        Help ->
+          case ev of
+            -- VtyEvent (EvKey (KChar 'q') []) -> halt
+            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
+            VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
+            _                    -> helpHandle ev
 
-    Normal ->
-      case ev of
-        VtyEvent (EvKey (KChar 'q') []) -> halt
-        -- EvKey (KChar 'l') [MCtrl] -> do
-        VtyEvent (EvKey KEsc        []) -> put $ resetScreens d ui
-        VtyEvent (EvKey (KChar c)   []) | c == '?' -> put $ setMode Help ui
-        -- XXX AppEvents currently handled only in Normal mode
-        -- XXX be sure we don't leave unconsumed events piling up
-        AppEvent (DateChange old _) | isStandardPeriod p && p `periodContainsDate` old ->
-          put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
-          where
-            p = reportPeriod ui
-        e | e `elem` [VtyEvent (EvKey (KChar 'g') []), AppEvent FileChange] ->
-          liftIO (uiReloadJournal copts d ui) >>= put
-        VtyEvent (EvKey (KChar 'I') []) -> put $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
-        VtyEvent (EvKey (KChar 'a') []) -> suspendAndResume $ clearScreen >> setCursorPosition 0 0 >> add copts j >> uiReloadJournalIfChanged copts d j ui
-        VtyEvent (EvKey (KChar 'A') []) -> suspendAndResume $ void (runIadd (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
-        VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor endPosition (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
-        VtyEvent (EvKey (KChar 'B') []) -> put $ regenerateScreens j d $ toggleConversionOp ui
-        VtyEvent (EvKey (KChar 'V') []) -> put $ regenerateScreens j d $ toggleValue ui
-        VtyEvent (EvKey (KChar '0') []) -> put $ regenerateScreens j d $ setDepth (Just 0) ui
-        VtyEvent (EvKey (KChar '1') []) -> put $ regenerateScreens j d $ setDepth (Just 1) ui
-        VtyEvent (EvKey (KChar '2') []) -> put $ regenerateScreens j d $ setDepth (Just 2) ui
-        VtyEvent (EvKey (KChar '3') []) -> put $ regenerateScreens j d $ setDepth (Just 3) ui
-        VtyEvent (EvKey (KChar '4') []) -> put $ regenerateScreens j d $ setDepth (Just 4) ui
-        VtyEvent (EvKey (KChar '5') []) -> put $ regenerateScreens j d $ setDepth (Just 5) ui
-        VtyEvent (EvKey (KChar '6') []) -> put $ regenerateScreens j d $ setDepth (Just 6) ui
-        VtyEvent (EvKey (KChar '7') []) -> put $ regenerateScreens j d $ setDepth (Just 7) ui
-        VtyEvent (EvKey (KChar '8') []) -> put $ regenerateScreens j d $ setDepth (Just 8) ui
-        VtyEvent (EvKey (KChar '9') []) -> put $ regenerateScreens j d $ setDepth (Just 9) ui
-        VtyEvent (EvKey (KChar '-') []) -> put $ regenerateScreens j d $ decDepth ui
-        VtyEvent (EvKey (KChar '_') []) -> put $ regenerateScreens j d $ decDepth ui
-        VtyEvent (EvKey (KChar c)   []) | c `elem` ['+','='] -> put $ regenerateScreens j d $ incDepth ui
-        VtyEvent (EvKey (KChar 'T') []) -> put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
+        Normal ->
+          case ev of
+            VtyEvent (EvKey (KChar 'q') []) -> halt
+            -- EvKey (KChar 'l') [MCtrl] -> do
+            VtyEvent (EvKey KEsc        []) -> put $ resetScreens d ui
+            VtyEvent (EvKey (KChar c)   []) | c == '?' -> put $ setMode Help ui
+            -- XXX AppEvents currently handled only in Normal mode
+            -- XXX be sure we don't leave unconsumed events piling up
+            AppEvent (DateChange old _) | isStandardPeriod p && p `periodContainsDate` old ->
+              put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
+              where
+                p = reportPeriod ui
+            e | e `elem` [VtyEvent (EvKey (KChar 'g') []), AppEvent FileChange] ->
+              liftIO (uiReloadJournal copts d ui) >>= put
+            VtyEvent (EvKey (KChar 'I') []) -> put $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
+            VtyEvent (EvKey (KChar 'a') []) -> suspendAndResume $ clearScreen >> setCursorPosition 0 0 >> add copts j >> uiReloadJournalIfChanged copts d j ui
+            VtyEvent (EvKey (KChar 'A') []) -> suspendAndResume $ void (runIadd (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
+            VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor endPosition (journalFilePath j)) >> uiReloadJournalIfChanged copts d j ui
+            VtyEvent (EvKey (KChar 'B') []) -> put $ regenerateScreens j d $ toggleConversionOp ui
+            VtyEvent (EvKey (KChar 'V') []) -> put $ regenerateScreens j d $ toggleValue ui
+            VtyEvent (EvKey (KChar '0') []) -> put $ regenerateScreens j d $ setDepth (Just 0) ui
+            VtyEvent (EvKey (KChar '1') []) -> put $ regenerateScreens j d $ setDepth (Just 1) ui
+            VtyEvent (EvKey (KChar '2') []) -> put $ regenerateScreens j d $ setDepth (Just 2) ui
+            VtyEvent (EvKey (KChar '3') []) -> put $ regenerateScreens j d $ setDepth (Just 3) ui
+            VtyEvent (EvKey (KChar '4') []) -> put $ regenerateScreens j d $ setDepth (Just 4) ui
+            VtyEvent (EvKey (KChar '5') []) -> put $ regenerateScreens j d $ setDepth (Just 5) ui
+            VtyEvent (EvKey (KChar '6') []) -> put $ regenerateScreens j d $ setDepth (Just 6) ui
+            VtyEvent (EvKey (KChar '7') []) -> put $ regenerateScreens j d $ setDepth (Just 7) ui
+            VtyEvent (EvKey (KChar '8') []) -> put $ regenerateScreens j d $ setDepth (Just 8) ui
+            VtyEvent (EvKey (KChar '9') []) -> put $ regenerateScreens j d $ setDepth (Just 9) ui
+            VtyEvent (EvKey (KChar '-') []) -> put $ regenerateScreens j d $ decDepth ui
+            VtyEvent (EvKey (KChar '_') []) -> put $ regenerateScreens j d $ decDepth ui
+            VtyEvent (EvKey (KChar c)   []) | c `elem` ['+','='] -> put $ regenerateScreens j d $ incDepth ui
+            VtyEvent (EvKey (KChar 'T') []) -> put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
 
-        -- display mode/query toggles
-        VtyEvent (EvKey (KChar 'H') []) -> modify (regenerateScreens j d . toggleHistorical) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar 't') []) -> modify (regenerateScreens j d . toggleTree) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar c) []) | c `elem` ['z','Z'] -> modify (regenerateScreens j d . toggleEmpty) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar 'R') []) -> modify (regenerateScreens j d . toggleReal) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar 'U') []) -> modify (regenerateScreens j d . toggleUnmarked) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar 'P') []) -> modify (regenerateScreens j d . togglePending) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar 'C') []) -> modify (regenerateScreens j d . toggleCleared) >> asCenterAndContinue
-        VtyEvent (EvKey (KChar 'F') []) -> modify (regenerateScreens j d . toggleForecast d)
+            -- display mode/query toggles
+            VtyEvent (EvKey (KChar 'H') []) -> modify (regenerateScreens j d . toggleHistorical) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar 't') []) -> modify (regenerateScreens j d . toggleTree) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar c) []) | c `elem` ['z','Z'] -> modify (regenerateScreens j d . toggleEmpty) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar 'R') []) -> modify (regenerateScreens j d . toggleReal) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar 'U') []) -> modify (regenerateScreens j d . toggleUnmarked) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar 'P') []) -> modify (regenerateScreens j d . togglePending) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar 'C') []) -> modify (regenerateScreens j d . toggleCleared) >> asCenterAndContinue
+            VtyEvent (EvKey (KChar 'F') []) -> modify (regenerateScreens j d . toggleForecast d)
 
-        VtyEvent (EvKey (KDown)     [MShift]) -> put $ regenerateScreens j d $ shrinkReportPeriod d ui
-        VtyEvent (EvKey (KUp)       [MShift]) -> put $ regenerateScreens j d $ growReportPeriod d ui
-        VtyEvent (EvKey (KRight)    [MShift]) -> put $ regenerateScreens j d $ nextReportPeriod journalspan ui
-        VtyEvent (EvKey (KLeft)     [MShift]) -> put $ regenerateScreens j d $ previousReportPeriod journalspan ui
-        VtyEvent (EvKey (KChar '/') []) -> put $ regenerateScreens j d $ showMinibuffer "filter" Nothing ui
-        VtyEvent (EvKey k           []) | k `elem` [KBS, KDel] -> (put $ regenerateScreens j d $ resetFilter ui)
-        VtyEvent e | e `elem` moveLeftEvents -> put $ popScreen ui
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle _asList >> redraw
-        VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
+            VtyEvent (EvKey (KDown)     [MShift]) -> put $ regenerateScreens j d $ shrinkReportPeriod d ui
+            VtyEvent (EvKey (KUp)       [MShift]) -> put $ regenerateScreens j d $ growReportPeriod d ui
+            VtyEvent (EvKey (KRight)    [MShift]) -> put $ regenerateScreens j d $ nextReportPeriod journalspan ui
+            VtyEvent (EvKey (KLeft)     [MShift]) -> put $ regenerateScreens j d $ previousReportPeriod journalspan ui
+            VtyEvent (EvKey (KChar '/') []) -> put $ regenerateScreens j d $ showMinibuffer "filter" Nothing ui
+            VtyEvent (EvKey k           []) | k `elem` [KBS, KDel] -> (put $ regenerateScreens j d $ resetFilter ui)
+            VtyEvent e | e `elem` moveLeftEvents -> put $ popScreen ui
+            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle _asList >> redraw
+            VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
 
-        -- enter register screen for selected account (if there is one),
-        -- centering its selected transaction if possible
-        VtyEvent e | e `elem` moveRightEvents
-                   , not $ isBlankElement $ listSelectedElement _asList -> asEnterRegister d selacct ui
+            -- enter register screen for selected account (if there is one),
+            -- centering its selected transaction if possible
+            VtyEvent e | e `elem` moveRightEvents
+                      , not $ isBlankElement $ listSelectedElement _asList -> asEnterRegister d selacct ui
 
-        -- MouseDown is sometimes duplicated, https://github.com/jtdaugherty/brick/issues/347
-        -- just use it to move the selection
-        MouseDown _n BLeft _mods Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
-          case scr of AccountsScreen{} -> put ui{aScreen=scr}; _ -> fail ""  -- PARTIAL: should not happen
-          where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
-        -- and on MouseUp, enter the subscreen
-        MouseUp _n (Just BLeft) Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
-          asEnterRegister d clickedacct ui
-          where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
+            -- MouseDown is sometimes duplicated, https://github.com/jtdaugherty/brick/issues/347
+            -- just use it to move the selection
+            MouseDown _n BLeft _mods Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
+              put ui{aScreen=scr}  -- XXX does this do anything ?
+              where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
+            -- and on MouseUp, enter the subscreen
+            MouseUp _n (Just BLeft) Location{loc=(_x,y)} | not $ (=="") clickedacct -> do
+              asEnterRegister d clickedacct ui
+              where clickedacct = maybe "" asItemAccountName $ listElements _asList !? y
 
-        -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
-        VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
-          vScrollBy (viewportScroll $ _asList^.listNameL) 1 >> put ui
-          where mnextelement = listSelectedElement $ listMoveDown _asList
+            -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
+            VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
+              vScrollBy (viewportScroll $ _asList^.listNameL) 1
+              where mnextelement = listSelectedElement $ listMoveDown _asList
 
-        -- mouse scroll wheel scrolls the viewport up or down to its maximum extent,
-        -- pushing the selection when necessary.
-        MouseDown name btn _mods _loc | btn `elem` [BScrollUp, BScrollDown] -> do
-          let scrollamt = if btn==BScrollUp then -1 else 1
-          list' <- nestEventM' _asList $ listScrollPushingSelection name (asListSize _asList) scrollamt
-          case scr of AccountsScreen{} -> put ui{aScreen=scr{_asList=list'}}; _ -> fail ""  -- PARTIAL: should not fail
+            -- mouse scroll wheel scrolls the viewport up or down to its maximum extent,
+            -- pushing the selection when necessary.
+            MouseDown name btn _mods _loc | btn `elem` [BScrollUp, BScrollDown] -> do
+              let scrollamt = if btn==BScrollUp then -1 else 1
+              list' <- nestEventM' _asList $ listScrollPushingSelection name (asListSize _asList) scrollamt
+              put ui{aScreen=scr{_asList=list'}}
 
-        -- if page down or end leads to a blank padding item, stop at last non-blank
-        VtyEvent e@(EvKey k           []) | k `elem` [KPageDown, KEnd] -> do
-          list <- nestEventM' _asList $ handleListEvent e
-          if isBlankElement $ listSelectedElement list
-          then do
-            let list' = listMoveTo lastnonblankidx list
-            scrollSelectionToMiddle list'
-            case scr of AccountsScreen{} -> put ui{aScreen=scr{_asList=list'}}; _ -> fail ""  -- PARTIAL: should not fail
-          else
-            case scr of AccountsScreen{} -> put ui{aScreen=scr{_asList=list}}; _ -> fail ""  -- PARTIAL: should not fail
+            -- if page down or end leads to a blank padding item, stop at last non-blank
+            VtyEvent e@(EvKey k           []) | k `elem` [KPageDown, KEnd] -> do
+              list <- nestEventM' _asList $ handleListEvent e
+              if isBlankElement $ listSelectedElement list
+              then do
+                let list' = listMoveTo lastnonblankidx list
+                scrollSelectionToMiddle list'
+                put ui{aScreen=scr{_asList=list'}}
+              else
+                put ui{aScreen=scr{_asList=list}}
 
-        -- fall through to the list's event handler (handles up/down)
-        VtyEvent ev -> do
-          list' <- nestEventM' _asList $ handleListEvent (normaliseMovementKeys ev)
-          put $ ui{aScreen=scr & asList .~ list' & asSelectedAccount .~ selacct }
+            -- fall through to the list's event handler (handles up/down)
+            VtyEvent ev -> do
+              list' <- nestEventM' _asList $ handleListEvent (normaliseMovementKeys ev)
+              put $ ui{aScreen=scr & asList .~ list' & asSelectedAccount .~ selacct }
 
-        MouseDown{} -> put ui
-        MouseUp{}   -> put ui
-        AppEvent _  -> put ui
+            MouseDown{} -> put ui
+            MouseUp{}   -> put ui
+            AppEvent _  -> put ui
+
+    _ -> errorWrongScreenType
 
 asEnterRegister d selacct ui = do
   rsCenterAndContinue $

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -54,10 +54,10 @@ esDraw UIState{aopts=UIOpts{uoCliOpts=copts}
     _          -> [maincontent]
   where
     maincontent = Widget Greedy Greedy $ do
-      render $ defaultLayout toplabel bottomlabel $ withAttr "error" $ str $ esError
+      render $ defaultLayout toplabel bottomlabel $ withAttr (attrName "error") $ str $ esError
       where
         toplabel =
-              withAttr ("border" <> "bold") (str "Oops. Please fix this problem then press g to reload")
+              withAttr (attrName "border" <> attrName "bold") (str "Oops. Please fix this problem then press g to reload")
               -- <+> (if ignore_assertions_ copts then withAttr ("border" <> "query") (str " ignoring") else str " not ignoring")
 
         bottomlabel = quickhelp
@@ -75,44 +75,42 @@ esDraw UIState{aopts=UIOpts{uoCliOpts=copts}
 
 esDraw _ = error "draw function called with wrong screen type, should not happen"  -- PARTIAL:
 
-esHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
-esHandle ui@UIState{aScreen=ErrorScreen{..}
+esHandle :: BrickEvent Name AppEvent -> EventM Name UIState ()
+esHandle ev = do
+  ui@UIState{aScreen=ErrorScreen{..}
                    ,aopts=UIOpts{uoCliOpts=copts}
                    ,ajournal=j
                    ,aMode=mode
-                   }
-         ev =
+                   } <- get
   case mode of
     Help ->
       case ev of
-        VtyEvent (EvKey (KChar 'q') []) -> halt ui
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
+        VtyEvent (EvKey (KChar 'q') []) -> halt
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        _                    -> helpHandle ui ev
+        _                    -> helpHandle ev
 
     _ -> do
       let d = copts^.rsDay
       case ev of
-        VtyEvent (EvKey (KChar 'q') []) -> halt ui
-        VtyEvent (EvKey KEsc        []) -> continue $ uiCheckBalanceAssertions d $ resetScreens d ui
-        VtyEvent (EvKey (KChar c)   []) | c `elem` ['h','?'] -> continue $ setMode Help ui
+        VtyEvent (EvKey (KChar 'q') []) -> halt
+        VtyEvent (EvKey KEsc        []) -> put $ uiCheckBalanceAssertions d $ resetScreens d ui
+        VtyEvent (EvKey (KChar c)   []) | c `elem` ['h','?'] -> put $ setMode Help ui
         VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor pos f) >> uiReloadJournalIfChanged copts d j (popScreen ui)
           where
             (pos,f) = case parsewithString hledgerparseerrorpositionp esError of
                         Right (f,l,c) -> (Just (l, Just c),f)
                         Left  _       -> (endPosition, journalFilePath j)
         e | e `elem` [VtyEvent (EvKey (KChar 'g') []), AppEvent FileChange] ->
-          liftIO (uiReloadJournal copts d (popScreen ui)) >>= continue . uiCheckBalanceAssertions d
+          liftIO (uiReloadJournal copts d (popScreen ui)) >>= put . uiCheckBalanceAssertions d
 --           (ej, _) <- liftIO $ journalReloadIfChanged copts d j
 --           case ej of
 --             Left err -> continue ui{aScreen=s{esError=err}} -- show latest parse error
 --             Right j' -> continue $ regenerateScreens j' d $ popScreen ui  -- return to previous screen, and reload it
-        VtyEvent (EvKey (KChar 'I') []) -> continue $ uiCheckBalanceAssertions d (popScreen $ toggleIgnoreBalanceAssertions ui)
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
+        VtyEvent (EvKey (KChar 'I') []) -> put $ uiCheckBalanceAssertions d (popScreen $ toggleIgnoreBalanceAssertions ui)
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        _ -> continue ui
-
-esHandle _ _ = error "event handler called with wrong screen type, should not happen"  -- PARTIAL:
+        _ -> return ()
 
 -- | Parse the file name, line and column number from a hledger parse error message, if possible.
 -- Temporary, we should keep the original parse error location. XXX

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -1,3 +1,5 @@
+-- TODO: brick 1 support
+-- https://hackage.haskell.org/package/brick-1.0/changelog
 {-|
 hledger-ui - a hledger add-on providing a curses-style interface.
 Copyright (c) 2007-2015 Simon Michael <simon@joyful.com>
@@ -159,11 +161,11 @@ runBrickUi uopts@UIOpts{uoCliOpts=copts@CliOpts{inputopts_=_iopts,reportspec_=rs
 
     brickapp :: App UIState AppEvent Name
     brickapp = App {
-        appStartEvent   = return
+        appStartEvent   = return ()
       , appAttrMap      = const $ fromMaybe defaultTheme $ getTheme =<< uoTheme uopts'
       , appChooseCursor = showFirstCursor
-      , appHandleEvent  = \ui ev -> sHandle (aScreen ui) ui ev
-      , appDraw         = \ui    -> sDraw   (aScreen ui) ui
+      , appHandleEvent  = sHandle (aScreen ui)
+      , appDraw         = sDraw   (aScreen ui)
       }
 
   -- print (length (show ui)) >> exitSuccess  -- show any debug output to this point & quit

--- a/hledger-ui/Hledger/UI/Theme.hs
+++ b/hledger-ui/Hledger/UI/Theme.hs
@@ -65,42 +65,42 @@ select = black `on` selectbg
 themesList :: [(String, AttrMap)]
 themesList = [
    ("default", attrMap (black `on` white) [
-     ("border"                                        , white `on` black & dim)
-    ,("border" <> "bold"                              , currentAttr & bold)
-    ,("border" <> "depth"                             , active)
-    ,("border" <> "filename"                          , currentAttr)
-    ,("border" <> "key"                               , active)
-    ,("border" <> "minibuffer"                        , white `on` black & bold)
-    ,("border" <> "query"                             , active)
-    ,("border" <> "selected"                          , active)
-    ,("error"                                         , fg red)
-    ,("help"                                          , white `on` black & dim)
-    ,("help" <> "heading"                             , fg yellow)
-    ,("help" <> "key"                                 , active)
-    -- ,("list"                                          , black `on` white)
-    -- ,("list" <> "amount"                              , currentAttr)
-    ,("list" <> "amount" <> "decrease"                , fg red)
-    -- ,("list" <> "amount" <> "increase"                , fg green)
-    ,("list" <> "amount" <> "decrease" <> "selected"  , red `on` selectbg & bold)
-    -- ,("list" <> "amount" <> "increase" <> "selected"  , green `on` selectbg & bold)
-    ,("list" <> "balance"                             , currentAttr & bold)
-    ,("list" <> "balance" <> "negative"               , fg red)
-    ,("list" <> "balance" <> "positive"               , fg black)
-    ,("list" <> "balance" <> "negative" <> "selected" , red `on` selectbg & bold)
-    ,("list" <> "balance" <> "positive" <> "selected" , select & bold)
-    ,("list" <> "selected"                            , select)
-    -- ,("list" <> "accounts"                         , white `on` brightGreen)
-    -- ,("list" <> "selected"                         , black `on` brightYellow)
+     (attrName "border"                                        , white `on` black & dim)
+    ,(attrName "border" <> attrName "bold"                              , currentAttr & bold)
+    ,(attrName "border" <> attrName "depth"                             , active)
+    ,(attrName "border" <> attrName "filename"                          , currentAttr)
+    ,(attrName "border" <> attrName "key"                               , active)
+    ,(attrName "border" <> attrName "minibuffer"                        , white `on` black & bold)
+    ,(attrName "border" <> attrName "query"                             , active)
+    ,(attrName "border" <> attrName "selected"                          , active)
+    ,(attrName "error"                                         , fg red)
+    ,(attrName "help"                                          , white `on` black & dim)
+    ,(attrName "help" <> attrName "heading"                             , fg yellow)
+    ,(attrName "help" <> attrName "key"                                 , active)
+    -- ,(attrName "list"                                          , black `on` white)
+    -- ,(attrName "list" <> attrName "amount"                              , currentAttr)
+    ,(attrName "list" <> attrName "amount" <> attrName "decrease"                , fg red)
+    -- ,(attrName "list" <> attrName "amount" <> attrName "increase"                , fg green)
+    ,(attrName "list" <> attrName "amount" <> attrName "decrease" <> attrName "selected"  , red `on` selectbg & bold)
+    -- ,(attrName "list" <> attrName "amount" <> attrName "increase" <> attrName "selected"  , green `on` selectbg & bold)
+    ,(attrName "list" <> attrName "balance"                             , currentAttr & bold)
+    ,(attrName "list" <> attrName "balance" <> attrName "negative"               , fg red)
+    ,(attrName "list" <> attrName "balance" <> attrName "positive"               , fg black)
+    ,(attrName "list" <> attrName "balance" <> attrName "negative" <> attrName "selected" , red `on` selectbg & bold)
+    ,(attrName "list" <> attrName "balance" <> attrName "positive" <> attrName "selected" , select & bold)
+    ,(attrName "list" <> attrName "selected"                            , select)
+    -- ,(attrName "list" <> attrName "accounts"                         , white `on` brightGreen)
+    -- ,(attrName "list" <> attrName "selected"                         , black `on` brightYellow)
   ])
 
   ,("greenterm", attrMap (green `on` black) [
-    ("list" <> "selected"                             , black `on` green)
+    (attrName "list" <> attrName "selected"                             , black `on` green)
   ])
 
   ,("terminal", attrMap defAttr [
-    ("border"                                         , white `on` black),
-    ("list"                                           , defAttr),
-    ("list" <> "selected"                             , defAttr & reverseVideo)
+    (attrName "border"                                         , white `on` black),
+    (attrName "list"                                           , defAttr),
+    (attrName "list" <> attrName "selected"                             , defAttr & reverseVideo)
   ])
 
   ]

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -107,12 +107,12 @@ tsDraw UIState{aopts=UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec
           -- <+> str (" ("++show i++" of "++show (length nts)++" in "++acct++")")
           <+> (str $ "#" ++ show (tindex t))
           <+> str " ("
-          <+> withAttr ("border" <> "bold") (str $ show i)
+          <+> withAttr (attrName "border" <> attrName "bold") (str $ show i)
           <+> str (" of "++show (length nts))
           <+> togglefilters
           <+> borderQueryStr (unwords . map (quoteIfNeeded . T.unpack) $ querystring_ ropts)
           <+> str (" in "++T.unpack (replaceHiddenAccountsNameWith "All" acct)++")")
-          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts then withAttr ("border" <> "query") (str " ignoring balance assertions") else str "")
+          <+> (if ignore_assertions_ . balancingopts_ $ inputopts_ copts then withAttr (attrName "border" <> attrName "query") (str " ignoring balance assertions") else str "")
           where
             togglefilters =
               case concat [
@@ -121,7 +121,7 @@ tsDraw UIState{aopts=UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec
                   ,if empty_ ropts then [] else ["nonzero"]
                   ] of
                 [] -> str ""
-                fs -> withAttr ("border" <> "query") (str $ " " ++ intercalate ", " fs)
+                fs -> withAttr (attrName "border" <> attrName "query") (str $ " " ++ intercalate ", " fs)
 
         bottomlabel = quickhelp
                         -- case mode of
@@ -141,20 +141,20 @@ tsDraw UIState{aopts=UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec
 
 tsDraw _ = error "draw function called with wrong screen type, should not happen"  -- PARTIAL:
 
-tsHandle :: UIState -> BrickEvent Name AppEvent -> EventM Name (Next UIState)
-tsHandle ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransactions=nts}
+tsHandle :: BrickEvent Name AppEvent -> EventM Name UIState ()
+tsHandle ev = do
+  ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransactions=nts}
                    ,aopts=UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}}
                    ,ajournal=j
                    ,aMode=mode
-                   }
-         ev =
+                   } <- get
   case mode of
     Help ->
       case ev of
-        -- VtyEvent (EvKey (KChar 'q') []) -> halt ui
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
+        -- VtyEvent (EvKey (KChar 'q') []) -> halt
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        _                    -> helpHandle ui ev
+        _                    -> helpHandle ev
 
     _ -> do
       let
@@ -162,49 +162,47 @@ tsHandle ui@UIState{aScreen=TransactionScreen{tsTransaction=(i,t), tsTransaction
         (iprev,tprev) = maybe (i,t) ((i-1),) $ lookup (i-1) nts
         (inext,tnext) = maybe (i,t) ((i+1),) $ lookup (i+1) nts
       case ev of
-        VtyEvent (EvKey (KChar 'q') []) -> halt ui
-        VtyEvent (EvKey KEsc        []) -> continue $ resetScreens d ui
-        VtyEvent (EvKey (KChar c)   []) | c == '?' -> continue $ setMode Help ui
+        VtyEvent (EvKey (KChar 'q') []) -> halt
+        VtyEvent (EvKey KEsc        []) -> put $ resetScreens d ui
+        VtyEvent (EvKey (KChar c)   []) | c == '?' -> put $ setMode Help ui
         VtyEvent (EvKey (KChar 'E') []) -> suspendAndResume $ void (runEditor pos f) >> uiReloadJournalIfChanged copts d j ui
           where
             (pos,f) = case tsourcepos t of
                         (SourcePos f l1 c1,_) -> (Just (unPos l1, Just $ unPos c1),f)
         AppEvent (DateChange old _) | isStandardPeriod p && p `periodContainsDate` old ->
-          continue $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
+          put $ regenerateScreens j d $ setReportPeriod (DayPeriod d) ui
           where
             p = reportPeriod ui
         e | e `elem` [VtyEvent (EvKey (KChar 'g') []), AppEvent FileChange] -> do
           -- plog (if e == AppEvent FileChange then "file change" else "manual reload") "" `seq` return ()
           ej <- liftIO . runExceptT $ journalReload copts
           case ej of
-            Left err -> continue $ screenEnter d errorScreen{esError=err} ui
-            Right j' -> continue $ regenerateScreens j' d ui
-        VtyEvent (EvKey (KChar 'I') []) -> continue $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
+            Left err -> put $ screenEnter d errorScreen{esError=err} ui
+            Right j' -> put $ regenerateScreens j' d ui
+        VtyEvent (EvKey (KChar 'I') []) -> put $ uiCheckBalanceAssertions d (toggleIgnoreBalanceAssertions ui)
 
         -- for toggles that may change the current/prev/next transactions,
         -- we must regenerate the transaction list, like the g handler above ? with regenerateTransactions ? TODO WIP
-        -- EvKey (KChar 'E') [] -> continue $ regenerateScreens j d $ stToggleEmpty ui
-        -- EvKey (KChar 'C') [] -> continue $ regenerateScreens j d $ stToggleCleared ui
-        -- EvKey (KChar 'R') [] -> continue $ regenerateScreens j d $ stToggleReal ui
-        VtyEvent (EvKey (KChar 'B') []) -> continue . regenerateScreens j d $ toggleConversionOp ui
-        VtyEvent (EvKey (KChar 'V') []) -> continue . regenerateScreens j d $ toggleValue ui
+        -- EvKey (KChar 'E') [] -> put $ regenerateScreens j d $ stToggleEmpty ui
+        -- EvKey (KChar 'C') [] -> put $ regenerateScreens j d $ stToggleCleared ui
+        -- EvKey (KChar 'R') [] -> put $ regenerateScreens j d $ stToggleReal ui
+        VtyEvent (EvKey (KChar 'B') []) -> put . regenerateScreens j d $ toggleConversionOp ui
+        VtyEvent (EvKey (KChar 'V') []) -> put . regenerateScreens j d $ toggleValue ui
 
-        VtyEvent e | e `elem` moveUpEvents   -> continue $ tsSelect iprev tprev ui
-        VtyEvent e | e `elem` moveDownEvents -> continue $ tsSelect inext tnext ui
+        VtyEvent e | e `elem` moveUpEvents   -> put $ tsSelect iprev tprev ui
+        VtyEvent e | e `elem` moveDownEvents -> put $ tsSelect inext tnext ui
 
         -- exit screen on LEFT
-        VtyEvent e | e `elem` moveLeftEvents -> continue . popScreen $ tsSelect i t ui  -- Probably not necessary to tsSelect here, but it's safe.
+        VtyEvent e | e `elem` moveLeftEvents -> put . popScreen $ tsSelect i t ui  -- Probably not necessary to tsSelect here, but it's safe.
         -- or on a click in the app's left margin.
-        VtyEvent (EvMouseUp x _y (Just BLeft)) | x==0 -> continue . popScreen $ tsSelect i t ui
+        VtyEvent (EvMouseUp x _y (Just BLeft)) | x==0 -> put . popScreen $ tsSelect i t ui
         -- or on clicking the blank area below the transaction.
-        MouseUp _ (Just BLeft) Location{loc=(_,y)} | y+1 > numentrylines -> continue . popScreen $ tsSelect i t ui
+        MouseUp _ (Just BLeft) Location{loc=(_,y)} | y+1 > numentrylines -> put . popScreen $ tsSelect i t ui
           where numentrylines = length (T.lines $ showTxn ropts rspec j t) - 1
 
-        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw ui
+        VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
         VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
-        _ -> continue ui
-
-tsHandle _ _ = error "event handler called with wrong screen type, should not happen"  -- PARTIAL:
+        _ -> return ()
 
 -- | Select a new transaction and update the previous register screen
 tsSelect i t ui@UIState{aScreen=s@TransactionScreen{}} = case aPrevScreens ui of

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -135,6 +135,9 @@ data Screen =
     }
   deriving (Show)
 
+-- | Error message to use in case statements adapting to the different Screen shapes.
+errorWrongScreenType = error' "handler called with wrong screen type, should not happen"
+
 -- | An item in the accounts screen's list of accounts and balances.
 data AccountsScreenItem = AccountsScreenItem {
    asItemIndentLevel        :: Int                -- ^ indent level
@@ -154,10 +157,6 @@ data RegisterScreenItem = RegisterScreenItem {
   ,rsItemTransaction    :: Transaction  -- ^ the full transaction
   }
   deriving (Show)
-
-instance MonadFail (EventM Name UIState) where fail _ = wrongScreenTypeError
-
-wrongScreenTypeError = error' "handler called with wrong screen type, should not happen"
 
 type NumberedTransaction = (Integer, Transaction)
 

--- a/hledger-ui/hledger-ui.cabal
+++ b/hledger-ui/hledger-ui.cabal
@@ -68,7 +68,7 @@ executable hledger-ui
       ansi-terminal >=0.9
     , async
     , base >=4.11 && <4.17
-    , brick >=0.23
+    , brick >=1.0
     , cmdargs >=0.8
     , containers >=0.5.9
     , data-default

--- a/hledger-ui/package.yaml
+++ b/hledger-ui/package.yaml
@@ -76,7 +76,7 @@ dependencies:
 - transformers
 - vector
 # not installable on windows, cf buildable flag below
-- brick >=0.23 && <1
+- brick >=1.0
 - vty >=5.15
 - unix
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack build plan using GHC 9.2.4
 
-resolver: nightly-2022-08-04
+resolver: nightly-2022-08-14
 
 packages:
 - hledger-lib
@@ -8,10 +8,11 @@ packages:
 - hledger-ui
 - hledger-web
 
-# extra-deps:
+extra-deps:
 # for hledger-lib:
 # for hledger:
 # for hledger-ui:
+- brick-1.0
 # for hledger-web:
 # for Shake.hs:
 

--- a/stack8.10.yaml
+++ b/stack8.10.yaml
@@ -17,6 +17,10 @@ extra-deps:
 - doctest-0.20.0
 # for hledger:
 # for hledger-ui:
+- brick-1.0
+- bimap-0.5.0
+- text-zipper-0.12
+- vty-5.36
 # for hledger-web:
 # for Shake.hs:
 

--- a/stack8.6.yaml
+++ b/stack8.6.yaml
@@ -34,6 +34,11 @@ extra-deps:
 - githash-0.1.6.2
 - th-compat-0.1.4
 # for hledger-ui:
+- brick-1.0
+- bimap-0.5.0
+- text-zipper-0.12
+- vty-5.36
+- ansi-terminal-0.10.3
 # for hledger-web:
 - ghc-byteorder-4.11.0.0.10
 - base64-0.4.2.3

--- a/stack8.8.yaml
+++ b/stack8.8.yaml
@@ -23,6 +23,10 @@ extra-deps:
 - githash-0.1.6.2
 - th-compat-0.1.4
 # for hledger-ui:
+- brick-1.0
+- bimap-0.5.0
+- text-zipper-0.12
+- vty-5.36
 # for hledger-web:
 - ghc-byteorder-4.11.0.0.10
 # for Shake.hs:

--- a/stack9.0.yaml
+++ b/stack9.0.yaml
@@ -16,10 +16,14 @@ packages:
 - hledger-ui
 - hledger-web
 
-#extra-deps:
+extra-deps:
 # for hledger-lib:
 # for hledger:
 # for hledger-ui:
+- brick-1.0
+- bimap-0.5.0
+- text-zipper-0.12
+- vty-5.36
 # for hledger-web:
 # for Shake.hs:
 


### PR DESCRIPTION
Adapt to brick's new API, #1889.

- dev: make ghci[d]-ui: fix/update
- pkg: ui: use/require brick 1.0+ (1889)
- stack: use brick 1.0 with older GHCs also
