### PR TITLE
imp: allow timestamp syntax in transaction dates

### DIFF
--- a/hledger-lib/Hledger/Data/Balancing.hs
+++ b/hledger-lib/Hledger/Data/Balancing.hs
@@ -793,6 +793,7 @@ tests_Balancing =
                   0
                   ""
                   nullsourcepos
+                  Nothing
                   (fromGregorian 2007 01 28)
                   Nothing
                   Unmarked
@@ -808,6 +809,7 @@ tests_Balancing =
                   0
                   ""
                   nullsourcepos
+                  Nothing
                   (fromGregorian 2007 01 28)
                   Nothing
                   Unmarked
@@ -825,6 +827,7 @@ tests_Balancing =
                 0
                 ""
                 nullsourcepos
+                Nothing
                 (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
@@ -841,6 +844,7 @@ tests_Balancing =
                 0
                 ""
                 nullsourcepos
+                Nothing
                 (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
@@ -859,6 +863,7 @@ tests_Balancing =
                0
                ""
                nullsourcepos
+               Nothing
                (fromGregorian 2011 01 01)
                Nothing
                Unmarked
@@ -876,6 +881,7 @@ tests_Balancing =
                0
                ""
                nullsourcepos
+               Nothing
                (fromGregorian 2011 01 01)
                Nothing
                Unmarked
@@ -895,6 +901,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked
@@ -913,6 +920,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked
@@ -931,6 +939,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked
@@ -946,6 +955,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked
@@ -961,6 +971,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked
@@ -980,6 +991,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked
@@ -998,6 +1010,7 @@ tests_Balancing =
             0
             ""
             nullsourcepos
+            Nothing
             (fromGregorian 2009 01 01)
             Nothing
             Unmarked

--- a/hledger-lib/Hledger/Data/Timeclock.hs
+++ b/hledger-lib/Hledger/Data/Timeclock.hs
@@ -115,6 +115,7 @@ entryFromTimeclockInOut i o
       t = Transaction {
             tindex       = 0,
             tsourcepos   = (tlsourcepos i, tlsourcepos i),
+            tdatetime   = Nothing,
             tdate        = idate,
             tdate2       = Nothing,
             tstatus      = Cleared,

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -83,6 +83,7 @@ nulltransaction :: Transaction
 nulltransaction = Transaction {
                     tindex=0,
                     tsourcepos=nullsourcepos,
+                    tdatetime=Nothing,
                     tdate=nulldate,
                     tdate2=Nothing,
                     tstatus=Unmarked,
@@ -605,6 +606,7 @@ tests_Transaction =
                    0
                    ""
                    nullsourcepos
+                   Nothing
                    (fromGregorian 2007 01 28)
                    Nothing
                    Unmarked
@@ -629,6 +631,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
+                Nothing
                 (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
@@ -652,6 +655,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
+                Nothing
                 (fromGregorian 2007 01 28)
                 Nothing
                 Unmarked
@@ -668,6 +672,7 @@ tests_Transaction =
                 0
                 ""
                 nullsourcepos
+                Nothing
                 (fromGregorian 2010 01 01)
                 Nothing
                 Unmarked

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -45,6 +45,7 @@ import qualified Data.Map as M
 import Data.Ord (comparing)
 import Data.Text (Text)
 import Data.Time.Calendar (Day)
+import Data.Time.Clock (UTCTime)
 import Data.Time.Clock.POSIX (POSIXTime)
 import Data.Time.LocalTime (LocalTime)
 import Data.Word (Word8)
@@ -467,6 +468,7 @@ data Transaction = Transaction {
       tindex                   :: Integer,   -- ^ this transaction's 1-based position in the transaction stream, or 0 when not available
       tprecedingcomment        :: Text,      -- ^ any comment lines immediately preceding this transaction
       tsourcepos               :: (SourcePos, SourcePos),  -- ^ the file position where the date starts, and where the last posting ends
+      tdatetime                :: Maybe UTCTime,
       tdate                    :: Day,
       tdate2                   :: Maybe Day,
       tstatus                  :: Status,

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -86,6 +86,7 @@ Right samplejournal2 =
         txnTieKnot Transaction{
           tindex=0,
           tsourcepos=nullsourcepos,
+          tdatetime=Nothing,
           tdate=fromGregorian 2008 01 01,
           tdate2=Just $ fromGregorian 2009 01 01,
           tstatus=Unmarked,

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -652,6 +652,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
+             tdatetime=Nothing,
              tdate=fromGregorian 2007 01 01,
              tdate2=Nothing,
              tstatus=Unmarked,
@@ -669,6 +670,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
+             tdatetime=Nothing,
              tdate=fromGregorian 2007 02 01,
              tdate2=Nothing,
              tstatus=Unmarked,
@@ -686,6 +688,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
+             tdatetime=Nothing,
              tdate=fromGregorian 2007 01 02,
              tdate2=Nothing,
              tstatus=Unmarked,
@@ -703,6 +706,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
+             tdatetime=Nothing,
              tdate=fromGregorian 2007 01 03,
              tdate2=Nothing,
              tstatus=Unmarked,
@@ -720,6 +724,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
+             tdatetime=Nothing,
              tdate=fromGregorian 2007 01 03,
              tdate2=Nothing,
              tstatus=Unmarked,
@@ -737,6 +742,7 @@ journal7 = nulljournal {jtxns =
            txnTieKnot Transaction {
              tindex=0,
              tsourcepos=nullsourcepos,
+             tdatetime=Nothing,
              tdate=fromGregorian 2007 01 03,
              tdate2=Nothing,
              tstatus=Unmarked,


### PR DESCRIPTION
This commit makes it possible to specify timestamps in hledger transactions. For example: 2024-01-01 12:43:56+09:00. All existing logic that uses the transaction's date information has been left unchanged - that is to say, the time of day is not used anywhere yet. The intention behind this is to modify such logic in future commits/pull requests.

Furthermore, backwards compatibility with existing ledgers using plain dates has been fully preserved (barring any bugs that I missed).

ref: #117