### PR TITLE
Add border and class attributes to Spreadsheet data type

### DIFF
--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -6,6 +6,8 @@ This is derived from <https://hackage.haskell.org/package/classify-frog-0.2.4.3/
 -}
 module Hledger.Write.Html (
     printHtml,
+    formatRow,
+    formatCell,
     ) where
 
 import qualified Hledger.Write.Spreadsheet as Spr
@@ -15,7 +17,7 @@ import qualified Data.Text as Text
 import qualified Lucid.Base as LucidBase
 import qualified Lucid
 import Data.Text (Text)
-import Data.Foldable (for_)
+import Data.Foldable (traverse_)
 
 
 printHtml :: (Lines border) => [[Cell border (Lucid.Html ())]] -> Lucid.Html ()
@@ -26,9 +28,10 @@ printHtml table = do
         "th, td {padding-left:1em}" :
         "th.account, td.account {padding-left:0;}" :
         []
-    Lucid.table_ $ for_ table $ \row ->
-        Lucid.tr_ $ for_ row $ \cell ->
-        formatCell cell
+    Lucid.table_ $ traverse_ formatRow table
+
+formatRow:: (Lines border) => [Cell border (Lucid.Html ())] -> Lucid.Html ()
+formatRow = Lucid.tr_ . traverse_ formatCell
 
 formatCell :: (Lines border) => Cell border (Lucid.Html ()) -> Lucid.Html ()
 formatCell cell =
@@ -43,8 +46,11 @@ formatCell cell =
             case leftBorder++rightBorder++topBorder++bottomBorder of
                 [] -> []
                 ss -> [Lucid.style_ $ Text.intercalate "; " ss] in
+    let class_ =
+            map Lucid.class_ $
+            filter (not . Text.null) [Spr.textFromClass $ cellClass cell] in
     case cellStyle cell of
-        Head -> Lucid.th_ style str
+        Head -> Lucid.th_ (style++class_) str
         Body emph ->
             let align =
                     case cellType cell of
@@ -55,7 +61,7 @@ formatCell cell =
                     case emph of
                         Item -> id
                         Total -> Lucid.b_
-            in  Lucid.td_ (style++align) $ withEmph str
+            in  Lucid.td_ (style++align++class_) $ withEmph str
 
 
 class (Spr.Lines border) => Lines border where

--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -8,24 +8,43 @@ module Hledger.Write.Html (
     printHtml,
     ) where
 
+import qualified Hledger.Write.Spreadsheet as Spr
 import Hledger.Write.Spreadsheet (Type(..), Style(..), Emphasis(..), Cell(..))
 
+import qualified Data.Text as Text
 import qualified Lucid.Base as LucidBase
 import qualified Lucid
+import Data.Text (Text)
 import Data.Foldable (for_)
 
 
-printHtml :: [[Cell (Lucid.Html ())]] -> Lucid.Html ()
-printHtml table =
+printHtml :: (Lines border) => [[Cell border (Lucid.Html ())]] -> Lucid.Html ()
+printHtml table = do
+    Lucid.style_ $ Text.unlines $
+        "" :
+        "table {border-collapse:collapse}" :
+        "th, td {padding-left:1em}" :
+        "th.account, td.account {padding-left:0;}" :
+        []
     Lucid.table_ $ for_ table $ \row ->
-    Lucid.tr_ $ for_ row $ \cell ->
-    formatCell cell
+        Lucid.tr_ $ for_ row $ \cell ->
+        formatCell cell
 
-formatCell :: Cell (Lucid.Html ()) -> Lucid.Html ()
+formatCell :: (Lines border) => Cell border (Lucid.Html ()) -> Lucid.Html ()
 formatCell cell =
     let str = cellContent cell in
+    let border field access =
+            map (field<>) $ borderLines $ access $ cellBorder cell in
+    let leftBorder   = border "border-left:"   Spr.borderLeft   in
+    let rightBorder  = border "border-right:"  Spr.borderRight  in
+    let topBorder    = border "border-top:"    Spr.borderTop    in
+    let bottomBorder = border "border-bottom:" Spr.borderBottom in
+    let style =
+            case leftBorder++rightBorder++topBorder++bottomBorder of
+                [] -> []
+                ss -> [Lucid.style_ $ Text.intercalate "; " ss] in
     case cellStyle cell of
-        Head -> Lucid.th_ str
+        Head -> Lucid.th_ style str
         Body emph ->
             let align =
                     case cellType cell of
@@ -36,4 +55,18 @@ formatCell cell =
                     case emph of
                         Item -> id
                         Total -> Lucid.b_
