### PR TITLE
fix: css to preserve linebreaks in messages

### DIFF
--- a/hledger-web/static/hledger.css
+++ b/hledger-web/static/hledger.css
@@ -86,6 +86,11 @@ ul {
     padding-left: 30px;
 }
 
+#message {
+    white-space: pre;
+    overflow-x: auto;
+}
+
 #sidebar-menu {
     overflow:hidden;
     border-right: 1px solid #ebebeb;


### PR DESCRIPTION
<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->

Super minimal change. Just preserving line breaks in hledger-web. See the following before and after screenshots:

Before:
![the error message about an unbalanced transaction is all on one line.](https://github.com/simonmichael/hledger/assets/490579/626038d9-08a2-44c2-9486-f5b881e7dc8d)

After:
![the error message about an unbalanced transaction is split over multiple lines.](https://github.com/simonmichael/hledger/assets/490579/2565b13d-c2b1-479e-957a-92267bdb2523)

I was not sure if this would be nice to have in the changelog or not. Let me know if you would prefer me to prefix the commit message with `;`.