### PR TITLE
dev: Runs shellcheck on hledger-simplebal

### DIFF
--- a/bin/hledger-simplebal
+++ b/bin/hledger-simplebal
@@ -3,8 +3,10 @@
 # total of `hledger balance`, optionally with arguments, as a single
 # machine-readable number.  Requires hledger 1.24 or newer.
 
+set -o pipefail
+
 VALUATION_COMMODITY="$"
-hledger bal -0 -N -X "$VALUATION_COMMODITY" --infer-market-prices -c "$VALUATION_COMMODITY 1000" --layout=bare "$@" | awk '{print $1}'
+hledger bal -0 -N -X "${VALUATION_COMMODITY}" --infer-market-prices -c "${VALUATION_COMMODITY} 1000" --layout=bare "$@" | awk '{print $1}'
 
 # Tired of complex financial reports ? This is a silly but fun and
 # occasionally useful script showing how to get "one number" semi-robustly
@@ -16,7 +18,7 @@ hledger bal -0 -N -X "$VALUATION_COMMODITY" --infer-market-prices -c "$VALUATION
 # Explanation:
 # -0 (--depth 0) hides all but top-level accounts
 # -N (--no-total) hides the totals line
-# -X COMM (--value=end,COMM) converts to a single commodity if possible (needs at least one suitable P market price declaration) 
+# -X COMM (--value=end,COMM) converts to a single commodity if possible (needs at least one suitable P market price declaration)
 # --infer-market-prices guesses P price from conversion transactions if necessary
 # -c (--commodity-style) sets a predictable number format free of thousands separators
 # --layout=bare moves the commodity symbol away from the number


### PR DESCRIPTION
Shellcheck handled the variable fixups. The pipefail flag avoids another Shellcheck warning w.r.t. handling pipe failures. This script is so minimal that it's safe to simply fail the pipe entirely if the hledger command fails.

_(Last shellcheck eval unless you're open to more and I find time. Doing these as I prep a PR to include them to be installed by default in the [Homebrew package][1].)_

[1]: https://github.com/Homebrew/homebrew-core/pull/160590
