### PR TITLE
Balance export FODS and HTML

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -155,6 +155,7 @@ module Hledger.Data.Amount (
   showMixedAmountWithZeroCommodity,
   showMixedAmountB,
   showMixedAmountLinesB,
+  showMixedAmountLinesPartsB,
   wbToText,
   wbUnpack,
   mixedAmountSetPrecision,
@@ -1120,10 +1121,17 @@ showMixedAmountB opts ma
 -- This returns the list of WideBuilders: one for each Amount, and padded/elided to the appropriate width.
 -- This does not honour displayOneLine; all amounts will be displayed as if displayOneLine were False.
 showMixedAmountLinesB :: AmountFormat -> MixedAmount -> [WideBuilder]
-showMixedAmountLinesB opts@AmountFormat{displayMaxWidth=mmax,displayMinWidth=mmin} ma =
-    map (adBuilder . pad) elided
+showMixedAmountLinesB opts ma =
+    map fst $ showMixedAmountLinesPartsB opts ma
+
+-- | Like 'showMixedAmountLinesB' but also returns
+-- the amounts associated with each text builder.
+showMixedAmountLinesPartsB :: AmountFormat -> MixedAmount -> [(WideBuilder, Amount)]
+showMixedAmountLinesPartsB opts@AmountFormat{displayMaxWidth=mmax,displayMinWidth=mmin} ma =
+    zip (map (adBuilder . pad) elided) amts
   where
-    astrs = amtDisplayList (wbWidth sep) (showAmountB opts) . orderedAmounts opts $
+    astrs = amtDisplayList (wbWidth sep) (showAmountB opts) amts
+    amts = orderedAmounts opts $
               if displayCost opts then ma else mixedAmountStripCosts ma
     sep   = WideBuilder (TB.singleton '\n') 0
     width = maximum $ map (wbWidth . adBuilder) elided

--- a/hledger-lib/Hledger/Read/RulesReader.hs
+++ b/hledger-lib/Hledger/Read/RulesReader.hs
@@ -77,7 +77,7 @@ import Text.Printf (printf)
 import Hledger.Data
 import Hledger.Utils
 import Hledger.Read.Common (aliasesFromOpts, Reader(..), InputOpts(..), amountp, statusp, journalFinalise, accountnamep, commenttagsp )
-import Hledger.Read.CsvUtils
+import Hledger.Write.Csv
 import System.Directory (doesFileExist, getHomeDirectory)
 import Data.Either (fromRight)
 

--- a/hledger-lib/Hledger/Write/Csv.hs
+++ b/hledger-lib/Hledger/Write/Csv.hs
@@ -10,7 +10,7 @@ CSV utilities.
 {-# LANGUAGE OverloadedStrings    #-}
 
 --- ** exports
-module Hledger.Read.CsvUtils (
+module Hledger.Write.Csv (
   CSV, CsvRecord, CsvValue,
   printCSV,
   printTSV,
@@ -37,12 +37,12 @@ type CSV       = [CsvRecord]
 type CsvRecord = [CsvValue]
 type CsvValue  = Text
 
-printCSV :: [CsvRecord] -> TL.Text
+printCSV :: CSV -> TL.Text
 printCSV = TB.toLazyText . unlinesB . map printRecord
     where printRecord = foldMap TB.fromText . intersperse "," . map printField
           printField = wrap "\"" "\"" . T.replace "\"" "\"\""
 
-printTSV :: [CsvRecord] -> TL.Text
+printTSV :: CSV -> TL.Text
 printTSV = TB.toLazyText . unlinesB . map printRecord
     where printRecord = foldMap TB.fromText . intersperse "\t" . map printField
           printField = T.map replaceWhitespace

--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -15,15 +15,15 @@ import qualified Lucid
 import Data.Foldable (for_)
 
 
-printHtml :: [[Cell]] -> Lucid.Html ()
+printHtml :: [[Cell (Lucid.Html ())]] -> Lucid.Html ()
 printHtml table =
     Lucid.table_ $ for_ table $ \row ->
     Lucid.tr_ $ for_ row $ \cell ->
     formatCell cell
 
-formatCell :: Cell -> Lucid.Html ()
+formatCell :: Cell (Lucid.Html ()) -> Lucid.Html ()
 formatCell cell =
-    let str = Lucid.toHtml $ cellContent cell in
+    let str = cellContent cell in
     case cellStyle cell of
         Head -> Lucid.th_ str
         Body emph ->

--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -1,0 +1,58 @@
+{- |
+Export spreadsheet table data as HTML table.
+
+This is derived from <https://hackage.haskell.org/package/classify-frog-0.2.4.3/src/src/Spreadsheet/Format.hs>
+-}
+module Hledger.Write.Html (
+    printHtml,
+    ) where
+
+import Hledger.Write.Spreadsheet (Type(..), Style(..), Emphasis(..), Cell(..))
+
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
+
+import Text.Printf (printf)
+
+
+printHtml :: [[Cell]] -> TL.Text
+printHtml table =
+    TL.unlines $ map (TL.fromStrict . T.pack) $
+    "<table>" :
+    (table >>= \row ->
+        "<tr>" :
+        (row >>= formatCell) ++
+        "</tr>" :
+        []) ++
+    "</table>" :
+    []
+
+formatCell :: Cell -> [String]
+formatCell cell =
+    (let str = escape $ T.unpack $ cellContent cell in
+     case cellStyle cell of
+        Head -> printf "<th>%s</th>" str
+        Body emph ->
+            let align =
+                    case cellType cell of
+                        TypeString -> ""
+                        _ -> " align=right"
+                (emphOpen, emphClose) =
+                    case emph of
+                        Item -> ("", "")
+                        Total -> ("<b>", "</b>")
+            in  printf "<td%s>%s%s%s</td>" align emphOpen str emphClose) :
+    []
+
+
+escape :: String -> String
+escape =
+    concatMap $ \c ->
+        case c of
+            '\n' -> "<br>"
+            '&' -> "&amp;"
+            '<' -> "&lt;"
+            '>' -> "&gt;"
+            '"' -> "&quot;"
+            '\'' -> "&apos;"
+            _ -> [c]

--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -30,6 +30,7 @@ formatCell cell =
             let align =
                     case cellType cell of
                         TypeString -> []
+                        TypeDate -> []
                         _ -> [LucidBase.makeAttribute "align" "right"]
                 withEmph =
                     case emph of

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -32,7 +32,8 @@ import Text.Printf (printf)
 
 
 printFods ::
-    IO.TextEncoding -> Map Text ((Maybe Int, Maybe Int), [[Cell]]) -> TL.Text
+    IO.TextEncoding ->
+    Map Text ((Maybe Int, Maybe Int), [[Cell Text]]) -> TL.Text
 printFods encoding tables =
     let fileOpen customStyles =
           map (map (\c -> case c of '\'' -> '"'; _ -> c)) $
@@ -136,7 +137,7 @@ printFods encoding tables =
         fileClose
 
 
-cellStyles :: [Cell] -> Set (Emphasis, (CommoditySymbol, AmountPrecision))
+cellStyles :: [Cell Text] -> Set (Emphasis, (CommoditySymbol, AmountPrecision))
 cellStyles =
     Set.fromList .
     mapMaybe (\cell ->
@@ -195,7 +196,7 @@ cellConfig (emph, numParam) =
             []
 
 
-formatCell :: Cell -> [String]
+formatCell :: Cell Text -> [String]
 formatCell cell =
     let style, valueType :: String
         style =

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -1,0 +1,109 @@
+{- |
+Export table data as OpenDocument Spreadsheet
+<https://docs.oasis-open.org/office/OpenDocument/v1.3/>.
+This format supports character encodings, fixed header rows and columns,
+number formatting, text styles, merged cells, formulas, hyperlinks.
+Currently we support Flat ODS, a plain uncompressed XML format.
+
+This is derived from <https://hackage.haskell.org/package/classify-frog-0.2.4.3/src/src/Spreadsheet/Format.hs>
+-}
+module Hledger.Write.Ods where
+
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
+import Data.Text (Text)
+
+import qualified Data.Map as Map
+import Data.Foldable (fold)
+import Data.Map (Map)
+
+import qualified System.IO as IO
+import Text.Printf (printf)
+
+
+printFods ::
+    IO.TextEncoding -> Map Text ((Maybe Int, Maybe Int), [[Text]]) -> TL.Text
+printFods encoding tables =
+    let fileOpen =
+          map (map (\c -> case c of '\'' -> '"'; _ -> c)) $
+          printf "<?xml version='1.0' encoding='%s'?>" (show encoding) :
+          "<office:document" :
+          "  office:mimetype='application/vnd.oasis.opendocument.spreadsheet'" :
+          "  office:version='1.3'" :
+          "  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" :
+          "  xmlns:xsd='http://www.w3.org/2001/XMLSchema'" :
+          "  xmlns:text='urn:oasis:names:tc:opendocument:xmlns:text:1.0'" :
+          "  xmlns:style='urn:oasis:names:tc:opendocument:xmlns:style:1.0'" :
+          "  xmlns:meta='urn:oasis:names:tc:opendocument:xmlns:meta:1.0'" :
+          "  xmlns:config='urn:oasis:names:tc:opendocument:xmlns:config:1.0'" :
+          "  xmlns:xlink='http://www.w3.org/1999/xlink'" :
+          "  xmlns:fo='urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0'" :
+          "  xmlns:ooo='http://openoffice.org/2004/office'" :
+          "  xmlns:office='urn:oasis:names:tc:opendocument:xmlns:office:1.0'" :
+          "  xmlns:table='urn:oasis:names:tc:opendocument:xmlns:table:1.0'" :
+          "  xmlns:number='urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0'" :
+          "  xmlns:of='urn:oasis:names:tc:opendocument:xmlns:of:1.2'" :
+          "  xmlns:field='urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0'" :
+          "  xmlns:form='urn:oasis:names:tc:opendocument:xmlns:form:1.0'>" :
+          []
+
+        fileClose =
+          "</office:document>" :
+          []
+
+        tableConfig tableNames =
+          " <office:settings>" :
+          "  <config:config-item-set config:name='ooo:view-settings'>" :
+          "   <config:config-item-map-indexed config:name='Views'>" :
+          "    <config:config-item-map-entry>" :
+          "     <config:config-item-map-named config:name='Tables'>" :
+          (fold $
+           flip Map.mapWithKey tableNames $ \tableName (mTopRow,mLeftColumn) ->
+             printf "      <config:config-item-map-entry config:name='%s'>" tableName :
+             (flip foldMap mLeftColumn $ \leftColumn ->
+                "       <config:config-item config:name='HorizontalSplitMode' config:type='short'>2</config:config-item>" :
+                printf "       <config:config-item config:name='HorizontalSplitPosition' config:type='int'>%d</config:config-item>" leftColumn :
+                printf "       <config:config-item config:name='PositionRight' config:type='int'>%d</config:config-item>" leftColumn :
+                []) ++
+             (flip foldMap mTopRow $ \topRow ->
+                "       <config:config-item config:name='VerticalSplitMode' config:type='short'>2</config:config-item>" :
+                printf "       <config:config-item config:name='VerticalSplitPosition' config:type='int'>%d</config:config-item>" topRow :
+                printf "       <config:config-item config:name='PositionBottom' config:type='int'>%d</config:config-item>" topRow :
+                []) ++
+             "      </config:config-item-map-entry>" :
+             []) ++
+          "     </config:config-item-map-named>" :
+          "    </config:config-item-map-entry>" :
+          "   </config:config-item-map-indexed>" :
+          "  </config:config-item-set>" :
+          " </office:settings>" :
+          []
+
+        tableOpen name =
+          "<office:body>" :
+          "<office:spreadsheet>" :
+          printf "<table:table table:name='%s'>" name :
+          []
+
+        tableClose =
+          "</table:table>" :
+          "</office:spreadsheet>" :
+          "</office:body>" :
+          []
+
+    in  TL.unlines $ map (TL.fromStrict . T.pack) $
+        fileOpen ++
+        tableConfig (fmap fst tables) ++
+        (Map.toAscList tables >>= \(name,(_,table)) ->
+            tableOpen name ++
+            (table >>= \row ->
+                "<table:table-row>" :
+                (row >>= \cell ->
+                    "<table:table-cell office:value-type='string'>" :
+                    printf "<text:p>%s</text:p>" cell :
+                    "</table:table-cell>" :
+                    []) ++
+                "</table:table-row>" :
+                []) ++
+            tableClose) ++
+        fileClose

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -213,6 +213,18 @@ formatCell cell =
 
     in
     printf "<table:table-cell%s %s>" style valueType :
-    printf "<text:p>%s</text:p>" (cellContent cell) :
+    printf "<text:p>%s</text:p>" (escape $ T.unpack $ cellContent cell) :
     "</table:table-cell>" :
     []
+
+escape :: String -> String
+escape =
+    concatMap $ \c ->
+        case c of
+            '\n' -> "&#10;"
+            '&' -> "&amp;"
+            '<' -> "&lt;"
+            '>' -> "&gt;"
+            '"' -> "&quot;"
+            '\'' -> "&apos;"
+            _ -> [c]

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -6,10 +6,14 @@ number formatting, text styles, merged cells, formulas, hyperlinks.
 Currently we support Flat ODS, a plain uncompressed XML format.
 
 This is derived from <https://hackage.haskell.org/package/classify-frog-0.2.4.3/src/src/Spreadsheet/Format.hs>
--}
-module Hledger.Write.Ods where
 
-import Hledger.Data.Types (CommoditySymbol, Amount, AmountPrecision(..))
+-}
+module Hledger.Write.Ods (
+    printFods,
+    ) where
+
+import Hledger.Write.Spreadsheet (Type(..), Style(..), Emphasis(..), Cell(..))
+import Hledger.Data.Types (CommoditySymbol, AmountPrecision(..))
 import Hledger.Data.Types (acommodity, aquantity, astyle, asprecision)
 
 import qualified Data.Text.Lazy as TL
@@ -25,34 +29,6 @@ import Data.Maybe (mapMaybe)
 
 import qualified System.IO as IO
 import Text.Printf (printf)
-
-
-data Type =
-      TypeString
-    | TypeAmount !Amount
-    | TypeMixedAmount
-    deriving (Eq, Ord, Show)
-
-data Style = Body Emphasis | Head
-    deriving (Eq, Ord, Show)
-
-data Emphasis = Item | Total
-    deriving (Eq, Ord, Show)
-
-data Cell =
-    Cell {
-        cellType :: Type,
-        cellStyle :: Style,
-        cellContent :: Text
-    }
-
-defaultCell :: Cell
-defaultCell =
-    Cell {
-        cellType = TypeString,
-        cellStyle = Body Item,
-        cellContent = T.empty
-    }
 
 
 printFods ::

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -71,6 +71,19 @@ printFods encoding tables =
           "    <style:paragraph-properties fo:text-align='end'/>" :
           "    <style:text-properties fo:font-weight='bold'/>" :
           "  </style:style>" :
+          "  <number:date-style style:name='iso-date'>" :
+          "    <number:year number:style='long'/>" :
+          "    <number:text>-</number:text>" :
+          "    <number:month number:style='long'/>" :
+          "    <number:text>-</number:text>" :
+          "    <number:day number:style='long'/>" :
+          "  </number:date-style>" :
+          "  <style:style style:name='date' style:family='table-cell'" :
+          "      style:data-style-name='iso-date'/>" :
+          "  <style:style style:name='foot-date' style:family='table-cell'" :
+          "      style:data-style-name='iso-date'>" :
+          "    <style:text-properties fo:font-weight='bold'/>" :
+          "  </style:style>" :
           customStyles ++
           "</office:styles>" :
           []
@@ -201,23 +214,30 @@ formatCell cell =
     let style, valueType :: String
         style =
           case (cellStyle cell, cellType cell) of
-            (Body emph, TypeAmount amt) -> numberStyle emph amt
+            (Body emph, TypeAmount amt) -> tableStyle $ numberStyle emph amt
             (Body Item, TypeString) -> ""
-            (Body Item, TypeMixedAmount) -> " table:style-name='amount'"
-            (Body Total, TypeString) -> " table:style-name='foot'"
-            (Body Total, TypeMixedAmount) -> " table:style-name='total-amount'"
-            (Head, _) -> " table:style-name='head'"
-
+            (Body Item, TypeMixedAmount) -> tableStyle "amount"
+            (Body Item, TypeDate) -> tableStyle "date"
+            (Body Total, TypeString) -> tableStyle "foot"
+            (Body Total, TypeMixedAmount) -> tableStyle "total-amount"
+            (Body Total, TypeDate) -> tableStyle "foot-date"
+            (Head, _) -> tableStyle "head"
         numberStyle emph amt =
-            printf " table:style-name='%s-%s'"
+            printf "%s-%s"
                 (emphasisName emph)
                 (numberStyleName (acommodity amt, asprecision $ astyle amt))
+        tableStyle = printf " table:style-name='%s'"
+
         valueType =
             case cellType cell of
                 TypeAmount amt ->
                     printf
                         "office:value-type='float' office:value='%s'"
                         (show $ aquantity amt)
+                TypeDate ->
+                    printf
+                        "office:value-type='date' office:date-value='%s'"
+                        (cellContent cell)
                 _ -> "office:value-type='string'"
 
     in

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -8,12 +8,10 @@ module Hledger.Write.Spreadsheet (
     Emphasis(..),
     Cell(..),
     defaultCell,
+    emptyCell,
     ) where
 
 import Hledger.Data.Types (Amount)
-
-import qualified Data.Text as T
-import Data.Text (Text)
 
 
 data Type =
@@ -28,17 +26,23 @@ data Style = Body Emphasis | Head
 data Emphasis = Item | Total
     deriving (Eq, Ord, Show)
 
-data Cell =
+data Cell text =
     Cell {
         cellType :: Type,
         cellStyle :: Style,
-        cellContent :: Text
+        cellContent :: text
     }
 
-defaultCell :: Cell
-defaultCell =
+instance Functor Cell where
+    fmap f (Cell typ style content) = Cell typ style $ f content
+
+defaultCell :: text -> Cell text
+defaultCell text =
     Cell {
         cellType = TypeString,
         cellStyle = Body Item,
-        cellContent = T.empty
+        cellContent = text
     }
+
+emptyCell :: (Monoid text) => Cell text
+emptyCell = defaultCell mempty

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -18,6 +18,7 @@ data Type =
       TypeString
     | TypeAmount !Amount
     | TypeMixedAmount
+    | TypeDate
     deriving (Eq, Ord, Show)
 
 data Style = Body Emphasis | Head

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -1,0 +1,44 @@
+{- |
+Rich data type to describe data in a table.
+This is the basis for ODS and HTML export.
+-}
+module Hledger.Write.Spreadsheet (
+    Type(..),
+    Style(..),
+    Emphasis(..),
+    Cell(..),
+    defaultCell,
+    ) where
+
+import Hledger.Data.Types (Amount)
+
+import qualified Data.Text as T
+import Data.Text (Text)
+
+
+data Type =
+      TypeString
+    | TypeAmount !Amount
+    | TypeMixedAmount
+    deriving (Eq, Ord, Show)
+
+data Style = Body Emphasis | Head
+    deriving (Eq, Ord, Show)
+
+data Emphasis = Item | Total
+    deriving (Eq, Ord, Show)
+
+data Cell =
+    Cell {
+        cellType :: Type,
+        cellStyle :: Style,
+        cellContent :: Text
+    }
+
+defaultCell :: Cell
+defaultCell =
+    Cell {
+        cellType = TypeString,
+        cellStyle = Body Item,
+        cellContent = T.empty
+    }

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -86,6 +86,7 @@ library
       Hledger.Read.TimedotReader
       Hledger.Read.TimeclockReader
       Hledger.Write.Csv
+      Hledger.Write.Ods
       Hledger.Reports
       Hledger.Reports.ReportOptions
       Hledger.Reports.ReportTypes

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -87,6 +87,8 @@ library
       Hledger.Read.TimeclockReader
       Hledger.Write.Csv
       Hledger.Write.Ods
+      Hledger.Write.Html
+      Hledger.Write.Spreadsheet
       Hledger.Reports
       Hledger.Reports.ReportOptions
       Hledger.Reports.ReportTypes

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -80,12 +80,12 @@ library
       Hledger.Read
       Hledger.Read.Common
       Hledger.Read.CsvReader
-      Hledger.Read.CsvUtils
       Hledger.Read.InputOptions
       Hledger.Read.JournalReader
       Hledger.Read.RulesReader
       Hledger.Read.TimedotReader
       Hledger.Read.TimeclockReader
+      Hledger.Write.Csv
       Hledger.Reports
       Hledger.Reports.ReportOptions
       Hledger.Reports.ReportTypes

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -138,6 +138,7 @@ library
     , file-embed >=0.0.10
     , filepath
     , hashtables >=1.2.3.1
+    , lucid
     , megaparsec >=7.0.0 && <9.7
     , microlens >=0.4
     , microlens-th >=0.4

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -149,6 +149,7 @@ library:
   - Hledger.Read.TimedotReader
   - Hledger.Read.TimeclockReader
   - Hledger.Write.Csv
+  - Hledger.Write.Ods
   - Hledger.Reports
   - Hledger.Reports.ReportOptions
   - Hledger.Reports.ReportTypes

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -150,6 +150,8 @@ library:
   - Hledger.Read.TimeclockReader
   - Hledger.Write.Csv
   - Hledger.Write.Ods
+  - Hledger.Write.Html
+  - Hledger.Write.Spreadsheet
   - Hledger.Reports
   - Hledger.Reports.ReportOptions
   - Hledger.Reports.ReportTypes

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -142,13 +142,13 @@ library:
   - Hledger.Read
   - Hledger.Read.Common
   - Hledger.Read.CsvReader
-  - Hledger.Read.CsvUtils
   - Hledger.Read.InputOptions
   - Hledger.Read.JournalReader
   - Hledger.Read.RulesReader
 #  - Hledger.Read.LedgerReader
   - Hledger.Read.TimedotReader
   - Hledger.Read.TimeclockReader
+  - Hledger.Write.Csv
   - Hledger.Reports
   - Hledger.Reports.ReportOptions
   - Hledger.Reports.ReportTypes

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -61,6 +61,7 @@ dependencies:
 - file-embed >=0.0.10
 - filepath
 - hashtables >=1.2.3.1
+- lucid
 - megaparsec >=7.0.0 && <9.7
 - microlens >=0.4
 - microlens-th >=0.4

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -718,7 +718,7 @@ defaultOutputFormat = "txt"
 -- | All the output formats known by any command, for outputFormatFromOpts.
 -- To automatically infer it from -o/--output-file, it needs to be listed here.
 outputFormats :: [String]
-outputFormats = [defaultOutputFormat, "beancount", "csv", "json", "html", "sql", "tsv"]
+outputFormats = [defaultOutputFormat, "beancount", "csv", "json", "html", "sql", "tsv", "fods"]
 
 -- | Get the output format from the --output-format option,
 -- otherwise from a recognised file extension in the --output-file option,

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -29,7 +29,7 @@ import Lucid as L hiding (value_)
 import System.Console.CmdArgs.Explicit (flagNone, flagReq)
 
 import Hledger
-import Hledger.Read.CsvUtils (CSV, CsvRecord, printCSV, printTSV)
+import Hledger.Write.Csv (CSV, CsvRecord, printCSV, printTSV)
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
 import Text.Tabular.AsciiWide hiding (render)

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -403,7 +403,8 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ of
               "txt"  -> \ropts1 -> TB.toLazyText . balanceReportAsText ropts1
               "csv"  -> \ropts1 -> printCSV . balanceReportAsCsv ropts1
               "tsv"  -> \ropts1 -> printTSV . balanceReportAsCsv ropts1
-              "html" -> \ropts1 -> printHtml . balanceReportAsSpreadsheet ropts1
+              "html" -> \ropts1 -> (<>"\n") . L.renderText .
+                                   printHtml . balanceReportAsSpreadsheet ropts1
               "json" -> const $ (<>"\n") . toJsonText
               "fods" -> \ropts1 -> printFods IO.localeEncoding . Map.singleton "Hledger" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts1
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -282,6 +282,7 @@ import Data.Decimal (roundTo)
 import Data.Default (def)
 import Data.Function (on)
 import Data.List (find, transpose, foldl')
+import qualified Data.Map as Map
 import qualified Data.Set as S
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
@@ -296,10 +297,13 @@ import Text.Tabular.AsciiWide
     (Header(..), Align(..), Properties(..), Cell(..), Table(..), TableOpts(..),
     cellWidth, concatTables, renderColumns, renderRowB, renderTableByRowsB, textCell)
 
+import qualified System.IO as IO
+
 import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
+import Hledger.Write.Ods (printFods)
 
 
 -- | Command line options for this command.
@@ -354,7 +358,7 @@ balancemode = hledgerCommandMode
         ,"'tidy'        : every attribute in its own column"
         ])
     -- output:
-    ,outputFormatFlag ["txt","html","csv","tsv","json"]
+    ,outputFormatFlag ["txt","html","csv","tsv","json","fods"]
     ,outputFileFlag
     ]
   )
