### PR TITLE
web: guess a more robust default base url; validate --base-url

### DIFF
--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -157,6 +157,10 @@ rawOptsToWebOpts rawopts =
     let
       h = fromMaybe defhost $ maybestringopt "host" rawopts
       p = fromMaybe defport $ maybeposintopt "port" rawopts
+      -- Always set a base-url, constructing it from host and port if not specified.
+      -- This will be used when opening a web browser, eg.
+      -- App.hs approot will use it if it was specified by --base-url,
+      -- otherwise it will infer a better one from the request, which browsers prefer.
       b = maybe (defbaseurl h p) stripTrailingSlash $ maybestringopt "base-url" rawopts
       sock = stripTrailingSlash <$> maybestringopt "socket" rawopts
       access =

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -152,17 +152,18 @@ rawOptsToWebOpts :: RawOpts -> IO WebOpts
 rawOptsToWebOpts rawopts =
   checkWebOpts <$> do
     cliopts <- rawOptsToCliOpts rawopts
-    let h = fromMaybe defhost $ maybestringopt "host" rawopts
-        p = fromMaybe defport $ maybeposintopt "port" rawopts
-        b = maybe (defbaseurl h p) stripTrailingSlash $ maybestringopt "base-url" rawopts
-        sock = stripTrailingSlash <$> maybestringopt "socket" rawopts
-        access =
-          case lastMay $ listofstringopt "allow" rawopts of
-            Nothing -> AddAccess
-            Just t ->
-              case parseAccessLevel t of
-                Right al -> al
-                Left err -> error' ("Unknown access level: " ++ err)  -- PARTIAL:
+    let
+      h = fromMaybe defhost $ maybestringopt "host" rawopts
+      p = fromMaybe defport $ maybeposintopt "port" rawopts
+      b = maybe (defbaseurl h p) stripTrailingSlash $ maybestringopt "base-url" rawopts
+      sock = stripTrailingSlash <$> maybestringopt "socket" rawopts
+      access =
+        case lastMay $ listofstringopt "allow" rawopts of
+          Nothing -> AddAccess
+          Just t ->
+            case parseAccessLevel t of
+              Right al -> al
+              Left err -> error' ("Unknown access level: " ++ err)  -- PARTIAL:
     return
       defwebopts
       { serve_ = case sock of

--- a/hledger-web/Hledger/Web/WebOptions.hs
+++ b/hledger-web/Hledger/Web/WebOptions.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Hledger.Web.WebOptions where
 
@@ -20,6 +21,7 @@ import Hledger.Cli hiding (packageversion, progname, prognameandversion)
 import Hledger.Web.Settings (defhost, defport, defbaseurl)
 import qualified Data.Text as T
 import Data.Char (toLower)
+import Data.List (isPrefixOf)
 
 -- cf Hledger.Cli.Version
 
@@ -183,7 +185,10 @@ rawOptsToWebOpts rawopts =
     stripTrailingSlash = reverse . dropWhile (== '/') . reverse -- yesod don't like it
 
 checkWebOpts :: WebOpts -> WebOpts
-checkWebOpts = id
+checkWebOpts wopts@WebOpts{..}
+  | not $ null base_url_ || "http://" `isPrefixOf` base_url_ || "https://" `isPrefixOf` base_url_ =
+      error' "please begin the --base-url value with http:// or https://"
+  | otherwise = wopts
 
 getHledgerWebOpts :: IO WebOpts
 getHledgerWebOpts = do

--- a/hledger.conf.sample
+++ b/hledger.conf.sample
@@ -9,18 +9,18 @@
 # If a command is not working as expected, run with --debug to troubleshoot.
 # To avoid using any config file, you can run hledger with -n/--no-conf.
 #
-# You can also choose a config file with --conf, or add a shebang line (eg
+# You can also: choose a config file with --conf, or add a shebang line (eg
 # #!/usr/bin/env -S hledger --conf) to config files and run them like scripts.
 
 
 # 1. General options. These will be used with all commands which support them.
 
-# Show prettier tables in reports. Recommended unless your font doesn't
-# support box drawing characters.
+# Show prettier tables in reports.
+# Recommended unless your font doesn't support box drawing characters.
 --pretty
 
-# Maybe don't check balance assertions all the time ? When you're ready,
-# check them with -s or hledger check assertions.
+# Postpone balance assertions until you use -s or `hledger check assertions`.
+# Less need to write -I while fixing issues.
 --ignore-assertions
 
 # Always infer these things ? Why not.


### PR DESCRIPTION
A followup to https://github.com/simonmichael/hledger/issues/2099, https://github.com/simonmichael/hledger/pull/2100 and https://github.com/simonmichael/hledger/issues/2127. Now relative links to js/css resources will use the same hostname etc. that the main page was requested from, making them work better when accessed via multiple IP addresses/hostnames without an explicit --base-url setting.

Also, --base-url's value must now begin with `http[s]://`; previously it accepted just a hostname, causing bad links.