### PR TITLE
Add contrib script that can help normalize postings

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -60,6 +60,20 @@ $ watchaccounts expenses -2
 $ watchaccounts -f time.journal client1 date:thismonth -l
 ```
 
+### sortandmergepostings
+
+[`sortandmergepostings`](https://github.com/simonmichael/hledger/blob/master/bin/sortandmergepostings)
+can be used to cleanup and normalize postings.
+It will sort postings so that positive ones are first, negative ones last.
+Inside of that it sorts postings by account name alphabetically.
+Lastly it facilitates merging postings on transactions with more than one posting in the same direction on the same account.
+This works by removing the duplicates and cleaning the amount field for at-most one account per run
+Piping the output to `hledger print` can recalculate the missing amounts.
+Subsequent runs can cleanup further duplicates.
+```cli
+$ sortandmergepostings input.journal | hledger -f - print -x
+```
+
 ### hledger-simplebal
 
 [`hledger-simplebal`](https://github.com/simonmichael/hledger/blob/master/bin/hledger-simplebal)

--- a/bin/sortandmergepostings
+++ b/bin/sortandmergepostings
@@ -1,0 +1,96 @@
+#!/usr/bin/awk -f
+# Script adapted from suggestions on https://unix.stackexchange.com/a/527004/1925
+#
+# Passed a ledger file, this will:
+# 1. Sort accretion postings before deductions
+# 2. Sort postings by account alphabetically
+# 3. Merge 1 set of postings with the same account and direction by clearing
+#    the amount field. Note all posting meta data must also match to merge.
+#
+# Suggested usage:
+# $ sortandmergepostings journal.ledger | hledger -f - print -x
+#
+# Given that each run will only merge and recalculate amounts on one account per
+# transaction it may need to be run multiple times to fully normalize a ledger.
+
+BEGIN { FS = "[[:space:]][[:space:]]+" }
+
+function dump() {
+    an = asorti(accretions, as)
+    dn = asorti(deductions, ds)
+    for (i=1; i<=an; i++) {
+        postings[length(postings)+1] = accretions[as[i]]
+    }
+    for (i=1; i<=dn; i++) {
+        postings[length(postings)+1] = deductions[ds[i]]
+    }
+    for (i in postings) {
+        posting = postings[i]
+        split(posting, parts, FS)
+        currency = parts[3]
+        gsub(/[[:digit:]., ]+/, "", currency)
+        if (!inferred && (!merge || merge == parts[2]) && seen[parts[2] currency parts[4]]>1 && parts[3] !~ /@/) {
+            if (!merge) merged[i] = "    " parts[2] "  " parts[4]
+            merge = parts[2]
+        } else {
+            merged[i] = posting
+        }
+    }
+    for (i in merged) print merged[i]
+    if (inferred) print inferred
+    inferred = ""
+    merge = ""
+    delete accretions
+    delete deductions
+    delete postings
+    delete merged
+    delete seen
+}
+
+!NF {
+    dump()
+    print
+    next
+}
+
+END {
+    dump()
+}
+
+/^[^[:space:]]/ {
+    dump()
+    print $0
+    next
+}
+
+{
+    postingct++
+    account = $2
+    amount = $3
+    comments = $4
+    currency = amount
+    gsub(/[[:digit:]., ]+/, "", currency)
+    sub(/^[*!] /, "", account)
+}
+
+account ~ /^;/ {
+    print
+    next
+}
+
+!amount {
+    inferred = $0
+    next
+}
+
+amount !~ /@/ {
+    seen[account currency comments]++
+}
+
+amount !~ /-/ {
+    accretions[account postingct] = $0
+}
+
+amount ~ /-/ {
+    deductions[account postingct] = $0
+}


### PR DESCRIPTION
After mentioning my data entry process [in Matrix chat](https://matrix.to/#/!EPSbhTFKacHmjCdoQb:matrix.org/$b7-H__YJO3hK97jr9YYMjfDWRb8SiRdOCUYm5mTNOK8?via=matrix.org&via=libera.chat&via=gottsnack.net) it occurred to me I've been meaning to see if there was any collection of contrib scripts interested in this bit extracted from some of my other normalization steps.
