### PR TITLE
dev: make groupByDateSpan return data when first DateSpan's begin is Nothing

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -317,7 +317,7 @@ groupByDateSpan showempty date colspans =
     groupByCols (c:cs) ps = (c, map snd matches) : groupByCols cs later
       where (matches, later) = span ((spanEnd c >) . Just . fst) ps
 
-    beforeStart = maybe (const True) (>) $ spanStart =<< headMay colspans
+    beforeStart = maybe (const False) (>) $ spanStart =<< headMay colspans
 
 -- | Calculate the intersection of a number of datespans.
 spansIntersect [] = nulldatespan


### PR DESCRIPTION
There doesn't seem to be any report code that would hit this bug—just noticed it while working on a script :)