### PR TITLE
imp: Support brick 2.2

### DIFF
--- a/hledger-ui/hledger-ui.cabal
+++ b/hledger-ui/hledger-ui.cabal
@@ -73,7 +73,7 @@ library
       ansi-terminal >=0.9
     , async
     , base >=4.14 && <4.19
-    , brick >=2.1.1 && <2.2
+    , brick >=2.1.1 && <2.3
     , cmdargs >=0.8
     , containers >=0.5.9
     , data-default

--- a/hledger-ui/package.yaml
+++ b/hledger-ui/package.yaml
@@ -98,7 +98,7 @@ library:
   - time >=1.5
   - transformers
   - vector
-  - brick >=2.1.1 && <2.2
+  - brick >=2.1.1 && <2.3
   - vty >=6.1 && <6.2
   - vty-crossplatform >= 0.4.0.0 && < 0.5.0.0
   when:


### PR DESCRIPTION
`brick` 2.2 is a minor improvement over 2.1.1, so no API breakages expected. See also https://github.com/simonmichael/hledger/pull/2128#discussion_r1431765057
Builds and tests fine with hledger-ui `1.32.1`.