### PR TITLE
print fixes, new amount styling api

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -197,6 +197,7 @@ quoteCommoditySymbolIfNeeded s
 
 
 -- | Options for the display of Amount and MixedAmount.
+-- (See also Types.AmountStyle)
 data AmountDisplayOpts = AmountDisplayOpts
   { displayPrice         :: Bool       -- ^ Whether to display the Price of an Amount.
   , displayZeroCommodity :: Bool       -- ^ If the Amount rounds to 0, whether to display its commodity string.
@@ -420,7 +421,7 @@ showAmountPriceDebug (Just (TotalPrice pa)) = " @@ " ++ showAmountDebug pa
 -- | Given a map of standard commodity display styles, apply the
 -- appropriate one to this amount. If there's no standard style for
 -- this amount's commodity, return the amount unchanged.
--- Also apply the style to the price (except for precision)
+-- Also apply the style, except for precision, to the cost.
 styleAmount :: M.Map CommoditySymbol AmountStyle -> Amount -> Amount
 styleAmount styles a = styledAmount{aprice = stylePrice styles (aprice styledAmount)}
   where
@@ -806,8 +807,8 @@ mixedAmountCost (Mixed ma) =
 --     where a' = mixedAmountStripPrices a
 --           b' = mixedAmountStripPrices b
 
--- | Given a map of standard commodity display styles, apply the
--- appropriate one to each individual amount.
+-- | Given a map of standard commodity display styles, find and apply
+-- the appropriate style to each individual amount.
 styleMixedAmount :: M.Map CommoditySymbol AmountStyle -> MixedAmount -> MixedAmount
 styleMixedAmount styles = mapMixedAmountUnsafe (styleAmount styles)
 

--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -246,7 +246,7 @@ csvDisplay = oneLine{displayThousandsSep=False}
 -- Amount styles
 
 -- | Default amount style
-amountstyle = AmountStyle L False (Precision 0) (Just '.') Nothing
+amountstyle = AmountStyle L False Nothing (Just '.') (Precision 0)
 
 -------------------------------------------------------------------------------
 -- Amount
@@ -400,7 +400,7 @@ withInternalPrecision = flip setAmountInternalPrecision
 
 -- | Set (or clear) an amount's display decimal point.
 setAmountDecimalPoint :: Maybe Char -> Amount -> Amount
-setAmountDecimalPoint mc a@Amount{ astyle=s } = a{ astyle=s{asdecimalpoint=mc} }
+setAmountDecimalPoint mc a@Amount{ astyle=s } = a{ astyle=s{asdecimalmark=mc} }
 
 -- | Set (or clear) an amount's display decimal point, flipped.
 withDecimalPoint :: Amount -> Maybe Char -> Amount
@@ -547,7 +547,7 @@ showAmountDebug Amount{..} =
 -- using the display settings from its commodity. Also returns the width of the
 -- number.
 showamountquantity :: Amount -> WideBuilder
-showamountquantity amt@Amount{astyle=AmountStyle{asdecimalpoint=mdec, asdigitgroups=mgrps}} =
+showamountquantity amt@Amount{astyle=AmountStyle{asdecimalmark=mdec, asdigitgroups=mgrps}} =
     signB <> intB <> fracB
   where
     Decimal e n = amountRoundedQuantity amt

--- a/hledger-lib/Hledger/Data/Balancing.hs
+++ b/hledger-lib/Hledger/Data/Balancing.hs
@@ -454,6 +454,9 @@ journalBalanceTransactions bopts' j' =
     -- display precisions used in balanced checking
     styles = Just $ journalCommodityStyles j
     bopts = bopts'{commodity_styles_=styles}
+      -- XXX ^ The commodity directive styles and default style and inferred styles
+      -- are merged into the command line styles in commodity_styles_ - why ?
+      -- Mainly for the precisions, used during amount and cost inference and balanced checking ?
     -- balance assignments are not allowed on accounts affected by auto postings
     autopostingaccts = S.fromList . map (paccount . tmprPosting) . concatMap tmpostingrules $ jtxnmodifiers j
   in

--- a/hledger-lib/Hledger/Data/Balancing.hs
+++ b/hledger-lib/Hledger/Data/Balancing.hs
@@ -337,8 +337,8 @@ costInferrerFor t pt = maybe id infercost inferFromAndTo
 
         unitprice     = aquantity fromamount `divideAmount` toamount
         unitprecision = case (asprecision $ astyle fromamount, asprecision $ astyle toamount) of
-            (Precision a, Precision b) -> Precision . max 2 $ saturatedAdd a b
-            _                          -> NaturalPrecision
+            (Just (Precision a), Just (Precision b)) -> Precision . max 2 $ saturatedAdd a b
+            _                                        -> NaturalPrecision
         saturatedAdd a b = if maxBound - a < b then maxBound else a + b
 
 
@@ -1005,26 +1005,26 @@ tests_Balancing =
       --
       testCase "1091a" $ do
         commodityStylesFromAmounts [
-           nullamt{aquantity=1000, astyle=AmountStyle L False Nothing (Just ',') (Precision 3)}
-          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 2)}
+           nullamt{aquantity=1000, astyle=AmountStyle L False Nothing (Just ',') (Just $ Precision 3)}
+          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Just $ Precision 2)}
           ]
          @?=
           -- The commodity style should have period as decimal mark
           -- and comma as digit group mark.
           Right (M.fromList [
-            ("", AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 3))
+            ("", AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Just $ Precision 3))
           ])
         -- same journal, entries in reverse order
       ,testCase "1091b" $ do
         commodityStylesFromAmounts [
-           nullamt{aquantity=1000, astyle=AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 2)}
-          ,nullamt{aquantity=1000, astyle=AmountStyle L False Nothing (Just ',') (Precision 3)}
+           nullamt{aquantity=1000, astyle=AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Just $ Precision 2)}
+          ,nullamt{aquantity=1000, astyle=AmountStyle L False Nothing (Just ',') (Just $ Precision 3)}
           ]
          @?=
           -- The commodity style should have period as decimal mark
           -- and comma as digit group mark.
           Right (M.fromList [
-            ("", AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 3))
+            ("", AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Just $ Precision 3))
           ])
 
      ]

--- a/hledger-lib/Hledger/Data/Balancing.hs
+++ b/hledger-lib/Hledger/Data/Balancing.hs
@@ -1005,26 +1005,26 @@ tests_Balancing =
       --
       testCase "1091a" $ do
         commodityStylesFromAmounts [
-           nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 3) (Just ',') Nothing}
-          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 2) (Just '.') (Just (DigitGroups ',' [3]))}
+           nullamt{aquantity=1000, astyle=AmountStyle L False Nothing (Just ',') (Precision 3)}
+          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 2)}
           ]
          @?=
           -- The commodity style should have period as decimal mark
           -- and comma as digit group mark.
           Right (M.fromList [
-            ("", AmountStyle L False (Precision 3) (Just '.') (Just (DigitGroups ',' [3])))
+            ("", AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 3))
           ])
         -- same journal, entries in reverse order
       ,testCase "1091b" $ do
         commodityStylesFromAmounts [
-           nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 2) (Just '.') (Just (DigitGroups ',' [3]))}
-          ,nullamt{aquantity=1000, astyle=AmountStyle L False (Precision 3) (Just ',') Nothing}
+           nullamt{aquantity=1000, astyle=AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 2)}
+          ,nullamt{aquantity=1000, astyle=AmountStyle L False Nothing (Just ',') (Precision 3)}
           ]
          @?=
           -- The commodity style should have period as decimal mark
           -- and comma as digit group mark.
           Right (M.fromList [
-            ("", AmountStyle L False (Precision 3) (Just '.') (Just (DigitGroups ',' [3])))
+            ("", AmountStyle L False (Just (DigitGroups ',' [3])) (Just '.') (Precision 3))
           ])
 
      ]

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -793,13 +793,14 @@ journalModifyTransactions verbosetags d j =
     Left err -> Left err
 
 -- | Choose and apply a consistent display style to the posting
