### PR TITLE
Add hyperlinks to accounts and dates in HTML and FODS export

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -140,6 +140,7 @@ data ReportOpts = ReportOpts {
     ,no_elide_         :: Bool
     ,real_             :: Bool
     ,format_           :: StringFormat
+    ,balance_base_url_ :: Maybe T.Text
     ,pretty_           :: Bool
     ,querystring_      :: [T.Text]
     --
@@ -199,6 +200,7 @@ defreportopts = ReportOpts
     , no_elide_         = False
     , real_             = False
     , format_           = def
+    , balance_base_url_ = Nothing
     , pretty_           = False
     , querystring_      = []
     , average_          = False
@@ -255,6 +257,7 @@ rawOptsToReportOpts d rawopts =
           ,no_elide_         = boolopt "no-elide" rawopts
           ,real_             = boolopt "real" rawopts
           ,format_           = format
+          ,balance_base_url_ = T.pack <$> maybestringopt "base-url" rawopts
           ,querystring_      = querystring
           ,average_          = boolopt "average" rawopts
           ,related_          = boolopt "related" rawopts

--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -37,6 +37,10 @@ formatRow = Lucid.tr_ . traverse_ formatCell
 formatCell :: (Lines border) => Cell border (Lucid.Html ()) -> Lucid.Html ()
 formatCell cell =
     let str = cellContent cell in
+    let content =
+            if Text.null $ cellAnchor cell
+                then str
+                else Lucid.a_ [Lucid.href_ $ cellAnchor cell] str in
     let border field access =
             map (field<>) $ borderLines $ access $ cellBorder cell in
     let leftBorder   = border "border-left:"   Spr.borderLeft   in
@@ -51,7 +55,7 @@ formatCell cell =
             map Lucid.class_ $
             filter (not . Text.null) [Spr.textFromClass $ cellClass cell] in
     case cellStyle cell of
-        Head -> Lucid.th_ (style++class_) str
+        Head -> Lucid.th_ (style++class_) content
         Body emph ->
             let align =
                     case cellType cell of
@@ -62,7 +66,7 @@ formatCell cell =
                     case emph of
                         Item -> id
                         Total -> Lucid.b_
-            in  Lucid.td_ (style++align++class_) $ withEmph str
+            in  Lucid.td_ (style++align++class_) $ withEmph content
 
 
 class (Spr.Lines border) => Lines border where

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -314,9 +314,16 @@ formatCell cell =
                         (cellContent cell)
                 _ -> "office:value-type='string'"
 
+        anchor text =
+            if T.null $ Spr.cellAnchor cell
+                then text
+                else printf "<text:a xlink:href='%s'>%s</text:a>"
+                        (escape $ T.unpack $ Spr.cellAnchor cell) text
+
     in
     printf "<table:table-cell%s %s>" style valueType :
-    printf "<text:p>%s</text:p>" (escape $ T.unpack $ cellContent cell) :
+    printf "<text:p>%s</text:p>"
+        (anchor $ escape $ T.unpack $ cellContent cell) :
     "</table:table-cell>" :
     []
 

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -87,13 +87,14 @@ data Cell border text =
         cellType :: Type,
         cellBorder :: Border border,
         cellStyle :: Style,
+        cellAnchor :: Text,
         cellClass :: Class,
         cellContent :: text
     }
 
 instance Functor (Cell border) where
-    fmap f (Cell typ border style class_ content) =
-        Cell typ border style class_ $ f content
+    fmap f (Cell typ border style anchor class_ content) =
+        Cell typ border style anchor class_ $ f content
 
 defaultCell :: (Lines border) => text -> Cell border text
 defaultCell text =
@@ -101,6 +102,7 @@ defaultCell text =
         cellType = TypeString,
         cellBorder = noBorder,
         cellStyle = Body Item,
