### PR TITLE
Removed a redundant paragraph in the documentation.

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4780,11 +4780,6 @@ Some queries can also be expressed as command-line options:
 When you mix command options and query arguments, 
 generally the resulting query is their intersection.
 
-## Queries and account aliases
-
-When account names are [rewritten](#account-aliases) with `--alias` or `alias`,
-`acct:` will match either the old or the new account name.
-
 ## Queries and valuation
 
 When amounts are converted to other commodities in [cost](#cost-reporting) or [value](#valuation) reports,


### PR DESCRIPTION
I found two nearly-identical copies of a paragraph in the documentation, so I propose to remove one of them. I chose the one to remove somewhat arbitrarily.

The copy of the removed lines can be found a few lines under the removed lines---two paragraphs after it.