### PR TITLE
Bump example script resolver to nightly

### DIFF
--- a/bin/hledger-script-example.hs
+++ b/bin/hledger-script-example.hs
@@ -1,8 +1,8 @@
 #!/usr/bin/env stack
 -- stack runghc --verbosity error --package hledger
 -- stack runghc --verbosity error --package hledger --package hledger-lib --package text --package safe 
--- stack script --compile --resolver lts-20.13 --verbosity error --package hledger --package text
--- stack script --compile --resolver lts-20.13 --verbosity error --package hledger --package hledger-lib --package text --package safe
+-- stack script --compile --resolver nightly --verbosity error --package hledger --package text
+-- stack script --compile --resolver nightly --verbosity error --package hledger --package hledger-lib --package text --package safe
 -- The topmost stack command above is used to run this script.
 -- stack script uses released hledger, stack runghc uses local hledger source.
 -- This script currently requires local hledger source, for Hledger.Cli.Script.


### PR DESCRIPTION
<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->

The `lts-20.13` has old `hledger`
https://github.com/simonmichael/hledger/blob/4a61caefd760e0eb74c53f1daa421326e43fd7f3/bin/hledger-script-example.hs#L4-L5

The script uses `Hledger.Cli.Script`, which was added in `1.29`.
https://github.com/simonmichael/hledger/blob/4a61caefd760e0eb74c53f1daa421326e43fd7f3/bin/hledger-script-example.hs#L13

To make the example work we'd have to use the `nightly` resolver.


Also described in #2036 
Fixes #2036