--- amounts in each commodity (see journalCommodityStyles).
+-- amounts in each commodity (see journalCommodityStyles),
+-- keeping all display precisions unchanged.
 -- Can return an error message eg if inconsistent number formats are found.
 journalApplyCommodityStyles :: Journal -> Either String Journal
 journalApplyCommodityStyles = fmap fixjournal . journalInferCommodityStyles
   where
     fixjournal j@Journal{jpricedirectives=pds} =
-        journalMapPostings (postingApplyCommodityStyles styles) j{jpricedirectives=map fixpricedirective pds}
+        journalMapPostings (postingApplyCommodityStylesExceptPrecision styles) j{jpricedirectives=map fixpricedirective pds}
       where
         styles = journalCommodityStyles j
         fixpricedirective pd@PriceDirective{pdamount=a} = pd{pdamount=amountSetStylesExceptPrecision styles a}

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -802,7 +802,7 @@ journalApplyCommodityStyles = fmap fixjournal . journalInferCommodityStyles
         journalMapPostings (postingApplyCommodityStyles styles) j{jpricedirectives=map fixpricedirective pds}
       where
         styles = journalCommodityStyles j
-        fixpricedirective pd@PriceDirective{pdamount=a} = pd{pdamount=styleAmountExceptPrecision styles a}
+        fixpricedirective pd@PriceDirective{pdamount=a} = pd{pdamount=amountSetStylesExceptPrecision styles a}
 
 -- | Get the canonical amount styles for this journal, whether (in order of precedence):
 -- set globally in InputOpts,

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -909,12 +909,9 @@ journalInferMarketPricesFromTransactions j =
        journalPostings j
    }
 
--- | Convert all this journal's amounts to cost using the transaction prices, if any.
--- The journal's commodity styles are applied to the resulting amounts.
+-- | Convert all this journal's amounts to cost using their attached prices, if any.
 journalToCost :: ConversionOp -> Journal -> Journal
-journalToCost cost j@Journal{jtxns=ts} = j{jtxns=map (transactionToCost styles cost) ts}
-  where
-    styles = journalCommodityStyles j
+journalToCost cost j@Journal{jtxns=ts} = j{jtxns=map (transactionToCost cost) ts}
 
 -- | Add equity postings inferred from costs, where needed and possible.
 -- See hledger manual > Cost reporting.

--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -858,7 +858,7 @@ canonicalStyleFrom = foldl' canonicalStyle amountstyle
 -- with the first digit group style seen,
 -- with the maximum precision of all.
 canonicalStyle :: AmountStyle -> AmountStyle -> AmountStyle
-canonicalStyle a b = a{asprecision=prec, asdecimalpoint=decmark, asdigitgroups=mgrps}
+canonicalStyle a b = a{asprecision=prec, asdecimalmark=decmark, asdigitgroups=mgrps}
   where
     -- precision is maximum of all precisions
     prec = max (asprecision a) (asprecision b)
