### PR TITLE
imp:print: zero posting amounts are now shown with commodity & style

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -911,11 +911,18 @@ showMixedAmountOneLineB opts@AmountDisplayOpts{displayMaxWidth=mmax,displayMinWi
     -- Add the elision strings (if any) to each amount
     withElided = zipWith (\n2 amt -> (amt, elisionDisplay Nothing (wbWidth sep) n2 amt)) [n-1,n-2..0]
 
+-- Get a mixed amount's component amounts with a bit of cleanup (like @amounts@),
+-- and if a commodity display order is provided, sort them according to that.
 orderedAmounts :: AmountDisplayOpts -> MixedAmount -> [Amount]
-orderedAmounts dopts = maybe id (mapM pad) (displayOrder dopts) . amounts
+orderedAmounts AmountDisplayOpts{displayOrder=mcommodityorder} =
+  amounts
+  <&> maybe id (mapM findfirst) mcommodityorder  -- maybe sort them (somehow..)
   where
-    pad c = fromMaybe (amountWithCommodity c nullamt) . find ((c==) . acommodity)
-
+    -- Find the first amount with the given commodity, otherwise a null amount in that commodity.
+    findfirst :: CommoditySymbol -> [Amount] -> Amount
+    findfirst c = fromMaybe nullamtc . find ((c==) . acommodity)
+      where
+        nullamtc = amountWithCommodity c nullamt
 
 data AmountDisplay = AmountDisplay
   { adBuilder :: !WideBuilder  -- ^ String representation of the Amount

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -253,11 +253,14 @@ instance Num Amount where
     (-)                          = similarAmountsOp (-)
     (*)                          = similarAmountsOp (*)
 
--- | The empty simple amount.
+-- | The empty simple amount - a zero with no commodity symbol or cost
+-- and the default amount display style.
 nullamt :: Amount
 nullamt = Amount{acommodity="", aquantity=0, aprice=Nothing, astyle=amountstyle}
 
--- | A temporary value for parsed transactions which had no amount specified.
+-- | A special amount used as a marker, meaning
+-- "no explicit amount provided here, infer it when needed".
+-- It is nullamt with commodity symbol "AUTO".
 missingamt :: Amount
 missingamt = nullamt{acommodity="AUTO"}
 
@@ -567,11 +570,15 @@ amountKey amt@Amount{acommodity=c} = case aprice amt of
 nullmixedamt :: MixedAmount
 nullmixedamt = Mixed mempty
 
--- | A temporary value for parsed transactions which had no amount specified.
+-- | A special mixed amount used as a marker, meaning
+-- "no explicit amount provided here, infer it when needed".
 missingmixedamt :: MixedAmount
 missingmixedamt = mixedAmount missingamt
 
--- | Whether a MixedAmount has a missing amount
+-- | Does this MixedAmount include the "missing amount" marker ?
+-- Note: currently does not test for equality with missingmixedamt,
+-- instead it looks for missingamt among the Amounts.
+-- missingamt should always be alone, but detect it even if not.
 isMissingMixedAmount :: MixedAmount -> Bool
 isMissingMixedAmount (Mixed ma) = amountKey missingamt `M.member` ma
 

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -463,13 +463,15 @@ showAmountB opts a@Amount{astyle=style} =
       L -> showC (wbFromText c) space <> quantity' <> price
       R -> quantity' <> showC space (wbFromText c) <> price
   where
+    color = if displayColour opts && isNegativeAmount a then colorB Dull Red else id
     quantity = showamountquantity $ if displayThousandsSep opts then a else a{astyle=(astyle a){asdigitgroups=Nothing}}
     (quantity',c) | amountLooksZero a && not (displayZeroCommodity opts) = (WideBuilder (TB.singleton '0') 1,"")
                   | otherwise = (quantity, quoteCommoditySymbolIfNeeded $ acommodity a)
     space = if not (T.null c) && ascommodityspaced style then WideBuilder (TB.singleton ' ') 1 else mempty
+    -- concatenate these texts,
+    -- or return the empty text if there's a commodity display order. XXX why ?
     showC l r = if isJust (displayOrder opts) then mempty else l <> r
     price = if displayPrice opts then showAmountPrice a else mempty
-    color = if displayColour opts && isNegativeAmount a then colorB Dull Red else id
 
 -- | Colour version. For a negative amount, adds ANSI codes to change the colour,
 -- currently to hard-coded red.

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -855,10 +855,9 @@ showMixedAmountB opts ma
     width = headDef 0 $ map wbWidth ls
     sep = WideBuilder (TB.singleton '\n') 0
 
--- | Helper for showMixedAmountB to show a list of Amounts on multiple lines. This returns
--- the list of WideBuilders: one for each Amount, and padded/elided to the appropriate
--- width. This does not honour displayOneLine: all amounts will be displayed as if
--- displayOneLine were False.
+-- | Helper for showMixedAmountB (and postingAsLines, ...) to show a list of Amounts on multiple lines.
+-- This returns the list of WideBuilders: one for each Amount, and padded/elided to the appropriate width.
+-- This does not honour displayOneLine; all amounts will be displayed as if displayOneLine were False.
 showMixedAmountLinesB :: AmountDisplayOpts -> MixedAmount -> [WideBuilder]
 showMixedAmountLinesB opts@AmountDisplayOpts{displayMaxWidth=mmax,displayMinWidth=mmin} ma =
     map (adBuilder . pad) elided

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -220,6 +220,9 @@ postingsAsLines onelineamounts ps = concatMap first3 linesWithWidths
 -- Or if onelineamounts is true, such amounts are shown on one line, comma-separated
 -- (and the output will not be valid journal syntax).
 --
+-- If an amount is zero, any commodity symbol attached to it is shown
+-- (and the corresponding commodity display style is used).
+--
 -- By default, 4 spaces (2 if there's a status flag) are shown between
 -- account name and start of amount area, which is typically 12 chars wide
 -- and contains a right-aligned amount (so 10-12 visible spaces between
@@ -262,7 +265,7 @@ postingAsLines elideamount onelineamounts acctwidth amtwidth p =
     -- amtwidth at all.
     shownAmounts
       | elideamount = [mempty]
-      | otherwise   = showMixedAmountLinesB noColour{displayOneLine=onelineamounts} $ pamount p
+      | otherwise   = showMixedAmountLinesB noColour{displayZeroCommodity=True, displayOneLine=onelineamounts} $ pamount p
     thisamtwidth = maximumBound 0 $ map wbWidth shownAmounts
 
     -- when there is a balance assertion, show it only on the last posting line

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -906,6 +906,11 @@ Examples:
   "total","VHT","294.00"
   ```
 
+- Note: bare layout will sometimes display an extra row for the no-symbol commodity,
+  because of zero amounts (hledger treats zeroes as commodity-less, usually).
+  This can break `hledger-bar` confusingly (workaround: add a `cur:` query to exclude
+  the no-symbol row).
+
 - Tidy layout produces normalised "tidy data", where every variable
   has its own column and each row represents a single data point.
   See <https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html> for more.

--- a/hledger/Hledger/Cli/Commands/Check.md
+++ b/hledger/Hledger/Cli/Commands/Check.md
@@ -24,13 +24,12 @@ providing instant feedback as you edit the journal.
 
 Here are the checks currently available:
 
-### Basic checks
+### Default checks
 
-These checks are always run automatically, by (almost) all hledger commands,
-including `check`:
+These checks are run automatically by (almost) all hledger commands:
 
-- **parseable** - data files are well-formed and can be 
-  [successfully parsed](hledger.html#input-files)
+- **parseable** - data files are in a supported [format](hledger.md#data-formats),
+  with no syntax errors and no invalid include directives.
 
 - **autobalanced** - all transactions are [balanced](hledger.html#postings), after converting to cost.
   Missing amounts and missing [costs] are inferred automatically where possible.
@@ -43,20 +42,20 @@ including `check`:
 These additional checks are run when the `-s`/`--strict` ([strict mode]) flag is used.
 Or, they can be run by giving their names as arguments to `check`:
 
+- **balanced** - all transactions are balanced after converting to cost,
+  without inferring missing costs.
+  If conversion costs are required, they must be explicit.
+
 - **accounts** - all account names used by transactions 
   [have been declared](hledger.html#account-error-checking)
 
 - **commodities** - all commodity symbols used 
   [have been declared](hledger.html#commodity-error-checking)
 
-- **balanced** - all transactions are balanced after converting to cost,
-  without inferring missing costs.
-  If conversion costs are required, they must be explicit.
-
 ### Other checks
 
 These checks can be run only by giving their names as arguments to `check`.
-They are more specialised and not desirable for everyone, therefore optional:
+They are more specialised and not desirable for everyone:
 
 - **ordereddates** - transactions are ordered by date within each file
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -2171,7 +2171,7 @@ avoid include cycles and including directories, but this can be done, eg:
 
 The path may also be prefixed to force a specific file format,
 overriding the file extension (as described in
-[hledger.1 -> Input files](#input-files)):
+[Data formats](#data-formats)):
 `include timedot:~/notes/2023*.md`.
 
 [glob patterns]: https://hackage.haskell.org/package/Glob-0.9.2/docs/System-FilePath-Glob.html#v:compile

--- a/hledger/test/amount-rendering.test
+++ b/hledger/test/amount-rendering.test
@@ -46,8 +46,8 @@ $ hledger -f - balance -N
   b
 $ hledger -f- print --explicit --empty
 2010-03-01 x
-    a        0 @ 3EUR
-    b               0
+    a    $0.00 @ 3EUR
+    b            0EUR
 
 >= 0
 

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -1006,8 +1006,8 @@ account1 assets:bank:checking
 
 $  ./csvtest.sh
 2020-01-21 Client card point of sale fee
-    assets:bank:checking               0 = $1068.94
-    expenses:unknown                   0
+    assets:bank:checking              $0 = $1068.94
+    expenses:unknown                  $0
 
 >=0
 

--- a/hledger/test/journal/parse-errors.test
+++ b/hledger/test/journal/parse-errors.test
@@ -96,8 +96,8 @@ $ hledger -f- print
   b  B 0
 $ hledger -f- print
 2020-01-01
-    a               0
-    b               0
+    a             A 0
+    b             B 0
 
 >=0
 

--- a/hledger/test/journal/precision.test
+++ b/hledger/test/journal/precision.test
@@ -23,7 +23,7 @@ $ hledger -f - print
    a
 $ hledger -f - print --explicit
 2010-01-01
-    a               0
+    a           $0.00
     a    1C @ $1.0049
     a        $-1.0049
 

--- a/hledger/test/journal/valuation2.test
+++ b/hledger/test/journal/valuation2.test
@@ -62,8 +62,8 @@ $ hledger -f- print -x --value=now,Z
 # and sign are not shown either.
 $ hledger -f- print -x --value=now,C
 2019-06-01
-    a               0
-    b               0
+    a              C0
+    b              C0
 
 >=
 # # There's nothing setting C display style, so the default style is used,

--- a/hledger/test/print/explicit.test
+++ b/hledger/test/print/explicit.test
@@ -92,8 +92,8 @@ $ hledger -f - print
     equity
 $ hledger -f - print --explicit
 2017-01-01
-    assets               0
-    equity               0
+    assets              $0
+    equity              $0
 
 >= 0
 

--- a/hledger/test/print/print.test
+++ b/hledger/test/print/print.test
@@ -1,13 +1,27 @@
-# test -B and #551
-#hledger -f- print -B
-#<<<
-#2009/1/1
-#  assets:foreign currency   €100
-#  assets:cash              $-135
-#>>>
-#2009/01/01
-#    assets:foreign currency          $135
-#    assets:cash                     $-135
-#
-#>>>2
-#>>>= 0
+# 1. print preserves the commodity symbol of zero amounts.
+<
+2023-01-01
+  (a)    0 A @ 0 B == 0 A @ 0 B
+
+$ hledger -f- print
+2023-01-01
+    (a)       0 A @ 0 B == 0 A @ 0 B
+
+>=
+
+# 2. The inferred balancing amount for zeros in multiple commodities
+# is preserved and shown accurately, with a posting for each commodity.
+<
+2023-01-01
+  a   0 A
+  b   0 B
+  z
+
+$ hledger -f- print -x
+2023-01-01
+    a             0 A
+    b             0 B
+    z             0 A
+    z             0 B
+
+>=

--- a/hledger/test/rewrite.test
+++ b/hledger/test/rewrite.test
@@ -178,6 +178,7 @@ $ hledger rewrite -f- assets:bank and 'amt:<0' --add-posting 'expenses:fee  $5' 
 ; but relative order matters to refer-rewritten transactions
 = ^expenses not:housing not:grocery not:food
     (budget:misc)  *-1
+
 $ hledger rewrite -f- date:2017/1  --add-posting 'Here comes Santa  $0' --verbose-tags
 2016-12-31  ; modified:
     expenses:housing         $600.00
@@ -187,24 +188,24 @@ $ hledger rewrite -f- date:2017/1  --add-posting 'Here comes Santa  $0' --verbos
 2017-01-01  ; modified:
     expenses:food             $20.00
     (budget:food)            $-20.00  ; generated-posting: = ^expenses:grocery ^expenses:food
-    Here comes Santa               0  ; generated-posting: = date:2017/1
+    Here comes Santa              $0  ; generated-posting: = date:2017/1
     expenses:leisure          $15.00
     (budget:misc)            $-15.00  ; generated-posting: = ^expenses not:housing not:grocery not:food
-    Here comes Santa               0  ; generated-posting: = date:2017/1
+    Here comes Santa              $0  ; generated-posting: = date:2017/1
     expenses:grocery          $30.00
     (budget:food)            $-30.00  ; generated-posting: = ^expenses:grocery ^expenses:food
-    Here comes Santa               0  ; generated-posting: = date:2017/1
+    Here comes Santa              $0  ; generated-posting: = date:2017/1
     assets:cash
-    Here comes Santa               0  ; generated-posting: = date:2017/1
+    Here comes Santa              $0  ; generated-posting: = date:2017/1
 
 2017-01-02  ; modified:
     assets:cash              $200.00
-    Here comes Santa               0  ; generated-posting: = date:2017/1
+    Here comes Santa              $0  ; generated-posting: = date:2017/1
     assets:bank
     assets:bank               $-1.60  ; generated-posting: = ^assets:bank$ date:2017/1 amt:<0
     expenses:fee               $1.60  ; cash withdraw fee, generated-posting: = ^assets:bank$ date:2017/1 amt:<0
     (budget:misc)             $-1.60  ; generated-posting: = ^expenses not:housing not:grocery not:food
-    Here comes Santa               0  ; generated-posting: = date:2017/1
+    Here comes Santa              $0  ; generated-posting: = date:2017/1
 
 2017-02-01
     assets:cash         $100.00


### PR DESCRIPTION
I noticed that `print` strips the commodity symbol from zero posting amounts, transforming eg `$0` to `0`. This can be awkward when trying to clean up/regenerate a journal, eg. This PR makes print (and print-like) reports preserve the commodity of zeroes more carefully. Other reports like balance and register are expected to work as before, but any additional testing is welcome.

```
print now shows zero posting amounts with their original commodity
symbol and the corresponding style (instead of stripping the symbol).

If an inferred amount has multiple zeroes in different commodities,
a posting is displayed for each of these.

Possible breaking changes:

showMixedAmountLinesB, showAmountB, showAmountPrice now preserve
commodityful zeroes when rendering. This is intended to improve print output,
but it seems possible it might also affect balance and register reports,
though our tests show no change in those.
```

Example:
```
# 1. print preserves the commodity symbol of zero amounts.
2023-01-01
  (a)    0 A @ 0 B = 0 A @ 0 B

# 2. The inferred balancing amount for zeros in multiple commodities
# is preserved and shown accurately, with a posting for each commodity.
2023-01-01
  a   0 A
  b   0 B
  z
```
```
$ hledger print -x
2023-01-01
    (a)       0 A @ 0 B = 0 A @ 0 B

2023-01-01
    a             0 A
    b             0 B
    z             0 A
    z             0 B

```
