### PR TITLE
Fix all scripts in bin/

### DIFF
--- a/bin/hledger-balance-as-budget.hs
+++ b/bin/hledger-balance-as-budget.hs
@@ -10,7 +10,7 @@
 -}
 import Data.Text.Lazy.IO as TL
 import System.Environment (getArgs)
-import Hledger.Cli
+import Hledger.Cli.Script
 
 ------------------------------------------------------------------------------
 cmdmode = hledgerCommandMode
@@ -34,13 +34,13 @@ main = do
   args <- getArgs
   let report1args = takeWhile (/= "--") args
   let report2args = drop 1 $ dropWhile (/= "--") args
-  (_,_,report1) <- mbReport report1args
-  (ropts2,j,report2) <- mbReport report2args
+  (opts,_,_,report1) <- mbReport report1args
+  (_,ropts2,j,report2) <- mbReport report2args
   let pastAsBudget = combineBudgetAndActual ropts2 j report1{prDates=prDates report2} report2
-  TL.putStrLn $ budgetReportAsText ropts2 pastAsBudget
+  writeOutputLazyText opts $ budgetReportAsText ropts2 pastAsBudget
   where
     mbReport args = do
       opts@CliOpts{reportspec_=rspec} <- getHledgerCliOpts' cmdmode args
       d <- getCurrentDay
       (report,j) <- withJournalDo opts $ \j -> return (multiBalanceReport rspec j, j)
-      return (_rsReportOpts rspec,j,report)
+      return (opts, _rsReportOpts rspec,j,report)

--- a/bin/hledger-check-postable.hs
+++ b/bin/hledger-check-postable.hs
@@ -19,7 +19,7 @@ import qualified Data.Text as T
 import Safe
 import System.Exit
 import Hledger
-import Hledger.Cli
+import Hledger.Cli.Script
 
 ------------------------------------------------------------------------------
 cmdmode :: Mode RawOpts

--- a/bin/hledger-check-tagfiles.cabal.hs
+++ b/bin/hledger-check-tagfiles.cabal.hs
@@ -17,7 +17,7 @@ $ hledger check-tagfiles       # compiles every time (?)
 
 import Control.Monad
 import qualified Data.Text as T
-import Hledger.Cli
+import Hledger.Cli.Script
 import System.Directory
 import System.Exit
 

--- a/bin/hledger-check-tagfiles.hs
+++ b/bin/hledger-check-tagfiles.hs
@@ -18,7 +18,7 @@ $ hledger check-tagfiles       # compiles if there's no compiled version
 
 import Control.Monad
 import qualified Data.Text as T
-import Hledger.Cli
+import Hledger.Cli.Script
 import System.Directory
 import System.Exit
 

--- a/bin/hledger-combine-balances.hs
+++ b/bin/hledger-combine-balances.hs
@@ -8,7 +8,7 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 import System.Environment (getArgs)
-import Hledger.Cli
+import Hledger.Cli.Script
 import qualified Data.Map as M
 import Data.Map.Merge.Strict
 import qualified Data.Text.Lazy.IO as TL

--- a/bin/hledger-move.hs
+++ b/bin/hledger-move.hs
@@ -40,7 +40,7 @@ import Text.Printf
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
-import Hledger.Cli
+import Hledger.Cli.Script
 
 ------------------------------------------------------------------------------
 cmdmode = hledgerCommandMode
@@ -156,7 +156,7 @@ main = do
       force       = boolopt "force" rawopts
 
       -- parse the AMT arg as a cost-less Amount (any provided cost is ignored)
-      eamt = styleAmount (journalCommodityStyles j) . amountStripCost <$> parseamount amtarg
+      eamt = styleAmounts (journalCommodityStyles j) . amountStripCost <$> parseamount amtarg
       amt = case eamt of
         Left err ->
           error' $ "could not parse " ++ show amtarg ++ " as a hledger amount\n" ++ customErrorBundlePretty err ++ "\n" ++shortusage

--- a/bin/hledger-print-location.hs
+++ b/bin/hledger-print-location.hs
@@ -20,7 +20,7 @@ $ hledger print-location -f examples/sample.journal desc:eat
 
 import Data.String.QQ (s)
 import qualified Data.Text as T
-import Hledger.Cli
+import Hledger.Cli.Script
 
 ------------------------------------------------------------------------------
 cmdmode = hledgerCommandMode

--- a/bin/hledger-smooth.hs
+++ b/bin/hledger-smooth.hs
@@ -24,7 +24,7 @@ import qualified Data.Text as T
 import Data.Time.Calendar
 import Safe
 -- import Hledger
-import Hledger.Cli
+import Hledger.Cli.Script
 
 ------------------------------------------------------------------------------
 cmdmode = hledgerCommandMode

--- a/bin/hledger-swap-dates.hs
+++ b/bin/hledger-swap-dates.hs
@@ -11,7 +11,7 @@
 import Data.String.QQ (s)
 import qualified Data.Text.IO as T
 import Hledger
-import Hledger.Cli
+import Hledger.Cli.Script
 
 ------------------------------------------------------------------------------
 cmdmode = hledgerCommandMode

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -250,6 +250,9 @@ module Hledger.Cli.Commands.Balance (
  ,balanceReportAsCsv
  ,balanceReportAsSpreadsheet
  ,balanceReportItemAsText
+ ,budgetReportAsText
+ ,budgetReportAsCsv
+ ,budgetReportAsSpreadsheet
  ,multiBalanceRowAsCellBuilders
  ,multiBalanceRowAsCsvText
  ,multiBalanceRowAsText


### PR DESCRIPTION
I've fixed the compilation errors in all the scripts in bin/

This necessitatied adding `budgetReportAs...` to the export list of Commands.Balance - I think there are no special reasons for them being omitted, as all the other reporting functions are exported.