### PR TITLE
fix: doc: remove duplicate in `hledger close` docs

### DIFF
--- a/hledger/Hledger/Cli/Commands/Close.md
+++ b/hledger/Hledger/Cli/Commands/Close.md
@@ -46,11 +46,6 @@ will be generated for each commodity.
 With `--interleaved`, each equity posting is shown next to the 
 corresponding source/destination posting.
 
-The default closing date is yesterday or the journal's end date, whichever is later.
-You can change this by specifying a [report end date](#report-start--end-date);
-the last day of the report period will be the closing date.
-Eg `-e 2022` means "close on 2022-12-31".
-
 The default closing date is yesterday, or the journal's end date, whichever is later.
 You can change this by specifying a [report end date](#report-start--end-date);
 (The report start date does not matter.)

--- a/hledger/Hledger/Cli/Commands/Close.txt
+++ b/hledger/Hledger/Cli/Commands/Close.txt
@@ -42,11 +42,6 @@ each commodity.
 With --interleaved, each equity posting is shown next to the
 corresponding source/destination posting.
 
-The default closing date is yesterday or the journal's end date,
-whichever is later. You can change this by specifying a report end date;
-the last day of the report period will be the closing date. Eg -e 2022
-means "close on 2022-12-31".
-
 The default closing date is yesterday, or the journal's end date,
 whichever is later. You can change this by specifying a report end date;
 (The report start date does not matter.) The last day of the report


### PR DESCRIPTION
thanks for all the great work in hledger!

i've come across (when looking up the changed in the new release) a duplicate: (the second one has a bit more, and a tiny bit different)

```
The default closing date is yesterday or the journal's end date, whichever is later. You can change this by specifying a [report end date](https://hledger.org/dev/hledger.html#report-start--end-date); the last day of the report period will be the closing date. Eg -e 2022 means "close on 2022-12-31".

The default closing date is yesterday, or the journal's end date, whichever is later. You can change this by specifying a [report end date](https://hledger.org/dev/hledger.html#report-start--end-date); (The report start date does not matter.) The last day of the report period will be the closing date; eg -e 2022 means "close on 2022-12-31". The opening date is always the day after the closing date.
```

this just removed the first time.