### PR TITLE
fix: cli: updates hledger-git record command to use plain git

### DIFF
--- a/bin/hledger-git
+++ b/bin/hledger-git
@@ -8,7 +8,7 @@ hledger-git - easyish version control for your hledger journal, using git.
 An experimental prototype, currently works for the default journal only.
 A git repo in the main file's directory will be autocreated if needed.
 
-Subcommands: 
+Subcommands:
 
 hledger git record [MSG] - record the journal's files (as listed by 'files')
 hledger git status       - show unrecorded changes (after first record)
@@ -16,7 +16,7 @@ hledger git log          - list the journal's change history (after record)
 hledger git              - show this help
 
 Extra arguments are passed to git (git-specific flags should be preceded by --).
-You can install these as more convenient top-level commands by creating 
+You can install these as more convenient top-level commands by creating
 hledger-record, hledger-status, hledger-log scripts like:
 
     #!/bin/sh
@@ -74,8 +74,11 @@ record() {
     ensure_git_repo
     cd "$DIR"
     for F in $FILES; do $GIT add -f "$F"; done
-    MSG=${1:-$(date +'%Y-%m-%d %H:%M:%S %Z')}; shift
-    $GIT record -m "$MSG" "$@" -- "$FILES"
+    MSG=${1:-$(date +'%Y-%m-%d %H:%M:%S %Z')}
+    if [ $# -ge 1 ]; then
+        shift
+    fi
+    $GIT commit -m "$MSG" "$@" || $GIT reset
 }
 
 status() {


### PR DESCRIPTION
This fixes the issue in https://github.com/simonmichael/hledger/issues/1942.
Instead of relying on a `git record` alias being present `hledger git record`
uses only vanilla git.

The expected alias for record is:
```
record = ! sh -c '(git add -p -- $@ && git commit) || git reset' --
```

The removed `git record` is in the script is implemented using:
- `git commit` with the given messages (and additional arguments if given)
- `git reset` if the commit fails

`git add -p` isn't needed because the files are added already above. Also
this would be interactive which isn't the goal for this call.

The message still defaults to the date if not given, however I had to add
a check to only shift if arguments were passed in, otherwise shift fails.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and learn how to get hledger PRs accepted swiftly, 
please check the latest guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
-->
