### PR TITLE
Boolean Queries

### DIFF
--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -945,6 +945,7 @@ tests_Query = testGroup "Query" [
      parseBooleanQuery nulldate "(acct:'a' acct:'b')" @?= Right (Or [Acct $ toRegexCI' "a", Acct $ toRegexCI' "b"], [])
      parseBooleanQuery nulldate " acct:'a' acct:'b'" @?= Right (Or [Acct $ toRegexCI' "a", Acct $ toRegexCI' "b"], [])
      parseBooleanQuery nulldate "not:a" @?= Right (Not $ Acct $ toRegexCI' "a", [])
+     parseBooleanQuery nulldate "expenses:food OR (tag:A expenses:drink)" @?= Right (Or [Acct $ toRegexCI' "expenses:food", And [Acct $ toRegexCI' "expenses:drink", Tag (toRegexCI' "A") Nothing]], [])
 
   ,testCase "words''" $ do
       (words'' [] "a b")                   @?= ["a","b"]

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -125,7 +125,7 @@ import Control.Monad.State.Strict hiding (fail)
 import Data.Bifunctor (bimap, second)
 import Data.Char (digitToInt, isDigit, isSpace)
 import Data.Decimal (DecimalRaw (Decimal), Decimal)
-import Data.Either (lefts, rights)
+import Data.Either (rights)
 import Data.Function ((&))
 import Data.Functor ((<&>), ($>))
 import Data.List (find, genericReplicate, union)
@@ -195,7 +195,7 @@ rawOptsToInputOpts day rawopts =
         -- Do we really need to do all this work just to get the requested end date? This is duplicating
         -- much of reportOptsToSpec.
         ropts = rawOptsToReportOpts day rawopts
-        argsquery = lefts . rights . map (parseQueryTerm day) $ querystring_ ropts
+        argsquery = map fst . rights . map (parseQueryTerm day) $ querystring_ ropts
         datequery = simplifyQuery . filterQuery queryIsDate . And $ queryFromFlags ropts : argsquery
 
         styles = either err id $ commodityStyleFromRawOpts rawopts

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -803,7 +803,7 @@ makeHledgerClassyLenses ''ReportSpec
 -- >>> _rsQuery <$> setEither querystring ["assets"] defreportspec
 -- Right (Acct (RegexpCI "assets"))
 -- >>> _rsQuery <$> setEither querystring ["(assets"] defreportspec
--- Left "This regular expression is malformed...
+-- Left "failed to parse query:1:8:\n  |\n1 | (assets\n  |        ^\nunexpected end of input\nexpecting \"AND\", \"OR\", or ')'\n"
 -- >>> _rsQuery $ set querystring ["assets"] defreportspec
 -- Acct (RegexpCI "assets")
 -- >>> _rsQuery $ set querystring ["(assets"] defreportspec
@@ -854,7 +854,7 @@ instance HasReportOpts ReportSpec where
 -- | Generate a ReportSpec from a set of ReportOpts on a given day.
 reportOptsToSpec :: Day -> ReportOpts -> Either String ReportSpec
 reportOptsToSpec day ropts = do
-    (argsquery, queryopts) <- parseQueryList day $ querystring_ ropts
+    (argsquery, queryopts) <- parseQueries day $ querystring_ ropts
     return ReportSpec
       { _rsReportOpts = ropts
       , _rsDay        = day

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -803,7 +803,7 @@ makeHledgerClassyLenses ''ReportSpec
 -- >>> _rsQuery <$> setEither querystring ["assets"] defreportspec
 -- Right (Acct (RegexpCI "assets"))
 -- >>> _rsQuery <$> setEither querystring ["(assets"] defreportspec
--- Left "failed to parse query:1:8:\n  |\n1 | (assets\n  |        ^\nunexpected end of input\nexpecting \"AND\", \"OR\", or ')'\n"
+-- Left "This regular expression is malformed, please correct it:\n(assets"
 -- >>> _rsQuery $ set querystring ["assets"] defreportspec
 -- Acct (RegexpCI "assets")
 -- >>> _rsQuery $ set querystring ["(assets"] defreportspec
@@ -854,7 +854,7 @@ instance HasReportOpts ReportSpec where
 -- | Generate a ReportSpec from a set of ReportOpts on a given day.
 reportOptsToSpec :: Day -> ReportOpts -> Either String ReportSpec
 reportOptsToSpec day ropts = do
-    (argsquery, queryopts) <- parseQueries day $ querystring_ ropts
+    (argsquery, queryopts) <- parseQueryList day $ querystring_ ropts
     return ReportSpec
       { _rsReportOpts = ropts
       , _rsDay        = day

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -36,7 +36,7 @@ tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     values   = boolopt "values" rawopts
     parsed   = boolopt "parsed" rawopts
     empty    = empty_ $ _rsReportOpts rspec
-  query <- either usageError (return . fst) $ parseQueryList today querystr
+  query <- either usageError (return . fst) $ parseQueries today querystr
   let
     q = simplifyQuery $ And [queryFromFlags $ _rsReportOpts rspec, query]
     matchedtxns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -36,7 +36,7 @@ tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     values   = boolopt "values" rawopts
     parsed   = boolopt "parsed" rawopts
     empty    = empty_ $ _rsReportOpts rspec
-  query <- either usageError (return . fst) $ parseQueries today querystr
+  query <- either usageError (return . fst) $ parseQueryList today querystr
   let
     q = simplifyQuery $ And [queryFromFlags $ _rsReportOpts rspec, query]
     matchedtxns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4631,11 +4631,11 @@ These are most often [account name](#account-names) substrings:
 
 - Terms with spaces or other [special characters](#special-characters) should be enclosed in quotes:
 
-  `"personal care"`
+  `'personal care'`
 
 - [Regular expressions](#regular-expressions) are also supported:
 
-  `"^expenses\b" "accounts (payable|receivable)"`
+  `'^expenses\b' 'accounts (payable|receivable)'`
 
 - Add a query type prefix to match other parts of the data:
 
@@ -4644,6 +4644,15 @@ These are most often [account name](#account-names) substrings:
 - Add a `not:` prefix to negate a term:
 
   `not:cur:USD`
+
+When quotes are used to escape spaces and/or special characters, the entire query should be enclosed with quotes as well:
+
+   `"'^expenses\b' 'accounts (payable|receivable)\""`
+
+Note that we use double quotes to escape the query and single quotes to escape the individual parts of the query.
+Escaping parts of the query with double quotes would also be possible, but those quotes would need to be escaped to be part of the query:
+
+   `"'^expenses\b' \"accounts (payable|receivable)\""`
 
 ## Query types
 
@@ -4730,7 +4739,7 @@ tells hledger-web to show the transaction register for an account.)
 
 ## Combining query terms
 
-When given multiple query terms, most commands select things which match:
+When given multiple space-separated query terms, most commands select things which match:
 
 - any of the description terms AND
 - any of the account terms AND
@@ -4744,25 +4753,25 @@ The [print](#print) command is a little different, showing transactions which:
 - have no postings matching any of the negative account terms AND
 - match all the other terms.
 
-Although these fixed rules are enough for many needs,
-we do not support full boolean expressions ([#203](https://github.com/simonmichael/hledger/issues/203)),
-(and you should not write AND or OR in your queries).
-This makes certain queries hard to express, but here are some tricks that can help:
+We also support more complex boolean queries.
+This allows one to combine queries using one of three operators:
+AND, OR, and NOT, where NOT is different syntax for 'not:'.
 
-1. Use a doubled `not:` prefix.
-    Eg, to print only the food expenses paid with cash:
+Examples of such queries are:
 
-    ```shell
-    $ hledger print food not:not:cash
-    ```
+- Match transactions with 'cool' in the description AND with the 'A' tag
 
-2. Or pre-filter the transactions with `print`, 
-   piping the result into a second hledger command
-   (with balance assertions disabled):
+  `desc:cool AND tag:A`
 
-    ```shell
-    $ hledger print cash | hledger -f- -I balance food
-    ```
+- Match transactions NOT to the 'expenses:food' account OR with the 'A' tag
+
+  `NOT expenses:food OR tag:A`
+
+- Match transactions NOT involving the 'expenses:food' account OR 
+  with the 'A' tag AND involving the 'expenses:drink' account.
+  (the AND is implicitly added by space-separation, following the rules above)
+
+  `expenses:food OR (tag:A expenses:drink)`
 
 ## Queries and command options
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4631,11 +4631,11 @@ These are most often [account name](#account-names) substrings:
 
 - Terms with spaces or other [special characters](#special-characters) should be enclosed in quotes:
 
-  `'personal care'`
+  `"personal care"`
 
 - [Regular expressions](#regular-expressions) are also supported:
 
-  `'^expenses\b' 'accounts (payable|receivable)'`
+  `"^expenses\b" "accounts (payable|receivable)"`
 
 - Add a query type prefix to match other parts of the data:
 
@@ -4644,15 +4644,6 @@ These are most often [account name](#account-names) substrings:
 - Add a `not:` prefix to negate a term:
 
   `not:cur:USD`
-
-When quotes are used to escape spaces and/or special characters, the entire query should be enclosed with quotes as well:
-
-   `"'^expenses\b' 'accounts (payable|receivable)\""`
-
-Note that we use double quotes to escape the query and single quotes to escape the individual parts of the query.
-Escaping parts of the query with double quotes would also be possible, but those quotes would need to be escaped to be part of the query:
-
-   `"'^expenses\b' \"accounts (payable|receivable)\""`
 
 ## Query types
 
@@ -4753,7 +4744,7 @@ The [print](#print) command is a little different, showing transactions which:
 - have no postings matching any of the negative account terms AND
 - match all the other terms.
 
-We also support more complex boolean queries.
+We also support more complex boolean queries with the 'expr:' prefix.
 This allows one to combine queries using one of three operators:
 AND, OR, and NOT, where NOT is different syntax for 'not:'.
 
@@ -4761,17 +4752,17 @@ Examples of such queries are:
 
 - Match transactions with 'cool' in the description AND with the 'A' tag
 
-  `desc:cool AND tag:A`
+  `expr:"desc:cool AND tag:A"`
 
 - Match transactions NOT to the 'expenses:food' account OR with the 'A' tag
 
-  `NOT expenses:food OR tag:A`
+  `expr:"NOT expenses:food OR tag:A"`
 
 - Match transactions NOT involving the 'expenses:food' account OR 
   with the 'A' tag AND involving the 'expenses:drink' account.
   (the AND is implicitly added by space-separation, following the rules above)
 
-  `expenses:food OR (tag:A expenses:drink)`
+  `expr:"expenses:food OR (tag:A expenses:drink)"`
 
 ## Queries and command options
 

--- a/hledger/test/cli/query-args.test
+++ b/hledger/test/cli/query-args.test
@@ -8,7 +8,7 @@
   a    1
   b
 
-$ hledger -f- register "'a a'"
+$ hledger -f- register 'a a'
 >
 2010-03-01 x                    a a                              1             1
 >=0
@@ -24,7 +24,7 @@ $ hledger -f- register "'a a'"
   a  1
   b
 
-$ hledger -f- register "desc:'x x'"
+$ hledger -f- register desc:'x x'
 >
 2010-03-02 x x                  a                                1             1
                                 b                               -1             0
@@ -37,7 +37,7 @@ $ hledger -f- register "desc:'x x'"
   a a  1
   'b
 
-$ hledger -f- register "'a a' \"'b\""
+$ hledger -f- register 'a a' "'b"
 >
 2011-09-11                      a a                              1             1
                                 'b                              -1             0

--- a/hledger/test/cli/query-args.test
+++ b/hledger/test/cli/query-args.test
@@ -4,7 +4,11 @@
   a a  1
   b
 
-$ hledger -f- register 'a a'
+2010/3/1 y
+  a    1
+  b
+
+$ hledger -f- register "'a a'"
 >
 2010-03-01 x                    a a                              1             1
 >=0
@@ -20,7 +24,7 @@ $ hledger -f- register 'a a'
   a  1
   b
 
-$ hledger -f- register desc:'x x'
+$ hledger -f- register "desc:'x x'"
 >
 2010-03-02 x x                  a                                1             1
                                 b                               -1             0
@@ -33,7 +37,7 @@ $ hledger -f- register desc:'x x'
   a a  1
   'b
 
-$ hledger -f- register 'a a' "'b"
+$ hledger -f- register "'a a' \"'b\""
 >
 2011-09-11                      a a                              1             1
                                 'b                              -1             0

--- a/hledger/test/query-bool.test
+++ b/hledger/test/query-bool.test
@@ -93,3 +93,54 @@ $ hledger -f - print expr:"NOT tag:'transactiontag=B' OR desc:4"
     expenses:drink
 
 >=
+
+# 7. Boolean expression query keywords are case insensitive
+$ hledger -f - print expr:"NoT tag:'transactiontag=B' OR desc:4"
+2022-01-01 Transaction 1  ; transactiontag:A
+    assets:bank:main              -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 2  ; transactiontag:A
+    assets:bank:main                   -1
+    assets:bank:secondary              -1  ; atag:a
+    expenses:food
+
+2022-01-01 Transaction 4  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:food                  2
+    expenses:drink
+
+>=
+
+# 8. Lower case not is not confused with existing not: queries
+$ hledger -f - print expr:"not tag:transactiontag=B"
+2022-01-01 Transaction 1  ; transactiontag:A
+    assets:bank:main              -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 2  ; transactiontag:A
+    assets:bank:main                   -1
+    assets:bank:secondary              -1  ; atag:a
+    expenses:food
+
+>=
+
+# 9. Having parentheses directly follow 'not' sees 'not' as part of a query.
+$ hledger -f - print expr:"not(tag:transactiontag=B)"
+>2
+hledger: Error: This regular expression is malformed, please correct it:
+not(tag:transactiontag=B
+>=1
+
+# 10. ... whereas parentheses with a space between 'not' and '(' is fine.
+$ hledger -f - print expr:"not (tag:transactiontag=B)"
+2022-01-01 Transaction 1  ; transactiontag:A
+    assets:bank:main              -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 2  ; transactiontag:A
+    assets:bank:main                   -1
+    assets:bank:secondary              -1  ; atag:a
+    expenses:food
+
+>=

--- a/hledger/test/query-bool.test
+++ b/hledger/test/query-bool.test
@@ -17,8 +17,8 @@
     expenses:food           2
     expenses:drink
 
-# 1. Simple queries can be encased in an arbitrary number of parentheses (1)
-$ hledger -f - print "(tag:'transactiontag=B')"
+# 1. Simple queries can be directly embedded in expression queries
+$ hledger -f - print expr:"tag:transactiontag=B"
 2022-01-01 Transaction 3  ; transactiontag:B
     assets:bank:main              -1  ; A comment
     expenses:drink
@@ -30,8 +30,8 @@ $ hledger -f - print "(tag:'transactiontag=B')"
 
 >=
 
-# 2. Simple queries can be encased in an arbitrary number of parentheses (3)
-$ hledger -f - print "(((tag:'transactiontag=B')))"
+# 2. Simple queries can be encased in an arbitrary number of parentheses
+$ hledger -f - print "expr:(((tag:transactiontag=B)))"
 2022-01-01 Transaction 3  ; transactiontag:B
     assets:bank:main              -1  ; A comment
     expenses:drink
@@ -44,7 +44,7 @@ $ hledger -f - print "(((tag:'transactiontag=B')))"
 >=
 
 # 3. Simple boolean AND query works
-$ hledger -f - print tag:'transactiontag=B' AND desc:3
+$ hledger -f - print expr:"tag:'transactiontag=B' AND desc:3"
 2022-01-01 Transaction 3  ; transactiontag:B
     assets:bank:main              -1  ; A comment
     expenses:drink
@@ -52,7 +52,7 @@ $ hledger -f - print tag:'transactiontag=B' AND desc:3
 >=
 
 # 4. AND + OR works without parentheses
-$ hledger -f - print tag:'transactiontag=B' AND desc:3 OR desc:1
+$ hledger -f - print expr:"tag:'transactiontag=B' AND desc:3 OR desc:1"
 2022-01-01 Transaction 1  ; transactiontag:A
     assets:bank:main              -1  ; A comment
     expenses:food
@@ -64,7 +64,7 @@ $ hledger -f - print tag:'transactiontag=B' AND desc:3 OR desc:1
 >=
 
 # 5. Unnecessary NOT + OR works without parentheses
-$ hledger -f - print NOT tag:'transactiontag=B' OR desc:1
+$ hledger -f - print expr:"NOT tag:'transactiontag=B' OR desc:1"
 2022-01-01 Transaction 1  ; transactiontag:A
     assets:bank:main              -1  ; A comment
     expenses:food
@@ -77,7 +77,7 @@ $ hledger -f - print NOT tag:'transactiontag=B' OR desc:1
 >=
 
 # 6. Necessary NOT + OR works without parentheses
-$ hledger -f - print NOT tag:'transactiontag=B' OR desc:4
+$ hledger -f - print expr:"NOT tag:'transactiontag=B' OR desc:4"
 2022-01-01 Transaction 1  ; transactiontag:A
     assets:bank:main              -1  ; A comment
     expenses:food

--- a/hledger/test/query-bool.test
+++ b/hledger/test/query-bool.test
@@ -1,0 +1,95 @@
+<
+2022-01-01 Transaction 1       ; transactiontag:A
+    assets:bank:main       -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 2       ; transactiontag:A
+    assets:bank:main       -1
+    assets:bank:secondary  -1  ; atag:a
+    expenses:food
+
+2022-01-01 Transaction 3       ; transactiontag:B
+    assets:bank:main       -1  ; A comment
+    expenses:drink
+
+2022-01-01 Transaction 4       ; transactiontag:B
+    assets:bank:main       -1  ; A comment
+    expenses:food           2
+    expenses:drink
+
+# 1. Simple queries can be encased in an arbitrary number of parentheses (1)
+$ hledger -f - print "(tag:'transactiontag=B')"
+2022-01-01 Transaction 3  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:drink
+
+2022-01-01 Transaction 4  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:food                  2
+    expenses:drink
+
+>=
+
+# 2. Simple queries can be encased in an arbitrary number of parentheses (3)
+$ hledger -f - print "(((tag:'transactiontag=B')))"
+2022-01-01 Transaction 3  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:drink
+
+2022-01-01 Transaction 4  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:food                  2
+    expenses:drink
+
+>=
+
+# 3. Simple boolean AND query works
+$ hledger -f - print tag:'transactiontag=B' AND desc:3
+2022-01-01 Transaction 3  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:drink
+
+>=
+
+# 4. AND + OR works without parentheses
+$ hledger -f - print tag:'transactiontag=B' AND desc:3 OR desc:1
+2022-01-01 Transaction 1  ; transactiontag:A
+    assets:bank:main              -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 3  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:drink
+
+>=
+
+# 5. Unnecessary NOT + OR works without parentheses
+$ hledger -f - print NOT tag:'transactiontag=B' OR desc:1
+2022-01-01 Transaction 1  ; transactiontag:A
+    assets:bank:main              -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 2  ; transactiontag:A
+    assets:bank:main                   -1
+    assets:bank:secondary              -1  ; atag:a
+    expenses:food
+
+>=
+
+# 6. Necessary NOT + OR works without parentheses
+$ hledger -f - print NOT tag:'transactiontag=B' OR desc:4
+2022-01-01 Transaction 1  ; transactiontag:A
+    assets:bank:main              -1  ; A comment
+    expenses:food
+
+2022-01-01 Transaction 2  ; transactiontag:A
+    assets:bank:main                   -1
+    assets:bank:secondary              -1  ; atag:a
+    expenses:food
+
+2022-01-01 Transaction 4  ; transactiontag:B
+    assets:bank:main              -1  ; A comment
+    expenses:food                  2
+    expenses:drink
+
+>=


### PR DESCRIPTION
This PR attempts to resolve issue #203.

This enables queries like:
```shell
hledger -f - print "(NOT tag:'transactiontag=B' OR desc:4) AND tag:cooltag"
```

## Compatibility
I tried to implement the solution conservatively, hopefully breaking as little workflows as possible.
The changes needed for fixing the tests seemed minimal enough that this mostly worked.
The only change to old queries that needed to be made was that queries like `acct:'a a'` would be parsed as two queries. The workaround in my PR would be to write `"acct:'a a'"` instead.

In other words, all old queries without spaces in the regex should work exactly the same as they did before.
Queries with spaces might need additional escaping.

## TODO
I noticed the `words''` function is used in a few other places than just in `Query.hs`.
I didn't work out the exact need for the `words''` function, but it should probably be checked what it is used for, as the way queries can be written is quite different now.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and learn how to get hledger PRs accepted swiftly, 
please check the latest guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
-->
