### PR TITLE
 fix: cli: don't crash multicol with few strings

### DIFF
--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -277,7 +277,7 @@ multicol _ [] = []
 multicol width strs =
   let
     maxwidth = maximum' $ map length strs
-    numcols = width `div` (maxwidth+2)
+    numcols = min (length strs) (width `div` (maxwidth+2))
     itemspercol = length strs `div` numcols
     colitems = chunksOf itemspercol strs
     cols = map unlines colitems


### PR DESCRIPTION
When there are only few, short strs and width is large, then the div operation in itemspercol would return zero, triggering and error in chunksOf.

This fix makes numcols have always at least as many entries as strs, filling one line.

This specifically happens when having few (e.g., one) extra commands around and just running `hledger` without parameters:

```
$ hledger
hledger: chunksOf, number must be positive, got 0
CallStack (from HasCallStack):
  error, called at src/Data/List/Extra.hs:784:26 in extra-1.7.12-5XIucFYKx256evYE8dUSC8:Data.List.Extra
  chunksOf, called at ./Hledger/Cli/Commands.hs:282:16 in hledger-1.28.99-8ZdPpZLOhW1Dcld1Fw0yDn:Hledger.Cli.Commands
```