### PR TITLE
imp: generate auto postings on forecast transactions by default

### DIFF
--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -41,7 +41,7 @@ rewrite opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j@Journal{jtxns=ts} = d
   -- rewrite matched transactions
   let today = _rsDay rspec
   let modifiers = transactionModifierFromOpts opts : jtxnmodifiers j
-  let j' = j{jtxns=either error' id $ modifyTransactions (journalAccountType j) (journalInheritedAccountTags j) mempty today modifiers ts}  -- PARTIAL:
+  let j' = j{jtxns=either error' id $ modifyTransactions (const True) (journalAccountType j) (journalInheritedAccountTags j) mempty today modifiers ts}  -- PARTIAL:
   -- run the print command, showing all transactions, or show diffs
   printOrDiff rawopts opts{reportspec_=rspec{_rsQuery=Any}} j j'
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -2436,27 +2436,26 @@ So,
 - Do write two spaces between your period expression and your transaction description, if any.
 - Don't accidentally write two spaces in the middle of your period expression.
 
-## Other syntax
+## Auto postings
 
-hledger journal format supports quite a few other features,
-mainly to make interoperating with or converting from Ledger easier.
-Note some of the features below are powerful and can be useful in special cases,
-but in general, features in this section are considered less important
-or even not recommended for most users.
-Downsides are mentioned to help you decide if you want to use them.
+The `=` directive declares a rule for generating temporary extra postings 
+on transactions. Wherever the rule matches an existing posting, it can
+add one or more companion postings below that one, optionally influenced
+by the matched posting's amount. This can be useful for generating
+tax postings with a standard percentage, for example.
 
-### Auto postings
+By default, these auto posting rules are applied to transactions generated
+with --forecast (since 1.30), but not to transactions recorded in the journal.
+This means you can use `~` (periodic transaction) and `=` (auto posting) rules
+together to generate forecast transactions, and when such a transaction actually occurs,
+you can save the generated entry to the journal, finalising it.
 
-The `=` directive declares a rule for automatically adding
-temporary extra postings (visible in reports, not in the journal file)
-to all transactions matched by a certain query,
-when you use the `--auto` flag.
-
-Downsides: depending on generated data for your reports makes
-your financial data less portable, less future-proof,
-and less trustworthy in an audit. Also, because the feature
-is optional, other features like balance assertions can break
-depending on whether it is on or off.
+If instead you want to apply auto posting rules to recorded transactions
+as well, then use the `--auto` flag.
+This is not the default behaviour because depending on generated data
+is not ideal for financial records (it's less portable, less future-proof,
+less auditable, and less robust, since other features like balance assertions
+will be affected by the use or non-use of `--auto`.)
 
 An auto posting rule looks a bit like a transaction:
 ```journal
@@ -2562,6 +2561,14 @@ Also, any transaction that has been changed by auto posting rules will have thes
 - `modified:` - this transaction was modified
 - `_modified:` - a hidden tag not appearing in the comment; this transaction was modified "just now".
 
+## Other syntax
+
+hledger journal format supports quite a few other features,
+mainly to make interoperating with or converting from Ledger easier.
+Note some of the features below are powerful and can be useful in special cases,
+but in general, features in this section are considered less important
+or even not recommended for most users.
+Downsides are mentioned to help you decide if you want to use them.
 
 ### Balance assignments
 
@@ -4984,6 +4991,12 @@ When --forecast is not doing what you expect, one of these tips should help:
 - Try setting explicit forecast start and/or end dates with `--forecast=START..END`
 - Consult [Forecast period, in detail](#forecast-period-in-detail), above.
 - Check inside the engine: add `--debug=2` (eg).
+
+## Forecast and auto postings
+
+Forecast transactions have one more feature: when they are generated,
+any applicable [auto posting rules](#auto-postings) will also be applied to them,
+generating additional postings. These are described below.
 
 # Budgeting
 

--- a/hledger/test/journal/auto-postings.test
+++ b/hledger/test/journal/auto-postings.test
@@ -241,7 +241,7 @@ $ hledger -f- print --auto
 #
 
 
-## Transaction modifiers affect forecast transactions (#959)
+## Transaction modifiers affect only forecast transactions by default:
 <
 = ^income
   (liabilities:tax)  *.33  ; income tax
@@ -251,15 +251,15 @@ $ hledger -f- print --auto
     income:donations         $-15
     assets:bank
 
-2016/1/3 withdraw
-    assets:cash             $20
-    assets:bank
+2016/1/3
+    assets:cash             $100
+    income:gifts
 
 # 13.
-$ hledger print -f- --auto --forecast -b 2016-01 -e 2016-03
-2016-01-03 withdraw
-    assets:cash             $20
-    assets:bank
+$ hledger print -f- --forecast -b 2016-01 -e 2016-03
+2016-01-03
+    assets:cash             $100
+    income:gifts
 
 2016-02-01 paycheck
     ; generated-transaction: ~ monthly from 2016-01, modified: 
@@ -271,16 +271,19 @@ $ hledger print -f- --auto --forecast -b 2016-01 -e 2016-03
 
 >=
 
-# 14. and they don't force --auto on
-$ hledger print -f- --forecast -b 2016-01 -e 2016-03
-2016-01-03 withdraw
-    assets:cash             $20
-    assets:bank
+# 14. With --auto, they affect all transactions:
+$ hledger print -f- --auto --forecast -b 2016-01 -e 2016-03
+2016-01-03  ; modified:
+    assets:cash                  $100
+    income:gifts
+    (liabilities:tax)            $-33  ; income tax, generated-posting: = ^income
 
 2016-02-01 paycheck
-    ; generated-transaction: ~ monthly from 2016-01
+    ; generated-transaction: ~ monthly from 2016-01, modified: 
     income:remuneration           $-100
+    (liabilities:tax)              $-33  ; income tax, generated-posting: = ^income
     income:donations               $-15
+    (liabilities:tax)            $-4.95  ; income tax, generated-posting: = ^income
     assets:bank
 
 >=


### PR DESCRIPTION
I was thinking that auto posting rules should be applied to --forecast transactions (only) by default. In my usage, they are best used for generating new entries, not for modifying existing entries which ideally are complete and finalised. But that is still accessible via --auto as before.

I suppose this is a breaking change: if you were generating forecast txns, and you have applicable auto posting rules, the auto postings will now be added to your forecast txns and there's no way to turn that off except by changing/removing those rules, perhaps moving them to a separate file selected with -f.

This also moves Auto Postings out of the Other Syntax sin bin, making it a first class feature again.