-            in  Lucid.td_ align $ withEmph str
+            in  Lucid.td_ (style++align) $ withEmph str
+
+
+class (Spr.Lines border) => Lines border where
+    borderLines :: border -> [Text]
+
+instance Lines () where
+    borderLines () = []
+
+instance Lines Spr.NumLines where
+    borderLines prop =
+        case prop of
+            Spr.NoLine -> []
+            Spr.SingleLine -> ["black"]
+            Spr.DoubleLine -> ["double black"]

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -7,6 +7,7 @@ module Hledger.Write.Spreadsheet (
     Style(..),
     Emphasis(..),
     Cell(..),
+    Class(Class), textFromClass,
     Border(..),
     Lines(..),
     NumLines(..),
@@ -20,6 +21,7 @@ module Hledger.Write.Spreadsheet (
 import Hledger.Data.Types (Amount)
 
 import qualified Data.List as List
+import Data.Text (Text)
 
 
 data Type =
@@ -75,17 +77,23 @@ transposeBorder (Border left right top bottom) =
     Border top bottom left right
 
 
+newtype Class = Class Text
+
+textFromClass :: Class -> Text
+textFromClass (Class cls) = cls
+
 data Cell border text =
     Cell {
         cellType :: Type,
         cellBorder :: Border border,
         cellStyle :: Style,
+        cellClass :: Class,
         cellContent :: text
     }
 
 instance Functor (Cell border) where
-    fmap f (Cell typ border style content) =
-        Cell typ border style $ f content
+    fmap f (Cell typ border style class_ content) =
+        Cell typ border style class_ $ f content
 
 defaultCell :: (Lines border) => text -> Cell border text
 defaultCell text =
@@ -93,6 +101,7 @@ defaultCell text =
         cellType = TypeString,
         cellBorder = noBorder,
         cellStyle = Body Item,
+        cellClass = Class mempty,
         cellContent = text
     }
 

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -7,6 +7,10 @@ module Hledger.Write.Spreadsheet (
     Style(..),
     Emphasis(..),
     Cell(..),
+    Border(..),
+    Lines(..),
+    NumLines(..),
+    noBorder,
     defaultCell,
     emptyCell,
     ) where
@@ -27,23 +31,62 @@ data Style = Body Emphasis | Head
 data Emphasis = Item | Total
     deriving (Eq, Ord, Show)
 
-data Cell text =
+
+class Lines border where noLine :: border
+instance Lines () where noLine = ()
+instance Lines NumLines where noLine = NoLine
+
+{- |
+The same as Tab.Properties, but has 'Eq' and 'Ord' instances.
+We need those for storing 'NumLines' in 'Set's.
+-}
+data NumLines = NoLine | SingleLine | DoubleLine
+    deriving (Eq, Ord, Show)
+
+data Border lines =
+    Border {
+        borderLeft, borderRight,
+        borderTop, borderBottom :: lines
+    }
+    deriving (Eq, Ord, Show)
+
+instance Functor Border where
+    fmap f (Border left right top bottom) =
+        Border (f left) (f right) (f top) (f bottom)
+
+instance Applicative Border where
+    pure a = Border a a a a
+    Border fLeft fRight fTop fBottom <*> Border left right top bottom =
+        Border (fLeft left) (fRight right) (fTop top) (fBottom bottom)
+
+instance Foldable Border where
+    foldMap f (Border left right top bottom) =
+        f left <> f right <> f top <> f bottom
+
+noBorder :: (Lines border) => Border border
+noBorder = pure noLine
+
+
+data Cell border text =
     Cell {
         cellType :: Type,
+        cellBorder :: Border border,
         cellStyle :: Style,
         cellContent :: text
     }
 
-instance Functor Cell where
-    fmap f (Cell typ style content) = Cell typ style $ f content
+instance Functor (Cell border) where
+    fmap f (Cell typ border style content) =
+        Cell typ border style $ f content
 
-defaultCell :: text -> Cell text
+defaultCell :: (Lines border) => text -> Cell border text
 defaultCell text =
     Cell {
         cellType = TypeString,
+        cellBorder = noBorder,
         cellStyle = Body Item,
         cellContent = text
     }
 
-emptyCell :: (Monoid text) => Cell text
+emptyCell :: (Lines border, Monoid text) => Cell border text
 emptyCell = defaultCell mempty

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -13,9 +13,13 @@ module Hledger.Write.Spreadsheet (
     noBorder,
     defaultCell,
     emptyCell,
+    transposeCell,
+    transpose,
     ) where
 
 import Hledger.Data.Types (Amount)
+
+import qualified Data.List as List
 
 
 data Type =
@@ -66,6 +70,10 @@ instance Foldable Border where
 noBorder :: (Lines border) => Border border
 noBorder = pure noLine
 
+transposeBorder :: Border lines -> Border lines
+transposeBorder (Border left right top bottom) =
+    Border top bottom left right
+
 
 data Cell border text =
     Cell {
@@ -90,3 +98,10 @@ defaultCell text =
 
 emptyCell :: (Lines border, Monoid text) => Cell border text
 emptyCell = defaultCell mempty
+
+transposeCell :: Cell border text -> Cell border text
+transposeCell cell =
+    cell {cellBorder = transposeBorder $ cellBorder cell}
+
+transpose :: [[Cell border text]] -> [[Cell border text]]
+transpose = List.transpose . map (map transposeCell)

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -440,7 +440,7 @@ totalRowHeadingBudgetCsv  = "Total:"
 -- | Render a single-column balance report as CSV.
 balanceReportAsCsv :: ReportOpts -> BalanceReport -> CSV
 balanceReportAsCsv opts =
-    map (map Ods.cellContent) . balanceReportAsSpreadsheet opts
+    rawTableContent . balanceReportAsSpreadsheet opts
 
 -- | Render a single-column balance report as plain text.
 balanceReportAsText :: ReportOpts -> BalanceReport -> TB.Builder
@@ -571,6 +571,10 @@ addTotalBorders =
                     Ods.cellBorder = Ods.noBorder {Ods.borderTop = border}}))
         (Ods.DoubleLine : repeat Ods.NoLine)
 
