### PR TITLE
fix: amount formatting of the Net row in the balancesheet HTML output

### DIFF
--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -364,7 +364,7 @@ compoundBalanceReportAsHtml ropts cbr =
     totalrows =
       if no_total_ ropts || length subreports == 1 then []
       else
-        multiBalanceRowAsCellBuilders machineFmt ropts colspans Total totalrow
+        multiBalanceRowAsCellBuilders oneLineNoCostFmt ropts colspans Total totalrow
                              -- make a table of rendered lines of the report totals row
         & map (map (fmap wbToText))
         & zipWith (:) (Spr.defaultCell "Net:" : repeat Spr.emptyCell)


### PR DESCRIPTION
The "Net" row in the HTML output of `balancesheet` formatted amounts using `machineFmt` which is inconsistent with all the other amounts in the balance sheet. This fixes that by formatting Net amounts using `oneLineNoCostFmt`.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