@@ -398,6 +402,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ of
               "tsv"  -> \ropts1 -> printTSV . balanceReportAsCsv ropts1
               -- "html" -> \ropts -> (<>"\n") . L.renderText . multiBalanceReportAsHtml ropts . balanceReportAsMultiBalanceReport ropts
               "json" -> const $ (<>"\n") . toJsonText
+              "fods" -> \ropts1 -> printFods IO.localeEncoding . Map.singleton "Hledger" . (,) (Just 1, Nothing) . balanceReportAsCsv ropts1
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render ropts report
   where

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -565,7 +565,7 @@ balanceReportAsFods opts (items, total) =
     headers :
     concatMap (\(a, _, _, b) -> rows a b) items ++
     if no_total_ opts then []
-      else map (map (\c -> c {Ods.cellStyle = Ods.Foot})) $
+      else map (map (\c -> c {Ods.cellStyle = Ods.Body Ods.Total})) $
             rows totalRowHeadingCsv total
   where
     cell content = Ods.defaultCell { Ods.cellContent = content }

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -430,26 +430,8 @@ totalRowHeadingBudgetCsv  = "Total:"
 
 -- | Render a single-column balance report as CSV.
 balanceReportAsCsv :: ReportOpts -> BalanceReport -> CSV
-balanceReportAsCsv opts (items, total) =
-    headers : concatMap (\(a, _, _, b) -> rows a b) items ++ if no_total_ opts then [] else rows totalRowHeadingCsv total
-  where
-    headers = "account" : case layout_ opts of
-      LayoutBare -> ["commodity", "balance"]
-      _          -> ["balance"]
-    rows :: AccountName -> MixedAmount -> [[T.Text]]
-    rows name ma = case layout_ opts of
-      LayoutBare ->
-          map (\a -> [showName name, acommodity a, renderAmount $ mixedAmount a])
-          . amounts $ mixedAmountStripCosts ma
-      _ -> [[showName name, renderAmount ma]]
-
-    showName = accountNameDrop (drop_ opts)
-    renderAmount amt = wbToText $ showMixedAmountB bopts amt
-      where
-        bopts = machineFmt{displayCommodity=showcomm, displayCommodityOrder = commorder}
-        (showcomm, commorder)
-          | layout_ opts == LayoutBare = (False, Just $ S.toList $ maCommodities amt)
-          | otherwise                  = (True, Nothing)
+balanceReportAsCsv opts =
+    map (map Ods.cellContent) . balanceReportAsSpreadsheet opts
 
 -- | Render a single-column balance report as plain text.
 balanceReportAsText :: ReportOpts -> BalanceReport -> TB.Builder

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -900,14 +900,15 @@ multiBalanceRowAsCellBuilders bopts ReportOpts{..} colspans (PeriodicReportRow _
                                  -- complicates the data representation and can be easily calculated
   where
     wbCell = Ods.defaultCell . wbFromText
+    wbDate content = (wbCell content) {Ods.cellType = Ods.TypeDate}
     totalscolumn = row_total_ && balanceaccum_ `notElem` [Cumulative, Historical]
     cs = if all mixedAmountLooksZero allamts then [""] else S.toList $ foldMap maCommodities allamts
     allamts = (if not summary_only_ then as else []) ++
                 [rowtot | totalscolumn && not (null as)] ++
                 [rowavg | average_ && not (null as)]
     addDateColumns spn@(DateSpan s e) = (wbCell (showDateSpan spn) :)
-                                       . (wbCell (maybe "" showEFDate s) :)
-                                       . (wbCell (maybe "" (showEFDate . modifyEFDay (addDays (-1))) e) :)
+                                       . (wbDate (maybe "" showEFDate s) :)
+                                       . (wbDate (maybe "" (showEFDate . modifyEFDay (addDays (-1))) e) :)
 
     paddedTranspose :: a -> [[a]] -> [[a]]
     paddedTranspose _ [] = [[]]

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -585,14 +585,21 @@ balanceReportAsFods opts (items, total) =
       _ -> [[showName name, renderAmount ma]]
 
     showName = cell . accountNameDrop (drop_ opts)
-    renderAmount amt =
-      (cell $ wbToText $ showMixedAmountB bopts amt) {
-        Ods.cellType = Ods.TypeAmount
+    renderAmount mixedAmt =
+      (cell $ wbToText $ showMixedAmountB bopts mixedAmt) {
+        Ods.cellType =
+          case unifyMixedAmount mixedAmt of
+            Just amt ->
+              Ods.TypeAmount $
+              if showcomm
+                then amt
+                else amt {acommodity = T.empty}
+            Nothing -> Ods.TypeMixedAmount
       }
       where
         bopts = machineFmt{displayCommodity=showcomm, displayCommodityOrder = commorder}
         (showcomm, commorder)
-          | layout_ opts == LayoutBare = (False, Just $ S.toList $ maCommodities amt)
+          | layout_ opts == LayoutBare = (False, Just $ S.toList $ maCommodities mixedAmt)
           | otherwise                  = (True, Nothing)
 
 -- Multi-column balance reports

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -299,7 +299,7 @@ import Text.Tabular.AsciiWide
 import Hledger
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
-import Hledger.Read.CsvUtils (CSV, printCSV, printTSV)
+import Hledger.Write.Csv (CSV, printCSV, printTSV)
 
 
 -- | Command line options for this command.

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -59,7 +59,7 @@ Flags:
                             'bare'        : commodity symbols in one column
                             'tidy'        : every attribute in its own column
   -O --output-format=FMT    select the output format. Supported formats:
-                            txt, html, csv, tsv, json.
+                            txt, html, csv, tsv, json, fods.
   -o --output-file=FILE     write output to FILE. A file extension matching
                             one of the above formats selects that format.
 ```
@@ -133,7 +133,7 @@ Many of these work with the higher-level commands as well.
 This command supports the
 [output destination](#output-destination) and
 [output format](#output-format) options,
-with output formats `txt`, `csv`, `tsv` (*Added in 1.32*), `json`, and (multi-period reports only:) `html`.
+with output formats `txt`, `csv`, `tsv` (*Added in 1.32*), `json`, and (multi-period reports only:) `html`, `fods` (*Added in 1.40*).
 In `txt` output in a colour-supporting terminal, negative amounts are shown in red.
 
 ### Simple balance report

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -27,7 +27,7 @@ import Lens.Micro ((^.), _Just, has)
 import System.Console.CmdArgs.Explicit
 
 import Hledger
-import Hledger.Read.CsvUtils (CSV, printCSV, printTSV)
+import Hledger.Write.Csv (CSV, printCSV, printTSV)
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
 import System.Exit (exitFailure)

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -27,7 +27,7 @@ import qualified Data.Text.Lazy.Builder as TB
 import System.Console.CmdArgs.Explicit (flagNone, flagReq)
 
 import Hledger hiding (per)
-import Hledger.Read.CsvUtils (CSV, CsvRecord, printCSV, printTSV)
+import Hledger.Write.Csv (CSV, CsvRecord, printCSV, printTSV)
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils
 import Text.Tabular.AsciiWide hiding (render)

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -21,7 +21,7 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import Data.Time.Calendar (Day, addDays)
 import System.Console.CmdArgs.Explicit as C (Mode, flagNone, flagReq)
-import Hledger.Read.CsvUtils (CSV, printCSV, printTSV)
+import Hledger.Write.Csv (CSV, printCSV, printTSV)
 import Lucid as L hiding (value_)
 import Safe (tailDef)
 import Text.Tabular.AsciiWide as Tabular hiding (render)

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -564,19 +564,18 @@ $ hledger print -o -        # write to stdout (the default)
 Some commands offer other kinds of output, not just text on the terminal.
 Here are those commands and the formats currently supported:
 
-| -                  | txt              | csv/tsv          | html               | json | sql |
-|--------------------|------------------|------------------|--------------------|------|-----|
-| aregister          | Y                | Y                | Y                  | Y    |     |
-| balance            | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1,2</sup>* | Y    |     |
-| balancesheet       | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>*   | Y    |     |
-| balancesheetequity | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>*   | Y    |     |
-| cashflow           | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>*   | Y    |     |
-| incomestatement    | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>*   | Y    |     |
-| print              | Y                | Y                |                    | Y    | Y   |
-| register           | Y                | Y                |                    | Y    |     |
+| -                  | txt              | csv/tsv          | html             | fods             | json | sql |
+|--------------------|------------------|------------------|------------------|------------------|------|-----|
+| aregister          | Y                | Y                | Y                |                  | Y    |     |
+| balance            | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y    |     |
+| balancesheet       | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>* |                  | Y    |     |
+| balancesheetequity | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>* |                  | Y    |     |
+| cashflow           | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>* |                  | Y    |     |
+| incomestatement    | Y *<sup>1</sup>* | Y *<sup>1</sup>* | Y *<sup>1</sup>* |                  | Y    |     |
+| print              | Y                | Y                |                  |                  | Y    | Y   |
+| register           | Y                | Y                |                  |                  | Y    |     |
 
 - *<sup>1</sup> Also affected by the balance commands' [`--layout` option](#balance-report-layout).*
-- *<sup>2</sup> `balance` does not support html output without a report interval or with `--budget`.*
 
 <!--
 | accounts              |     |     |      |      |     |


### PR DESCRIPTION
Here is my proposal for an export of balance reports to the formats FODS and HTML.

What I plan to do next:
[ ] Base the CSV export on the same machinery.
[ ] FODS export for multiperiod balances.
[ ] base multiperiod CSV and HTML export on this machinery.
[ ] add a FODS column to the format support matrix in hledger.m4.md

Here are some ideas for further improvements:
[ ] Add hyperlinks to HTML and FODS documents, e.g. an account name could link to an according hledger-web URL. This feature could be enabled by a command-line option like `--anchor-url=http://localhost:5000/`.
[ ] I could make the total sum in FODS a formula. This would show the user what the number means and LibreOffice would recompute the sum if someone edits the balance report there.
[ ] Support for ODS currencies. ODS has special support for currencies. I do not use this currently, but instead simply use numbers with the currency name added to the cell display. In case a commodity is a currency it feels to be right to use the ODS currency feature, but that one has e.g. its own definition of the precision. We would need a mapping from hledger currency names (Euro, EUR, €) to ODS currencies (EUR). I do not know, whether it is worth the trouble, because LibreOffice ignores the displayed units anyway for computations.

(Please leave the single commits intact, every one is compilable and reasonable. I may rebase them according to your wishes.)
