### PR TITLE
Register export to HTML and FODS

### DIFF
--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -69,6 +69,9 @@ printFods encoding tables =
           "    <number:text>-</number:text>" :
           "    <number:day number:style='long'/>" :
           "  </number:date-style>" :
+          "  <number:number-style style:name='integer'>" :
+          "    <number:number number:min-integer-digits='1'/>" :
+          "  </number:number-style>" :
           customStyles ++
           "</office:styles>" :
           []
@@ -139,6 +142,7 @@ dataStyleFromType :: Type -> DataStyle
 dataStyleFromType typ =
     case typ of
         TypeString -> DataString
+        TypeInteger -> DataInteger
         TypeDate -> DataDate
         TypeAmount amt -> DataAmount (acommodity amt) (asprecision $ astyle amt)
         TypeMixedAmount -> DataMixedAmount
@@ -234,6 +238,7 @@ borderStyle border =
 
 data DataStyle =
       DataString
+    | DataInteger
     | DataDate
     | DataAmount CommoditySymbol AmountPrecision
     | DataMixedAmount
@@ -299,6 +304,10 @@ formatCell cell =
 
         valueType =
             case cellType cell of
+                TypeInteger ->
+                    printf
+                        "office:value-type='float' office:value='%s'"
+                        (cellContent cell)
                 TypeAmount amt ->
                     printf
                         "office:value-type='float' office:value='%s'"
@@ -343,6 +352,8 @@ styleNames cstyle border dataStyle =
     case dataStyle of
         DataDate ->
             (printf "%s-%s-date" cstyleName bordName, Just "iso-date")
