### PR TITLE
imp: Support tsv and ssv prefixes (#2164)

### DIFF
--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -622,9 +622,38 @@ data Journal = Journal {
 -- The data is partial, and list fields are in reverse order.
 type ParsedJournal = Journal
 
+-- | One of the standard *-separated value file types known by hledger,
+data SepFormat 
+  = Csv  -- comma-separated
+  | Tsv  -- tab-separated
+  | Ssv  -- semicolon-separated
+  deriving Eq
+
 -- | The id of a data format understood by hledger, eg @journal@ or @csv@.
 -- The --output-format option selects one of these for output.
-type StorageFormat = String
+data StorageFormat 
+  = Rules 
+  | Journal' 
+  | Ledger' 
+  | Timeclock 
+  | Timedot 
+  | Sep SepFormat 
+  deriving Eq
+
+instance Show SepFormat where
+  show Csv = "csv"
+  show Ssv = "ssv"
+  show Tsv = "tsv"
+
+instance Show StorageFormat where
+  show Rules = "rules"
+  show Journal' = "journal"
+  show Ledger' = "ledger"
+  show Timeclock = "timeclock"
+  show Timedot = "timedot"
+  show (Sep Csv) = "csv"
+  show (Sep Ssv) = "ssv"
+  show (Sep Tsv) = "tsv"
 
 -- | Extra information found in a payee directive.
 data PayeeDeclarationInfo = PayeeDeclarationInfo {

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -190,7 +190,7 @@ data Reader m = Reader {
     ,rParser :: MonadIO m => ErroringJournalParser m ParsedJournal
     }
 
-instance Show (Reader m) where show r = rFormat r ++ " reader"
+instance Show (Reader m) where show r = show (rFormat r) ++ " reader"
 
 -- | Parse an InputOpts from a RawOpts and a provided date.
 -- This will fail with a usage error if the forecast period expression cannot be parsed.

--- a/hledger-lib/Hledger/Read/CsvReader.hs
+++ b/hledger-lib/Hledger/Read/CsvReader.hs
@@ -41,11 +41,11 @@ import Hledger.Read.RulesReader (readJournalFromCsv)
 
 --- ** reader
 
-reader :: MonadIO m => Reader m
-reader = Reader
-  {rFormat     = "csv"
-  ,rExtensions = ["csv","tsv","ssv"]
-  ,rReadFn     = parse
+reader :: MonadIO m => SepFormat -> Reader m
+reader sep = Reader
+  {rFormat     = Sep sep
+  ,rExtensions = [show sep]
+  ,rReadFn     = parse sep
   ,rParser     = error' "sorry, CSV files can't be included yet"  -- PARTIAL:
   }
 
@@ -54,10 +54,10 @@ reader = Reader
 -- This file path is normally the CSV(/SSV/TSV) data file, and a corresponding rules file is inferred.
 -- But it can also be the rules file, in which case the corresponding data file is inferred.
 -- This does not check balance assertions.
-parse :: InputOpts -> FilePath -> Text -> ExceptT String IO Journal
-parse iopts f t = do
+parse :: SepFormat -> InputOpts -> FilePath -> Text -> ExceptT String IO Journal
+parse sep iopts f t = do
   let mrulesfile = mrules_file_ iopts
-  readJournalFromCsv (Right <$> mrulesfile) f t
+  readJournalFromCsv (Right <$> mrulesfile) f t (Just sep)
   -- apply any command line account aliases. Can fail with a bad replacement pattern.
   >>= liftEither . journalApplyAliases (aliasesFromOpts iopts)
       -- journalFinalise assumes the journal's items are

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -77,7 +77,7 @@ import Data.Text as T (strip)
 
 reader :: MonadIO m => Reader m
 reader = Reader
-  {rFormat     = "timeclock"
+  {rFormat     = Timeclock
   ,rExtensions = ["timeclock"]
   ,rReadFn     = parse
   ,rParser    = timeclockfilep

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -66,7 +66,7 @@ import Data.List (group)
 
 reader :: MonadIO m => Reader m
 reader = Reader
-  {rFormat     = "timedot"
+  {rFormat     = Timedot
   ,rExtensions = ["timedot"]
   ,rReadFn     = parse
   ,rParser    = timedotp

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -625,7 +625,7 @@ expandPathPreservingPrefix d prefixedf = do
   let (p,f) = splitReaderPrefix prefixedf
   f' <- expandPath d f
   return $ case p of
-    Just p'  -> p' ++ ":" ++ f'
+    Just p'  -> (show p') ++ ":" ++ f'
     Nothing -> f'
 
 -- | Get the expanded, absolute output file path specified by an

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -1131,6 +1131,19 @@ $  ./csvtest.sh
 
 >=
 
+# ** 59. specify ssv prefix and no extension
+<
+12/11/2019;Foo;123;10.23
+RULES
+fields date, description, , amount
+date-format %d/%m/%Y
+$  ./ssvtest.sh
+2019-11-12 Foo
+    expenses:unknown           10.23
+    income:unknown            -10.23
+
+>=
+
 # ** .
 #<
 #$  ./csvtest.sh

--- a/hledger/test/ssvtest.sh
+++ b/hledger/test/ssvtest.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# sh version, ported from bash so freebsd users can run these tests.
+# This scripts expects stdin formatted like this:
+# <multi-line ssv file (at least one line required, even if blank)>
+# RULES
+# <multi-line rules>
+#
+# Here, unlike in csvtest.sh, the ssv extension is intentionally NOT set
+# This allows us to verify that the prefix detection is working
+
+cat > t.$$.input
+sed '1,/^RULES/d' t.$$.input > t.$$.rules
+sed '/^RULES/,$d' t.$$.input > t.$$
+
+trap 'rm -f t.$$.input t.$$ t.$$.rules t.$$.stderr' EXIT
+
+# Remove variable file name from error messages
+mkfifo t.$$.stderr
+sed -Ee "s/t\.$$/input/" t.$$.stderr >&2 &
+
+hledger -f ssv:t.$$ print "$@" 2> t.$$.stderr


### PR DESCRIPTION
<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->

With these changes, `hledger` now supports using the `ssv:` and `tsv:` prefixes to determine the file separator. For example:

```
$ cat basic_s
Date;Description;Id;Amount
12/11/2019;Foo;123;10.23
$ cat basic_s.rules
skip         1
fields       date, description, , amount
date-format  %d/%m/%Y
$ hledger print -f ssv:basic_s # stock hledger cannot parse the file
The hledger journal file "/home/michael/builds/hledger/ssv:basic_s" was not found.
Please create it first, eg with "hledger add" or a text editor.
Or, specify an existing journal file with -f or LEDGER_FILE.
$ stack exec -- hledger print -f ssv:basic_s # But this new build can!
2019-11-12 Foo
    expenses:unknown           10.23
    income:unknown            -10.23
```

Some notes from my end:
* Since I was already poking around this area, I went ahead and created a new type for all of the storage formats supported by `hledger`, but if this is too wide-reaching a change, it would be straightforward to use something like `Raw String`, which would in turn be `Raw "journal"`, `Raw "timeclock"`, etc., for everything except the CSV/etc. files.
* The comments in `CsvReader.hs` suggest that it should be possible to pass the _rules_ file as an argument and have the _data_ file be inferred. However, I wasn't able to figure out how to do this, either with stock `hledger` or with my build. This means I very well might have broken this feature. Could you please share how this is supposed to work so I can verify if it still functions?
* I don't love adding `ssvtest.sh`, which is mostly a copy of `csvtest.sh`, but I wasn't immediately sure how else to avoid the `csv:.*.csv` pattern used in `csvtest.sh`.