### PR TITLE
fix: Hide ambiguous instance for (!?)

### DIFF
--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -1,5 +1,6 @@
 -- The accounts screen, showing accounts and balances like the CLI balance command.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
@@ -23,7 +24,11 @@ import Brick.Widgets.List
 import Brick.Widgets.Edit
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
+#if MIN_VERSION_base(4,19,0)
+import Data.List hiding (reverse, (!?))
+#else
 import Data.List hiding (reverse)
+#endif
 import Data.Maybe
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -19,7 +19,11 @@ where
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.Bifunctor (bimap, Bifunctor (second))
+#if MIN_VERSION_base(4,19,0)
+import Data.List hiding ((!?))
+#else
 import Data.List
+#endif
 import Data.Maybe
 import qualified Data.Text as T
 import qualified Data.Vector as V


### PR DESCRIPTION
base 4.19.0.0 introduces Data.List.!? which clashes with Data.Vector.!?, the latter of which is needed for vector operations.

This PR hides Data.List.!? in the relevant locations to prevent the name clash.