+        DataInteger ->
+            (printf "%s-%s-integer" cstyleName bordName, Just "integer")
         DataAmount comm prec ->
             let name = numberStyleName (comm, prec) in
             (printf "%s-%s-%s" cstyleName bordName name,

--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -283,7 +283,9 @@ cellConfig ((border, cstyle), dataStyle) =
                     printf
                       "style:name='%s-%s-%s' style:data-style-name='number-%s'"
                       cstyleName bordName name name
-                _ -> printf "style:name='%s-%s'" cstyleName bordName
+                DataMixedAmount ->
+                    printf "style:name='%s-%s-mixedamount'" cstyleName bordName
+                DataString -> printf "style:name='%s-%s'" cstyleName bordName
     in
     case moreStyles of
         [] ->
@@ -309,7 +311,9 @@ formatCell cell =
                 DataAmount comm prec ->
                     let name = numberStyleName (comm, prec) in
                     printf "%s-%s-%s" cstyleName bordName name
-                _ -> printf "%s-%s" cstyleName bordName
+                DataMixedAmount ->
+                    printf "%s-%s-mixedamount" cstyleName bordName
+                DataString -> printf "%s-%s" cstyleName bordName
         tableStyle = printf " table:style-name='%s'"
 
         valueType =

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -19,6 +19,7 @@ module Hledger.Write.Spreadsheet (
     transposeCell,
     transpose,
     horizontalSpan,
+    addHeaderBorders,
     addRowSpanHeader,
     rawTableContent,
     ) where
@@ -171,6 +172,10 @@ transposeCell cell =
 transpose :: [[Cell border text]] -> [[Cell border text]]
 transpose = List.transpose . map (map transposeCell)
 
+
+addHeaderBorders :: [Cell () text] -> [Cell NumLines text]
+addHeaderBorders =
+    map (\c -> c {cellBorder = noBorder {borderBottom = DoubleLine}})
 
 horizontalSpan ::
     (Lines border, Monoid text) =>

--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -40,6 +40,7 @@ import Prelude hiding (span)
 
 data Type =
       TypeString
+    | TypeInteger
     | TypeAmount !Amount
     | TypeMixedAmount
     | TypeDate

--- a/hledger/Hledger/Cli/Anchor.hs
+++ b/hledger/Hledger/Cli/Anchor.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE QuasiQuotes          #-}
+module Hledger.Cli.Anchor (
+    setAccountAnchor,
+    dateCell,
+    dateSpanCell,
+    headerDateSpanCell,
+    ) where
+
+import qualified Data.Text as Text
+import Data.Text (Text)
+import Data.Time (Day)
+import Data.Maybe (fromMaybe)
+
+import qualified Text.URI as Uri
+import qualified Text.URI.QQ as UriQQ
+
+import qualified Hledger.Write.Spreadsheet as Spr
+import Hledger.Write.Spreadsheet (headerCell)
+import Hledger.Utils.Text (quoteIfSpaced)
+import Hledger.Data.Dates (showDateSpan, showDate)
+import Hledger.Data.Types (DateSpan)
+
+
+registerQueryUrl :: [Text] -> Text
+registerQueryUrl query =
+    Uri.render $
+    [UriQQ.uri|register|] {
+        Uri.uriQuery =
+            [Uri.QueryParam [UriQQ.queryKey|q|] $
+             fromMaybe (error "register URI query construction failed") $
+             Uri.mkQueryValue $ Text.unwords $
+             map quoteIfSpaced $ filter (not . Text.null) query]
+    }
+
+{- |
+>>> composeAnchor Nothing ["date:2024"]
+""
+>>> composeAnchor (Just "") ["date:2024"]
+"register?q=date:2024"
+>>> composeAnchor (Just "/") ["date:2024"]
+"/register?q=date:2024"
+>>> composeAnchor (Just "foo") ["date:2024"]
+"foo/register?q=date:2024"
+>>> composeAnchor (Just "foo/") ["date:2024"]
+"foo/register?q=date:2024"
+-}
+composeAnchor :: Maybe Text -> [Text] -> Text
+composeAnchor Nothing _ = mempty
+composeAnchor (Just baseUrl) query =
+    baseUrl <>
+    (if all (('/'==) . snd) $ Text.unsnoc baseUrl then "" else "/") <>
+    registerQueryUrl query
+
+-- cf. Web.Widget.Common
+removeDates :: [Text] -> [Text]
+removeDates =
+    filter (\term_ ->
+        not $ Text.isPrefixOf "date:" term_ || Text.isPrefixOf "date2:" term_)
+
+replaceDate :: Text -> [Text] -> [Text]
+replaceDate prd query = "date:"<>prd : removeDates query
+
+headerDateSpanCell ::
+    Maybe Text -> [Text] -> DateSpan -> Spr.Cell () Text
+headerDateSpanCell base query spn =
+    let prd = showDateSpan spn in
+    (headerCell prd) {
+        Spr.cellAnchor = composeAnchor base $ replaceDate prd query
+    }
+
+
+dateQueryCell ::
+    (Spr.Lines border) =>
+    Maybe Text -> [Text] -> Text -> Text -> Spr.Cell border Text
+dateQueryCell base query acct dateTerm =
+    (Spr.defaultCell dateTerm) {
+        Spr.cellAnchor =
+            composeAnchor base $ "inacct:"<>acct : replaceDate dateTerm query
+    }
+
+dateCell ::
+    (Spr.Lines border) =>
+    Maybe Text -> [Text] -> Text -> Day -> Spr.Cell border Text
+dateCell base query acct = dateQueryCell base query acct . showDate
+
+dateSpanCell ::
+    (Spr.Lines border) =>
+    Maybe Text -> [Text] -> Text -> DateSpan -> Spr.Cell border Text
+dateSpanCell base query acct = dateQueryCell base query acct . showDateSpan
+
+setAccountAnchor ::
+    Maybe Text -> [Text] -> Text -> Spr.Cell border text -> Spr.Cell border text
+setAccountAnchor base query acct cell =
+    cell {Spr.cellAnchor = composeAnchor base $ "inacct:"<>acct : query}

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -308,7 +308,7 @@ import Hledger.Cli.Utils
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
 import Hledger.Write.Ods (printFods)
 import Hledger.Write.Html.Lucid (printHtml)
-import Hledger.Write.Spreadsheet (rawTableContent, addRowSpanHeader, headerCell)
+import Hledger.Write.Spreadsheet (rawTableContent, addHeaderBorders, addRowSpanHeader, headerCell)
 import qualified Hledger.Write.Spreadsheet as Ods
 
 
@@ -640,11 +640,6 @@ headerDateSpanCell base query spn =
     (headerCell prd) {
         Ods.cellAnchor = composeAnchor base $ replaceDate prd query
     }
-
-addHeaderBorders :: [Ods.Cell () text] -> [Ods.Cell Ods.NumLines text]
-addHeaderBorders =
-    map (\c -> c {Ods.cellBorder =
-                        Ods.noBorder {Ods.borderBottom = Ods.DoubleLine}})
 
 simpleDateSpanCell :: DateSpan -> Ods.Cell Ods.NumLines Text
 simpleDateSpanCell = Ods.defaultCell . showDateSpan

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -308,7 +308,9 @@ import Hledger.Cli.Utils
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
 import Hledger.Write.Ods (printFods)
 import Hledger.Write.Html.Lucid (printHtml)
-import Hledger.Write.Spreadsheet (rawTableContent, addHeaderBorders, addRowSpanHeader, headerCell)
+import Hledger.Write.Spreadsheet (rawTableContent, headerCell,
+            addHeaderBorders, addRowSpanHeader,
+            cellFromMixedAmount, cellsFromMixedAmount)
 import qualified Hledger.Write.Spreadsheet as Ods
 
 
@@ -709,37 +711,6 @@ balanceReportAsSpreadsheet opts (items, total) =
         (showcomm, commorder)
           | layout_ opts == LayoutBare = (False, Just $ S.toList $ maCommodities mixedAmt)
           | otherwise                  = (True, Nothing)
-
-cellFromMixedAmount ::
-    (Ods.Lines border) =>
-    AmountFormat -> (Ods.Class, MixedAmount) -> Ods.Cell border WideBuilder
-cellFromMixedAmount bopts (cls, mixedAmt) =
-    (Ods.defaultCell $ showMixedAmountB bopts mixedAmt) {
-        Ods.cellClass = cls,
-        Ods.cellType =
-          case unifyMixedAmount mixedAmt of
-            Just amt -> amountType bopts amt
-            Nothing -> Ods.TypeMixedAmount
-    }
-
-cellsFromMixedAmount ::
-    (Ods.Lines border) =>
-    AmountFormat -> (Ods.Class, MixedAmount) -> [Ods.Cell border WideBuilder]
-cellsFromMixedAmount bopts (cls, mixedAmt) =
-    map
-        (\(str,amt) ->
-            (Ods.defaultCell str) {
-                Ods.cellClass = cls,
-                Ods.cellType = amountType bopts amt
-            })
-        (showMixedAmountLinesPartsB bopts mixedAmt)
-
-amountType :: AmountFormat -> Amount -> Ods.Type
-amountType bopts amt =
-    Ods.TypeAmount $
-    if displayCommodity bopts
-      then amt
-      else amt {acommodity = T.empty}
 
 
 

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -127,7 +127,7 @@ postingsReportItemAsRecord ::
     (Spr.Lines border) =>
     AmountFormat -> PostingsReportItem -> [Spr.Cell border T.Text]
 postingsReportItemAsRecord fmt (_, _, _, p, b) =
-    [cell idx,
+    [(cell idx) {Spr.cellType = Spr.TypeInteger},
      (cell date) {Spr.cellType = Spr.TypeDate},
      cell code, cell desc, cell acct,
      amountCell (pamount p),

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -110,6 +110,7 @@ flag threaded
 library
   exposed-modules:
       Hledger.Cli
+      Hledger.Cli.Anchor
       Hledger.Cli.Anon
       Hledger.Cli.CliOptions
       Hledger.Cli.Commands

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -674,7 +674,7 @@ Here are those commands and the formats currently supported:
 | cashflow           | Y   | Y    | Y       |      |           |     | Y    |
 | incomestatement    | Y   | Y    | Y       |      |           |     | Y    |
 | print              | Y   |      | Y       |      | Y         | Y   | Y    |
-| register           | Y   |      | Y       |      |           |     | Y    |
+| register           | Y   | Y    | Y       | Y    |           |     | Y    |
 
 <!--
 | accounts              |     |     |      |      |     |

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -681,7 +681,7 @@ Output
        cashflow                Y       Y        Y                                           Y
        incomestatement         Y       Y        Y                                           Y
        print                   Y                Y                    Y              Y       Y
-       register                Y                Y                                           Y
+       register                Y       Y        Y           Y                               Y
 
        The output format is selected by the -O/--output-format=FMT option:
 

--- a/hledger/package.yaml
+++ b/hledger/package.yaml
@@ -164,6 +164,7 @@ library:
   cpp-options: -DVERSION="1.40.99"
   exposed-modules:
   - Hledger.Cli
+  - Hledger.Cli.Anchor
   - Hledger.Cli.Anon
   - Hledger.Cli.CliOptions
   - Hledger.Cli.Commands


### PR DESCRIPTION
Unified export to CSV, HTML, FODS via Write.Spreadsheet.

Supports --base-url and hyperlinks to hledger-web.
I intended to hyperlink from txnidx to hledger-web/journal page, however, this would require to move Web.Widget.Common.transactionFragment to `hledger` package. It's not super important for now.
