### PR TITLE
imp:web: access control UX cleanups (fix #834)

### DIFF
--- a/.sandstorm/launcher.sh
+++ b/.sandstorm/launcher.sh
@@ -29,4 +29,4 @@ set -euo pipefail
 mkdir -p /var/lib/hledger
 touch /var/lib/hledger/Ledger
 cd /var
-hledger-web --capabilities-header=X-Sandstorm-Permissions --serve --base-url='' -f /var/lib/hledger/Ledger --port 8000
+hledger-web --allow=sandstorm --serve --base-url='' -f /var/lib/hledger/Ledger --port 8000

--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -54,7 +54,7 @@ const pkgdef :Spk.PackageDefinition = (
         #marketBig = (svg = embed "path/to/market-big-300x300.svg"),
       ),
 
-      website = "http://hledger.org",
+      website = "https://hledger.org",
       # This should be the app's main website url.
 
       codeUrl = "https://github.com/simonmichael/hledger",
@@ -204,41 +204,38 @@ const pkgdef :Spk.PackageDefinition = (
           description = (defaultText = "grants ability to append transactions to the ledger"),
         ),
         (
-          name = "manage",
-          title = (defaultText = "manage"),
-          description = (defaultText = "grants ability to modify or replace the entire ledger"),
+          name = "edit",
+          title = (defaultText = "edit"),
+          description = (defaultText = "grants ability to modify transactions and directives or erase the entire ledger"),
         ),
       ],
       roles = [
         # Roles are logical collections of permissions.  For instance, your app may have
         # a "viewer" role and an "editor" role
         (
-          title = (defaultText = "manager"),
           # Name of the role.  Shown in the Sandstorm UI to indicate which users have which roles.
-
-          permissions  = [true, true, true],
+          title = (defaultText = "viewer"),
           # An array indicating which permissions this role carries.
           # It should be the same length as the permissions array in
           # viewInfo, and the order of the lists must match.
-
-          verbPhrase = (defaultText = "has full access to the ledger"),
+          permissions  = [true, false, false],
           # Brief explanatory text to show in the sharing UI indicating
           # what a user assigned this role will be able to do with the grain.
-
-          description = (defaultText = "managers can modify the ledger in any way."),
+          verbPhrase = (defaultText = "can view the ledger"),
           # Prose describing what this role means, suitable for a tool tip or similar help text.
+          description = (defaultText = "viewers can only view the ledger."),
+        ),
+        (
+          title = (defaultText = "adder"),
+          permissions  = [true, true, false],
+          verbPhrase = (defaultText = "can append new transactions"),
+          description = (defaultText = "adders can view the ledger and add new transactions to it."),
         ),
         (
           title = (defaultText = "editor"),
-          permissions  = [true, true, false],
-          verbPhrase = (defaultText = "can append new transactions"),
-          description = (defaultText = "editors can view the ledger or append new transactions to it."),
-        ),
-        (
-          title = (defaultText = "viewer"),
-          permissions  = [true, false, false],
-          verbPhrase = (defaultText = "can view the ledger"),
-          description = (defaultText = "viewers can only view the ledger."),
+          permissions  = [true, true, true],
+          verbPhrase = (defaultText = "has full access to the ledger"),
+          description = (defaultText = "editors can change or erase transactions and directives."),
         ),
       ],
     ),

--- a/hledger-web/Hledger/Web/Handler/AddR.hs
+++ b/hledger-web/Hledger/Web/Handler/AddR.hs
@@ -30,8 +30,8 @@ getAddR = do
 postAddR :: Handler ()
 postAddR = do
   checkServerSideUiEnabled
-  VD{caps, j, today} <- getViewData
-  when (CapAdd `notElem` caps) (permissionDenied "Missing the 'add' capability")
+  VD{perms, j, today} <- getViewData
+  when (AddPermission `notElem` perms) (permissionDenied "Missing the 'add' permission")
 
   ((res, view), enctype) <- runFormPost $ addForm j today
   case res of
@@ -59,8 +59,8 @@ postAddR = do
 -- The web form handler above should probably use PUT as well.
 putAddR :: Handler RepJson
 putAddR = do
-  VD{caps, j, opts} <- getViewData
-  when (CapAdd `notElem` caps) (permissionDenied "Missing the 'add' capability")
+  VD{perms, j, opts} <- getViewData
+  when (AddPermission `notElem` perms) (permissionDenied "Missing the 'add' permission")
 
   (r :: Result Transaction) <- parseCheckJsonBody
   case r of

