### PR TITLE
web: RegisterR.getRegisterR.addCommas: do not drop last account

### DIFF
--- a/hledger-web/Hledger/Web/Handler/RegisterR.hs
+++ b/hledger-web/Hledger/Web/Handler/RegisterR.hs
@@ -9,9 +9,9 @@
 
 module Hledger.Web.Handler.RegisterR where
 
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.List (intersperse, nub, partition)
 import qualified Data.Text as T
-import Safe (tailDef)
 import Text.Hamlet (hamletFile)
 
 import Hledger
@@ -42,10 +42,11 @@ getRegisterR = do
           map (\(acct,(name,comma)) -> (acct, (T.pack name, T.pack comma))) .
           undecorateLinks . elideRightDecorated 40 . decorateLinks .
           addCommas . preferReal . otherTransactionAccounts q acctQuery
+      snoc xs x = NonEmpty.prependList xs $ NonEmpty.singleton x
       addCommas xs =
           zip xs $
           zip (map (T.unpack . accountSummarisedName . paccount) xs) $
-          tailDef [""] $ (", "<$xs)
+          NonEmpty.tail $ snoc (", "<$xs) ""
       items =
         styleAmounts (journalCommodityStylesWith HardRounding j) $
         accountTransactionsReport rspec{_rsQuery=q} j acctQuery


### PR DESCRIPTION
Bug was introduced in commit 2a99b3d45634f26cd62745ddce6136361001b3f8 in an effort to get rid of partial List.tail,
because GHC-9.8 started to warn about it.

Problem is that the rewritten code with tailDef always removes the last account, whereas the original intention was to replace all accounts by a comma except the last one. addCommas should prepare a comma separated list like List.intercalate.
