### PR TITLE
journal: Fully unbracket AccountNames in account directives

### DIFF
--- a/hledger-lib/Hledger/Data/AccountName.hs
+++ b/hledger-lib/Hledger/Data/AccountName.hs
@@ -376,5 +376,21 @@ tests_AccountName = testGroup "AccountName" [
     accountNameInferType "revenues"          @?= Just Revenue
     accountNameInferType "revenue"           @?= Just Revenue
     accountNameInferType "income"            @?= Just Revenue
+  ,testCase "joinAccountNames" $ do
+    joinAccountNames "assets" "cash"     @?= "assets:cash"
+    joinAccountNames "assets:cash" "a"   @?= "assets:cash:a"
+    joinAccountNames "assets" "(cash)"   @?= "(assets:cash)"
+    joinAccountNames "assets" "[cash]"   @?= "[assets:cash]"
+    joinAccountNames "(assets)" "cash"   @?= "(assets:cash)"
+    joinAccountNames "" "assets"         @?= "assets"
+    joinAccountNames "assets" ""         @?= "assets"
+  ,testCase "concatAccountNames" $ do
+    concatAccountNames ["assets", "cash"]   @?= "assets:cash"
+    concatAccountNames ["assets:cash", "a"] @?= "assets:cash:a"
+    concatAccountNames ["assets", "(cash)"] @?= "(assets:cash)"
+    concatAccountNames ["assets", "[cash]"] @?= "[assets:cash]"
+    concatAccountNames ["(assets)", "cash"] @?= "(assets:cash)"
+    concatAccountNames ["", "assets"]       @?= ":assets"
+    concatAccountNames ["assets", ""]       @?= "assets:"
  ]
 

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -433,7 +433,7 @@ addAccountDeclaration (a,cmt,tags,pos) = do
   modify' (\j ->
              let
                decls = jdeclaredaccounts j
-               d     = (a, nullaccountdeclarationinfo{
+               d     = (textUnbracket a, nullaccountdeclarationinfo{
                               adicomment          = cmt
                              ,aditags             = tags
                              ,adideclarationorder = length decls + 1  -- gets renumbered when Journals are finalised or merged

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -1769,6 +1769,12 @@ They are written as the word `account` followed by a hledger-style [account name
 account assets:bank:checking
 ```
 
+Note, however, that account names declared in the account directive are stripped of surrounding brackets and parentheses. 
+The above directive is thus equivalent to this:
+```journal 
+account (assets:bank:checking)
+```
+
 ### Account comments
 
 Text following **two or more spaces** and `;` at the end of an account directive line,

--- a/hledger/test/journal/directive-account.test
+++ b/hledger/test/journal/directive-account.test
@@ -68,6 +68,29 @@ account Expenses:Food
 $ hledger -f- accounts
 Expenses:Food
 
+# 5. It unbrackets account names.
+<
+account (a)
+account (a:aa)
+account (a:(aaa))
+account [b]
+account [b:bb]
+account [b:[bbb]]
+account [([c])]
+account [([c:cc])]
+account [([c:[ccc]])]
+
+$ hledger -f- accounts
+a
+a:aa
+a:(aaa)
+b
+b:bb
+b:[bbb]
+c
+c:cc
+c:[ccc]
+
 # TODO
 # a trailing : should give a clear error
 # 2009/1/1

--- a/hledger/test/journal/parens-in-account-name.test
+++ b/hledger/test/journal/parens-in-account-name.test
@@ -1,13 +1,33 @@
+# Tests for parentheses and brackets in account names
+
+# 1. Parentheses in the middle of an account name are ignored.
 hledger -f - print
 <<<
 2009-01-01 x
   a  2
   b (b) b  -1
   c
+
 >>>
 2009-01-01 x
     a                     2
     b (b) b              -1
     c
+
+>>>=0
+
+# 2. Nested parentheses are removed and the outer brackets are used as the type.
+hledger -f- print
+<<<
+2023-01-01
+  [([(a)])]  1
+  [(b:bb)]   1
+  [b:[bbb]]
+
+>>>
+2023-01-01
+    [a]                     1
+    [b:bb]                  1
+    [b:[bbb]]
 
 >>>=0


### PR DESCRIPTION
Currently an account name like "a:(aa)" will not have (aa) unbracketed. However, this seems reasonable since the full name is unbracketed and thus will not be confused with virtual or virtual-balanced posting.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and learn how to get hledger PRs accepted swiftly, 
please check the latest guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
-->

Resolves #1915 