+        cellAnchor = mempty,
         cellClass = Class mempty,
         cellContent = text
     }

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -238,6 +238,7 @@ Currently, empty cells show 0.
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE QuasiQuotes          #-}
 
 module Hledger.Cli.Commands.Balance (
   -- ** balance command
@@ -283,6 +284,8 @@ import Data.Time (addDays, fromGregorian)
 import System.Console.CmdArgs.Explicit as C (flagNone, flagReq, flagOpt)
 import Lucid as L hiding (value_)
 import Safe (headMay, maximumMay)
+import qualified Text.URI as Uri
+import qualified Text.URI.QQ as UriQQ
 import Text.Tabular.AsciiWide
     (Header(..), Align(..), Properties(..), Cell(..), Table(..), TableOpts(..),
     cellWidth, concatTables, renderColumns, renderRowB, renderTableByRowsB, textCell)
@@ -586,8 +589,14 @@ headerCell text =
 
 registerQueryUrl :: [Text] -> Text
 registerQueryUrl query =
-    "register?q=" <>
-    T.intercalate "+" (map quoteIfSpaced $ filter (not . T.null) query)
+    Uri.render $
+    [UriQQ.uri|register|] {
+        Uri.uriQuery =
+            [Uri.QueryParam [UriQQ.queryKey|q|] $
+             fromMaybe (error "register URI query construction failed") $
+             Uri.mkQueryValue $ T.unwords $
+             map quoteIfSpaced $ filter (not . T.null) query]
+    }
 
 -- cf. Web.Widget.Common
 removeDates :: [Text] -> [Text]

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -385,6 +385,19 @@ $ hledger bal -% cur:\\$
 $ hledger bal -% cur:€
 ```
 
+### Hyperlinks
+
+The HTML and FODS output formats support hyperlinks to `hledger-web`'s
+Register pages for every account and period.
+E.g. if your `hledger-web` server is reachable
+under the URL `http://localhost:5000/`
+then you might run the `balance` command
+with the extra option `--base-url=http://localhost:5000/`.
+The export function will not add any slash
+in order to support relative hyperreferences.
+Thus it is important that you add the trailing slash to the URL yourselves,
+where needed.
+
 ### Multi-period balance report
 
 With a [report interval](#report-intervals) (set by the `-D/--daily`,

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -91,6 +91,7 @@ compoundBalanceCommandMode CompoundBalanceCommandSpec{..} =
     ,flagNone ["no-total","N"] (setboolopt "no-total") "omit the final total row"
     ,flagNone ["no-elide"] (setboolopt "no-elide") "don't squash boring parent accounts (in tree mode)"
     ,flagReq  ["format"] (\s opts -> Right $ setopt "format" s opts) "FORMATSTR" "use this custom line format (in simple reports)"
+    ,flagReq  ["base-url"] (\s opts -> Right $ setopt "base-url" s opts) "URLPREFIX" "add anchors to table cells with resepct to this base URL"
     ,flagNone ["sort-amount","S"] (setboolopt "sort-amount") "sort by amount instead of account code/name"
     ,flagNone ["percent", "%"] (setboolopt "percent") "express values in percentage of each column's total"
     ,flagReq  ["layout"] (\s opts -> Right $ setopt "layout" s opts) "ARG"

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -366,7 +366,8 @@ compoundBalanceReportAsHtml ropts cbr =
     totalrows =
       if no_total_ ropts || length subreports == 1 then []
       else
-        multiBalanceRowAsCellBuilders oneLineNoCostFmt ropts colspans Total totalrow
+        multiBalanceRowAsCellBuilders oneLineNoCostFmt ropts colspans
+            Total simpleDateSpanCell totalrow
                              -- make a table of rendered lines of the report totals row
         & map (map (fmap wbToText))
         & zipWith (:) (Spr.defaultCell "Net:" : repeat Spr.emptyCell)

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -172,6 +172,7 @@ library
     , math-functions >=0.3.3.0
     , megaparsec >=7.0.0 && <9.7
     , microlens >=0.4
+    , modern-uri >=0.3
     , mtl >=2.2.1
     , process
     , regex-tdfa

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -205,6 +205,7 @@ library:
   - Diff >=0.2
   - hashable >=1.2.4
   - lucid
+  - modern-uri >=0.3
 
 executables:
   hledger:


### PR DESCRIPTION
This adds the option `--anchor` to `hledger-cli`. If the user passes this option, then in HTML and FODS output the account and date header cells become hyperlinks to `hledger-web`.
If you like this feature, I add some documentation.
I could also rename the option to `--base-url` for consistency with `hledger-web`.
There is a problem though. Some special characters like `+` or umlauts in account names are not correctly escaped in percent URL syntax by Lucid. I do not know how to solve this correctly with Lucid and whether it is solvable with Lucid, at all.