### PR TITLE
imp: web: include account declaration info in accounts JSON

### DIFF
--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -165,20 +165,21 @@ accountKV ::
 #endif
   => Account -> [kv]
 accountKV a =
-    [ "aname"        .= aname a
-    , "aebalance"    .= aebalance a
-    , "aibalance"    .= aibalance a
-    , "anumpostings" .= anumpostings a
-    , "aboring"      .= aboring a
+    [ "aname"            .= aname a
+    , "adeclarationinfo" .= adeclarationinfo a
+    , "aebalance"        .= aebalance a
+    , "aibalance"        .= aibalance a
+    , "anumpostings"     .= anumpostings a
+    , "aboring"          .= aboring a
     -- To avoid a cycle, show just the parent account's name
     -- in a dummy field. When re-parsed, there will be no parent.
-    , "aparent_"     .= maybe "" aname (aparent a)
+    , "aparent_"         .= maybe "" aname (aparent a)
     -- Just the names of subaccounts, as a dummy field, ignored when parsed.
-    , "asubs_"       .= map aname (asubs a)
+    , "asubs_"           .= map aname (asubs a)
     -- The actual subaccounts (and their subs..), making a (probably highly redundant) tree
     -- ,"asubs"        .= asubs a
     -- Omit the actual subaccounts
-    , "asubs"        .= ([]::[Account])
+    , "asubs"            .= ([]::[Account])
     ]
 
 instance ToJSON Ledger

--- a/hledger-web/Hledger/Web/Handler/MiscR.hs
+++ b/hledger-web/Hledger/Web/Handler/MiscR.hs
@@ -95,7 +95,7 @@ getAccountsR = do
   VD{caps, j} <- getViewData
   when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
   selectRep $ do
-    provideJson $ laccounts $ ledgerFromJournal Any j
+    provideJson $ flattenAccounts $ mapAccounts (accountSetDeclarationInfo j) $ ledgerRootAccount $ ledgerFromJournal Any j
 
 getAccounttransactionsR :: Text -> Handler TypedContent
 getAccounttransactionsR a = do


### PR DESCRIPTION
This adds the accounts' declaration info to the `/accounts` endpoint in hledger-web.  My use case is to be able to access account tags in some (unpublished as of now) client-side JS I'm working on.

This does add a new field to `accountsKV` in `Hledger.Data.Json`.  That field can have a value of `Nothing`/`null` if the declaration info hasn't been added.  (I'm doing this in the Web-side code.)

I have compared the output from before and after this commit ([script](https://gist.github.com/s-zeid/05db466eb3158522a0d5f99fdc812663)), and at least for my journal (and some random ones in `/examples/`), there were no changes other than the declaration info being added.

This is my first time working with Haskell, so I apologize if I did this the wrong way or made some other noob mistake.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
