### PR TITLE
imp: journal: periodic txns need not start on an interval boundary

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1002,7 +1002,7 @@ journalStyleInfluencingAmounts j =
 --     pamt  g p          = (\amt -> p {pamount  =amt}) <$> g (pamount p)
 --     amts  g (Mixed as) = Mixed <$> g as
 
--- | The fully specified date span enclosing the dates (primary or secondary)
+-- | The fully specified exact date span enclosing the dates (primary or secondary)
 -- of all this journal's transactions and postings, or DateSpan Nothing Nothing
 -- if there are none.
 journalDateSpan :: Bool -> Journal -> DateSpan
@@ -1019,7 +1019,7 @@ journalDateSpanBothDates = journalDateSpanHelper Nothing
 -- uses both primary and secondary dates.
 journalDateSpanHelper :: Maybe WhichDate -> Journal -> DateSpan
 journalDateSpanHelper whichdate j =
-    DateSpan (minimumMay dates) (addDays 1 <$> maximumMay dates)
+    DateSpan (Exact <$> minimumMay dates) (Exact . addDays 1 <$> maximumMay dates)
   where
     dates    = pdates ++ tdates
     tdates   = concatMap gettdate ts
@@ -1037,12 +1037,12 @@ journalDateSpanHelper whichdate j =
 -- | The earliest of this journal's transaction and posting dates, or
 -- Nothing if there are none.
 journalStartDate :: Bool -> Journal -> Maybe Day
-journalStartDate secondary j = b where DateSpan b _ = journalDateSpan secondary j
+journalStartDate secondary j = fromEFDay <$> b where DateSpan b _ = journalDateSpan secondary j
 
 -- | The "exclusive end date" of this journal: the day following its latest transaction 
 -- or posting date, or Nothing if there are none.
 journalEndDate :: Bool -> Journal -> Maybe Day
-journalEndDate secondary j = e where DateSpan _ e = journalDateSpan secondary j
+journalEndDate secondary j = fromEFDay <$> e where DateSpan _ e = journalDateSpan secondary j
 
 -- | The latest of this journal's transaction and posting dates, or
 -- Nothing if there are none.
@@ -1254,5 +1254,5 @@ tests_Journal = testGroup "Journal" [
                               }
               ]
       }
-    @?= (DateSpan (Just $ fromGregorian 2014 1 10) (Just $ fromGregorian 2014 10 11))
+    @?= (DateSpan (Just $ Exact $ fromGregorian 2014 1 10) (Just $ Exact $ fromGregorian 2014 10 11))
   ]

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -125,6 +125,7 @@ instance ToJSON TransactionModifier
 instance ToJSON TMPostingRule
 instance ToJSON PeriodicTransaction
 instance ToJSON PriceDirective
+instance ToJSON EFDay
 instance ToJSON DateSpan
 instance ToJSON Interval
 instance ToJSON Period

--- a/hledger-lib/Hledger/Data/PeriodicTransaction.hs
+++ b/hledger-lib/Hledger/Data/PeriodicTransaction.hs
@@ -57,7 +57,8 @@ _ptgenspan str spn = do
 -- for better pretty-printing:
 instance Show PeriodicTransaction where
   show PeriodicTransaction{..} =
-    printf "PeriodicTransactionPP {%s, %s, %s, %s, %s, %s, %s, %s, %s}"
+    printf "PeriodicTransactionPP {%s, %s, %s, %s, %s, %s, %s, %s, %s, %s}"
+      -- Warning, be careful to keep these synced ^ v
       ("ptperiodexpr=" ++ show ptperiodexpr)
       ("ptinterval=" ++ show ptinterval)
       ("ptspan=" ++ show (show ptspan))

--- a/hledger-lib/Hledger/Data/PeriodicTransaction.hs
+++ b/hledger-lib/Hledger/Data/PeriodicTransaction.hs
@@ -186,17 +186,17 @@ instance Show PeriodicTransaction where
 --     a           $1.00
 -- <BLANKLINE>
 --
--- >>> let reportperiod="daily from 2018/01/03" in let (i,s) = parsePeriodExpr' nulldate reportperiod in runPeriodicTransaction (nullperiodictransaction{ptperiodexpr=reportperiod, ptspan=s, ptinterval=i, ptpostings=["a" `post` usd 1]}) (DateSpan (Just $ fromGregorian 2018 01 01) (Just $ fromGregorian 2018 01 03))
+-- >>> let reportperiod="daily from 2018/01/03" in let (i,s) = parsePeriodExpr' nulldate reportperiod in runPeriodicTransaction (nullperiodictransaction{ptperiodexpr=reportperiod, ptspan=s, ptinterval=i, ptpostings=["a" `post` usd 1]}) (DateSpan (Just $ Flex $ fromGregorian 2018 01 01) (Just $ Flex $ fromGregorian 2018 01 03))
 -- []
 --
