### PR TITLE
lib: Write.Html.Attributes: extracted HTML output helpers from Cli.Commands.Balance

### DIFF
--- a/hledger-lib/Hledger/Write/Html.hs
+++ b/hledger-lib/Hledger/Write/Html.hs
@@ -10,6 +10,7 @@ module Hledger.Write.Html (
     formatCell,
     ) where
 
+import qualified Hledger.Write.Html.Attribute as Attr
 import qualified Hledger.Write.Spreadsheet as Spr
 import Hledger.Write.Spreadsheet (Type(..), Style(..), Emphasis(..), Cell(..))
 
@@ -45,7 +46,7 @@ formatCell cell =
     let style =
             case leftBorder++rightBorder++topBorder++bottomBorder of
                 [] -> []
-                ss -> [Lucid.style_ $ Text.intercalate "; " ss] in
+                ss -> [Attr.styles_ ss] in
     let class_ =
             map Lucid.class_ $
             filter (not . Text.null) [Spr.textFromClass $ cellClass cell] in

--- a/hledger-lib/Hledger/Write/Html/Attribute.hs
+++ b/hledger-lib/Hledger/Write/Html/Attribute.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}      -- for stylesheet_
+{- |
+Helpers and CSS styles for HTML output.
+-}
+module Hledger.Write.Html.Attribute (
+    stylesheet_,
+    styles_,
+    bold,
+    doubleborder,
+    topdoubleborder,
+    bottomdoubleborder,
+    alignright,
+    alignleft,
+    aligncenter,
+    collapse,
+    lpad,
+    rpad,
+    hpad,
+    vpad,
+    ) where
+
+import qualified Lucid.Base as LucidBase
+import qualified Lucid
+import qualified Data.Text as Text
+import Data.Text (Text)
+
+
+-- | result can be 'Lucid.Attribute' or @Lucid.Html ()@
+stylesheet_ :: LucidBase.TermRaw Text result => [(Text,Text)] -> result
+stylesheet_ elstyles =
+    Lucid.style_ $ Text.unlines $
+        "" : [el<>" {"<>styles<>"}" | (el,styles) <- elstyles]
+
+styles_ :: [Text] -> Lucid.Attribute
+styles_ = Lucid.style_ . Text.intercalate "; "
+
+bold, doubleborder, topdoubleborder, bottomdoubleborder :: Text
+bold = "font-weight:bold"
+doubleborder = "double black"
+topdoubleborder    = "border-top:"<>doubleborder
+bottomdoubleborder = "border-bottom:"<>doubleborder
+
+alignright, alignleft, aligncenter :: Text
+alignright  = "text-align:right"
+alignleft   = "text-align:left"
+aligncenter = "text-align:center"
+
+collapse :: Text
+collapse = "border-collapse:collapse"
+
+lpad, rpad, hpad, vpad :: Text
+lpad = "padding-left:1em"
+rpad = "padding-right:1em"
+hpad = "padding-left:1em; padding-right:1em"
+vpad = "padding-top:1em;  padding-bottom:1em"

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -88,6 +88,7 @@ library
       Hledger.Write.Csv
       Hledger.Write.Ods
       Hledger.Write.Html
+      Hledger.Write.Html.Attribute
       Hledger.Write.Spreadsheet
       Hledger.Reports
       Hledger.Reports.ReportOptions

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -152,6 +152,7 @@ library:
   - Hledger.Write.Csv
   - Hledger.Write.Ods
   - Hledger.Write.Html
+  - Hledger.Write.Html.Attribute
   - Hledger.Write.Spreadsheet
   - Hledger.Reports
   - Hledger.Reports.ReportOptions

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -234,8 +234,6 @@ Currently, empty cells show 0.
 -}
 
 {-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE ExtendedDefaultRules #-}  -- for lucid_
-{-# LANGUAGE FlexibleContexts #-}      -- for stylesheet_
 {-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
@@ -262,21 +260,6 @@ module Hledger.Cli.Commands.Balance (
  ,multiBalanceReportAsSpreadsheet
  ,addTotalBorders
  ,RowClass(..)
-  -- ** HTML output helpers
- ,stylesheet_
- ,styles_
- ,bold
- ,doubleborder
- ,topdoubleborder
- ,bottomdoubleborder
- ,alignright
- ,alignleft
- ,aligncenter
- ,collapse
- ,lpad
- ,rpad
- ,hpad
- ,vpad
   -- ** Tests
  ,tests_Balance
 ) where
@@ -310,6 +293,7 @@ import Hledger.Cli.Utils
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
 import Hledger.Write.Ods (printFods)
 import Hledger.Write.Html (printHtml)
+import Hledger.Write.Html.Attribute (stylesheet_, collapse, lpad)
 import qualified Hledger.Write.Html as Html
 import qualified Hledger.Write.Spreadsheet as Ods
 
@@ -733,24 +717,6 @@ multiBalanceReportAsSpreadsheetHelper ishtml opts@ReportOpts{..} (PeriodicReport
         let fmt = if ishtml then oneLineNoCostFmt else machineFmt
         in  map (map (fmap wbToText)) . multiBalanceRowAsCellBuilders fmt opts colspans rc
 
--- Helpers and CSS styles for HTML output.
-
-stylesheet_ elstyles = style_ $ T.unlines $ "" : [el<>" {"<>styles<>"}" | (el,styles) <- elstyles]
-styles_ :: [Text] -> L.Attribute
-styles_ = style_ . T.intercalate "; "
-bold = "font-weight:bold"
-doubleborder = "double black"
-topdoubleborder    = "border-top:"<>doubleborder
-bottomdoubleborder = "border-bottom:"<>doubleborder
-alignright, alignleft, aligncenter :: Text
-alignright  = "text-align:right"
-alignleft   = "text-align:left"
-aligncenter = "text-align:center"
-collapse = "border-collapse:collapse"
-lpad = "padding-left:1em"
-rpad = "padding-right:1em"
-hpad = "padding-left:1em; padding-right:1em"
-vpad = "padding-top:1em;  padding-bottom:1em"
 
 -- | Render a multi-column balance report as HTML.
 multiBalanceReportAsHtml :: ReportOpts -> MultiBalanceReport -> Html ()

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -22,6 +22,7 @@ import qualified Data.Text.Lazy.Builder as TB
 import Data.Time.Calendar (Day, addDays)
 import System.Console.CmdArgs.Explicit as C (Mode, flagNone, flagReq)
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
+import Hledger.Write.Html.Attribute (stylesheet_, collapse, lpad, alignright)
 import qualified Hledger.Write.Html as Html
 import qualified Hledger.Write.Spreadsheet as Spr
 import Lucid as L hiding (value_)


### PR DESCRIPTION
Some code cleaning. This way I can use the HTML output helpers in `Write.Html`.