+rawTableContent :: [[Ods.Cell border text]] -> [[text]]
+rawTableContent = map (map Ods.cellContent)
+
+
 -- | Render a single-column balance report as FODS.
 balanceReportAsSpreadsheet ::
     ReportOpts -> BalanceReport -> [[Ods.Cell Ods.NumLines Text]]
@@ -651,7 +655,7 @@ multiBalanceReportAsCsv opts@ReportOpts{..} report = maybeTranspose allRows
 -- Helper for CSV (and HTML) rendering.
 multiBalanceReportAsCsvHelper :: Bool -> ReportOpts -> MultiBalanceReport -> (CSV, CSV)
 multiBalanceReportAsCsvHelper ishtml opts =
-    (map (map Ods.cellContent) *** map (map Ods.cellContent)) .
+    (rawTableContent *** rawTableContent) .
     multiBalanceReportAsSpreadsheetHelper ishtml opts
 
 -- Helper for CSV and ODS and HTML rendering.
@@ -909,7 +913,7 @@ multiBalanceReportAsTable opts@ReportOpts{summary_only_, average_, row_total_, b
 
 multiBalanceRowAsTextBuilders :: AmountFormat -> ReportOpts -> [DateSpan] -> PeriodicReportRow a MixedAmount -> [[WideBuilder]]
 multiBalanceRowAsTextBuilders bopts ropts colspans row =
-    map (map Ods.cellContent) $
+    rawTableContent $
     multiBalanceRowAsCellBuilders bopts ropts colspans row
 
 multiBalanceRowAsCellBuilders ::
@@ -1218,7 +1222,7 @@ budgetReportAsTable ReportOpts{..} (PeriodicReport spans items totrow) =
 -- but includes alternating actual and budget amount columns.
 budgetReportAsCsv :: ReportOpts -> BudgetReport -> [[Text]]
 budgetReportAsCsv ropts report
-  = map (map Ods.cellContent) $
+  = rawTableContent $
     budgetReportAsSpreadsheet ropts report
 
 budgetReportAsSpreadsheet ::

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -287,6 +287,7 @@ import Data.List (find, transpose, foldl')
 import qualified Data.Map as Map
 import qualified Data.Set as S
 import Data.Maybe (catMaybes, fromMaybe)
+import Data.Tuple (swap)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -574,6 +575,7 @@ addTotalBorders =
 balanceReportAsSpreadsheet ::
     ReportOpts -> BalanceReport -> [[Ods.Cell Ods.NumLines Text]]
 balanceReportAsSpreadsheet opts (items, total) =
+    (if transpose_ opts then Ods.transpose else id) $
     headers :
     concatMap (\(a, _, _, b) -> rows a b) items ++
     if no_total_ opts then []
@@ -810,7 +812,8 @@ multiBalanceReportAsSpreadsheet ::
   ((Maybe Int, Maybe Int), [[Ods.Cell Ods.NumLines Text]])
 multiBalanceReportAsSpreadsheet ropts mbr =
   let (upper,lower) = multiBalanceReportAsSpreadsheetHelper True ropts mbr
-  in  ((Just 1, case layout_ ropts of LayoutWide _ -> Just 1; _ -> Nothing),
+  in  (if transpose_ ropts then swap *** Ods.transpose else id) $
+      ((Just 1, case layout_ ropts of LayoutWide _ -> Just 1; _ -> Nothing),
             upper ++ lower)
 
 

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -1223,7 +1223,7 @@ budgetReportAsSpreadsheet ::
 budgetReportAsSpreadsheet
   ReportOpts{..}
   (PeriodicReport colspans items totrow)
-  = (if transpose_ then transpose else id) $
+  = (if transpose_ then Ods.transpose else id) $
 
   -- heading row
   (map headerCell $


### PR DESCRIPTION
Here are some more commits for unifying existing multibalance HTML export with my Spreadsheet data type.
One visible effect is that now FODS tables also get the double lines like the multibalance HTML
and that the formats CSV, HTML, FODS should be transposable for all three kinds of balance exports.

I was also able to remove the dissection of already formated rows in
Commands.Balance.multiBalanceReportHtmlHeadRow, multiBalanceReportHtmlBodyRow, multiBalanceReportHtmlFootRow.

However, there was a comment "TODO pad totals ..." that I do not understand.
It belonged to multiBalanceReportHtmlHeadRow, which is now gone.
Thus the comment is probably no longer at a sensible position if it is still relevant, at all.