### PR TITLE
simpler conversion account with --infer-equity

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -96,11 +96,13 @@ module Hledger.Data.Journal (
   journalAccountTypes,
   journalAddAccountTypes,
   journalPostingsAddAccountTags,
+  defaultConversionAccount,
   -- journalPrices,
   journalConversionAccount,
   journalConversionAccounts,
   -- * Misc
   canonicalStyleFrom,
+
   nulljournal,
   journalConcat,
   journalNumberTransactions,

--- a/hledger-lib/Hledger/Data/JournalChecks.hs
+++ b/hledger-lib/Hledger/Data/JournalChecks.hs
@@ -67,7 +67,6 @@ journalCheckAccounts j = mapM_ checkacct (journalPostings j)
           ,"Consider adding an account directive. Examples:"
           ,""
           ,"account %s"
-          ,"account %s    ; type:A  ; (L,E,R,X,C,V)"
           ]) f l ex (show a) a a
         where
           (f,l,_mcols,ex) = makePostingAccountErrorExcerpt p

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -714,9 +714,7 @@ hledger will try adjust your account names, if needed, to
 [Beancount account names](https://beancount.github.io/docs/beancount_language_syntax.html#accounts),
 by capitalising, replacing unsupported characters with `-`, and
 prepending `B` to parts which don't begin with a letter or digit.
-(It's possible for this to convert distinct hledger account names to the same beancount name.
-Eg, hledger's automatic equity conversion accounts can have currency symbols in their name,
-so `equity:conversion:$-€` becomes `equity:conversion:B---`.)
+(It's possible for this to convert distinct hledger account names to the same beancount name.)
 
 In addition, you must ensure that the top level account names are `Assets`, `Liabilities`, `Equity`, `Income`, and `Expenses`,
 which Beancount requires.
@@ -1980,7 +1978,8 @@ Some notes:
 - The account directive's scope is "whole file and below" (see [directives](#directives)). This means it affects all of the current file, and any files it includes, but not parent or sibling files. The position of account directives within the file does not matter, though it's usual to put them at the top.
 - Accounts can only be declared in `journal` files, but will affect [included](#include-directive) files of all types.
 - It's currently not possible to declare "all possible subaccounts" with a wildcard; every account posted to must be declared.
-- If you use the [--infer-equity](#inferring-equity-conversion-postings) flag, you will also need declarations for the account names it generates.
+- The account [--infer-equity](#inferring-equity-conversion-postings) uses by default - equity:conversion - need not be declared.
+  (If you configure a different conversion account, that will need to be declared.)
 
 ### Account display order
 
@@ -2049,7 +2048,8 @@ account expenses           ; type: X
 account assets:bank        ; type: C
 account assets:cash        ; type: C
 
-account equity:conversion  ; type: V
+; if you want to override the conversion account name, which is equity:conversion by default:
+;account equity:exchange   ; type: V
 ```
 
 [five main account types]:      https://en.wikipedia.org/wiki/Chart_of_accounts#Types_of_accounts
@@ -5709,15 +5709,12 @@ $ hledger print --infer-equity
 2022-01-01
     assets:dollars                    $-135
     assets:euros               €100 @ $1.35
-    equity:conversion:$-€:€           €-100
-    equity:conversion:$-€:$         $135.00
+    equity:conversion                 €-100
+    equity:conversion               $135.00
 ```
 
-The equity account names will be "equity:conversion:A-B:A" and "equity:conversion:A-B:B"
-where A is the alphabetically first commodity symbol.
-You can customise the "equity:conversion" part by declaring an account with the `V`/`Conversion` [account type](#account-types).
-
-Note you will need to add [account declarations](#account-error-checking) for these to your journal, if you use `check accounts` or `check --strict`.
+`--infer-equity` will use the "equity:conversion" account by default (and you don't have to declare this account for `check accounts` or `check --strict`).
+If you declare some other account with the `V`/`Conversion` [account type](#account-types), it will use that instead.
 
 ## Combining costs and equity conversion postings
 
@@ -5762,9 +5759,9 @@ It will infer costs only in transactions with:
   Equity conversion accounts are:
 
   - any accounts declared with account type `V`/`Conversion`, or their subaccounts
-  - otherwise, accounts named `equity:conversion`, `equity:trade`, or `equity:trading`, or their subaccounts.
+  - otherwise, accounts named `equity:conversion`, `equity:trade`, `equity:trades`, `equity:trading`, or any subaccounts of these.
 
-And multiple such four-posting groups can coexist within a single transaction.
+Multiple such four-posting groups can coexist within a single transaction.
 When `--infer-costs` fails, it does not infer a cost in that transaction, and does not raise an error (ie, it infers costs where it can).
 
 Reading variant 5 journal entries, combining cost notation and equity postings, has all the same requirements.

--- a/hledger/test/check-accounts.test
+++ b/hledger/test/check-accounts.test
@@ -51,3 +51,27 @@ $ hledger -f- --auto check accounts
 $ hledger -f- --auto --strict bal
 >2 /account "b" has not been declared/
 >=1
+
+# ** 7. The default equity:conversion account used by --infer-equity does not need to be declared for check accounts.
+<
+account a
+account b
+
+2024-01-01
+    a    1A
+    b   -1B
+
+$ hledger -f- check accounts --infer-equity
+
+# ** 8. It does not need to be declared, even without --infer-equity, and even if a different conversion account is declared. (For simplicity.)
+<
+account a
+account b
+account equity  ; type:V
+
+2024-01-01
+    a    1A
+    b   -1B
+    equity:conversion   0
+
+$ hledger -f- check accounts

--- a/hledger/test/errors/accounts.test
+++ b/hledger/test/errors/accounts.test
@@ -9,7 +9,6 @@ account "a" has not been declared.
 Consider adding an account directive. Examples:
 
 account a
-account a    ; type:A  ; \(L,E,R,X,C,V\)
 
 /
 >>>= 1

--- a/hledger/test/journal/costs.test
+++ b/hledger/test/journal/costs.test
@@ -30,8 +30,8 @@ $ hledger -f- print --explicit --cost
 $ hledger -f- print --infer-equity --verbose-tags
 2011-01-01
     expenses:foreign currency    €100 @ $1.35
-    equity:conversion:$-€:€             €-100  ; generated-posting: conversion
-    equity:conversion:$-€:$           $135.00  ; generated-posting: conversion
+    equity:conversion                   €-100  ; generated-posting: conversion
+    equity:conversion                 $135.00  ; generated-posting: conversion
     assets                           $-135.00
 
 >=0
@@ -142,8 +142,8 @@ $ hledger -f - balance --value=cost,XXX
 $ hledger -f - balance --infer-equity
                  10£  a
                 -16$  b
-                 16$  equity:conversion:$-£:$
-                -10£  equity:conversion:$-£:£
+                 16$
+                -10£  equity:conversion
 --------------------
                    0  
 >=0
@@ -366,8 +366,8 @@ account  equity:trades   ; type:V
 $ hledger -f- print --infer-equity
 2011-01-01
     expenses:foreign currency    €100 @ $1.35
-    equity:trades:$-€:€                 €-100
-    equity:trades:$-€:$               $135.00
+    equity:trades                       €-100
+    equity:trades                     $135.00
     assets
 
 >=0


### PR DESCRIPTION
This implements today's proposal on ~~mail list~~ & chat:
[Actually, it never reached the mail list; never mind.]

> The --infer-equity flag generates postings to accounts named something like `equity:conversion:A-B:A` and `equity:conversion:A-B:B`, where A and B are the commodity symbols being converted between. 
> 
> I feel these :A-B:* subaccounts 
> 
> - add noise 
> 
> - complicate exporting to beancount, since currency symbols in account names generally aren't allowed there. 
> 
> - complicate hledger check accounts and check -s, as seen in https://github.com/simonmichael/hledger/issues/2247 
> 
> - are not much needed; you can always filter commodities with cur: 
> 
> So I think I’d like to drop the subaccounts. —infer-equity would just use equity:conversion (or other conversion account you have designated). Do you see any problems with it ? 