### PR TITLE
journal: json: Add source positions to forecast transactions

### DIFF
--- a/hledger-lib/Hledger/Data/PeriodicTransaction.hs
+++ b/hledger-lib/Hledger/Data/PeriodicTransaction.hs
@@ -61,6 +61,7 @@ instance Show PeriodicTransaction where
       ("ptperiodexpr=" ++ show ptperiodexpr)
       ("ptinterval=" ++ show ptinterval)
       ("ptspan=" ++ show (show ptspan))
+      ("ptsourcepos=" ++ show ptsourcepos)
       ("ptstatus=" ++ show (show ptstatus))
       ("ptcode=" ++ show ptcode)
       ("ptdescription=" ++ show ptdescription)
@@ -236,7 +237,8 @@ runPeriodicTransaction PeriodicTransaction{..} requestedspan =
     [ t{tdate=d} | (DateSpan (Just d) _) <- alltxnspans, spanContainsDate requestedspan d ]
   where
     t = nulltransaction{
-           tstatus      = ptstatus
+           tsourcepos   = ptsourcepos
+          ,tstatus      = ptstatus
           ,tcode        = ptcode
           ,tdescription = ptdescription
           ,tcomment     = ptcomment

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -455,6 +455,7 @@ data PeriodicTransaction = PeriodicTransaction {
       ptinterval     :: Interval, -- ^ the interval at which this transaction recurs
       ptspan         :: DateSpan, -- ^ the (possibly unbounded) period during which this transaction recurs. Contains a whole number of intervals.
       --
+      ptsourcepos    :: (SourcePos, SourcePos),  -- ^ the file position where the period expression starts, and where the last posting ends
       ptstatus       :: Status,   -- ^ some of Transaction's fields
       ptcode         :: Text,
       ptdescription  :: Text,
@@ -467,6 +468,7 @@ nullperiodictransaction = PeriodicTransaction{
       ptperiodexpr   = ""
      ,ptinterval     = def
      ,ptspan         = def
+     ,ptsourcepos    = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 1) (mkPos 1))
      ,ptstatus       = Unmarked
      ,ptcode         = ""
      ,ptdescription  = ""

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -708,6 +708,7 @@ transactionmodifierp = do
 -- relative to Y/1/1. If not, they are calculated related to today as usual.
 periodictransactionp :: MonadIO m => JournalParser m PeriodicTransaction
 periodictransactionp = do
+  startpos <- getSourcePos
 
   -- first line
   char '~' <?> "periodic transaction"
@@ -752,10 +753,14 @@ periodictransactionp = do
   -- next lines; use same year determined above
   postings <- postingsp (Just $ first3 $ toGregorian refdate)
 
+  endpos <- getSourcePos
+  let sourcepos = (startpos, endpos)
+
   return $ nullperiodictransaction{
      ptperiodexpr=periodtxt
     ,ptinterval=interval
     ,ptspan=spn
+    ,ptsourcepos=sourcepos
     ,ptstatus=status
     ,ptcode=code
     ,ptdescription=description
@@ -892,6 +897,7 @@ tests_JournalReader = testGroup "JournalReader" [
          ptperiodexpr  = "monthly from 2018/6"
         ,ptinterval    = Months 1
         ,ptspan        = DateSpan (Just $ fromGregorian 2018 6 1) Nothing
+        ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = ""
         ,ptcomment     = "In 2019 we will change this\n"
         }
@@ -902,6 +908,7 @@ tests_JournalReader = testGroup "JournalReader" [
          ptperiodexpr  = "monthly from 2018/6"
         ,ptinterval    = Months 1
         ,ptspan        = DateSpan (Just $ fromGregorian 2018 6 1) Nothing
+        ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = "In 2019 we will change this"
         ,ptcomment     = ""
         }
@@ -912,6 +919,7 @@ tests_JournalReader = testGroup "JournalReader" [
          ptperiodexpr  = "monthly"
         ,ptinterval    = Months 1
         ,ptspan        = DateSpan Nothing Nothing
+        ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = "Next year blah blah"
         ,ptcomment     = ""
         }
@@ -922,6 +930,7 @@ tests_JournalReader = testGroup "JournalReader" [
          ptperiodexpr  = "2019-01-04"
         ,ptinterval    = NoInterval
         ,ptspan        = DateSpan (Just $ fromGregorian 2019 1 4) (Just $ fromGregorian 2019 1 5)
+        ,ptsourcepos   = (SourcePos "" (mkPos 1) (mkPos 1), SourcePos "" (mkPos 2) (mkPos 1))
         ,ptdescription = ""
         ,ptcomment     = ""
         }

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -97,5 +97,5 @@ hledgerWebTest = do
       yit "serves a journal page showing forecasted transactions" $ do
         get JournalR
         statusIs 200
-        bodyContains "id=\"transaction-0-1\""  -- 0 indicates a fileless (forecasted) txn
-        bodyContains "id=\"transaction-0-2\""  -- etc.
+        bodyContains "id=\"transaction-2-1\""
+        bodyContains "id=\"transaction-2-2\""

--- a/hledger/test/forecast.test
+++ b/hledger/test/forecast.test
@@ -374,3 +374,21 @@ $ hledger -f- --today=2021-05-01 reg --period=2020-2022 --forecast=2020-2022
 # 2021-07-01                      (a)                              1             2
 # 2021-10-01                      (a)                              1             3
 # >=0
+
+# 22. Printed JSON with forecast transactions reference periodic transactions source position
+<
+~ next quarter   Forecasted
+    A      -1
+    B       1
+
+$ hledger -f- print --forecast -O json
+> /.*
+        "sourceColumn": 1,
+        "sourceLine": 1,
+        "sourceName": "-"
+      },
+      {
+        "sourceColumn": 1,
+        "sourceLine": 4,
+        "sourceName": "-"
+.*/


### PR DESCRIPTION
This takes a shot at #1984. This PR adds source positions for periodic transactions and makes sure references are made to the periodic transaction in transactions generated in forecasts.

@simonmichael I wasn't able to find a nice way to test the full interaction as proposed by @nobodyinperson in #1984. The JSON generated is rather large and it seems unresponsible to put this directly into a `.test`-CLI test. Do you know a clean way to integrate a test with an output file that does not depend on the OS used? Or might it be fine to use the `diff`-fix you proposed in [this issue](https://github.com/simonmichael/shelltestrunner/issues/31)?

I did install and run the print command presented in the issue locally to find that it indeed now contains the correct source positions, referencing the periodic transactions.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and learn how to get hledger PRs accepted swiftly, 
please check the latest guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
-->

Resolves #1984 