--- >>> _ptgenspan "every 3 months from 2019-05" (DateSpan (Just $ fromGregorian 2020 01 01) (Just $ fromGregorian 2020 02 01))
+-- >>> _ptgenspan "every 3 months from 2019-05" (DateSpan (Just $ Flex $ fromGregorian 2020 01 01) (Just $ Flex $ fromGregorian 2020 02 01))
 --
--- >>> _ptgenspan "every 3 months from 2019-05" (DateSpan (Just $ fromGregorian 2020 02 01) (Just $ fromGregorian 2020 03 01))
+-- >>> _ptgenspan "every 3 months from 2019-05" (DateSpan (Just $ Flex $ fromGregorian 2020 02 01) (Just $ Flex $ fromGregorian 2020 03 01))
 -- 2020-02-01
 --     ; generated-transaction: ~ every 3 months from 2019-05
 --     a           $1.00
 -- <BLANKLINE>
--- >>> _ptgenspan "every 3 days from 2018" (DateSpan (Just $ fromGregorian 2018 01 01) (Just $ fromGregorian 2018 01 05))
+-- >>> _ptgenspan "every 3 days from 2018" (DateSpan (Just $ Flex $ fromGregorian 2018 01 01) (Just $ Flex $ fromGregorian 2018 01 05))
 -- 2018-01-01
 --     ; generated-transaction: ~ every 3 days from 2018
 --     a           $1.00
@@ -205,7 +205,7 @@ instance Show PeriodicTransaction where
 --     ; generated-transaction: ~ every 3 days from 2018
 --     a           $1.00
 -- <BLANKLINE>
--- >>> _ptgenspan "every 3 days from 2018" (DateSpan (Just $ fromGregorian 2018 01 02) (Just $ fromGregorian 2018 01 05))
+-- >>> _ptgenspan "every 3 days from 2018" (DateSpan (Just $ Flex $ fromGregorian 2018 01 02) (Just $ Flex $ fromGregorian 2018 01 05))
 -- 2018-01-04
 --     ; generated-transaction: ~ every 3 days from 2018
 --     a           $1.00
@@ -213,7 +213,7 @@ instance Show PeriodicTransaction where
 
 runPeriodicTransaction :: PeriodicTransaction -> DateSpan -> [Transaction]
 runPeriodicTransaction PeriodicTransaction{..} requestedspan =
