### PR TITLE
Layout Tidy: no total row

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -266,6 +266,7 @@ module Hledger.Cli.Commands.Balance (
  ,multiBalanceHasTotalsColumn
  ,addTotalBorders
  ,simpleDateSpanCell
+ ,tidyColumnLabels
  ,nbsp
  ,RowClass(..)
   -- ** Tests
@@ -777,9 +778,7 @@ multiBalanceReportAsSpreadsheetParts fmt opts@ReportOpts{..} (PeriodicReport col
       addHeaderBorders $
       hCell "account" "account" :
       case layout_ of
-      LayoutTidy ->
-          map headerCell
-              ["period", "start_date", "end_date", "commodity", "value"]
+      LayoutTidy -> map headerCell tidyColumnLabels
       LayoutBare -> headerCell "commodity" : dateHeaders
       _          -> dateHeaders
     dateHeaders =
@@ -801,6 +800,10 @@ multiBalanceReportAsSpreadsheetParts fmt opts@ReportOpts{..} (PeriodicReport col
     rowAsText rc dsCell =
         map (map (fmap wbToText)) .
         multiBalanceRowAsCellBuilders fmt opts colspans rc dsCell
+
+tidyColumnLabels :: [Text]
+tidyColumnLabels =
+    ["period", "start_date", "end_date", "commodity", "value"]
 
 
 -- | Render a multi-column balance report as HTML.

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -413,15 +413,15 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ of
     _ -> do  -- single period simple balance report
         let report = styleAmounts styles $ balanceReport rspec j -- simple Ledger-style balance report
             render = case fmt of
-              "txt"  -> \ropts1 -> TB.toLazyText . balanceReportAsText ropts1
-              "csv"  -> \ropts1 -> printCSV . balanceReportAsCsv ropts1
-              "tsv"  -> \ropts1 -> printTSV . balanceReportAsCsv ropts1
-              "html" -> \ropts1 -> (<>"\n") . L.renderText .
-                                   printHtml . map (map (fmap L.toHtml)) . balanceReportAsSpreadsheet ropts1
-              "json" -> const $ (<>"\n") . toJsonText
-              "fods" -> \ropts1 -> printFods IO.localeEncoding . Map.singleton "Hledger" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts1
+              "txt"  -> TB.toLazyText . balanceReportAsText ropts
+              "csv"  -> printCSV . balanceReportAsCsv ropts
+              "tsv"  -> printTSV . balanceReportAsCsv ropts
+              "html" -> (<>"\n") . L.renderText .
+                                   printHtml . map (map (fmap L.toHtml)) . balanceReportAsSpreadsheet ropts
+              "json" -> (<>"\n") . toJsonText
+              "fods" -> printFods IO.localeEncoding . Map.singleton "Hledger" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
-        writeOutputLazyText opts $ render ropts report
+        writeOutputLazyText opts $ render report
   where
     styles = journalCommodityStylesWith HardRounding j
     ropts@ReportOpts{..} = _rsReportOpts rspec

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -347,13 +347,19 @@ compoundBalanceReportAsSpreadsheet ::
 compoundBalanceReportAsSpreadsheet fmt accountLabel maybeBlank ropts cbr =
   let
     CompoundPeriodicReport title colspans subreports totalrow = cbr
-    headerrow =
+    leadingHeaders =
       Spr.headerCell accountLabel :
-      (guard (layout_ ropts == LayoutBare) >> [Spr.headerCell "Commodity"]) ++
+      case layout_ ropts of
+          LayoutTidy -> map Spr.headerCell tidyColumnLabels
+          LayoutBare -> [Spr.headerCell "Commodity"]
+          _ -> []
+    dataHeaders =
+      (guard (layout_ ropts /= LayoutTidy) >>) $
       map (Spr.headerCell . reportPeriodName (balanceaccum_ ropts) colspans)
         colspans ++
       (guard (multiBalanceHasTotalsColumn ropts) >> [Spr.headerCell "Total"]) ++
       (guard (average_   ropts) >> [Spr.headerCell "Average"])
+    headerrow = leadingHeaders ++ dataHeaders
 
     blankrow =
       fmap (Spr.horizontalSpan headerrow . Spr.defaultCell) maybeBlank


### PR DESCRIPTION
Disable total row for LayoutTidy in balance reports. CSV, FODS, HTML are now consistent in this respect.

Correct headings for LayoutTidy in CompoundBalance to CSV, FODS, HTML export, but totals are still shown.

Fixes https://github.com/simonmichael/hledger/issues/2252.