### PR TITLE
;doc: add version annotations for new features

### DIFF
--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -62,7 +62,7 @@ at the cost of more time and memory, use the `--align-all` flag.
 This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options.
-The output formats supported are `txt`, `csv`, `tsv`, and `json`.
+The output formats supported are `txt`, `csv`, `tsv` (*Added in 1.32*), and `json`.
 
 ### aregister and posting dates
 

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -74,7 +74,7 @@ Many of these work with the higher-level commands as well.
 This command supports the
 [output destination](#output-destination) and
 [output format](#output-format) options,
-with output formats `txt`, `csv`, `tsv`, `json`, and (multi-period reports only:) `html`.
+with output formats `txt`, `csv`, `tsv` (*Added in 1.32*), `json`, and (multi-period reports only:) `html`.
 In `txt` output in a colour-supporting terminal, negative amounts are shown in red.
 
 The `--related`/`-r` flag shows the balance of the *other* postings in the

--- a/hledger/Hledger/Cli/Commands/Balancesheet.md
+++ b/hledger/Hledger/Cli/Commands/Balancesheet.md
@@ -48,4 +48,4 @@ This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options
 The output formats supported are
-`txt`, `csv`, `tsv`, `html`, and `json`.
+`txt`, `csv`, `tsv` (*Added in 1.32*), `html`, and `json`.

--- a/hledger/Hledger/Cli/Commands/Cashflow.md
+++ b/hledger/Hledger/Cli/Commands/Cashflow.md
@@ -48,4 +48,4 @@ This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options
 The output formats supported are
-`txt`, `csv`, `tsv`, `html`, and `json`.
+`txt`, `csv`, `tsv` (*Added in 1.32*), `html`, and `json`.

--- a/hledger/Hledger/Cli/Commands/Incomestatement.md
+++ b/hledger/Hledger/Cli/Commands/Incomestatement.md
@@ -49,4 +49,4 @@ This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options
 The output formats supported are
-`txt`, `csv`, `tsv`, `html`, and `json`.
+`txt`, `csv`, `tsv` (*Added in 1.32*), `html`, and `json`.

--- a/hledger/Hledger/Cli/Commands/Print.md
+++ b/hledger/Hledger/Cli/Commands/Print.md
@@ -58,7 +58,7 @@ Amounts will be (mostly) normalised to their [commodity display style](#commodit
 their symbol placement, decimal mark, and digit group marks will be made consistent.
 By default, decimal digits are shown as they are written in the journal.
 
-With the `--round` option, `print` will try increasingly hard to
+With the `--round` (*Added in 1.32*) option, `print` will try increasingly hard to
 display decimal digits according to the [commodity display styles](#commodity-display-style):
 
 - `--round=none` show amounts with original precisions (default)
@@ -115,7 +115,7 @@ This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options
 The output formats supported are
-`txt`, `beancount`, `csv`, `tsv`, `json` and `sql`.
+`txt`, `beancount` (*Added in 1.32*), `csv`, `tsv` (*Added in 1.32*), `json` and `sql`.
 
 The `beancount` format tries to produce Beancount-compatible output, as follows:
 

--- a/hledger/Hledger/Cli/Commands/Register.md
+++ b/hledger/Hledger/Cli/Commands/Register.md
@@ -142,4 +142,4 @@ This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options
 The output formats supported are
-`txt`, `csv`, `tsv`, and `json`.
+`txt`, `csv`, `tsv` (*Added in 1.32*), and `json`.

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3323,12 +3323,14 @@ When an if block has multiple matchers, they are combined as follows:
 
 - By default they are OR'd (any one of them can match)
 - When a matcher is preceded by ampersand (`&`) it will be AND'ed with the previous matcher (both of them must match)
-- When a matcher is preceded by an exclamation mark (`!`), the matcher is negated (it may not match).
+- *Added in 1.32* When a matcher is preceded by an exclamation mark (`!`), the matcher is negated (it may not match).
 
 [Currently](https://github.com/simonmichael/hledger/pull/2088#issuecomment-1844200398) there is a limitation:
 you can't use both `&` and `!` on the same line (you can't AND a negated matcher).
 
 ### Match groups
+
+*Added in 1.32*
 
 Matchers can define match groups: parenthesised portions of the regular expression
 which are available for reference in field assignments. Groups are enclosed
@@ -4225,7 +4227,7 @@ After the date line are zero or more time postings, consisting of:
     These are the dots in "timedot".
     Spaces are ignored and can be used for grouping/alignment.
 
-  - one or more letters. These are like dots but they also generate
+  - *Added in 1.32* one or more letters. These are like dots but they also generate
     a tag `t:` (short for "type") with the letter as its value,
     and a separate posting for each of the values.
     This provides a second dimension of categorisation,


### PR DESCRIPTION
<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->


This draft PR aims to document the version a feature was introduced. As discussed in the Matrix room, `*Added in <version>*` will be prepended to;

1. heading, or if it doesn't exist
2. the description.

For v1.32,

- [x] timedot supports letters syntax (#2116)
- [x] print has `beancount` output
- [x] match groups in csv rules (#2009)
- [x] negating matchers (#2088)
- [x] tsv output support where csv is supported (#869)
- [x] print has a new option for controlling amount rounding (#2085)
- [ ] --summary-only, multi-column balance reports (#1012) (no docs present)


Dropped;
- [ ] import now works with -s/--strict (#2113) 
- [ ] https://hledger.org/1.32/hledger.html#part-3-reporting-concepts