-    [ t{tdate=d} | (DateSpan (Just d) _) <- alltxnspans, spanContainsDate requestedspan d ]
+    [ t{tdate=d} | (DateSpan (Just efd) _) <- alltxnspans, let d = fromEFDay efd, spanContainsDate requestedspan d ]
   where
     t = nulltransaction{
            tsourcepos   = ptsourcepos
@@ -249,7 +249,7 @@ checkPeriodicTransactionStartDate i s periodexpr =
     _                    -> Nothing
     where
       checkStart d x =
-        let firstDate = fixSmartDate d $ SmartRelative 0 x
+        let firstDate = fromEFDay $ fixSmartDate d $ SmartRelative 0 x
         in
          if d == firstDate
          then Nothing

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -211,7 +211,7 @@ rawOptsToInputOpts day rawopts =
       ,new_save_          = True
       ,pivot_             = stringopt "pivot" rawopts
       ,forecast_          = forecastPeriodFromRawOpts day rawopts
-      ,reportspan_        = DateSpan (queryStartDate False datequery) (queryEndDate False datequery)
+      ,reportspan_        = DateSpan (Exact <$> queryStartDate False datequery) (Exact <$> queryEndDate False datequery)
       ,auto_              = boolopt "auto" rawopts
       ,infer_equity_      = boolopt "infer-equity" rawopts && conversionop_ ropts /= Just ToCost
       ,infer_costs_       = boolopt "infer-costs" rawopts

--- a/hledger-lib/Hledger/Read/InputOptions.hs
+++ b/hledger-lib/Hledger/Read/InputOptions.hs
@@ -76,11 +76,11 @@ definputopts = InputOpts
 forecastPeriod :: InputOpts -> Journal -> Maybe DateSpan
 forecastPeriod iopts j = do
     DateSpan requestedStart requestedEnd <- forecast_ iopts
-    let forecastStart = requestedStart <|> max mjournalend reportStart <|> Just (_ioDay iopts)
-        forecastEnd   = requestedEnd <|> reportEnd <|> Just (addDays 180 $ _ioDay iopts)
+    let forecastStart = fromEFDay <$> requestedStart <|> max mjournalend (fromEFDay <$> reportStart) <|> Just (_ioDay iopts)
+        forecastEnd   = fromEFDay <$> requestedEnd <|> fromEFDay <$> reportEnd <|> (Just $ addDays 180 $ _ioDay iopts)
         mjournalend   = dbg2 "journalEndDate" $ journalEndDate False j  -- ignore secondary dates
         DateSpan reportStart reportEnd = reportspan_ iopts
-    return . dbg2 "forecastspan" $ DateSpan forecastStart forecastEnd
+    return . dbg2 "forecastspan" $ DateSpan (Exact <$> forecastStart) (Exact <$> forecastEnd)
 
 -- ** Lenses
 

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -722,8 +722,6 @@ periodictransactionp = do
   -- first line
   char '~' <?> "periodic transaction"
   lift $ skipNonNewlineSpaces
-  -- a period expression
-  off <- getOffset
 
   -- if there's a default year in effect, use Y/1/1 as base for partial/relative dates
   today <- liftIO getCurrentDay
@@ -749,11 +747,6 @@ periodictransactionp = do
         <> "\nperhaps you need to terminate the period expression with a double space?"
         <> "\na double space is required between period expression and description/comment"
     pure pexp
-
-  -- In periodic transactions, the period expression has an additional constraint:
-  case checkPeriodicTransactionStartDate interval spn periodtxt of
-    Just e -> customFailure $ parseErrorAt off e
-    Nothing -> pure ()
 
   status <- lift statusp <?> "cleared status"
   code <- lift codep <?> "transaction code"

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -898,7 +898,7 @@ tests_JournalReader = testGroup "JournalReader" [
       nullperiodictransaction {
          ptperiodexpr  = "monthly from 2018/6"
         ,ptinterval    = Months 1
-        ,ptspan        = DateSpan (Just $ fromGregorian 2018 6 1) Nothing
+        ,ptspan        = DateSpan (Just $ Flex $ fromGregorian 2018 6 1) Nothing
         ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = ""
         ,ptcomment     = "In 2019 we will change this\n"
@@ -909,7 +909,7 @@ tests_JournalReader = testGroup "JournalReader" [
       nullperiodictransaction {
          ptperiodexpr  = "monthly from 2018/6"
         ,ptinterval    = Months 1
-        ,ptspan        = DateSpan (Just $ fromGregorian 2018 6 1) Nothing
+        ,ptspan        = DateSpan (Just $ Flex $ fromGregorian 2018 6 1) Nothing
         ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = "In 2019 we will change this"
         ,ptcomment     = ""
@@ -931,7 +931,7 @@ tests_JournalReader = testGroup "JournalReader" [
       nullperiodictransaction {
          ptperiodexpr  = "2019-01-04"
         ,ptinterval    = NoInterval
-        ,ptspan        = DateSpan (Just $ fromGregorian 2019 1 4) (Just $ fromGregorian 2019 1 5)
+        ,ptspan        = DateSpan (Just $ Exact $ fromGregorian 2019 1 4) (Just $ Exact $ fromGregorian 2019 1 5)
         ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = ""
         ,ptcomment     = ""

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -147,7 +147,7 @@ accountTransactionsReport rspec@ReportSpec{_rsReportOpts=ropts} j thisacctq = it
         priorq = dbg5 "priorq" $ And [thisacctq, tostartdateq, datelessreportq]
         tostartdateq =
           case mstartdate of
-            Just _  -> Date (DateSpan Nothing mstartdate)
+            Just _  -> Date (DateSpan Nothing (Exact <$> mstartdate))
             Nothing -> None  -- no start date specified, there are no prior postings
         mstartdate = queryStartDate (date2_ ropts) reportq
         datelessreportq = filterQuery (not . queryIsDateOrDate2) reportq

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -162,11 +162,11 @@ tests_BalanceReport = testGroup "BalanceReport" [
        mixedAmount (usd 0))
 
     ,testCase "with date:" $
-     (defreportspec{_rsQuery=Date $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
+     (defreportspec{_rsQuery=Date $ DateSpan (Just $ Exact $ fromGregorian 2009 01 01) (Just $ Exact $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
       ([], nullmixedamt)
 
     ,testCase "with date2:" $
-     (defreportspec{_rsQuery=Date2 $ DateSpan (Just $ fromGregorian 2009 01 01) (Just $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
+     (defreportspec{_rsQuery=Date2 $ DateSpan (Just $ Exact $ fromGregorian 2009 01 01) (Just $ Exact $ fromGregorian 2010 01 01)}, samplejournal2) `gives`
       ([
         ("assets:bank:checking","assets:bank:checking",0,mixedAmount (usd 1))
        ,("income:salary","income:salary",0,mixedAmount (usd (-1)))

--- a/hledger-lib/Hledger/Reports/BudgetReport.hs
+++ b/hledger-lib/Hledger/Reports/BudgetReport.hs
@@ -112,7 +112,7 @@ journalAddBudgetGoalTransactions bopts ropts reportspan j =
   either error' id $  -- PARTIAL:
     (journalApplyCommodityStyles >=> journalBalanceTransactions bopts) j{ jtxns = budgetts }
   where
-    budgetspan = dbg3 "budget span" $ DateSpan mbudgetgoalsstartdate (spanEnd reportspan)
+    budgetspan = dbg3 "budget span" $ DateSpan (Exact <$> mbudgetgoalsstartdate) (Exact <$> spanEnd reportspan)
       where
         mbudgetgoalsstartdate =
           -- We want to also generate budget goal txns before the report start date, in case -H is used.

--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -42,7 +42,7 @@ entriesReport rspec@ReportSpec{_rsReportOpts=ropts} =
 tests_EntriesReport = testGroup "EntriesReport" [
   testGroup "entriesReport" [
      testCase "not acct" $ (length $ entriesReport defreportspec{_rsQuery=Not . Acct $ toRegex' "bank"} samplejournal) @?= 1
-    ,testCase "date" $ (length $ entriesReport defreportspec{_rsQuery=Date $ DateSpan (Just $ fromGregorian 2008 06 01) (Just $ fromGregorian 2008 07 01)} samplejournal) @?= 3
+    ,testCase "date" $ (length $ entriesReport defreportspec{_rsQuery=Date $ DateSpan (Just $ Exact $ fromGregorian 2008 06 01) (Just $ Exact $ fromGregorian 2008 07 01)} samplejournal) @?= 3
   ]
  ]
 

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -222,7 +222,7 @@ startingPostings rspec@ReportSpec{_rsQuery=query,_rsReportOpts=ropts} j priceora
 
     precedingperiod = dateSpanAsPeriod . spanIntersect precedingspan .
                          periodAsDateSpan $ period_ ropts
-    precedingspan = DateSpan Nothing $ spanStart reportspan
+    precedingspan = DateSpan Nothing (Exact <$> spanStart reportspan)
     precedingspanq = (if date2_ ropts then Date2 else Date) $ case precedingspan of
         DateSpan Nothing Nothing -> emptydatespan
         a -> a
@@ -331,7 +331,7 @@ calculateReportMatrix rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle startb
         -- since this is a cumulative sum of valued amounts, it should not be valued again
         cumulative = cumulativeSum nullacct changes
         startingBalance = HM.lookupDefault nullacct name startbals
-        valuedStart = avalue (DateSpan Nothing historicalDate) startingBalance
+        valuedStart = avalue (DateSpan Nothing (Exact <$> historicalDate)) startingBalance
 
     -- In each column, get each account's balance changes
     colacctchanges = dbg5 "colacctchanges" $ map (second $ acctChanges rspec j) colps :: [(DateSpan, HashMap ClippedAccountName Account)]

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -71,7 +71,7 @@ import Data.Either (fromRight)
 import Data.Either.Extra (eitherToMaybe)
 import Data.Functor.Identity (Identity(..))
 import Data.List.Extra (find, isPrefixOf, nubSort)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day, addDays)
 import Data.Default (Default(..))
@@ -687,8 +687,9 @@ reportSpanHelper bothdates j ReportSpec{_rsQuery=query, _rsReportOpts=ropts} =
     -- and all txns are in the future.
     intervalspans  = dbg3 "intervalspans" $ splitSpan adjust (interval_ ropts) requestedspan'
       where
-        -- When calculating report periods, we will always adjust the start date back to the nearest interval boundary.
-        adjust = True  -- isNothing $ spanStart requestedspan
+        -- When calculating report periods, we will adjust the start date back to the nearest interval boundary
+        -- unless a start date was specified explicitly.
+        adjust = isNothing $ spanStart requestedspan
     -- The requested span enlarged to enclose a whole number of intervals.
     -- This can be the null span if there were no intervals.
     reportspan = dbg3 "reportspan" $ DateSpan (spanStart =<< headMay intervalspans)

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -685,7 +685,10 @@ reportSpanHelper bothdates j ReportSpec{_rsQuery=query, _rsReportOpts=ropts} =
     -- This list can be empty if the journal was empty,
     -- or if hledger-ui has added its special date:-tomorrow to the query
     -- and all txns are in the future.
-    intervalspans  = dbg3 "intervalspans" $ splitSpan (interval_ ropts) requestedspan'
+    intervalspans  = dbg3 "intervalspans" $ splitSpan adjust (interval_ ropts) requestedspan'
+      where
+        -- When calculating report periods, we will always adjust the start date back to the nearest interval boundary.
+        adjust = True  -- isNothing $ spanStart requestedspan
     -- The requested span enlarged to enclose a whole number of intervals.
     -- This can be the null span if there were no intervals.
     reportspan = dbg3 "reportspan" $ DateSpan (spanStart =<< headMay intervalspans)

--- a/hledger-lib/Hledger/Reports/ReportTypes.hs
+++ b/hledger-lib/Hledger/Reports/ReportTypes.hs
@@ -120,7 +120,7 @@ zipWithPadded _ []     bs     = bs
 -- | Figure out the overall date span of a PeriodicReport
 periodicReportSpan :: PeriodicReport a b -> DateSpan
 periodicReportSpan (PeriodicReport [] _ _)       = DateSpan Nothing Nothing
-periodicReportSpan (PeriodicReport colspans _ _) = DateSpan (spanStart $ head colspans) (spanEnd $ last colspans)
+periodicReportSpan (PeriodicReport colspans _ _) = DateSpan (fmap Exact . spanStart $ head colspans) (fmap Exact . spanEnd $ last colspans)
 
 -- | Map a function over the row names.
 prMapName :: (a -> b) -> PeriodicReport a c -> PeriodicReport b c

--- a/hledger-ui/Hledger/UI/UIUtils.hs
+++ b/hledger-ui/Hledger/UI/UIUtils.hs
@@ -422,7 +422,7 @@ reportSpecSetFutureAndForecast fcast rspec =
     excludeforecastq (Just _) = Any
     excludeforecastq Nothing  =  -- not:date:tomorrow- not:tag:generated-transaction
       And [
-         Not (Date $ DateSpan (Just $ addDays 1 $ _rsDay rspec) Nothing)
+         Not (Date $ DateSpan (Just $ Exact $ addDays 1 $ _rsDay rspec) Nothing)
         ,Not generatedTransactionTag
       ]
 

--- a/hledger-web/Hledger/Web/Widget/AddForm.hs
+++ b/hledger-web/Hledger/Web/Widget/AddForm.hs
@@ -28,6 +28,7 @@ import Hledger
 import Hledger.Web.Foundation (App, Handler, Widget)
 import Hledger.Web.Settings (widgetFile)
 import Data.Function ((&))
+import Control.Arrow (right)
 
 addModal :: Route App -> Journal -> Day -> Widget
 addModal addR j today = do
@@ -61,7 +62,7 @@ addForm j today = identifyForm "add" $ \extra -> do
   return (formRes, $(widgetFile "add-form"))
   where
     -- custom fields
-    dateField = textField & checkMMap (pure . validateDate) (T.pack . show)
+    dateField = textField & checkMMap (pure . right fromEFDay . validateDate) (T.pack . show)
       where
         validateDate s =
           first (const ("Invalid date format" :: Text)) $

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -509,8 +509,8 @@ rawOptsToCliOpts rawopts = do
   currentDay <- getCurrentDay
   let day = case maybestringopt "today" rawopts of
               Nothing -> currentDay
-              Just d  -> fromRight (error' $ "Unable to parse date \"" ++ d ++ "\"") -- PARTIAL:
-                         $ fixSmartDateStrEither' currentDay (T.pack d)
+              Just d  -> fromRight (error' $ "Unable to parse date \"" ++ d ++ "\"") $ -- PARTIAL:
+                         fromEFDay <$> fixSmartDateStrEither' currentDay (T.pack d)
   let iopts = rawOptsToInputOpts day rawopts
   rspec <- either error' pure $ rawOptsToReportSpec day rawopts  -- PARTIAL:
   mcolumns <- readMay <$> getEnvSafe "COLUMNS"

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -160,14 +160,15 @@ confirmedTransactionWizard :: PrevInput -> EntryState -> [AddingStage] -> Wizard
 confirmedTransactionWizard prevInput es [] = confirmedTransactionWizard prevInput es [EnterDateAndCode]
 confirmedTransactionWizard prevInput es@EntryState{..} stack@(currentStage : _) = case currentStage of
   EnterDateAndCode -> dateAndCodeWizard prevInput es >>= \case
-    Just (date, code) -> do
-      let es' = es
-            { esArgs = drop 1 esArgs
-            , esDefDate = date
-            }
-          dateAndCodeString = formatTime defaultTimeLocale yyyymmddFormat date
+    Just (efd, code) -> do
+      let 
+        date = fromEFDay efd
+        es' = es{ esArgs = drop 1 esArgs
+                , esDefDate = date
+                }
+        dateAndCodeString = formatTime defaultTimeLocale yyyymmddFormat date
                             ++ T.unpack (if T.null code then "" else " (" <> code <> ")")
-          yyyymmddFormat = "%Y-%m-%d"
+        yyyymmddFormat = "%Y-%m-%d"
       confirmedTransactionWizard prevInput{prevDateAndCode=Just dateAndCodeString} es' (EnterDescAndComment (date, code) : stack)
     Nothing ->
       confirmedTransactionWizard prevInput es stack

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -739,8 +739,8 @@ multiBalanceRowAsWbs bopts ReportOpts{..} colspans (PeriodicReportRow _ as rowto
     cs = if all mixedAmountLooksZero allamts then [""] else S.toList $ foldMap maCommodities allamts
     allamts = as ++ [rowtot | totalscolumn && not (null as)] ++ [rowavg | average_ && not (null as)]
     addDateColumns spn@(DateSpan s e) = (wbFromText (showDateSpan spn) :)
-                                       . (wbFromText (maybe "" showDate s) :)
-                                       . (wbFromText (maybe "" (showDate . addDays (-1)) e) :)
+                                       . (wbFromText (maybe "" showEFDate s) :)
+                                       . (wbFromText (maybe "" (showEFDate . modifyEFDay (addDays (-1))) e) :)
 
     paddedTranspose :: a -> [[a]] -> [[a]]
     paddedTranspose _ [] = [[]]

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4544,10 +4544,10 @@ Some examples:
 | `-p "monthly in 2008"`                  |
 | `-p "quarterly"`                        |
 
-As mentioned above, the `weekly`, `monthly`, `quarterly` and `yearly` intervals 
-require a report start date that is the first day of a week, month, quarter or year.
-And, report start/end dates will be expanded if needed to span a whole number of intervals.
-
+When specifying report periods at the command line,
+the simple `weekly`, `monthly`, `quarterly` and `yearly` intervals 
+will force the report to start on the first day of a week, month, quarter or year
+(moving the start date backward if needed).
 For example:
 
 |                                                |                                                                                    |
@@ -4557,9 +4557,11 @@ For example:
 | `-p "quarterly from 2009-05-05 to 2009-06-01"` | starts on 2009/04/01, ends on 2009/06/30, which are first and last days of Q2 2009 |
 | `-p "yearly from 2009-12-29"`                  | starts on 2009/01/01, first day of 2009                                            |
 
+All periods in a multi-period report will have similar length.
+
 ### More complex report intervals
 
-Some more complex kinds of interval are also supported in period expressions:
+These other kinds of interval are also supported in period expressions:
 
 - `biweekly`
 - `fortnightly`
@@ -4567,9 +4569,8 @@ Some more complex kinds of interval are also supported in period expressions:
 - `every day|week|month|quarter|year`
 - `every N days|weeks|months|quarters|years`
 
-These too will cause report start/end dates to be expanded, if needed,
-to span a whole number of intervals.
-Examples:
+These too will force report start date to be adjusted to an interval boundary, if needed.
+
 
 |                                    |                                                             |
 |------------------------------------|-------------------------------------------------------------|
@@ -4577,22 +4578,21 @@ Examples:
 | `-p "every 2 weeks"`               | starts on closest preceding Monday                          |
 | `-p "every 5 months from 2009/03"` | periods will have boundaries on 2009/03/01, 2009/08/01, ... |
 
-### Intervals with custom start date
+### Intervals with arbitrary start date
 
-All intervals mentioned above are required to start on their natural calendar boundaries,
-but the following intervals can start on any date:
+You can start report periods on any date by using one of these forms:
 
-Weekly on custom day:
+Each certain day of the week:
 
 - `every Nth day of week` (`th`, `nd`, `rd`, or `st` are all accepted after the number)
 - `every WEEKDAYNAME` (full or three-letter english weekday name, case insensitive)
 
-Monthly on custom day:
+Each certain day of the month:
 
 - `every Nth day [of month]`
 - `every Nth WEEKDAYNAME [of month]`
 
-Yearly on custom day:
+Each certain day of the year:
 
 - `every MM/DD [of year]` (month number and day of month number)
 - `every MONTHNAME DDth [of year]` (full or three-letter english month name, case insensitive, and day of month number)
@@ -4622,30 +4622,10 @@ Group postings from the start of wednesday to end of the following tuesday (N is
 $ hledger register checking -p "every 3rd day of week"
 ```
 
-### Periods or dates ?
+### Starting on multiple weekdays
 
-Report intervals like the above are most often used with `-p/--period`,
-to divide reports into multiple subperiods -
-each generated date marks a subperiod boundary.
-Here, the periods between the dates are what's important.
-
-But report intervals can also be used 
-with `--forecast` to generate future transactions,
-or with `balance --budget` to generate budget goal-setting transactions.
-For these, the dates themselves are what matters.
-
-### Events on multiple weekdays
-
-The `every WEEKDAYNAME` form has a special variant with multiple day names, comma-separated. 
-Eg: `every mon,thu,sat`.
-Also, `weekday` and `weekendday` are shorthand for `mon,tue,wed,thu,fri` and `sat,sun` 
-respectively.
-
-This form is mainly intended for use with `--forecast`, to generate 
-[periodic transactions](#periodic-transactions) on arbitrary days of the week.
-It may be less useful with `-p`, since it divides each week into subperiods 
-of unequal length. (Because gaps between periods are not allowed;
-if you'd like to change this, see [#1632](https://github.com/simonmichael/hledger/pull/1632).)
+- `every WEEKDAYNAME,WEEKDAYNAME,...` allows multiple days of week to be specified.
+  `weekday` and `weekendday` are accepted as shorthand for `mon,tue,wed,thu,fri` and `sat,sun`.
 
 Examples:
 
@@ -4654,6 +4634,13 @@ Examples:
 | `-p "every mon,wed,fri"`     | dates will be Mon, Wed, Fri; <br>periods will be Mon-Tue, Wed-Thu, Fri-Sun             |
 | `-p "every weekday"`         | dates will be Mon, Tue, Wed, Thu, Fri; <br>periods will be Mon, Tue, Wed, Thu, Fri-Sun |
 | `-p "every weekendday"`      | dates will be Sat, Sun; <br>periods will be Sat, Sun-Fri                               |
+
+This form is mainly intended for use with `--forecast`, to generate 
+[periodic transactions](#periodic-transactions) on arbitrary days of the week.
+It may be less useful with `-p`, since it divides each week into subperiods of unequal length.
+Related: [#1632](https://github.com/simonmichael/hledger/pull/1632)
+
+
 
 # Depth
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -2397,13 +2397,20 @@ with the date replaced by a tilde (`~`) followed by a
 [period expression](#period-expressions)
 (mnemonic: `~` looks like a recurring sine wave.):
 ```journal
+# every first of month
 ~ monthly
     expenses:rent          $2000
     assets:bank:checking
+
+# every 15th of month in 2023's first quarter:
+~ monthly from 2023-04-15 to 2023-06-16
+    expenses:utilities          $400
+    assets:bank:checking
 ```
-There is an additional constraint on the period expression:
-the start date must fall on a natural boundary of the interval.
-Eg `monthly from 2018/1/1` is valid, but `monthly from 2018/1/15` is not.
+
+The period expression is the same syntax used for specifying multi-period reports,
+just interpreted differently; there, it specifies report periods; 
+here it specifies recurrence dates (the periods' start dates).
 
 ### Periodic rules and relative dates
 
@@ -4376,8 +4383,8 @@ Some notes:
   start/end dates from options and that from `date:` queries.
   That is, `date:2019-01 date:2019 -p'2000 to 2030'` yields January 2019, the
   smallest common time span.
-- A [report interval](#report-intervals) (see below) will adjust start/end dates,
-  when needed, so that they fall on subperiod boundaries.
+- With a [report interval](#report-intervals) (see below), the report start date
+  will be adjusted back to the nearest subperiod boundary, if needed.
 
 Examples:
 
@@ -4445,32 +4452,24 @@ their corresponding flag:
 - `-Q/--quarterly`
 - `-Y/--yearly`
 
-These standard intervals always start on natural interval boundaries:
-eg `--weekly` starts on mondays, `--monthly` starts on the first of
-the month, `--yearly` always starts on January 1st, etc.
+Intervals specified by these flags will always start on their natural
+boundaries: eg `--weekly` starts on mondays, `--monthly` starts on
+first days of months, `--yearly` starts on January 1st, etc.
 
-Certain more complex intervals, and more flexible boundary dates, can
-be specified by `-p/--period`. These are described in [period
-expressions](#period-expressions), below.
+Intervals starting on other dates, and more complex intervals, can be
+specified with the `-p/--period` option. These are described in
+[period expressions](#period-expressions), below.
 
-Report intervals can only be specified by the flags above, and not by
-[query](#queries) arguments, currently.
-
-Report intervals have another effect: multi-period reports are always
-expanded to fill a whole number of subperiods. So if you use a report
-interval (other than `--daily`), and you have specified a start or end
-date, you may notice those dates being overridden (ie, the report
-starts earlier than your requested start date, or ends later than your
-requested end date). This is done to ensure "full" first and last
-subperiods, so that all subperiods' numbers are comparable.
+When you use a report interval (other than `--daily`), the overall
+report period will be expanded to fill a whole number of subperiods,
+(possibly overriding your requested report start or end dates).
+This ensures first and last subperiods are comparable to the others.
 
 To summarise:
 
-- In multiperiod reports, all subperiods are forced to be the same length, to simplify reporting.
-- Reports with the standard `--weekly`/`--monthly`/`--quarterly`/`--yearly`  intervals
-  are required to start on the first day of a week/month/quarter/year. 
-  We'd like more flexibility here but it isn't supported yet.
+- Reports with the standard `--weekly`/`--monthly`/`--quarterly`/`--yearly` intervals will start on the first day of a week/month/quarter/year. 
 - `--period` (below) can specify more complex intervals, starting on any date.
+- In multiperiod reports, all subperiods will be the same length.
 
 ## Period expressions
 
@@ -4625,7 +4624,7 @@ $ hledger register checking -p "every 3rd day of week"
 
 ### Periods or dates ?
 
-Report intervals like the above are most often used with `-p|--period`,
+Report intervals like the above are most often used with `-p/--period`,
 to divide reports into multiple subperiods -
 each generated date marks a subperiod boundary.
 Here, the periods between the dates are what's important.

--- a/hledger/test/balance/intervals.test
+++ b/hledger/test/balance/intervals.test
@@ -207,24 +207,28 @@ Balance changes in 2014-01:
 ---++-----
    ||   2 
 
-# 18. All matched postings in the displayed intervals should be reported on.
+# 18. Here, the report interval is monthly (interval size is one month)
+# but the explicitly-specified start date causes report periods to start there.
+# And the end date is expanded to make a whole last period.
 <
 2014/1/5
- (before)  1
+ (before report period)  1ew
 
 2014/2/1
- (within)  1
+ (explicit report period)  10
 
 2014/2/25
- (after)  1
+ (expanded report period)  100
+
+2014/3/10
+ (after report period)  1000
 
 $ hledger -f- balance -p 'monthly 2014/1/10-2014/2/20'
-Balance changes in 2014-01-01..2014-02-28:
+Balance changes in 2014-01-10..2014-03-09:
 
-        || Jan  Feb 
-========++==========
- after  ||   0    1 
- before ||   1    0 
- within ||   0    1 
---------++----------
-        ||   1    2 
+                        || 2014-01-10..2014-02-09  2014-02-10..2014-03-09 
+========================++================================================
+ expanded report period ||                      0                     100 
+ explicit report period ||                     10                       0 
+------------------------++------------------------------------------------
+                        ||                     10                     100 

--- a/hledger/test/cli/report-interval.test
+++ b/hledger/test/cli/report-interval.test
@@ -20,18 +20,17 @@ $ hledger -f- register --monthly --weekly
 2018-12-31W01   a                                                2             2
 2019-01-28W05   a                                                1             3
 
-# 3. The last report interval option takes precedence.
-# The --period expression is no exception.
+# 3. The last report interval option (--weekly) takes precedence,
+# including over a -p option.
+# The -p option's "in 2019" sets an explicit start date here.
 $ hledger -f- register -p 'monthly in 2019' --weekly
-2018-12-31W01   a                                                2             2
-2019-01-28W05   a                                                1             3
+2019-01-01..2019-01-07   a                                       2             2
+2019-01-29..2019-02-04   a                                       1             3
 
 # 4.
 $ hledger -f- register --weekly -p 'monthly in 2019'
 2019-01   a                                                      2             2
 2019-02   a                                                      1             3
-
-
 
 # The next three tests test the bugfix for issue #1008:
 # The report interval from an --period expression only counts if it is

--- a/hledger/test/register/intervals.test
+++ b/hledger/test/register/intervals.test
@@ -53,26 +53,59 @@ $ hledger -f- register --monthly --date2
 2014-01   a                                                      1             1
           b                                                      1             2
 
-# 6. All matched postings in the displayed intervals should be reported on.
+#
 <
 2014/1/5
- (before)  1
+ (before report period)  1
 
 2014/2/1
- (within)  1
+ (explicit report period)  10
 
 2014/2/25
- (after)  1
+ (expanded report period)  100
 
+2014/3/12
+ (after report period)  1000
+
+# 6. Here, the report interval is monthly (interval size is one month)
+# but the explicitly-specified start date causes report periods to start there.
+# And the end date is expanded to make a whole month-long last period.
 $ hledger -f- register -p 'monthly 2014/1/10-2014/2/20'
-2014-01   before                                                 1             1
-2014-02   after                                                  1             2
-          within                                                 1             3
+2014-01-10..2014-02-09   explicit report period                 10            10
+2014-02-10..2014-03-09   expanded report period                100           110
 
+# 7. Here no definite start date has been specifed so it is inferred from the journal
+# (2014/1/5), but it is specified to be a tuesday, so that is adjusted to
+# the nearest previous tuesday (2013/12/31).
+# No end date has been specified so it is inferred from the journal (2014/3/11),
+# but that is adjusted to make a whole week-long last period (2014/3/18).
+# -E is required here to see the empty weeks.
+$ hledger -f- register -p 'every tue' -E
+2013-12-31..2014-01-06   before report period                    1             1
+2014-01-07..2014-01-13                                           0             1
+2014-01-14..2014-01-20                                           0             1
+2014-01-21..2014-01-27                                           0             1
+2014-01-28..2014-02-03   explicit report period                 10            11
+2014-02-04..2014-02-10                                           0            11
+2014-02-11..2014-02-17                                           0            11
+2014-02-18..2014-02-24                                           0            11
+2014-02-25..2014-03-03   expanded report period                100           111
+2014-03-04..2014-03-10                                           0           111
+2014-03-11..2014-03-17   after report period                  1000          1111
 
-# 7. Custom ranges should display fully.
-$ hledger -f- register -p 'every tue'
-2013-12-31..2014-01-06   before                                  1             1
-2014-01-28..2014-02-03   within                                  1             2
-2014-02-25..2014-03-03   after                                   1             3
+# 8. "in 2014-02" is considered to explicitly specify a start date of 2014/2/1
+# (a saturday), forcing the periods to start there.
+$ hledger -f- register -p 'weekly in 2014-02' -E
+2014-02-01..2014-02-07   explicit report period                 10            10
+2014-02-08..2014-02-14                                           0            10
+2014-02-15..2014-02-21                                           0            10
+2014-02-22..2014-02-28   expanded report period                100           110
 
+# 9. So to see simple monday-based week periods here, you must specify a start date
+# that is a monday.
+$ hledger -f- register -p 'weekly from 2014-01-27 to 2014-03' -E
+2014-01-27W05   explicit report period                          10            10
+2014-02-03W06                                                    0            10
+2014-02-10W07                                                    0            10
+2014-02-17W08                                                    0            10
+2014-02-24W09   expanded report period                         100           110


### PR DESCRIPTION
Eg,`~ monthly from 1/15` now works, instead of giving an error message or having to rewrite it as `~ every 15th day of month`.

The motivation here was #1962; such periodic transaction rules are one of the things that can prevent hledger reading a Ledger file. Also more generally this limitation just looks a bit arbitrary to users.