@@ -874,7 +874,7 @@ canonicalStyle a b = a{asprecision=prec, asdecimalpoint=decmark, asdigitgroups=m
     -- urgh.. refactor..
     decmark = case mgrps of
         Just _  -> Just defdecmark
-        Nothing -> asdecimalpoint a <|> asdecimalpoint b <|> Just defdecmark
+        Nothing -> asdecimalmark a <|> asdecimalmark b <|> Just defdecmark
 
 -- -- | Apply this journal's historical price records to unpriced amounts where possible.
 -- journalApplyPriceDirectives :: Journal -> Journal

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -447,14 +447,13 @@ postingApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle -> Day
 postingApplyValuation priceoracle styles periodlast today v p =
     postingTransformAmount (mixedAmountApplyValuation priceoracle styles periodlast today (postingDate p) v) p
 
--- | Maybe convert this 'Posting's amount to cost, and apply apply appropriate
--- amount styles.
-postingToCost :: M.Map CommoditySymbol AmountStyle -> ConversionOp -> Posting -> Maybe Posting
-postingToCost _      NoConversionOp p = Just p
-postingToCost styles ToCost         p
+-- | Maybe convert this 'Posting's amount to cost.
+postingToCost :: ConversionOp -> Posting -> Maybe Posting
+postingToCost NoConversionOp p = Just p
+postingToCost ToCost         p
     -- If this is a conversion posting with a matched transaction price posting, ignore it
     | "_conversion-matched" `elem` map fst (ptags p) && noCost = Nothing
-    | otherwise = Just $ postingTransformAmount (mixedAmountSetStyles styles . mixedAmountCost) p
+    | otherwise = Just $ postingTransformAmount mixedAmountCost p
   where
     noCost = (not . any (isJust . aprice) . amountsRaw) $ pamount p
 

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -413,7 +413,7 @@ postingApplyAliases aliases p@Posting{paccount} =
 -- | Choose and apply a consistent display style to the posting
 -- amounts in each commodity (see journalCommodityStyles).
 postingApplyCommodityStyles :: M.Map CommoditySymbol AmountStyle -> Posting -> Posting
-postingApplyCommodityStyles styles p = p{pamount=styleMixedAmount styles $ pamount p
+postingApplyCommodityStyles styles p = p{pamount=mixedAmountSetStyles styles $ pamount p
                                         ,pbalanceassertion=fixbalanceassertion <$> pbalanceassertion p}
   where
     fixbalanceassertion ba = ba{baamount=styleAmountExceptPrecision styles $ baamount ba}
@@ -436,7 +436,7 @@ postingToCost _      NoConversionOp p = Just p
 postingToCost styles ToCost         p
     -- If this is a conversion posting with a matched transaction price posting, ignore it
     | "_conversion-matched" `elem` map fst (ptags p) && noCost = Nothing
-    | otherwise = Just $ postingTransformAmount (styleMixedAmount styles . mixedAmountCost) p
+    | otherwise = Just $ postingTransformAmount (mixedAmountSetStyles styles . mixedAmountCost) p
   where
     noCost = (not . any (isJust . aprice) . amountsRaw) $ pamount p
 

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -74,6 +74,9 @@ import Data.Decimal (normalizeDecimal, decimalPlaces)
 import Data.Functor ((<&>))
 
 
+instance HasAmounts Transaction where
+  styleAmounts styles t = t{tpostings=styleAmounts styles $ tpostings t}
+
 nulltransaction :: Transaction
 nulltransaction = Transaction {
                     tindex=0,

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -221,10 +221,9 @@ transactionApplyValuation :: PriceOracle -> M.Map CommoditySymbol AmountStyle ->
 transactionApplyValuation priceoracle styles periodlast today v =
   transactionTransformPostings (postingApplyValuation priceoracle styles periodlast today v)
 
--- | Maybe convert this 'Transaction's amounts to cost and apply the
--- appropriate amount styles.
-transactionToCost :: M.Map CommoditySymbol AmountStyle -> ConversionOp -> Transaction -> Transaction
-transactionToCost styles cost t = t{tpostings = mapMaybe (postingToCost styles cost) $ tpostings t}
+-- | Maybe convert this 'Transaction's amounts to cost.
+transactionToCost :: ConversionOp -> Transaction -> Transaction
+transactionToCost cost t = t{tpostings = mapMaybe (postingToCost cost) $ tpostings t}
 
 -- | Add inferred equity postings to a 'Transaction' using transaction prices.
 transactionAddInferredEquityPostings :: Bool -> AccountName -> Transaction -> Transaction

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -259,14 +259,13 @@ data AmountStyle = AmountStyle {
 } deriving (Eq,Ord,Read,Generic)
 
 instance Show AmountStyle where
-  show AmountStyle{..} = concat
-    [ "AmountStylePP \""
+  show AmountStyle{..} = unwords
+    [ "AmountStylePP"
     , show ascommodityside
     , show ascommodityspaced
     , show asprecision
     , show asdecimalpoint
     , show asdigitgroups
-    , "..\""
     ]
 
 -- | The "display precision" for a hledger amount, by which we mean

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -249,14 +249,14 @@ deriving instance Generic (DecimalRaw a)
 data AmountPrice = UnitPrice !Amount | TotalPrice !Amount
   deriving (Eq,Ord,Generic,Show)
 
--- | Display style for an amount.
--- (See also Amount.AmountDisplayOpts)
+-- | The display style for an amount.
+-- (See also Amount.AmountDisplayOpts).
 data AmountStyle = AmountStyle {
-      ascommodityside   :: !Side,                   -- ^ does the symbol appear on the left or the right ?
-      ascommodityspaced :: !Bool,                   -- ^ space between symbol and quantity ?
-      asprecision       :: !AmountPrecision,        -- ^ number of digits displayed after the decimal point
-      asdecimalpoint    :: !(Maybe Char),           -- ^ character used as decimal point: period or comma. Nothing means "unspecified, use default"
-      asdigitgroups     :: !(Maybe DigitGroupStyle) -- ^ style for displaying digit groups, if any
+  ascommodityside   :: !Side,                     -- ^ show the symbol on the left or the right ?
+  ascommodityspaced :: !Bool,                     -- ^ show a space between symbol and quantity ?
+  asdigitgroups     :: !(Maybe DigitGroupStyle),  -- ^ show the integer part with these digit group marks, or not
+  asdecimalmark     :: !(Maybe Char),             -- ^ show this character (should be . or ,) as decimal mark, or use the default (.)
+  asprecision       :: !AmountPrecision           -- ^ show this number of digits after the decimal point
 } deriving (Eq,Ord,Read,Generic)
 
 instance Show AmountStyle where
@@ -264,9 +264,9 @@ instance Show AmountStyle where
     [ "AmountStylePP"
     , show ascommodityside
     , show ascommodityspaced
-    , show asprecision
-    , show asdecimalpoint
     , show asdigitgroups
+    , show asdecimalmark
+    , show asprecision
     ]
 
 -- | The "display precision" for a hledger amount, by which we mean

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -256,7 +256,9 @@ data AmountStyle = AmountStyle {
   ascommodityspaced :: !Bool,                     -- ^ show a space between symbol and quantity ?
   asdigitgroups     :: !(Maybe DigitGroupStyle),  -- ^ show the integer part with these digit group marks, or not
   asdecimalmark     :: !(Maybe Char),             -- ^ show this character (should be . or ,) as decimal mark, or use the default (.)
-  asprecision       :: !AmountPrecision           -- ^ show this number of digits after the decimal point
+  asprecision       :: !(Maybe AmountPrecision)   -- ^ show this number of digits after the decimal point, or show as-is (leave precision unchanged)
+    -- XXX Making asprecision a maybe simplifies code for styling with or without precision,
+    -- but complicates the semantics (Nothing is useful only when setting style).
 } deriving (Eq,Ord,Read,Generic)
 
 instance Show AmountStyle where

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -301,6 +301,24 @@ data Amount = Amount {
       aprice      :: !(Maybe AmountPrice)  -- ^ the (fixed, transaction-specific) price for this amount, if any
     } deriving (Eq,Ord,Generic,Show)
 
+-- | Types with this class have one or more amounts,
+-- which can have display styles applied to them.
+class HasAmounts a where
+  styleAmounts :: M.Map CommoditySymbol AmountStyle -> a -> a
+
+instance HasAmounts a =>
+  HasAmounts [a]
+  where styleAmounts styles = map (styleAmounts styles)
+
+instance (HasAmounts a, HasAmounts b) =>
+  HasAmounts (a,b)
+  where styleAmounts styles (aa,bb) = (styleAmounts styles aa, styleAmounts styles bb)
+
+instance HasAmounts a =>
+  HasAmounts (Maybe a)
+  where styleAmounts styles = fmap (styleAmounts styles)
+
+
 newtype MixedAmount = Mixed (M.Map MixedAmountKey Amount) deriving (Generic,Show)
 
 instance Eq  MixedAmount where a == b  = maCompare a b == EQ

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -250,6 +250,7 @@ data AmountPrice = UnitPrice !Amount | TotalPrice !Amount
   deriving (Eq,Ord,Generic,Show)
 
 -- | Display style for an amount.
+-- (See also Amount.AmountDisplayOpts)
 data AmountStyle = AmountStyle {
       ascommodityside   :: !Side,                   -- ^ does the symbol appear on the left or the right ?
       ascommodityspaced :: !Bool,                   -- ^ space between symbol and quantity ?
@@ -270,9 +271,10 @@ instance Show AmountStyle where
 
 -- | The "display precision" for a hledger amount, by which we mean
 -- the number of decimal digits to display to the right of the decimal mark.
--- This can be from 0 to 255 digits (the maximum supported by the Decimal library),
--- or NaturalPrecision meaning "show all significant decimal digits".
-data AmountPrecision = Precision !Word8 | NaturalPrecision deriving (Eq,Ord,Read,Show,Generic)
+data AmountPrecision =
+    Precision !Word8    -- ^ show this many decimal digits (0..255)
+  | NaturalPrecision    -- ^ show all significant decimal digits stored internally
+  deriving (Eq,Ord,Read,Show,Generic)
 
 -- | A style for displaying digit groups in the integer part of a
 -- floating point number. It consists of the character used to

--- a/hledger-lib/Hledger/Data/Valuation.hs
+++ b/hledger-lib/Hledger/Data/Valuation.hs
@@ -129,7 +129,7 @@ mixedAmountApplyValuation priceoracle styles periodlast today postingdate v =
 
 -- | Convert an Amount to its cost if requested, and style it appropriately.
 amountToCost :: M.Map CommoditySymbol AmountStyle -> ConversionOp -> Amount -> Amount
-amountToCost styles ToCost         = styleAmount styles . amountCost
+amountToCost styles ToCost         = amountSetStyles styles . amountCost
 amountToCost _      NoConversionOp = id
 
 -- | Apply a specified valuation to this amount, using the provided
@@ -192,7 +192,7 @@ amountValueAtDate priceoracle styles mto d a =
       -- setNaturalPrecisionUpTo 8 $  -- XXX force higher precision in case amount appears to be zero ?
                                       -- Make default display style use precision 2 instead of 0 ?
                                       -- Leave as is for now; mentioned in manual.
-      styleAmount styles
+      amountSetStyles styles
       nullamt{acommodity=comm, aquantity=rate * aquantity a}
 
 -- | Calculate the gain of each component amount, that is the difference

--- a/hledger-lib/Hledger/Data/Valuation.hs
+++ b/hledger-lib/Hledger/Data/Valuation.hs
@@ -110,8 +110,8 @@ amountPriceDirectiveFromCost d amt@Amount{acommodity=fromcomm, aquantity=fromq} 
       where
         style' = (astyle a) { asprecision = precision' }
         precision' = case asprecision (astyle a) of
-                          NaturalPrecision -> NaturalPrecision
-                          Precision p      -> Precision $ (numDigitsInt $ truncate n) + p
+                          Just (Precision p) -> Just $ Precision $ (numDigitsInt $ truncate n) + p
+                          mp -> mp
 
 ------------------------------------------------------------------------------
 -- Converting things to value

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -802,7 +802,7 @@ simpleamountp mult =
     offAfterNum <- getOffset
     let numRegion = (offBeforeNum, offAfterNum)
     (q,prec,mdec,mgrps) <- lift $ interpretNumber numRegion suggestedStyle ambiguousRawNum mExponent
-    let s = amountstyle{ascommodityside=L, ascommodityspaced=commodityspaced, asprecision=prec, asdecimalmark=mdec, asdigitgroups=mgrps}
+    let s = amountstyle{ascommodityside=L, ascommodityspaced=commodityspaced, asprecision=Just prec, asdecimalmark=mdec, asdigitgroups=mgrps}
     return nullamt{acommodity=c, aquantity=sign (sign2 q), astyle=s, aprice=Nothing}
 
   -- An amount with commodity symbol on the right or no commodity symbol.
@@ -824,7 +824,7 @@ simpleamountp mult =
         -- XXX amounts of this commodity in periodic transaction rules and auto posting rules ? #1461
         let msuggestedStyle = mdecmarkStyle <|> mcommodityStyle
         (q,prec,mdec,mgrps) <- lift $ interpretNumber numRegion msuggestedStyle ambiguousRawNum mExponent
-        let s = amountstyle{ascommodityside=R, ascommodityspaced=commodityspaced, asprecision=prec, asdecimalmark=mdec, asdigitgroups=mgrps}
+        let s = amountstyle{ascommodityside=R, ascommodityspaced=commodityspaced, asprecision=Just prec, asdecimalmark=mdec, asdigitgroups=mgrps}
         return nullamt{acommodity=c, aquantity=sign q, astyle=s, aprice=Nothing}
       -- no symbol amount
       Nothing -> do
@@ -840,8 +840,8 @@ simpleamountp mult =
         -- (unless it's a multiplier in an automated posting)
         defcs <- getDefaultCommodityAndStyle
         let (c,s) = case (mult, defcs) of
-              (False, Just (defc,defs)) -> (defc, defs{asprecision=max (asprecision defs) prec})
-              _ -> ("", amountstyle{asprecision=prec, asdecimalmark=mdec, asdigitgroups=mgrps})
+              (False, Just (defc,defs)) -> (defc, defs{asprecision=max (asprecision defs) (Just prec)})
+              _ -> ("", amountstyle{asprecision=Just prec, asdecimalmark=mdec, asdigitgroups=mgrps})
         return nullamt{acommodity=c, aquantity=sign q, astyle=s, aprice=Nothing}
 
   -- For reducing code duplication. Doesn't parse anything. Has the type
@@ -1068,7 +1068,7 @@ disambiguateNumber msuggestedStyle (AmbiguousNumber grp1 sep grp2) =
     isValidDecimalBy c = \case
       AmountStyle{asdecimalmark = Just d} -> d == c
       AmountStyle{asdigitgroups = Just (DigitGroups g _)} -> g /= c
-      AmountStyle{asprecision = Precision 0} -> False
+      AmountStyle{asprecision = Just (Precision 0)} -> False
       _ -> True
 
 -- | Parse and interpret the structure of a number without external hints.
@@ -1572,24 +1572,24 @@ tests_Common = testGroup "Common" [
       nullamt{
          acommodity="$"
         ,aquantity=10 -- need to test internal precision with roundTo ? I think not
-        ,astyle=amountstyle{asprecision=Precision 0, asdecimalmark=Nothing}
+        ,astyle=amountstyle{asprecision=Just $ Precision 0, asdecimalmark=Nothing}
         ,aprice=Just $ UnitPrice $
           nullamt{
              acommodity="€"
             ,aquantity=0.5
-            ,astyle=amountstyle{asprecision=Precision 1, asdecimalmark=Just '.'}
+            ,astyle=amountstyle{asprecision=Just $ Precision 1, asdecimalmark=Just '.'}
             }
         }
    ,testCase "total price"            $ assertParseEq amountp "$10 @@ €5"
       nullamt{
          acommodity="$"
         ,aquantity=10
-        ,astyle=amountstyle{asprecision=Precision 0, asdecimalmark=Nothing}
+        ,astyle=amountstyle{asprecision=Just $ Precision 0, asdecimalmark=Nothing}
         ,aprice=Just $ TotalPrice $
           nullamt{
              acommodity="€"
             ,aquantity=5
-            ,astyle=amountstyle{asprecision=Precision 0, asdecimalmark=Nothing}
+            ,astyle=amountstyle{asprecision=Just $ Precision 0, asdecimalmark=Nothing}
             }
         }
    ,testCase "unit price, parenthesised" $ assertParse amountp "$10 (@) €0.5"

--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -490,7 +490,7 @@ commoditydirectiveonelinep = do
   lift skipNonNewlineSpaces
   _ <- lift followingcommentp
   let comm = Commodity{csymbol=acommodity, cformat=Just $ dbg6 "style from commodity directive" astyle}
-  if isNothing $ asdecimalpoint astyle
+  if isNothing $ asdecimalmark astyle
   then customFailure $ parseErrorAt off pleaseincludedecimalpoint
   else modify' (\j -> j{jcommodities=M.insert acommodity comm $ jcommodities j})
 
@@ -533,7 +533,7 @@ formatdirectivep expectedsym = do
   _ <- lift followingcommentp
   if acommodity==expectedsym
     then
-      if isNothing $ asdecimalpoint astyle
+      if isNothing $ asdecimalmark astyle
       then customFailure $ parseErrorAt off pleaseincludedecimalpoint
       else return $ dbg6 "style from format subdirective" astyle
     else customFailure $ parseErrorAt off $
@@ -648,7 +648,7 @@ defaultcommoditydirectivep = do
   off <- getOffset
   Amount{acommodity,astyle} <- amountp
   lift restofline
-  if isNothing $ asdecimalpoint astyle
+  if isNothing $ asdecimalmark astyle
   then customFailure $ parseErrorAt off pleaseincludedecimalpoint
   else setDefaultCommodityAndStyle (acommodity, astyle)
 

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -192,8 +192,8 @@ timedotentryp = do
   mcs <- getDefaultCommodityAndStyle
   let 
     (c,s) = case mcs of
-      Just (defc,defs) -> (defc, defs{asprecision=max (asprecision defs) (Precision 2)})
-      _ -> ("", amountstyle{asprecision=Precision 2})
+      Just (defc,defs) -> (defc, defs{asprecision=max (asprecision defs) (Just $ Precision 2)})
+      _ -> ("", amountstyle{asprecision=Just $ Precision 2})
   -- lift $ traceparse' "timedotentryp end"
   return $ nullposting{paccount=a
                       ,pamount=mixedAmount $ nullamt{acommodity=c, aquantity=hours, astyle=s}

--- a/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
+++ b/hledger-lib/Hledger/Reports/AccountTransactionsReport.hs
@@ -85,6 +85,10 @@ type AccountTransactionsReportItem =
   ,MixedAmount -- the register's running total or the current account(s)'s historical balance, after this transaction
   )
 
+instance HasAmounts AccountTransactionsReportItem where
+  styleAmounts styles (torig,tacct,b,c,a1,a2) =
+    (styleAmounts styles torig,styleAmounts styles tacct,b,c,styleAmounts styles a1,styleAmounts styles a2)
+
 triOrigTransaction (torig,_,_,_,_,_) = torig
 triDate (_,tacct,_,_,_,_) = tdate tacct
 triAmount (_,_,_,_,a,_) = a

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -49,6 +49,9 @@ import Hledger.Reports.ReportTypes
 type BalanceReport = ([BalanceReportItem], MixedAmount)
 type BalanceReportItem = (AccountName, AccountName, Int, MixedAmount)
 
+instance HasAmounts BalanceReportItem where
+  styleAmounts styles (a,b,c,d) = (a,b,c,styleAmounts styles d)
+
 -- | When true (the default), this makes balance --flat reports and their implementation clearer.
 -- Single/multi-col balance reports currently aren't all correct if this is false.
 flatShowsExclusiveBalance    = True

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -617,7 +617,8 @@ balanceReportTableAsText ReportOpts{..} =
 tests_MultiBalanceReport = testGroup "MultiBalanceReport" [
 
   let
-    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asdigitgroups = Nothing, asdecimalmark = Just '.', asprecision = Precision 2}}
+    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, 
+      astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asdigitgroups = Nothing, asdecimalmark = Just '.', asprecision = Just $ Precision 2}}
     (rspec,journal) `gives` r = do
       let rspec' = rspec{_rsQuery=And [queryFromFlags $ _rsReportOpts rspec, _rsQuery rspec]}
           (eitems, etotal) = r

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -617,7 +617,7 @@ balanceReportTableAsText ReportOpts{..} =
 tests_MultiBalanceReport = testGroup "MultiBalanceReport" [
 
   let
-    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asprecision = Precision 2, asdecimalpoint = Just '.', asdigitgroups = Nothing}}
+    amt0 = Amount {acommodity="$", aquantity=0, aprice=Nothing, astyle=AmountStyle {ascommodityside = L, ascommodityspaced = False, asdigitgroups = Nothing, asdecimalmark = Just '.', asprecision = Precision 2}}
     (rspec,journal) `gives` r = do
       let rspec' = rspec{_rsQuery=And [queryFromFlags $ _rsReportOpts rspec, _rsQuery rspec]}
           (eitems, etotal) = r

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -52,6 +52,9 @@ type PostingsReportItem = (Maybe Day     -- The posting date, if this is the fir
                                          -- the running total/average.
                           )
 
+instance HasAmounts PostingsReportItem where
+  styleAmounts styles (a,b,c,d,e) = (a,b,c,styleAmounts styles d,styleAmounts styles e)
+
 -- | A summary posting summarises the activity in one account within a report
 -- interval. It is by a regular Posting with no description, the interval's
 -- start date stored as the posting date, and the interval's Period attached

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -623,7 +623,7 @@ mixedAmountApplyValuationAfterSumFromOptsWith ropts j priceoracle =
     gain mc spn = mixedAmountGainAtDate priceoracle styles mc (maybe err (addDays (-1)) $ spanEnd spn)
     costing = case fromMaybe NoConversionOp $ conversionop_ ropts of
         NoConversionOp -> id
-        ToCost         -> styleMixedAmount styles . mixedAmountCost
+        ToCost         -> mixedAmountSetStyles styles . mixedAmountCost
     styles = journalCommodityStyles j
     err = error "mixedAmountApplyValuationAfterSumFromOptsWith: expected all spans to have an end date"
 

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -102,7 +102,7 @@ showTxn :: ReportOpts -> ReportSpec -> Journal -> Transaction -> T.Text
 showTxn ropts rspec j t =
       showTransactionOneLineAmounts
     $ maybe id (transactionApplyValuation prices styles periodlast (_rsDay rspec)) (value_ ropts)
-    $ maybe id (transactionToCost styles) (conversionop_ ropts) t
+    $ maybe id transactionToCost (conversionop_ ropts) t
     -- (if real_ ropts then filterTransactionPostings (Real True) else id) -- filter postings by --real
   where
     prices = journalPriceOracle (infer_prices_ ropts) j

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -99,8 +99,10 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     -- run the report
     -- TODO: need to also pass the queries so we can choose which date to render - move them into the report ?
     items = accountTransactionsReport rspec' j thisacctq
-    items' = (if empty_ ropts' then id else filter (not . mixedAmountLooksZero . fifth6)) $
-             reverse items
+    items' =
+      styleAmounts (journalCommodityStyles j) $
+      (if empty_ ropts' then id else filter (not . mixedAmountLooksZero . fifth6)) $
+      reverse items
     -- select renderer
     render | fmt=="txt"  = accountTransactionsReportAsText opts (_rsQuery rspec') thisacctq
            | fmt=="html" = accountTransactionsReportAsHTML opts (_rsQuery rspec') thisacctq

--- a/hledger/Hledger/Cli/Commands/Prices.hs
+++ b/hledger/Hledger/Cli/Commands/Prices.hs
@@ -78,7 +78,7 @@ invertPrice a =
 -- But keep the number of decimal places unchanged.
 stylePriceDirectiveExceptPrecision :: M.Map CommoditySymbol AmountStyle -> PriceDirective -> PriceDirective
 stylePriceDirectiveExceptPrecision styles pd@PriceDirective{pdamount=a} =
-  pd{pdamount = styleAmountExceptPrecision styles a}
+  pd{pdamount = amountSetStylesExceptPrecision styles a}
 
 allPostings :: Journal -> [Posting]
 allPostings = concatMap tpostings . jtxns

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -28,6 +28,7 @@ import Hledger.Read.CsvUtils (CSV, printCSV)
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
 import System.Exit (exitFailure)
+import qualified Data.Map as M (map)
 
 
 printmode = hledgerCommandMode
@@ -69,8 +70,11 @@ print' opts j = do
 
 printEntries :: CliOpts -> Journal -> IO ()
 printEntries opts@CliOpts{reportspec_=rspec} j =
-  writeOutputLazyText opts . render $ entriesReport rspec j
+  writeOutputLazyText opts . render $
+  styleAmounts styles $
+  entriesReport rspec j
   where
+    styles = journalCommodityStyles j
     fmt = outputFormatFromOpts opts
     render | fmt=="txt"  = entriesReportAsText opts
            | fmt=="csv"  = printCSV . entriesReportAsCsv

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -74,7 +74,7 @@ printEntries opts@CliOpts{reportspec_=rspec} j =
   styleAmounts styles $
   entriesReport rspec j
   where
-    styles = journalCommodityStyles j
+    styles = M.map amountStyleUnsetPrecision $ journalCommodityStyles j  -- keep all precisions unchanged
     fmt = outputFormatFromOpts opts
     render | fmt=="txt"  = entriesReportAsText opts
            | fmt=="csv"  = printCSV . entriesReportAsCsv

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -162,7 +162,7 @@ entriesReportAsSql txns = TB.toLazyText $ mconcat
     toSql s  = TB.fromText "'" <> TB.fromText (T.replace "'" "''" s) <> TB.fromText "'"
     csv = concatMap (transactionToCSV . transactionMapPostingAmounts (mapMixedAmount setDecimalPoint)) txns
       where
-        setDecimalPoint a = a{astyle=(astyle a){asdecimalpoint=Just '.'}}
+        setDecimalPoint a = a{astyle=(astyle a){asdecimalmark=Just '.'}}
 
 entriesReportAsCsv :: EntriesReport -> CSV
 entriesReportAsCsv txns =

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -79,11 +79,12 @@ register opts@CliOpts{rawopts_=rawopts, reportspec_=rspec} j
                   where pri = (Just (postingDate p)
                               ,Nothing
                               ,tdescription <$> ptransaction p
-                              ,p
-                              ,nullmixedamt)
+                              ,styleAmounts styles p
+                              ,styleAmounts styles nullmixedamt)
   -- normal register report, list postings
-  | otherwise = writeOutputLazyText opts $ render rpt
+  | otherwise = writeOutputLazyText opts $ render $ styleAmounts styles rpt
   where
+    styles = journalCommodityStyles j
     rpt = postingsReport rspec j
     render | fmt=="txt"  = postingsReportAsText opts
            | fmt=="csv"  = printCSV . postingsReportAsCsv

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -109,7 +109,7 @@ compoundBalanceCommandMode CompoundBalanceCommandSpec{..} =
 -- | Generate a runnable command from a compound balance command specification.
 compoundBalanceCommand :: CompoundBalanceCommandSpec -> (CliOpts -> Journal -> IO ())
 compoundBalanceCommand CompoundBalanceCommandSpec{..} opts@CliOpts{reportspec_=rspec, rawopts_=rawopts} j = do
-    writeOutputLazyText opts $ render cbr
+    writeOutputLazyText opts $ render $ styleAmounts (journalCommodityStyles j) cbr
   where
     ropts@ReportOpts{..} = _rsReportOpts rspec
     -- use the default balance type for this report, unless the user overrides

--- a/hledger/test/cli/commodity-style.test
+++ b/hledger/test/cli/commodity-style.test
@@ -1,4 +1,4 @@
-# Test whether only the style without a symbol is changed
+# 1. Test whether only the style without a symbol is changed
 <
 2021-07-09 no symbol
     (a)   1234
@@ -10,7 +10,6 @@
     (a)      $ 1,234.56
 
 $ hledger -f- print -c '10 00'
->
 2021-07-09 no symbol
     (a)           12 34
 
@@ -20,40 +19,43 @@ $ hledger -f- print -c '10 00'
 2021-07-09 Dollar
     (a)      $ 1,234.56
 
->= 0
-# Test whether setting the style of multiple symbols work
+>=
+
+# 2. Test whether setting the style of multiple symbols work
 <
 2021-07-09 Euro
     (a)    EUR 1,234.56
 
 2021-07-09 Dollar
     (a)      $ 1.234,56
+
 $ hledger -f- print -c 'EUR 1.000,00' -c '$ 1,000.00'
->
 2021-07-09 Euro
     (a)    EUR 1.234,56
 
 2021-07-09 Dollar
     (a)      $ 1,234.56
 
->= 0
-# When setting the same symbol multiple times, the last one is in effect
+>=
+
+# 3. When setting the same symbol multiple times, the last one is in effect
 <
 2021-07-09 Euro
     (a)    EUR 1234
+
 $ hledger -f- print -c 'EUR 1.000,00' -c 'EUR 1,000.00'
->
 2021-07-09 Euro
     (a)    EUR 1,234.00
 
->= 0
-# Commodity styles are applied to quantity and price of a commodity (except for precision)
+>=
+
+# 4. Commodity styles are applied to quantity and price of a commodity (except for precision)
 <
 2021-09-12 buy A
     (a)    1,234 A @ $ 1234,56
+
 $ hledger -f- print -c '1,000.0 $' -c 'A 1000.0'
->
 2021-09-12 buy A
     (a)    A 1.234 @ 1,234.56 $
 
->= 0
+>=

--- a/hledger/test/cli/commodity-style.test
+++ b/hledger/test/cli/commodity-style.test
@@ -11,7 +11,7 @@
 
 $ hledger -f- print -c '10 00'
 2021-07-09 no symbol
-    (a)           12 34
+    (a)          12 34.
 
 2021-07-09 Euro
     (a)    EUR 1.234,56
@@ -45,17 +45,17 @@ $ hledger -f- print -c 'EUR 1.000,00' -c '$ 1,000.00'
 
 $ hledger -f- print -c 'EUR 1.000,00' -c 'EUR 1,000.00'
 2021-07-09 Euro
-    (a)    EUR 1,234.00
+    (a)      EUR 1,234.
 
 >=
 
 # 4. Commodity styles are applied to quantity and price of a commodity (except for precision)
 <
 2021-09-12 buy A
-    (a)    1,234 A @ $ 1234,56
+    (a)    1,234 A @ 1234,56 $
 
-$ hledger -f- print -c '1,000.0 $' -c 'A 1000.0'
+$ hledger -f- print -c '$1,000.0' -c 'A1000.0'
 2021-09-12 buy A
-    (a)    A 1.234 @ 1,234.56 $
+    (a)    A1.234 @ $1,234.56
 
 >=

--- a/hledger/test/close.test
+++ b/hledger/test/close.test
@@ -212,22 +212,22 @@ commodity AAA 0.00000000
 
 $ hledger -f- close -p 2019 assets --show-costs -x
 2019-12-31 closing balances
-    assets:aaa                                       AAA -510.00000000 = AAA 0.00000000
-    assets:usd                                                 $-49.50
-    assets:usd                          $49.390001 @ AAA 10.3528242505 = $0.00
-    equity:opening/closing balances                             $49.50
-    equity:opening/closing balances    $-49.390001 @ AAA 10.3528242505
-    equity:opening/closing balances                   AAA 510.00000000
+    assets:aaa                                              AAA -510 = AAA 0
+    assets:usd                                               $-49.50
+    assets:usd                          $49.3900010 @ AAA 10.3528243 = $0.0000000
+    equity:opening/closing balances                           $49.50
+    equity:opening/closing balances    $-49.3900010 @ AAA 10.3528243
+    equity:opening/closing balances                          AAA 510
 
 >=0
 
 # 14. The same, without costs and with --interleaved.
 $ hledger -f- close -p 2019 assets --interleaved -x
 2019-12-31 closing balances
-    assets:aaa                         AAA -510.00000000 = AAA 0.00000000
-    equity:opening/closing balances     AAA 510.00000000
-    assets:usd                                $-0.109999 = $0.00
-    equity:opening/closing balances            $0.109999
+    assets:aaa                             AAA -510 = AAA 0
+    equity:opening/closing balances         AAA 510
+    assets:usd                          $-0.1099990 = $0.0000000
+    equity:opening/closing balances      $0.1099990
 
 >=0
 

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -219,8 +219,8 @@ account4 the:remainder
 
 $  ./csvtest.sh
 2009-09-10 Flubber Co
-    assets:myacct          $50.000 = $321
-    income:unknown        $-50.000 = $123
+    assets:myacct              $50 = $321
+    income:unknown            $-50 = $123
     expenses:tax            $0.234  ; VAT
     the:remainder
 
@@ -903,7 +903,8 @@ $  ./csvtest.sh
 
 >=0
 
-# 45. decimal-mark helps parse ambiguous decimals correctly
+# 45. decimal-mark helps parse ambiguous decimals correctly.
+# Here it's one thousand, one.
 <
 2020-01-01,"1,000"
 2020-01-02,"1.000"
@@ -914,8 +915,8 @@ decimal-mark .
 
 $  ./csvtest.sh
 2020-01-01
-    expenses:unknown       1,000.000
-    income:unknown        -1,000.000
+    expenses:unknown          1,000.
+    income:unknown           -1,000.
 
 2020-01-02
     expenses:unknown           1.000
@@ -923,7 +924,8 @@ $  ./csvtest.sh
 
 >=
 
-# 46. decimal-mark again
+# 46. Again, this time with comma as decimal mark.
+# Here it's one, one thousand.
 <
 2020-01-01,"1,000"
 2020-01-02,"1.000"
@@ -938,8 +940,8 @@ $  ./csvtest.sh
     income:unknown            -1,000
 
 2020-01-02
-    expenses:unknown       1.000,000
-    income:unknown        -1.000,000
+    expenses:unknown          1.000,
+    income:unknown           -1.000,
 
 >=
 

--- a/hledger/test/journal/amounts-and-commodities.test
+++ b/hledger/test/journal/amounts-and-commodities.test
@@ -240,7 +240,7 @@ $ hledger -f- print cur:A1 amt:2
 
 $ hledger -f- print cur:A amt:12
 2021-01-01
-    (a)            A1 2
+    (a)           A1 2.
 
 >=
 
@@ -252,7 +252,7 @@ $ hledger -f- print cur:A amt:12
 
 $ hledger -f- print cur:A amt:12
 2021-01-01
-    (a)            1 2A
+    (a)           1 2.A
 
 >=
 
@@ -293,7 +293,7 @@ $ hledger -f- print cur:e amt:100
 
 $ hledger -f- print cur: amt:1112
 2021-01-01
-    (a)           111 2
+    (a)          111 2.
 
 >=
 

--- a/hledger/test/journal/costs.test
+++ b/hledger/test/journal/costs.test
@@ -71,11 +71,11 @@ $ hledger -f - print --explicit
 $ hledger -f - print --explicit
 2011-01-01
     expenses:foreign currency    €100 @ $1.35
-    misc                                $2.10
+    misc                                 $2.1
     assets                           $-135.00
     misc                           €1 @ $1.35
     misc                          €-1 @ $1.35
-    misc                               $-2.10
+    misc                                $-2.1
 
 >=0
 
@@ -591,17 +591,17 @@ $ hledger -f- print
 
 $ hledger -f- print --infer-costs
 2011-01-01
-    expenses:foreign currency    €100.00 @ $1.35
-    expenses:foreign currency       £100 @ $1.36
-    expenses:foreign currency     ¥1000 @@ €8.00
-    equity:conversion                   €-100.00
-    equity:conversion                       $135
-    equity:conversion                      £-100
-    equity:conversion                       $136
-    equity:conversion                     ¥-1000
-    equity:conversion                      €8.00
-    assets                                 $-271
-    assets                                €-8.00
+    expenses:foreign currency      €100 @ $1.35
+    expenses:foreign currency      £100 @ $1.36
+    expenses:foreign currency    ¥1000 @@ €8.00
+    equity:conversion                     €-100
+    equity:conversion                      $135
+    equity:conversion                     £-100
+    equity:conversion                      $136
+    equity:conversion                    ¥-1000
+    equity:conversion                     €8.00
+    assets                                $-271
+    assets                               €-8.00
 
 >=0
 

--- a/hledger/test/journal/include.test
+++ b/hledger/test/journal/include.test
@@ -23,7 +23,7 @@ include a.timeclock
 include b.timedot
 $ hledger -f - print
 2016-01-01
-    (x)            1.00
+    (x)               1
 
 2016-01-01 * 12:00-16:00
     (a:aa)           4.00h

--- a/hledger/test/journal/precision.test
+++ b/hledger/test/journal/precision.test
@@ -131,7 +131,7 @@ $ hledger -f- print --explicit
 $ hledger -f- print --explicit
 2015-01-01
     e    E 10.0000 @ F 15.2380952
-    e    E 11.0000 @ F 15.2380952
+    e         E 11 @ F 15.2380952
     f                  F -320.000
 
 >= 0

--- a/hledger/test/journal/scientific.test
+++ b/hledger/test/journal/scientific.test
@@ -1,4 +1,4 @@
-# just check
+# 1. just check
 <
 D $1,000.00
 
@@ -7,7 +7,7 @@ D $1,000.00
 $ hledger -f - bal --no-total
                $2.30  a
 
-# some basic cases with commodity
+# 2. some basic cases with commodity
 <
 commodity $1,000.00000000
 
@@ -22,7 +22,7 @@ $ hledger -f - bal --no-total
      $1,000.00000000  c
     $-1,108.14159260  d
 
-# some basic cases with commodity
+# 3. some basic cases with commodity
 <
 commodity $1,000.00000000
 
@@ -33,14 +33,14 @@ commodity $1,000.00000000
    d
 $ hledger -f - print --explicit
 2018-01-01
-    a       $105.00000000
-    b         $3.14159260
-    c     $1,000.00000000
+    a                $105
+    b          $3.1415926
+    c             $1,000.
     d    $-1,108.14159260
 
 >=
 
-# some basic cases
+# 4. some basic cases
 <
 2018/1/1
    a  1.05e2
@@ -53,7 +53,7 @@ $ hledger -f - bal --no-total
         1000.0000000  c
        -1108.1415926  d
 
-# we still should recognize commodities with e
+# 5. we still should recognize commodities with e
 <
 2018/1/1
    (a)  1.00005e
@@ -62,6 +62,7 @@ $ hledger -f - bal --no-total
             2.00003E
             1.00005e  a
 
+# 6.
 <
 2018/1/1
    (a)  1,000.5e-1

--- a/hledger/test/json.test
+++ b/hledger/test/json.test
@@ -23,7 +23,7 @@ $ hledger -f- reg --output-format=json
           "astyle": {
             "ascommodityside": "R",
             "ascommodityspaced": true,
-            "asdecimalpoint": ".",
+            "asdecimalmark": ".",
             "asdigitgroups": null,
             "asprecision": 1
           }
@@ -51,7 +51,7 @@ $ hledger -f- reg --output-format=json
         "astyle": {
           "ascommodityside": "R",
           "ascommodityspaced": true,
-          "asdecimalpoint": ".",
+          "asdecimalmark": ".",
           "asdigitgroups": null,
           "asprecision": 1
         }
@@ -80,7 +80,7 @@ $ hledger -f- bal --output-format=json
           "astyle": {
             "ascommodityside": "R",
             "ascommodityspaced": true,
-            "asdecimalpoint": ".",
+            "asdecimalmark": ".",
             "asdigitgroups": null,
             "asprecision": 1
           }
@@ -100,7 +100,7 @@ $ hledger -f- bal --output-format=json
       "astyle": {
         "ascommodityside": "R",
         "ascommodityspaced": true,
-        "asdecimalpoint": ".",
+        "asdecimalmark": ".",
         "asdigitgroups": null,
         "asprecision": 1
       }

--- a/hledger/test/print/print-style.test
+++ b/hledger/test/print/print-style.test
@@ -1,0 +1,75 @@
+# print amount styling tests
+#
+# The amounts are:
+#  amt     - the posting amount
+#  cost    - the posting amount's cost
+#  bal     - the balance assertion amount
+#  balcost - the balance assertion amount's cost
+#
+# Styling includes:
+#  basic - everything except precision
+#  prec  - precision (number of decimal places)
+#
+# Historical behaviour:
+# | hledger | amt basic | cost basic | bal basic | balcost basic | amt prec | cost prec | bal prec | balcost prec |
+# | 1.14    | Y         | N          | N         | N             | Y        | N         | N        | N            |
+# | 1.22    | Y         | N          | Y         | N             | N        | N         | N        | N            |
+# | 1.30    | Y         | Y          | Y         | N             | N        | N         | N        | N            |
+# | 1.31    | Y         | Y          | Y         | Y             | N        | N         | N        | N            |
+#
+# In the following,
+#  basic styling will move the commodity symbol to the left
+#  precision styling will hide the decimal place
+
+# 1. print styles all amounts, but leaves all precisions unchanged, even with -c.
+<
+commodity A 1000.
+commodity B 1000.
+
+2023-01-01
+    (a)    1.2 A @ 3.4 B = 1.2 A @ 3.4 B
+	
+$ hledger -f- print -c A1000.00 -c B1000.00
+2023-01-01
+    (a)     A1.2 @ B3.4 = A1.2 @ B3.4
+
+>=
+
+# 2. Precisions are also preserved when there's an implicit conversion (#2079).
+<
+commodity A 1000.
+
+2023-01-01
+    f       A 1.5
+    g       A 1.5
+    c      B -3
+
+$ hledger -f- print
+2023-01-01
+    f           A 1.5
+    g           A 1.5
+    c            B -3
+
+>=
+
+
+# Maybe later:
+
+# # 0. With print, -c has extra power: it can increase all amount precisions.
+# $ hledger -f- print -c A1000.00 -c B1000.00
+# 2023-01-01
+#     (a)    A1.20 @ B3.40 = A1.20 @ B3.40
+# 
+# >=
+# 
+# # 0. And -c can decrease trailing decimal zeros. But not significant decimal digits
+# (because that would change transactions).
+# <
+# 2023-01-01
+#     (a)    1.2340 A @ 3.4560 B = 1.234 A @ 3.456 B
+#
+# $ hledger -f- print -c A1000. -c B1000.
+# 2023-01-01
+#     (a)    A1.234 @ B3.456 = A1.234 @ B3.456
+# 
+# >=

--- a/hledger/test/print/print-style.test
+++ b/hledger/test/print/print-style.test
@@ -73,3 +73,17 @@ $ hledger -f- print
 #     (a)    A1.234 @ B3.456 = A1.234 @ B3.456
 # 
 # >=
+
+# 3. When showing digit group marks, print always shows a decimal mark as well,
+# even when no decimal digits are shown.
+<
+decimal-mark .
+2023-01-01
+    (a)    1,000
+
+$ hledger -f- print
+2023-01-01
+    (a)          1,000.
+
+>=
+

--- a/hledger/test/rewrite.test
+++ b/hledger/test/rewrite.test
@@ -181,19 +181,19 @@ $ hledger rewrite -f- assets:bank and 'amt:<0' --add-posting 'expenses:fee  $5' 
 
 $ hledger rewrite -f- date:2017/1  --add-posting 'Here comes Santa  $0' --verbose-tags
 2016-12-31  ; modified:
-    expenses:housing         $600.00
-    (budget:housing)        $-600.00  ; generated-posting: = ^expenses:housing
+    expenses:housing            $600
+    (budget:housing)           $-600  ; generated-posting: = ^expenses:housing
     assets:cash
 
 2017-01-01  ; modified:
-    expenses:food             $20.00
-    (budget:food)            $-20.00  ; generated-posting: = ^expenses:grocery ^expenses:food
+    expenses:food                $20
+    (budget:food)               $-20  ; generated-posting: = ^expenses:grocery ^expenses:food
     Here comes Santa              $0  ; generated-posting: = date:2017/1
-    expenses:leisure          $15.00
-    (budget:misc)            $-15.00  ; generated-posting: = ^expenses not:housing not:grocery not:food
+    expenses:leisure             $15
+    (budget:misc)               $-15  ; generated-posting: = ^expenses not:housing not:grocery not:food
     Here comes Santa              $0  ; generated-posting: = date:2017/1
-    expenses:grocery          $30.00
-    (budget:food)            $-30.00  ; generated-posting: = ^expenses:grocery ^expenses:food
+    expenses:grocery             $30
+    (budget:food)               $-30  ; generated-posting: = ^expenses:grocery ^expenses:food
     Here comes Santa              $0  ; generated-posting: = date:2017/1
     assets:cash
     Here comes Santa              $0  ; generated-posting: = date:2017/1


### PR DESCRIPTION
This is a rather extensive set of changes to fix a few issues with `print`.

**Internal changes:**

There's a new, consolidated amount styling api, with a new HasAmounts
typeclass. More cleanup is possible.

AmountStyle now makes setting the precision optional.
This simplifies the code for styling amounts, but it complicates
the semantics (Nothing is useful only when setting style).
Not sure if it's the best way.
Also some other fields have been renamed/reordered more mnemonically.

Reports now typically do a final amount styling pass, where they can
tweak amount rendering if needed (and can style only the amounts they
are rendering).

An internal styling pass when converting to cost is no longer needed
and has been dropped. (The initial styling pass in journalFinalise
could perhaps be dropped some day, but for now it is still needed.)

**User-visible changes:**

print now styles costs in balance assertions consistently.

print no longer does inappropriate rounding in implicit conversions (#2079).

print now shows a disambiguating decimal mark when needed,
for clarity and reparseability.
Eg "1,000" (with , as a thousands separator and no decimal digits) is
now displayed with a decimal mark: "1,000.".
"1 000" (where space is a thousands separator) is less ambiguous,
but we do the same thing (eg "1 000.") for consistency, and also to
help disambiguate when forgetting to quote a numeric commodity symbol
(eg "1234 0" where 1234 is a symbol that should have been in double quotes).
