### PR TITLE
;dev: Add a ghc-tags.yaml file

### DIFF
--- a/ghc-tags.yaml
+++ b/ghc-tags.yaml
@@ -1,0 +1,8 @@
+source_paths:
+- hledger
+- hledger-lib
+- hledger-ui
+- hledger-web
+cpp_options:
+- -DMIN_VERSION_megaparsec(x,y,z)=1
+- -DMIN_VERSION_aeson(x,y,z)=1


### PR DESCRIPTION
Provide a ghc-tags.yaml file to make use of ghc-tags with Hledger easy.

ghc-tags is a standalone tool to replace the formerly-builtto -in ":ctags" feature (and I presume ":etags") in GHCi. These walked over the source and produced a TAGS file (in vim-compatible ctags or Emacs-compatible etags format) that allows the relevant editors to quickly navigate around function definitions.

ghc-tags trips over some of the CPP used in Hledger. The solution is to provide ghc-tags with explicit CPP defines via a YAML file. However, if a YAML file is provided, one also must specify the source paths, as the tool XORs config file | paths-on-command-line.

See <https://github.com/arybczak/ghc-tags/issues/6> for more information.