### PR TITLE
Abbreviate week naming for weekly reports

### DIFF
--- a/hledger-lib/Hledger/Data/Dates.hs
+++ b/hledger-lib/Hledger/Data/Dates.hs
@@ -43,7 +43,7 @@ module Hledger.Data.Dates (
   showEFDate,
   showDateSpan,
   showDateSpanDebug,
-  showDateSpanMonthAbbrev,
+  showDateSpanAbbrev,
   elapsedSeconds,
   prevday,
   periodexprp,
@@ -139,8 +139,8 @@ showDateSpanDebug (DateSpan b e)= "DateSpan (" <> show b <> ") (" <> show e <> "
 
 -- | Like showDateSpan, but show month spans as just the abbreviated month name
 -- in the current locale.
-showDateSpanMonthAbbrev :: DateSpan -> Text
-showDateSpanMonthAbbrev = showPeriodMonthAbbrev . dateSpanAsPeriod
+showDateSpanAbbrev :: DateSpan -> Text
+showDateSpanAbbrev = showPeriodAbbrev . dateSpanAsPeriod
 
 -- | Get the current local date.
 getCurrentDay :: IO Day

--- a/hledger-lib/Hledger/Data/Period.hs
+++ b/hledger-lib/Hledger/Data/Period.hs
@@ -15,7 +15,7 @@ module Hledger.Data.Period (
   ,isStandardPeriod
   ,periodTextWidth
   ,showPeriod
-  ,showPeriodMonthAbbrev
+  ,showPeriodAbbrev
   ,periodStart
   ,periodEnd
   ,periodNext
@@ -176,7 +176,7 @@ periodTextWidth = periodTextWidth' . simplifyPeriod
 -- "2016-07-25W30"
 showPeriod :: Period -> Text
 showPeriod (DayPeriod b)       = T.pack $ formatTime defaultTimeLocale "%F" b              -- DATE
-showPeriod (WeekPeriod b)      = T.pack $ formatTime defaultTimeLocale "%FW%V" b           -- STARTDATEWYEARWEEK
+showPeriod (WeekPeriod b)      = T.pack $ formatTime defaultTimeLocale "%0Y-W%V" b         -- YYYY-Www
 showPeriod (MonthPeriod y m)   = T.pack $ printf "%04d-%02d" y m                           -- YYYY-MM
 showPeriod (QuarterPeriod y q) = T.pack $ printf "%04dQ%d" y q                             -- YYYYQN
 showPeriod (YearPeriod y)      = T.pack $ printf "%04d" y                                  -- YYYY
@@ -186,13 +186,16 @@ showPeriod (PeriodFrom b)      = T.pack $ formatTime defaultTimeLocale "%F.." b 
 showPeriod (PeriodTo e)        = T.pack $ formatTime defaultTimeLocale "..%F" (addDays (-1) e)    -- ..INCLUSIVEENDDATE
 showPeriod PeriodAll           = ".."
 
--- | Like showPeriod, but if it's a month period show just
--- the 3 letter month name abbreviation for the current locale.
-showPeriodMonthAbbrev :: Period -> Text
-showPeriodMonthAbbrev (MonthPeriod _ m)                           -- Jan
+-- | Like showPeriod, but if it's a month or week period show
+-- an abbreviated form.
+-- >>> showPeriodAbbrev (WeekPeriod (fromGregorian 2016 7 25))
+-- "W30"
+showPeriodAbbrev :: Period -> Text
+showPeriodAbbrev (MonthPeriod _ m)                                              -- Jan
   | m > 0 && m <= length monthnames = T.pack . snd $ monthnames !! (m-1)
   where monthnames = months defaultTimeLocale
-showPeriodMonthAbbrev p = showPeriod p
+showPeriodAbbrev (WeekPeriod b) = T.pack $ formatTime defaultTimeLocale "W%V" b -- Www
+showPeriodAbbrev p = showPeriod p
 
 periodStart :: Period -> Maybe Day
 periodStart p = fromEFDay <$> mb

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -766,7 +766,7 @@ reportPeriodOrJournalLastDay rspec j = reportPeriodLastDay rspec <|> journalOrPr
 reportPeriodName :: BalanceAccumulation -> [DateSpan] -> DateSpan -> T.Text
 reportPeriodName balanceaccumulation spans =
   case balanceaccumulation of
-    PerPeriod -> if multiyear then showDateSpan else showDateSpanMonthAbbrev
+    PerPeriod -> if multiyear then showDateSpan else showDateSpanAbbrev
       where
         multiyear = (>1) $ length $ nubSort $ map spanStartYear spans
     _ -> maybe "" (showDate . prevday) . spanEnd


### PR DESCRIPTION
This PR changes how the week name is displayed in the column header by shortening it for all reports, and omitting the year if all column are within the same year.

We rename `showPeriodMonthAbbrev` to `showPeriodAbbrev` as it's now used for weeks too, so not strictly just months.

It adds the following method
```haskell
showPeriodAbbrev (WeekPeriod b) = T.pack $ formatTime defaultTimeLocale "W%V" b
```

and changes the multi-year naming:
```diff
- showPeriod (WeekPeriod b) = T.pack $ formatTime defaultTimeLocale "%FW%V" b
+ showPeriod (WeekPeriod b) = T.pack $ formatTime defaultTimeLocale "%0Y-W%V" b
```