### PR TITLE
doc: add pandas to recommended tools; fix manual budgeting-and-foreca…

### DIFF
--- a/doc/DOCS.md
+++ b/doc/DOCS.md
@@ -80,7 +80,7 @@ $ make Shake
 
 Then render the per-package manuals from markdown-m4 source files (*.m4.md) 
 to text, man, info, and markdown formats. This requires some unix tools 
-such as m4:
+such as m4, as well as pandoc:
 
 ```
 $ ./Shake manuals

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4834,7 +4834,7 @@ each periodic transaction rule generates recurring budget goals in specified acc
 and goals and actual performance can be compared.
 See the balance command's doc below.
  
-See also: [Budgeting and Forecasting](/budgeting-and-forecasting.html).
+See also: [Budgeting and Forecasting](https://hledger.org/budgeting-and-forecasting.html).
 
 
 # Cost reporting


### PR DESCRIPTION
hey there! noticed that the link to `budgeting-and-forecasting` in the manual seems [broken](https://hledger.org/1.28/budgeting-and-forecasting.html) and instead should point to the versionless [link](https://hledger.org/budgeting-and-forecasting.html).

i *believe* this fixes the issue; seems to work locally after running `pandoc`, which i added a brief blurb to in the dev docs.

i wasn't super sure if i should commit the generated pages, since it seems to have trailing whitespace trimmed, which would have created a lot of files to review/etc. 

:heart: for all you do!