### PR TITLE
timeclock: support comments and tags (fix #1220)

### DIFF
--- a/examples/sample.timeclock
+++ b/examples/sample.timeclock
@@ -2,5 +2,5 @@ i 2009/03/27 09:00:00 projects:a
 o 2009/03/27 17:00:34
 i 2009/03/31 22:21:45 personal:reading:online
 o 2009/04/01 02:00:34
-i 2009/04/02 09:00:00 projects:b
+i 2009/04/02 09:00:00 projects:b ; a comment, with tag:
 o 2009/04/02 17:00:34

--- a/hledger-lib/Hledger/Data/Timeclock.hs
+++ b/hledger-lib/Hledger/Data/Timeclock.hs
@@ -57,7 +57,7 @@ timeclockEntriesToTransactions now [i]
     | odate > idate = entryFromTimeclockInOut i o' : timeclockEntriesToTransactions now [i',o]
     | otherwise = [entryFromTimeclockInOut i o]
     where
-      o = TimeclockEntry (tlsourcepos i) Out end "" ""
+      o = TimeclockEntry (tlsourcepos i) Out end "" "" "" []
       end = if itime > now then itime else now
       (itime,otime) = (tldatetime i,tldatetime o)
       (idate,odate) = (localDay itime,localDay otime)
@@ -120,8 +120,8 @@ entryFromTimeclockInOut i o
             tstatus      = Cleared,
             tcode        = "",
             tdescription = desc,
-            tcomment     = "",
-            ttags        = [],
+            tcomment     = tlcomment i,
+            ttags        = tltags i,
             tpostings    = ps,
             tprecedingcomment=""
           }
@@ -162,11 +162,11 @@ tests_Timeclock = testGroup "Timeclock" [
           future = utcToLocalTime tz $ addUTCTime 100 now'
           futurestr = showtime future
       step "started yesterday, split session at midnight"
-      txndescs [clockin (mktime yesterday "23:00:00") "" ""] @?= ["23:00-23:59","00:00-"++nowstr]
+      txndescs [clockin (mktime yesterday "23:00:00") "" "" "" []] @?= ["23:00-23:59","00:00-"++nowstr]
       step "split multi-day sessions at each midnight"
-      txndescs [clockin (mktime (addDays (-2) today) "23:00:00") "" ""] @?= ["23:00-23:59","00:00-23:59","00:00-"++nowstr]
+      txndescs [clockin (mktime (addDays (-2) today) "23:00:00") "" "" "" []] @?= ["23:00-23:59","00:00-23:59","00:00-"++nowstr]
       step "auto-clock-out if needed"
-      txndescs [clockin (mktime today "00:00:00") "" ""] @?= ["00:00-"++nowstr]
+      txndescs [clockin (mktime today "00:00:00") "" "" "" []] @?= ["00:00-"++nowstr]
       step "use the clockin time for auto-clockout if it's in the future"
-      txndescs [clockin future "" ""] @?= [printf "%s-%s" futurestr futurestr]
+      txndescs [clockin future "" "" "" []] @?= [printf "%s-%s" futurestr futurestr]
  ]

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -504,7 +504,9 @@ data TimeclockEntry = TimeclockEntry {
       tlcode        :: TimeclockCode,
       tldatetime    :: LocalTime,
       tlaccount     :: AccountName,
-      tldescription :: Text
+      tldescription :: Text,
+      tlcomment     :: Text,
+      tltags        :: [Tag]
     } deriving (Eq,Ord,Generic)
 
 -- | A market price declaration made by the journal format's P directive.

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4111,9 +4111,9 @@ The timezone, if present, must be four digits and is ignored
 Lines beginning with `#` or `;` or `*`, and blank lines, are ignored.
 
 ```timeclock
-i 2015/03/30 09:00:00 some:account name  optional description after two spaces
+i 2015/03/30 09:00:00 some account  optional description after 2 spaces ; optional comment, tags:
 o 2015/03/30 09:20:00
-i 2015/03/31 22:21:45 another account
+i 2015/03/31 22:21:45 another:account
 o 2015/04/01 02:00:34
 ```
 
@@ -4124,14 +4124,14 @@ the above time log, `hledger print` generates these journal entries:
 
 ``` shell
 $ hledger -f t.timeclock print
-2015-03-30 * optional description after two spaces
-    (some:account name)         0.33h
+2015-03-30 * optional description after 2 spaces   ; optional comment, tags:
+    (some account)           0.33h
 
 2015-03-31 * 22:21-23:59
-    (another account)         1.64h
+    (another:account)           1.64h
 
 2015-04-01 * 00:00-02:00
-    (another account)         2.01h
+    (another:account)           2.01h
 
 ```
 

--- a/hledger/test/timeclock.test
+++ b/hledger/test/timeclock.test
@@ -1,5 +1,4 @@
 # 1. a timeclock session is parsed as a similarly-named transaction with one virtual posting.
-# Note since 1.17 we need to specify stdin's format explicitly.
 <
 i 2009/1/1 08:00:00
 o 2009/1/1 09:00:00 stuff on checkout record  is ignored
@@ -8,6 +7,7 @@ i 2009/1/2 08:00:00 account name
 o 2009/1/2 09:00:00
 i 2009/1/3 08:00:00 some:account name  and a description
 o 2009/1/3 09:00:00
+
 $ hledger -f timeclock:- print
 >
 2009-01-01 * 08:00-09:00
@@ -19,8 +19,7 @@ $ hledger -f timeclock:- print
 2009-01-03 * and a description
     (some:account name)           1.00h
 
->2
->= 0
+>=
 
 # 2. Command-line account aliases are applied.
 $ hledger -ftimeclock:- print --alias '/account/=FOO'
@@ -33,14 +32,14 @@ $ hledger -ftimeclock:- print --alias '/account/=FOO'
 2009-01-03 * and a description
     (some:FOO name)           1.00h
 
->= 0
+>=
 
 # 3. For a missing clock-out, now is implied
 <
 i 2020/1/1 08:00
 $ hledger -f timeclock:- balance
 > /./
->= 0
+>=
 
 # 4. For a log not starting with clock-out, print error
 <
@@ -60,13 +59,32 @@ $ hledger -f timeclock:- balance
 # 6. Timeclock amounts are always rounded to two decimal places, 
 # even when displayed by print (#1527).
 <
-i 2020-01-30 08:38:35 a
+i 2020-01-30 08:38:35 acct
 o 2020-01-30 09:03:35
 $ hledger -f timeclock:- print
 2020-01-30 * 08:38-09:03
-    (a)           0.42h
+    (acct)           0.42h
 
 >=
+
+# 7. Comments and tags are supported. Double space is required between account name
+# and description or comment. It is not required between description and comment.
+<
+i 2023-05-01 08:00:00 acct 1  description ; a comment with tag:
+o 2023-05-01 09:00:00
+i 2023-05-02 08:00:00 acct 2  ; another comment
+o 2023-05-02 09:00:00
+$ hledger -f timeclock:- print tag:tag
+2023-05-01 * description  ; a comment with tag:
+    (acct 1)           1.00h
+
+>=
+
+# 8.
+$ hledger -f timeclock:- accounts
+acct 1
+acct 2
+
 
 ## TODO
 ## multi-day sessions get a new transaction for each day


### PR DESCRIPTION
Breaking change: previously timeclock descriptions could contain
semicolons. Now a semicolon in the description will end it and
start a comment (which may contain tags).
