### PR TITLE
feat: import: interpolate regex matches in field templates (#2009) 

### DIFF
--- a/hledger-lib/Hledger/Read/RulesReader.hs
+++ b/hledger-lib/Hledger/Read/RulesReader.hs
@@ -258,7 +258,7 @@ data CsvRules' a = CsvRules' {
 type CsvRulesParsed = CsvRules' ()
 
 -- | Type used after parsing is done. Directives, assignments and conditional blocks
--- are in the same order as they were in the unput file and rblocksassigning is functional.
+-- are in the same order as they were in the input file and rblocksassigning is functional.
 -- Ready to be used for CSV record processing
 type CsvRules = CsvRules' (Text -> [ConditionalBlock])  -- XXX simplify
 

--- a/hledger-lib/Hledger/Utils/Regex.hs
+++ b/hledger-lib/Hledger/Utils/Regex.hs
@@ -55,6 +55,7 @@ module Hledger.Utils.Regex (
    -- * total regex operations
   ,regexMatch
   ,regexMatchText
+  ,regexMatchTextGroups
   ,regexReplace
   ,regexReplaceUnmemo
   ,regexReplaceAllBy
@@ -72,7 +73,8 @@ import qualified Data.Text as T
 import Text.Regex.TDFA (
   Regex, CompOption(..), defaultCompOpt, defaultExecOpt,
   makeRegexOptsM, AllMatches(getAllMatches), match, MatchText,
-  RegexLike(..), RegexMaker(..), RegexOptions(..), RegexContext(..)
+  RegexLike(..), RegexMaker(..), RegexOptions(..), RegexContext(..),
+  (=~)
   )
 
 
@@ -165,6 +167,14 @@ regexMatch = matchTest
 -- a performance bug in regex-tdfa (#9), which may or may not be relevant here.
 regexMatchText :: Regexp -> Text -> Bool
 regexMatchText r = matchTest r . T.unpack
+
+-- | Return a (possibly empty) list of match groups derived by applying the
+-- Regex to a Text.
+regexMatchTextGroups :: Regexp -> Text -> [Text]
+regexMatchTextGroups r txt = let
+    pat = reString r
+    (_,_,_,matches) = txt =~ pat :: (Text,Text,Text,[Text])
+    in matches
 
 --------------------------------------------------------------------------------
 -- new total functions

--- a/hledger/test/import/match.csv
+++ b/hledger/test/import/match.csv
@@ -1,0 +1,1 @@
+"62","2022-12-15","","Zettle_*Robert W. Bell","liabilities:jon:expenses:snacks","£ 7.90","£ 8.90"

--- a/hledger/test/import/match.rules
+++ b/hledger/test/import/match.rules
@@ -1,0 +1,16 @@
+fields _, date, _, description, account1, amount, _
+# checking brackets in a field matcher are captured...
+if %account1 liabilities:jon:(.*)
+# ...and interpolated into field assignments (real-life use-case #2)
+    account1 \1
+# checking brackets in a record matcher are captured, including
+# nesting...
+if Zettle.*(Robert W. (Bell)).*£
+# ... and the interpolation token numerical offset is local to
+# this match group; and the token is interpolated into surrounding
+# text
+    comment1 Bell=\2.
+# Match the YYY-MM of a date field and warp the posting date, useful
+# for credit cards (real-life use-case #1))
+if %date (....-..)-..
+    comment2 date:\1-01

--- a/hledger/test/import/match.test
+++ b/hledger/test/import/match.test
@@ -1,0 +1,10 @@
+# Various match group interpolation tests. See the comments
+# in match.rules for specifics.
+$ hledger -f a.j import --rules-file match.rules --dry-run match.csv
+; would import 1 new transactions from match.csv:
+
+2022-12-15 Zettle_*Robert W. Bell
+    expenses:snacks          £ 7.90  ; Bell=Bell.
+    income:unknown          £ -7.90  ; date:2022-12-01
+
+>=


### PR DESCRIPTION
Extend CSV rules handling to support interpolating regular expression match groups into field assignments.

For example. Given a conditional block

    if %date (....-..)-..
        comment1 date:\1-01

The regular expression includes a region denoted by parenthesis which describe a match group. If the regular expression matches, the field assignment has '\1' substituted for the first match group value from applying the regular expression.

In this example, a date-warping comment is generated, setting the posting's date to the first of the month.

Another example

    if %account1 liabilities:jon:(.*)
        account1 \1

Here we use the match group to throw away a prefix on account names.

## Implementation notes

We extend `renderTemplate` to detect and process strings of the form '\N+' (isDigit N). Match groups are scoped to a conditional block that might be in terms of a `hledgerField`, therefore, `renderTemplate` grows a `hledgerField` parameter (and all callers are updated).

The new match group handling function `regexMatchValue` needs to determine the relevant Conditional Block scope using `isBlockActive`, formerly a sub-function of `getEffectiveAssignment`, now changed to a top-level function.

(The diff-view of the changes to `getEffectiveAssignment` aren't terribly legible. They might be clearer with `git diff --ignore-all-space`. Besides moving `isBlockActive` to a top-level, I also collapsed one of the nested levels of `where` clauses).

The match groups are calculated and collected using a new function `Hledger.Utils.Regex.regexMatchTextGroups`.

### Testing

I need to add testing to your particular test suite/approach. I did ad-hoc testing as I went but I haven't grokked your scheme yet.

### TODO

(feel free to edit and add to this)

 - [ ] settle on the delimiter (`%matchN`,`%\1`,`\1`?)
 - [ ] unit tests
 - [x] functional tests (shelltest)
 - [x] docs
 - [ ] `examples/`?
 - [ ] can `regexMatchTextGroups` throw `error`? Is that a problem?
 - [ ] Possibly validateCsvRules could check that backreferences refer to existing match groups ?

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
