### PR TITLE
journal: Account directives reject account names with brackets

### DIFF
--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -381,7 +381,8 @@ accountdirectivep = do
   lift skipNonNewlineSpaces1
 
   -- the account name, possibly modified by preceding alias or apply account directives
-  acct <- modifiedaccountnamep
+  acct <- (notFollowedBy (char '(' <|> char '[') <?> "account name without brackets") >>
+          modifiedaccountnamep
 
   -- maybe a comment, on this and/or following lines
   (cmt, tags) <- lift transactioncommentp
@@ -433,7 +434,7 @@ addAccountDeclaration (a,cmt,tags,pos) = do
   modify' (\j ->
              let
                decls = jdeclaredaccounts j
-               d     = (textUnbracket a, nullaccountdeclarationinfo{
+               d     = (a, nullaccountdeclarationinfo{
                               adicomment          = cmt
                              ,aditags             = tags
                              ,adideclarationorder = length decls + 1  -- gets renumbered when Journals are finalised or merged

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -1801,8 +1801,10 @@ They are written as the word `account` followed by a hledger-style [account name
 account assets:bank:checking
 ```
 
-Note, however, that account names declared in the account directive are stripped of surrounding brackets and parentheses. 
-The above directive is thus equivalent to this:
+Note, however, that accounts declared in account directives are not allowed to have surrounding
+brackets and parentheses, unlike accounts used in postings.
+So the following journal will not parse:
+
 ```journal 
 account (assets:bank:checking)
 ```

--- a/hledger/test/journal/directive-account.test
+++ b/hledger/test/journal/directive-account.test
@@ -68,28 +68,35 @@ account Expenses:Food
 $ hledger -f- accounts
 Expenses:Food
 
-# 5. It unbrackets account names.
+# 5. It does not allow parentheses in names.
 <
 account (a)
-account (a:aa)
-account (a:(aaa))
-account [b]
-account [b:bb]
-account [b:[bbb]]
-account [([c])]
-account [([c:cc])]
-account [([c:[ccc]])]
 
 $ hledger -f- accounts
-a
-a:aa
-a:(aaa)
-b
-b:bb
-b:[bbb]
-c
-c:cc
-c:[ccc]
+>2
+hledger: Error: -:1:9:
+  |
+1 | account (a)
+  |         ^
+unexpected '('
+expecting account name without brackets
+
+>=1
+
+# 6. It does not allow brackets in names.
+<
+account [a]
+
+$ hledger -f- accounts
+>2
+hledger: Error: -:1:9:
+  |
+1 | account [a]
+  |         ^
+unexpected '['
+expecting account name without brackets
+
+>=1
 
 # TODO
 # a trailing : should give a clear error


### PR DESCRIPTION
Attempt 2.

Previously, the accounts passed to account directives would be stripped of their surrounding brackets, but the required behaviour is to have account directives plain reject bracketed accounts. This change ensures that accounts in account directives may not start with a bracket character.

Resolves #1915 

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and learn how to get hledger PRs accepted swiftly, 
please check the latest guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
-->
