### PR TITLE
feat:timedot: tagged time logging with letters

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -52,6 +52,7 @@ module Hledger.Data.Posting (
   -- * comment/tag operations
   commentJoin,
   commentAddTag,
+  commentAddTagUnspaced,
   commentAddTagNextLine,
   -- * arithmetic
   sumPostings,
@@ -610,6 +611,15 @@ commentAddTag c (t,v)
   where
     c'  = T.stripEnd c
     tag = t <> ": " <> v
+
+-- | Like commentAddTag, but omits the space after the colon.
+commentAddTagUnspaced :: Text -> Tag -> Text
+commentAddTagUnspaced c (t,v)
+  | T.null c' = tag
+  | otherwise = c' `commentJoin` tag
+  where
+    c'  = T.stripEnd c
+    tag = t <> ":" <> v
 
 -- | Add a tag on its own line to a comment, preserving any prior content.
 -- A space is inserted following the colon, before the value.

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4217,7 +4217,13 @@ After the date line are zero or more time postings, consisting of:
   - one or more dots (period characters), each representing 0.25.
     These are the dots in "timedot".
     Spaces are ignored and can be used for grouping/alignment.
-  
+
+  - one or more letters. These are like dots but they also generate
+    a tag `t:` (short for "type") with the letter as its value,
+    and a separate posting for each of the values.
+    This provides a second dimension of categorisation,
+    viewable in reports with `--pivot t`.
+
 - **An optional comment** following a semicolon (a hledger-style [posting comment](#posting-comments)).
 
 There is some flexibility to help with keeping time log data and notes in the same file:
@@ -4280,6 +4286,37 @@ Balance changes in 2016-02-01-2016-02-03:
    client1  ||         6.00         2.00         4.00 
 ------------++----------------------------------------
             ||         7.75         2.25         8.00 
+```
+
+Letters:
+
+```timedot
+# Activity types: cleanup, enhancement, learning, support
+
+2023-11-01
+work:adm  ccecces
+```
+```journal
+$ hledger -f a.timedot print
+2023-11-01
+    (work:adm)  1     ; t:c
+    (work:adm)  0.5   ; t:e
+    (work:adm)  0.25  ; t:s
+
+```
+```shell
+$ hledger -f a.timedot bal
+                1.75  work:adm
+--------------------
+                1.75  
+```
+```shell
+$ hledger -f a.timedot bal --pivot t
+                1.00  c
+                0.50  e
+                0.25  s
+--------------------
+                1.75  
 ```
 
 Org:

--- a/hledger/test/timedot.test
+++ b/hledger/test/timedot.test
@@ -16,6 +16,10 @@ fos:haskell  .... ; a posting comment and posting-tag:
 ; more posting comment lines ? currently ignored
 per:admin    ....
 
+2023-01-02
+a            ; no quantity means zero
+b  aabbaca   ; letter "dots" are tagged with t:LETTER
+
 ** 2023-01-02  ; dates are allowed to be org headings
 
 # ** 1. The above timedot is converted to these transactions.
@@ -28,19 +32,29 @@ $ hledger -ftimedot:- print
     (fos:haskell)            1.00  ; a posting comment and posting-tag:
     (per:admin)              1.00
 
+2023-01-02 *
+    (a)            0.00  ; no quantity means zero
+    (b)            1.00  ; letter "dots" are tagged with t:LETTER, t:a
+    (b)            0.50  ; letter "dots" are tagged with t:LETTER, t:b
+    (b)            0.25  ; letter "dots" are tagged with t:LETTER, t:c
+
 2023-01-02 *  ; dates are allowed to be org headings
 
 >=
 
 # ** 2. And this register.
-$ hledger -ftimedot:- reg
+$ hledger -ftimedot:- reg -w80
 2023-01-01 transaction descr..  (biz:research)                1.00          1.00
                                 (inc:client1)                 1.50          2.50
 2023-01-01 different transac..  (fos:haskell)                 1.00          3.50
                                 (per:admin)                   1.00          4.50
+2023-01-02                      (a)                              0          4.50
+                                (b)                           1.00          5.50
+                                (b)                           0.50          6.00
+                                (b)                           0.25          6.25
 
 # ** 3. Tags are recognised. Account aliases are applied.
-$ hledger -ftimedot:- reg tag:posting-tag --alias fos:haskell=λ
+$ hledger -ftimedot:- reg -w80 tag:posting-tag --alias fos:haskell=λ
 2023-01-01 different transac..  (λ)                           1.00          1.00
 
 # ** 4. Each of these formats is printed as exactly a quarter hour.


### PR DESCRIPTION
This is another complication to the increasingly inaccurately-named timed format, but it's something I've long wanted for my own time logging:

In place of dots you can write letters, which also generate a tag `t:`
(short for "type") with the letter as its value (and one posting per value).
This provides a second dimension of categorisation, viewable in reports with `--pivot t`.
