### PR TITLE
fix!: cbr: Remove old account type query code. (#1921)

### DIFF
--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -165,15 +165,14 @@ compoundBalanceReportWith rspec' j priceoracle subreportspecs = cbr
             , cbcsubreportincreasestotal
             )
           where
+            ropts = cbcsubreportoptions $ _rsReportOpts rspec
             -- Add a restriction to this subreport to the report query.
             -- XXX in non-thorough way, consider updateReportSpec ?
-            q = cbcsubreportquery j
-            ropts = cbcsubreportoptions $ _rsReportOpts rspec
-            rspecsub = rspec{_rsReportOpts=ropts, _rsQuery=And [q, _rsQuery rspec]}
+            rspecsub = rspec{_rsReportOpts=ropts, _rsQuery=And [cbcsubreportquery, _rsQuery rspec]}
             -- Starting balances and column postings specific to this subreport.
             startbals' = startingBalances rspecsub j priceoracle $
-              filter (matchesPostingExtra (journalAccountType j) q) startps
-            colps' = map (second $ filter (matchesPostingExtra (journalAccountType j) q)) colps
+              filter (matchesPostingExtra (journalAccountType j) cbcsubreportquery) startps
+            colps' = map (second $ filter (matchesPostingExtra (journalAccountType j) cbcsubreportquery)) colps
 
     -- Sum the subreport totals by column. Handle these cases:
     -- - no subreports

--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -166,7 +166,7 @@ data CompoundPeriodicReport a b = CompoundPeriodicReport
 -- Part of a "CompoundBalanceCommandSpec", but also used in hledger-lib.
 data CBCSubreportSpec a = CBCSubreportSpec
   { cbcsubreporttitle          :: Text                      -- ^ The title to use for the subreport
-  , cbcsubreportquery          :: Journal -> Query          -- ^ The Query to use for the subreport
+  , cbcsubreportquery          :: Query                     -- ^ The Query to use for the subreport
   , cbcsubreportoptions        :: ReportOpts -> ReportOpts  -- ^ A function to transform the ReportOpts used to produce the subreport
   , cbcsubreporttransform      :: PeriodicReport DisplayName MixedAmount -> PeriodicReport a MixedAmount  -- ^ A function to transform the result of the subreport
   , cbcsubreportincreasestotal :: Bool                      -- ^ Whether the subreport and overall report total are of the same sign (e.g. Assets are normally

--- a/hledger/Hledger/Cli/Commands/Balancesheet.hs
+++ b/hledger/Hledger/Cli/Commands/Balancesheet.hs
@@ -24,14 +24,14 @@ balancesheetSpec = CompoundBalanceCommandSpec {
   cbcqueries  = [
      CBCSubreportSpec{
       cbcsubreporttitle="Assets"
-     ,cbcsubreportquery=journalAssetAccountQuery
+     ,cbcsubreportquery=Type [Asset]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyPositive})
      ,cbcsubreporttransform=id
      ,cbcsubreportincreasestotal=True
      }
     ,CBCSubreportSpec{
       cbcsubreporttitle="Liabilities"
-     ,cbcsubreportquery=journalLiabilityAccountQuery
+     ,cbcsubreportquery=Type [Liability]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
      ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=False

--- a/hledger/Hledger/Cli/Commands/Balancesheetequity.hs
+++ b/hledger/Hledger/Cli/Commands/Balancesheetequity.hs
@@ -25,21 +25,21 @@ balancesheetequitySpec = CompoundBalanceCommandSpec {
   cbcqueries  = [
      CBCSubreportSpec{
       cbcsubreporttitle="Assets"
-     ,cbcsubreportquery=journalAssetAccountQuery
+     ,cbcsubreportquery=Type [Asset]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyPositive})
      ,cbcsubreporttransform=id
      ,cbcsubreportincreasestotal=True
      }
     ,CBCSubreportSpec{
       cbcsubreporttitle="Liabilities"
-     ,cbcsubreportquery=journalLiabilityAccountQuery
+     ,cbcsubreportquery=Type [Liability]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
      ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=False
      }
     ,CBCSubreportSpec{
       cbcsubreporttitle="Equity"
-     ,cbcsubreportquery=journalEquityAccountQuery
+     ,cbcsubreportquery=Type [Equity]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
      ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=False

--- a/hledger/Hledger/Cli/Commands/Cashflow.hs
+++ b/hledger/Hledger/Cli/Commands/Cashflow.hs
@@ -28,7 +28,7 @@ cashflowSpec = CompoundBalanceCommandSpec {
   cbcqueries  = [
      CBCSubreportSpec{
       cbcsubreporttitle="Cash flows"
-     ,cbcsubreportquery=journalCashAccountQuery
+     ,cbcsubreportquery=Type [Cash]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_= Just NormallyPositive})
      ,cbcsubreporttransform=id
      ,cbcsubreportincreasestotal=True

--- a/hledger/Hledger/Cli/Commands/Incomestatement.hs
+++ b/hledger/Hledger/Cli/Commands/Incomestatement.hs
@@ -22,14 +22,14 @@ incomestatementSpec = CompoundBalanceCommandSpec {
   cbcqueries  = [
      CBCSubreportSpec{
       cbcsubreporttitle="Revenues"
-     ,cbcsubreportquery=journalRevenueAccountQuery
+     ,cbcsubreportquery=Type [Revenue]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyNegative})
      ,cbcsubreporttransform=fmap maNegate
      ,cbcsubreportincreasestotal=True
      }
     ,CBCSubreportSpec{
       cbcsubreporttitle="Expenses"
-     ,cbcsubreportquery=journalExpenseAccountQuery
+     ,cbcsubreportquery=Type [Expense]
      ,cbcsubreportoptions=(\ropts -> ropts{normalbalance_=Just NormallyPositive})
      ,cbcsubreporttransform=id
      ,cbcsubreportincreasestotal=False

--- a/hledger/test/journal/account-types.test
+++ b/hledger/test/journal/account-types.test
@@ -111,16 +111,26 @@ $ hledger -f- bal -N type:A
                    1  other
                    1  assets
 
-# # 6. bs detects both (#1858)
-# $ hledger -f- bs -N
-# Balance Sheet 2022-01-02
-# 
-#              || 2022-01-02 
-# =============++============
-#  Assets      ||            
-# -------------++------------
-#  other       ||          1 
-#  assets       ||         1 
-# =============++============
-#  Liabilities ||            
-# -------------++------------
+<
+account a         ; type:L
+account a:aa      ; type:X
+account a:aa:aaa  ; type:L
+
+2021-01-01
+    (a)                                            1
+    (a:aa)                                         1
+    (a:aa:aaa)                                     1
+
+# 6. bs will detect proper accounts even with an intervening parent account (#1921)
+$ hledger -f- bs -N
+Balance Sheet 2021-01-01
+
+             || 2021-01-01 
+=============++============
+ Assets      ||            
+-------------++------------
+=============++============
+ Liabilities ||            
+-------------++------------
+ a           ||         -1 
+ a:aa:aaa    ||         -1 


### PR DESCRIPTION
This replaces the old journal*AccountQuery with the new Type query. This
enables uniform treatment of account type, and fixes a subtle bug
(#1921).

Note that cbcsubreportquery no longer takes Journal as an argument.