### PR TITLE
Cli.Commands.Balance.multiBalanceReportAsHtml: now uses multiBalanceReportAsSpreadsheet

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -303,7 +303,6 @@ import Hledger.Cli.Utils
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
 import Hledger.Write.Ods (printFods)
 import Hledger.Write.Html.Lucid (printHtml)
-import Hledger.Write.Html.Attribute (tableStylesheet)
 import qualified Hledger.Write.Html.Lucid as Html
 import qualified Hledger.Write.Spreadsheet as Ods
 
@@ -822,15 +821,10 @@ multiBalanceReportAsSpreadsheetParts ishtml opts@ReportOpts{..} (PeriodicReport 
 -- | Render a multi-column balance report as HTML.
 multiBalanceReportAsHtml :: ReportOpts -> MultiBalanceReport -> Html ()
 multiBalanceReportAsHtml ropts mbr =
-  let
-    (headingsrow,bodyrows,mtotalsrows) = multiBalanceReportHtmlRows ropts mbr
-  in do
+  do
     link_ [rel_ "stylesheet", href_ "hledger.css"]
-    style_ tableStylesheet
-    table_ $ mconcat $
-         [headingsrow]
-      ++ bodyrows
-      ++ mtotalsrows
+    printHtml . map (map (fmap L.toHtml)) $
+      snd $ multiBalanceReportAsSpreadsheet ropts mbr
 
 -- | Render the HTML table rows for a MultiBalanceReport.
 -- Returns the heading row, 0 or more body rows, and the totals row if enabled.

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -774,16 +774,16 @@ multiBalanceReportAsCsv opts@ReportOpts{..} report = maybeTranspose allRows
       _ -> rows ++ totals
     rows = header:body
     (header, body, totals) =
-        multiBalanceReportAsSpreadsheetHelper False opts report
+        multiBalanceReportAsSpreadsheetParts False opts report
     maybeTranspose = if transpose_ then transpose else id
 
 -- Helper for CSV and ODS and HTML rendering.
-multiBalanceReportAsSpreadsheetHelper ::
+multiBalanceReportAsSpreadsheetParts ::
     Bool -> ReportOpts -> MultiBalanceReport ->
     ([Ods.Cell Ods.NumLines Text],
      [[Ods.Cell Ods.NumLines Text]],
      [[Ods.Cell Ods.NumLines Text]])
-multiBalanceReportAsSpreadsheetHelper ishtml opts@ReportOpts{..} (PeriodicReport colspans items tr) =
+multiBalanceReportAsSpreadsheetParts ishtml opts@ReportOpts{..} (PeriodicReport colspans items tr) =
     (headers, concatMap fullRowAsTexts items, addTotalBorders totalrows)
   where
     accountCell label =
@@ -840,7 +840,7 @@ multiBalanceReportHtmlRows ropts mbr =
     -- TODO: should the commodity_column be displayed as a subaccount in this case as well?
     (headingsrow, bodyrows, mtotalsrows)
       | transpose_ ropts = error' "Sorry, --transpose with HTML output is not yet supported"  -- PARTIAL:
-      | otherwise = multiBalanceReportAsSpreadsheetHelper True ropts mbr
+      | otherwise = multiBalanceReportAsSpreadsheetParts True ropts mbr
     formatRow = Html.formatRow . map (fmap L.toHtml)
   in
     (formatRow headingsrow
@@ -854,7 +854,7 @@ multiBalanceReportAsSpreadsheet ::
   ReportOpts -> MultiBalanceReport ->
   ((Maybe Int, Maybe Int), [[Ods.Cell Ods.NumLines Text]])
 multiBalanceReportAsSpreadsheet ropts mbr =
-  let (header,body,total) = multiBalanceReportAsSpreadsheetHelper True ropts mbr
+  let (header,body,total) = multiBalanceReportAsSpreadsheetParts True ropts mbr
   in  (if transpose_ ropts then swap *** Ods.transpose else id) $
       ((Just 1, case layout_ ropts of LayoutWide _ -> Just 1; _ -> Nothing),
             header : body ++ total)


### PR DESCRIPTION
instead of multiBalanceReportHtmlRows.

This way, HTML output automatically supports transposition.

I'd like to do the same for `multiBalanceReportAsCsv`,
unfortunately it has a special case for LayoutTidy which excludes totals.
You can achieve the same by explicit options, but this would be a user-visible change.
