### PR TITLE
Vertically merge cells showing account names and Total

### DIFF
--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -8,6 +8,7 @@ module Hledger.Write.Spreadsheet (
     Emphasis(..),
     Cell(..),
     Class(Class), textFromClass,
+    Span(..),
     Border(..),
     Lines(..),
     NumLines(..),
@@ -22,6 +23,8 @@ import Hledger.Data.Types (Amount)
 
 import qualified Data.List as List
 import Data.Text (Text)
+
+import Prelude hiding (span)
 
 
 data Type =
@@ -82,19 +85,59 @@ newtype Class = Class Text
 textFromClass :: Class -> Text
 textFromClass (Class cls) = cls
 
+
+{- |
+* 'NoSpan' means a single unmerged cell.
+
+* 'Covered' is a cell if it is part of a horizontally or vertically merged cell.
+  We maintain these cells although they are ignored in HTML output.
+  In contrast to that, FODS can store covered cells
+  and allows to access the hidden cell content via formulas.
+  CSV does not support merged cells
+  and thus simply writes the content of covered cells.
+  Maintaining 'Covered' cells also simplifies transposing.
+
+* @'SpanHorizontal' n@ denotes the first cell in a row
+  that is part of a merged cell.
+  The merged cell contains @n@ atomic cells, including the first one.
+  That is @SpanHorizontal 1@ is actually like @NoSpan@.
+  The content of this cell is shown as content of the merged cell.
+
+* @'SpanVertical' n@ starts a vertically merged cell.
+
+The writer functions expect consistent data,
+that is, 'Covered' cells must actually be part of a merged cell
+and merged cells must only cover 'Covered' cells.
+-}
+data Span =
+      NoSpan
+    | Covered
+    | SpanHorizontal Int
+    | SpanVertical Int
+    deriving (Eq)
+
+transposeSpan :: Span -> Span
+transposeSpan span =
+    case span of
+        NoSpan -> NoSpan
+        Covered -> Covered
+        SpanHorizontal n -> SpanVertical n
+        SpanVertical n -> SpanHorizontal n
+
 data Cell border text =
     Cell {
         cellType :: Type,
         cellBorder :: Border border,
         cellStyle :: Style,
+        cellSpan :: Span,
         cellAnchor :: Text,
         cellClass :: Class,
         cellContent :: text
     }
 
 instance Functor (Cell border) where
-    fmap f (Cell typ border style anchor class_ content) =
-        Cell typ border style anchor class_ $ f content
+    fmap f (Cell typ border style span anchor class_ content) =
+        Cell typ border style span anchor class_ $ f content
 
 defaultCell :: (Lines border) => text -> Cell border text
 defaultCell text =
@@ -102,6 +145,7 @@ defaultCell text =
         cellType = TypeString,
         cellBorder = noBorder,
         cellStyle = Body Item,
+        cellSpan = NoSpan,
         cellAnchor = mempty,
         cellClass = Class mempty,
         cellContent = text
@@ -112,7 +156,10 @@ emptyCell = defaultCell mempty
 
 transposeCell :: Cell border text -> Cell border text
 transposeCell cell =
-    cell {cellBorder = transposeBorder $ cellBorder cell}
+    cell {
+        cellBorder = transposeBorder $ cellBorder cell,
+        cellSpan = transposeSpan $ cellSpan cell
+    }
 
 transpose :: [[Cell border text]] -> [[Cell border text]]
 transpose = List.transpose . map (map transposeCell)

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -376,7 +376,7 @@ compoundBalanceReportAsHtml ropts cbr =
             Total simpleDateSpanCell totalrow
                              -- make a table of rendered lines of the report totals row
         & map (map (fmap wbToText))
-        & zipWith (:) (Spr.defaultCell "Net:" : repeat Spr.emptyCell)
+        & addRowSpanHeader (Spr.defaultCell "Net:")
                              -- insert a headings column, with Net: on the first line only
         & addTotalBorders    -- marking the first for special styling
         & map (Html.formatRow . map (fmap L.toHtml))


### PR DESCRIPTION
I think this is the best compromise for multibalance:

* In HTML there is only one merged Total cell.
* In CSV there is a Total header in every totals row.
* In FODS the Total header is contained in every row, but only the first one is shown in a merged cell. Formulas can still access the covered Total text e.g. for VLOOKUP.

Same applies to account names in `tidy` layout.