--- a/hledger-web/Hledger/Web/Handler/EditR.hs
+++ b/hledger-web/Hledger/Web/Handler/EditR.hs
@@ -31,8 +31,8 @@ getEditR f = do
 postEditR :: FilePath -> Handler ()
 postEditR f = do
   checkServerSideUiEnabled
-  VD {caps, j} <- getViewData
-  when (CapManage `notElem` caps) (permissionDenied "Missing the 'manage' capability")
+  VD {perms, j} <- getViewData
+  when (EditPermission `notElem` perms) (permissionDenied "Missing the 'edit' permission")
 
   (f', txt) <- journalFile404 f j
   ((res, view), enctype) <- runFormPost (editForm f' txt)

--- a/hledger-web/Hledger/Web/Handler/JournalR.hs
+++ b/hledger-web/Hledger/Web/Handler/JournalR.hs
@@ -20,8 +20,8 @@ import Hledger.Web.Widget.Common
 getJournalR :: Handler Html
 getJournalR = do
   checkServerSideUiEnabled
-  VD{caps, j, q, opts, qparam, qopts, today} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j, q, opts, qparam, qopts, today} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   let title = case inAccount qopts of
         Nothing -> "General Journal"
         Just (a, inclsubs) -> "Transactions in " <> a <> if inclsubs then "" else " (excluding subaccounts)"

--- a/hledger-web/Hledger/Web/Handler/MiscR.hs
+++ b/hledger-web/Hledger/Web/Handler/MiscR.hs
@@ -38,17 +38,17 @@ getRootR = do
 getManageR :: Handler Html
 getManageR = do
   checkServerSideUiEnabled
-  VD{caps, j} <- getViewData
-  when (CapManage `notElem` caps) (permissionDenied "Missing the 'manage' capability")
+  VD{perms, j} <- getViewData
+  when (EditPermission `notElem` perms) (permissionDenied "Missing the 'edit' permission")
   defaultLayout $ do
-    setTitle "Manage journal"
+    setTitle "Edit journal"
     $(widgetFile "manage")
 
 getDownloadR :: FilePath -> Handler TypedContent
 getDownloadR f = do
   checkServerSideUiEnabled
-  VD{caps, j} <- getViewData
-  when (CapManage `notElem` caps) (permissionDenied "Missing the 'manage' capability")
+  VD{perms, j} <- getViewData
+  when (EditPermission `notElem` perms) (permissionDenied "Missing the 'edit' permission")
   (f', txt) <- journalFile404 f j
   addHeader "Content-Disposition" ("attachment; filename=\"" <> T.pack f' <> "\"")
   sendResponse ("text/plain" :: ByteString, toContent txt)
@@ -57,50 +57,50 @@ getDownloadR f = do
 
 getVersionR :: Handler TypedContent
 getVersionR = do
-  VD{caps} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   selectRep $ do
     provideJson $ packageversion
 
 getAccountnamesR :: Handler TypedContent
 getAccountnamesR = do
-  VD{caps, j} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   selectRep $ do
     provideJson $ journalAccountNames j
 
 getTransactionsR :: Handler TypedContent
 getTransactionsR = do
-  VD{caps, j} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   selectRep $ do
     provideJson $ jtxns j
 
 getPricesR :: Handler TypedContent
 getPricesR = do
-  VD{caps, j} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   selectRep $ do
     provideJson $ map priceDirectiveToMarketPrice $ jpricedirectives j
 
 getCommoditiesR :: Handler TypedContent
 getCommoditiesR = do
-  VD{caps, j} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   selectRep $ do
     provideJson $ (M.keys . jinferredcommodities) j
 
 getAccountsR :: Handler TypedContent
 getAccountsR = do
-  VD{caps, j} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   selectRep $ do
     provideJson $ flattenAccounts $ mapAccounts (accountSetDeclarationInfo j) $ ledgerRootAccount $ ledgerFromJournal Any j
 
 getAccounttransactionsR :: Text -> Handler TypedContent
 getAccounttransactionsR a = do
-  VD{caps, j} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
   let
     rspec = defreportspec
     thisacctq = Acct $ accountNameToAccountRegex a -- includes subs

--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -26,8 +26,8 @@ import Hledger.Web.Widget.Common
 getRegisterR :: Handler Html
 getRegisterR = do
   checkServerSideUiEnabled
-  VD{caps, j, q, opts, qparam, qopts, today} <- getViewData
-  when (CapView `notElem` caps) (permissionDenied "Missing the 'view' capability")
+  VD{perms, j, q, opts, qparam, qopts, today} <- getViewData
+  when (ViewPermission `notElem` perms) (permissionDenied "Missing the 'view' permission")
 
   let (a,inclsubs) = fromMaybe ("all accounts",True) $ inAccount qopts
       s1 = if inclsubs then "" else " (excluding subaccounts)"

--- a/hledger-web/Hledger/Web/Handler/UploadR.hs
+++ b/hledger-web/Hledger/Web/Handler/UploadR.hs
@@ -35,8 +35,8 @@ getUploadR f = do
 postUploadR :: FilePath -> Handler ()
 postUploadR f = do
   checkServerSideUiEnabled
-  VD {caps, j} <- getViewData
-  when (CapManage `notElem` caps) (permissionDenied "Missing the 'manage' capability")
+  VD {perms, j} <- getViewData
+  when (EditPermission `notElem` perms) (permissionDenied "Missing the 'edit' permission")
 
   (f', _) <- journalFile404 f j
   ((res, view), enctype) <- runFormPost (uploadForm f')

--- a/hledger-web/Hledger/Web/Import.hs
+++ b/hledger-web/Hledger/Web/Import.hs
@@ -23,4 +23,4 @@ import           Text.Blaze           as Import (Markup)
 import           Hledger.Web.Foundation           as Import
 import           Hledger.Web.Settings             as Import
 import           Hledger.Web.Settings.StaticFiles as Import
-import           Hledger.Web.WebOptions           as Import (Capability(..))
+import           Hledger.Web.WebOptions           as Import (Permission(..))

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -46,6 +46,11 @@ webflags =
       (setboolopt "serve-api")
       "like --serve, but serve only the JSON web API, without the server-side web UI"
   , flagReq
+      ["allow"]
+      (\s opts -> Right $ setopt "allow" s opts)
+      "view|add|edit"
+      "set the user's access level for changing data (default: `add`). It also accepts `sandstorm` for use on that platform (reads permissions from the `X-Sandstorm-Permissions` request header)."
+  , flagReq
       ["cors"]
       (\s opts -> Right $ setopt "cors" s opts)
       "ORIGIN"
@@ -75,11 +80,6 @@ webflags =
       (\s opts -> Right $ setopt "file-url" s opts)
       "FILEURL"
       "set the static files url (default: BASEURL/static)"
-  , flagReq
-      ["allow"]
-      (\s opts -> Right $ setopt "allow" s opts)
-      "view|add|edit"
-      "set the user's access level for changing data (default: `add`). (There is also `sandstorm`, used when running on Sandstorm.)"
   , flagNone
       ["test"]
       (setboolopt "test")

--- a/hledger-web/hledger-web.cabal
+++ b/hledger-web/hledger-web.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -179,6 +179,7 @@ library
     , megaparsec >=7.0.0 && <9.6
     , mtl >=2.2.1
     , network
+    , safe >=0.3.19
     , shakespeare >=2.0.2.2
     , template-haskell
     , text >=1.2

--- a/hledger-web/hledger-web.m4.md
+++ b/hledger-web/hledger-web.m4.md
@@ -96,7 +96,8 @@ serve them from another server for efficiency, you would set the url with this.
 
 `--allow=view|add|edit`
 : set the user's access level for changing data (default: `add`).
-(There is also `sandstorm`, used when running on the Sandstorm app platform.)
+It also accepts `sandstorm` for use on that platform (reads
+permissions from the `X-Sandstorm-Permissions` request header).
 
 `--test`
 : run hledger-web's tests and exit. hspec test runner args may follow a --, eg: hledger-web --test -- --help

--- a/hledger-web/hledger-web.m4.md
+++ b/hledger-web/hledger-web.m4.md
@@ -94,11 +94,9 @@ Can be useful if running behind a reverse web proxy that does path rewriting.
 hledger-web normally serves static files itself, but if you wanted to
 serve them from another server for efficiency, you would set the url with this.
 
-`--capabilities=CAP[,CAP..]`
-: enable the view, add, and/or manage capabilities (default: view,add)
-
-`--capabilities-header=HTTPHEADER`
-: read capabilities to enable from a HTTP header, like X-Sandstorm-Permissions (default: disabled)
+`--allow=view|add|edit`
+: set the user's access level for changing data (default: `add`).
+(There is also `sandstorm`, used when running on the Sandstorm app platform.)
 
 `--test`
 : run hledger-web's tests and exit. hspec test runner args may follow a --, eg: hledger-web --test -- --help

--- a/hledger-web/package.yaml
+++ b/hledger-web/package.yaml
@@ -128,6 +128,7 @@ library:
   - megaparsec >=7.0.0 && <9.6
   - mtl >=2.2.1
   - network
+  - safe >=0.3.19
   - shakespeare >=2.0.2.2
   - template-haskell
   - text >=1.2

--- a/hledger-web/templates/default-layout.hamlet
+++ b/hledger-web/templates/default-layout.hamlet
@@ -7,7 +7,7 @@
 <div#topbar .col-md-8 .col-sm-8 .col-xs-10>
   <h1>#{takeFileName (journalFilePath j)}
 
-$if elem CapView caps
+$if elem ViewPermission perms
   <div#sidebar-menu .sidebar-offcanvas.#{sideShowmd}.#{sideShowsm}>
     <table .main-menu .table>
       ^{accounts}
@@ -15,7 +15,7 @@ $if elem CapView caps
 <div#main-content .col-xs-12.#{mainShowmd}.#{mainShowsm}>
   $maybe m <- msg
     <div #message .alert.alert-info>#{m}
-  $if elem CapView caps
+  $if elem ViewPermission perms
     <form#searchform.input-group method=GET>
       <input .form-control name=q value=#{qparam} placeholder="Search"
         title="Enter hledger search patterns to filter the data below">
@@ -25,7 +25,7 @@ $if elem CapView caps
             <span .glyphicon .glyphicon-remove-circle>
         <button .btn .btn-default type=submit title="Apply search terms">
           <span .glyphicon .glyphicon-search>
-        $if elem CapManage caps
+        $if elem EditPermission perms
           <a href="@{ManageR}" .btn.btn-default title="Manage journal files">
             <span .glyphicon .glyphicon-wrench>
         <button .btn .btn-default type=button data-toggle="modal" data-target="#helpmodal"

--- a/hledger-web/templates/journal.hamlet
+++ b/hledger-web/templates/journal.hamlet
@@ -1,7 +1,7 @@
 <h2>
   #{title'}
 
-$if elem CapAdd caps
+$if elem AddPermission perms
   <a #addformlink href="#" role="button" style="cursor:pointer; margin-top:1em;"
      data-toggle="modal" data-target="#addmodal" title="Add a new transaction to the journal">
     Add a transaction
@@ -33,5 +33,5 @@ $if elem CapAdd caps
           <td .amount style="text-align:right;">
             ^{mixedAmountAsHtml amt}
 
-$if elem CapAdd caps
+$if elem AddPermission perms
   ^{addModal AddR j today}

--- a/hledger-web/templates/register.hamlet
+++ b/hledger-web/templates/register.hamlet
@@ -35,5 +35,5 @@
           <td style="text-align:right;">
             ^{mixedAmountAsHtml bal}
 
-$if elem CapAdd caps
+$if elem AddPermission perms
   ^{addModal AddR j today}


### PR DESCRIPTION
Changes:

1. rename the sandstorm "manage" permission to "edit" (old permission names: view, add, manage;
 new permission names: view, add, edit).

Rationale: "edit" best describes this permission's current powers, to users and to operators. If we ever added more manager-type features we'd want that to be a new permission, not a rename of the existing one (which would change the powers of existing users).

2. rename the sandstorm roles for consistency with permissions (old role names: viewer, editor, manager;
 new role names: viewer, adder, editor)

Rationale: it's needed to avoid confusion.

3. add a new option: --allow=view|add|edit|sandstorm (default: add). 'sandstorm' sets permissions according to the X-Sandstorm-Permissions header. Drop the --capabilities and --capabilities-header options.

Rationale: it's simpler and more intuitive.

4. replace "capability" with "permission" in ui/docs/code.

Rationale: consistent with the above, more familiar.

[5. reverse the order of role definitions.

Rationale: "increasing power" order is consistent with the permissions and --allow definitions, hence less confusing. We thought it wouldn't change the roles' meaning, but it did, but no-one is using this yet anyway.]