### PR TITLE
feat: use a pager for all large terminal output, not just for help

### DIFF
--- a/hledger-lib/Hledger/Data/RawOptions.hs
+++ b/hledger-lib/Hledger/Data/RawOptions.hs
@@ -9,6 +9,7 @@ more easily by hledger commands/scripts in this and other packages.
 
 module Hledger.Data.RawOptions (
   RawOpts,
+  YNA,
   mkRawOpts,
   overRawOpts,
   setopt,
@@ -26,7 +27,9 @@ module Hledger.Data.RawOptions (
   posintopt,
   maybeintopt,
   maybeposintopt,
-  maybecharopt
+  maybecharopt,
+  maybeynopt,
+  maybeynaopt,
 )
 where
 
@@ -35,6 +38,8 @@ import Data.Default (Default(..))
 import Safe (headMay, lastMay, readDef)
 
 import Hledger.Utils
+import Data.Char (toLower)
+import Data.List (intercalate)
 
 
 -- | The result of running cmdargs: an association list of option names to string values.
@@ -139,3 +144,22 @@ maybeclippedintopt minVal maxVal name =
                                          ++ " must lie in the range "
                                          ++ show minVal ++ " to " ++ show maxVal
                                          ++ ", but is " ++ show n
+
+maybeynopt :: String -> RawOpts -> Maybe Bool
+maybeynopt name rawopts =
+  case maybestringopt name rawopts of
+    Just v | map toLower v `elem` ["y","yes","always"] -> Just True
+    Just v | map toLower v `elem` ["n","no","never"]   -> Just False
+    Just _ -> error' $ name <> " value should be one of " <> (intercalate ", " ["y","yes","n","no"])
+    _ -> Nothing
+
+data YNA = Yes | No | Auto deriving (Eq,Show)
+
+maybeynaopt :: String -> RawOpts -> Maybe YNA
+maybeynaopt name rawopts =
+  case maybestringopt name rawopts of
+    Just v | map toLower v `elem` ["y","yes","always"] -> Just Yes
+    Just v | map toLower v `elem` ["n","no","never"]   -> Just No
+    Just v | map toLower v `elem` ["a","auto"]         -> Just Auto
+    Just _ -> error' $ name <> " value should be one of " <> (intercalate ", " ["y","yes","n","no","a","auto"])
+    _ -> Nothing

--- a/hledger-lib/Hledger/Data/RawOptions.hs
+++ b/hledger-lib/Hledger/Data/RawOptions.hs
@@ -9,7 +9,6 @@ more easily by hledger commands/scripts in this and other packages.
 
 module Hledger.Data.RawOptions (
   RawOpts,
-  YNA,
   mkRawOpts,
   overRawOpts,
   setopt,
@@ -152,8 +151,6 @@ maybeynopt name rawopts =
     Just v | map toLower v `elem` ["n","no","never"]   -> Just False
     Just _ -> error' $ name <> " value should be one of " <> (intercalate ", " ["y","yes","n","no"])
     _ -> Nothing
-
-data YNA = Yes | No | Auto deriving (Eq,Show)
 
 maybeynaopt :: String -> RawOpts -> Maybe YNA
 maybeynaopt name rawopts =

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -192,14 +192,14 @@ instance Show (Reader m) where show r = show (rFormat r) ++ " reader"
 
 -- | Parse an InputOpts from a RawOpts and a provided date.
 -- This will fail with a usage error if the forecast period expression cannot be parsed.
-rawOptsToInputOpts :: Day -> RawOpts -> InputOpts
-rawOptsToInputOpts day rawopts =
+rawOptsToInputOpts :: Day -> Bool -> RawOpts -> InputOpts
+rawOptsToInputOpts day usecoloronstdout rawopts =
 
     let noinferbalancingcosts = boolopt "strict" rawopts || stringopt "args" rawopts == "balanced"
 
         -- Do we really need to do all this work just to get the requested end date? This is duplicating
         -- much of reportOptsToSpec.
-        ropts = rawOptsToReportOpts day rawopts
+        ropts = rawOptsToReportOpts day usecoloronstdout rawopts
         argsquery = map fst . rights . map (parseQueryTerm day) $ querystring_ ropts
         datequery = simplifyQuery . filterQuery queryIsDate . And $ queryFromFlags ropts : argsquery
 

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -346,7 +346,7 @@ ynopt opt rawopts = case maybestringopt opt rawopts of
     Just "never"  -> Just False
     Just "no"     -> Just False
     Just "n"      -> Just False
-    Just _        -> usageError "--pretty's argument should be \"yes\" or \"no\" (or y, n, always, never)"
+    Just _        -> usageError "this argument should be one of y, yes, n, no"
     _             -> Nothing
 
 balanceAccumulationOverride :: RawOpts -> Maybe BalanceAccumulation

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -226,14 +226,14 @@ defreportopts = ReportOpts
     , layout_           = LayoutWide Nothing
     }
 
--- | Generate a ReportOpts from raw command-line input, given a day.
+-- | Generate a ReportOpts from raw command-line input, given a day and whether to use ANSI colour/styles in standard output.
 -- This will fail with a usage error if it is passed
 -- - an invalid --format argument,
 -- - an invalid --value argument,
 -- - if --valuechange is called with a valuation type other than -V/--value=end.
 -- - an invalid --pretty argument,
-rawOptsToReportOpts :: Day -> RawOpts -> ReportOpts
-rawOptsToReportOpts d rawopts =
+rawOptsToReportOpts :: Day -> Bool -> RawOpts -> ReportOpts
+rawOptsToReportOpts d usecoloronstdout rawopts =
 
     let formatstring = T.pack <$> maybestringopt "format" rawopts
         querystring  = map T.pack $ listofstringopt "args" rawopts  -- doesn't handle an arg like "" right
@@ -277,7 +277,7 @@ rawOptsToReportOpts d rawopts =
           ,percent_          = boolopt "percent" rawopts
           ,invert_           = boolopt "invert" rawopts
           ,pretty_           = pretty
-          ,color_            = useColorOnStdout -- a lower-level helper
+          ,color_            = usecoloronstdout
           ,transpose_        = boolopt "transpose" rawopts
           ,layout_           = layoutopt rawopts
           }
@@ -941,5 +941,5 @@ updateReportSpecWith = overEither reportOpts
 
 -- | Generate a ReportSpec from RawOpts and a provided day, or return an error
 -- string if there are regular expression errors.
-rawOptsToReportSpec :: Day -> RawOpts -> Either String ReportSpec
-rawOptsToReportSpec day = reportOptsToSpec day . rawOptsToReportOpts day
+rawOptsToReportSpec :: Day -> Bool -> RawOpts -> Either String ReportSpec
+rawOptsToReportSpec day coloronstdout = reportOptsToSpec day . rawOptsToReportOpts day coloronstdout

--- a/hledger-lib/Hledger/Utils/IO.hs
+++ b/hledger-lib/Hledger/Utils/IO.hs
@@ -202,10 +202,6 @@ setupPager = do
   addR "LESS"
   addR "MORE"
 
--- | Check if the --no-pager command line flag was provided at program startup, using unsafePerformIO.
-noPagerFlag :: Bool
-noPagerFlag = "--no-pager" `elem` progArgs
-
 -- related: Hledger.Cli.DocFiles.runPagerForTopic
 -- | Display the given text on the terminal, using the user's $PAGER if the text is taller 
 -- than the current terminal and stdout is interactive and TERM is not "dumb";
@@ -220,7 +216,7 @@ pager = putStr
 #else
 pager s = do
   -- disable pager when --no-pager is specified
-  let nopager = noPagerFlag
+  nopager <- elem "--no-pager" <$> getArgs
   -- disable pager when TERM=dumb (for Emacs shell users)
   dumbterm <- (== Just "dumb") <$> lookupEnv "TERM"
   -- disable pager with single-line output (https://github.com/pharpend/pager/issues/2)
@@ -250,6 +246,13 @@ pager s = do
 {-# NOINLINE progArgs #-}
 progArgs :: [String]
 progArgs = unsafePerformIO getArgs
+-- XXX While convenient, using this has the following problem:
+-- it detects flags/options/arguments from the command line, but not from a config file.
+-- Currently this affects:
+--  --debug
+--  --color
+--  the enabling of orderdates and assertions checks in journalFinalise
+-- Separate these into unsafe and safe variants and try to use the latter more
 
 -- | Read the value of the -o/--output-file command line option provided at program startup,
 -- if any, using unsafePerformIO.

--- a/hledger-lib/Hledger/Utils/IO.hs
+++ b/hledger-lib/Hledger/Utils/IO.hs
@@ -171,12 +171,12 @@ pprint' = pPrintOpt NoCheckColorTty prettyoptsNoColor
 -- "Avoid using pshow, pprint, dbg* in the code below to prevent infinite loops." (?)
 
 -- | Display the given text on the terminal, using the user's $PAGER if the text is taller 
--- than the current terminal and stdout is interactive and TERM is not "dumb"
--- (except on Windows, where a pager will not be used).
+-- than the current terminal and stdout is interactive and TERM is not "dumb";
+-- except on Windows, where currently we don't attempt to use a pager.
 -- If the text contains ANSI codes, because hledger thinks the current terminal
 -- supports those, the pager should be configured to display those, otherwise
 -- users will see junk on screen (#2015).
--- We call "setLessR" at hledger startup to make that less likely.
+-- We call "setupPager" at hledger startup to make that less likely.
 pager :: String -> IO ()
 #ifdef mingw32_HOST_OS
 pager = putStrLn

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -138,7 +138,7 @@ library
     , containers >=0.5.9
     , data-default >=0.5
     , deepseq
-    , directory
+    , directory >=1.2.6.1
     , doclayout >=0.3 && <0.6
     , extra >=1.6.3
     , file-embed >=0.0.10
@@ -202,7 +202,7 @@ test-suite doctest
     , containers >=0.5.9
     , data-default >=0.5
     , deepseq
-    , directory
+    , directory >=1.2.6.1
     , doclayout >=0.3 && <0.6
     , doctest >=0.18.1
     , extra >=1.6.3
@@ -269,7 +269,7 @@ test-suite unittest
     , containers >=0.5.9
     , data-default >=0.5
     , deepseq
-    , directory
+    , directory >=1.2.6.1
     , doclayout >=0.3 && <0.6
     , extra >=1.6.3
     , file-embed >=0.0.10

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -57,7 +57,7 @@ dependencies:
 - data-default >=0.5
 - deepseq
 - Decimal >=0.5.1
-- directory
+- directory >=1.2.6.1
 - doclayout >=0.3 && <0.6
 - file-embed >=0.0.10
 - filepath

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -66,7 +66,8 @@ hledgerUiMain = withGhcDebug' $ withProgName "hledger-ui.log" $ do  -- force Hle
   dbg1IO "debugLevel" debugLevel
 
   -- try to encourage user's $PAGER to properly display ANSI (in command line help)
-  when useColorOnStdout setupPager
+  usecolor <- useColorOnStdout
+  when usecolor setupPager
 
   opts@UIOpts{uoCliOpts=copts@CliOpts{inputopts_=iopts,rawopts_=rawopts}} <- getHledgerUIOpts
   -- when (debug_ $ cliopts_ opts) $ printf "%s\n" prognameandversion >> printf "opts: %s\n" (show opts)

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -75,7 +75,7 @@ hledgerUiMain = withGhcDebug' $ withProgName "hledger-ui.log" $ do  -- force Hle
   let copts' = copts{inputopts_=iopts{forecast_=forecast_ iopts <|> Just nulldatespan}}
 
   case True of
-    _ | boolopt "help"    rawopts -> pager $ showModeUsage uimode ++ "\n"
+    _ | boolopt "help"    rawopts -> runPager $ showModeUsage uimode ++ "\n"
     _ | boolopt "tldr"    rawopts -> runTldrForPage "hledger-ui"
     _ | boolopt "info"    rawopts -> runInfoForTopic "hledger-ui" Nothing
     _ | boolopt "man"     rawopts -> runManForTopic  "hledger-ui" Nothing

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -50,7 +50,8 @@ hledgerWebMain = withGhcDebug' $ do
   when (ghcDebugMode == GDPauseAtStart) $ ghcDebugPause'
 
   -- try to encourage user's $PAGER to properly display ANSI (in command line help)
-  when useColorOnStdout setupPager
+  usecolor <- useColorOnStdout
+  when usecolor setupPager
 
   wopts@WebOpts{cliopts_=copts@CliOpts{debug_, rawopts_}} <- getHledgerWebOpts
   when (debug_ > 0) $ printf "%s\n" prognameandversion >> printf "opts: %s\n" (show wopts)

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -55,7 +55,7 @@ hledgerWebMain = withGhcDebug' $ do
   wopts@WebOpts{cliopts_=copts@CliOpts{debug_, rawopts_}} <- getHledgerWebOpts
   when (debug_ > 0) $ printf "%s\n" prognameandversion >> printf "opts: %s\n" (show wopts)
   if
-    | boolopt "help"            rawopts_ -> pager $ showModeUsage webmode ++ "\n"
+    | boolopt "help"            rawopts_ -> runPager $ showModeUsage webmode ++ "\n"
     | boolopt "tldr"            rawopts_ -> runTldrForPage "hledger-web"
     | boolopt "info"            rawopts_ -> runInfoForTopic "hledger-web" Nothing
     | boolopt "man"             rawopts_ -> runManForTopic  "hledger-web" Nothing

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -126,9 +126,10 @@ hledgerWebTest = do
 
     -- yit "can add transactions" $ do
 
+  usecolor <- useColorOnStdout
   let
     rawopts = [("forecast","")]
-    iopts = rawOptsToInputOpts d $ mkRawOpts rawopts
+    iopts = rawOptsToInputOpts d usecolor $ mkRawOpts rawopts
     f = "fake"  -- need a non-null filename so forecast transactions get index 0
   pj <- readJournal' (T.pack $ unlines  -- PARTIAL: readJournal' should not fail
     ["~ monthly"

--- a/hledger.conf
+++ b/hledger.conf
@@ -1,6 +1,14 @@
 # This is an empty config file, to disable your personal hledger config
 # while developing and testing hledger in this directory.
 # For an example config, see hledger.conf.sample.
---pager yes
-# --color=no
-# --debug
+
+# --pager n
+# this works
+
+# --color n
+# this mostly works, but does not affect
+# 1. debug output
+# 2. the ansi helpers used by check recentassertions
+
+#--debug
+# this doesn't work in config files yet

--- a/hledger.conf
+++ b/hledger.conf
@@ -1,3 +1,6 @@
 # This is an empty config file, to disable your personal hledger config
 # while developing and testing hledger in this directory.
 # For an example config, see hledger.conf.sample.
+--pager yes
+# --color=no
+# --debug

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -338,7 +338,12 @@ main = withGhcDebug' $ do
     manFlag     = boolopt "man"     rawopts
     versionFlag = boolopt "version" rawopts
 
-  if
+  -- Ensure that anything calling getArgs later will see all args, including config file args.
+  -- Some things (--color, --debug, some checks in journalFinalise) are detected by unsafePerformIO,
+  -- eg in Hledger.Utils.IO.progArgs, which means they aren't be seen in a config file
+  -- (because many things before this point have forced the one-time evaluation of progArgs).
+  withArgs (progname:finalargs) $
+   if
     -- 6.1. no command and a help/doc flag found - show general help/docs
     | nocmdprovided && helpFlag -> pager $ showModeUsage (mainmode []) ++ "\n"
     | nocmdprovided && tldrFlag -> runTldrForPage  "hledger"

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -345,7 +345,7 @@ main = withGhcDebug' $ do
   withArgs (progname:finalargs) $
    if
     -- 6.1. no command and a help/doc flag found - show general help/docs
-    | nocmdprovided && helpFlag -> pager $ showModeUsage (mainmode []) ++ "\n"
+    | nocmdprovided && helpFlag -> runPager $ showModeUsage (mainmode []) ++ "\n"
     | nocmdprovided && tldrFlag -> runTldrForPage  "hledger"
     | nocmdprovided && infoFlag -> runInfoForTopic "hledger" Nothing
     | nocmdprovided && manFlag  -> runManForTopic  "hledger" Nothing
@@ -375,7 +375,7 @@ main = withGhcDebug' $ do
       -- run the builtin command according to its type
       if
         -- 6.5.1. help/doc flag - show command help/docs
-        | helpFlag  -> pager $ showModeUsage cmdmode ++ "\n"
+        | helpFlag  -> runPager $ showModeUsage cmdmode ++ "\n"
         | tldrFlag  -> runTldrForPage tldrpagename
         | infoFlag  -> runInfoForTopic "hledger" mmodecmdname
         | manFlag   -> runManForTopic "hledger"  mmodecmdname

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -204,7 +204,8 @@ main = withGhcDebug' $ do
   -- give ghc-debug a chance to take control
   when (ghcDebugMode == GDPauseAtStart) $ ghcDebugPause'
   -- try to encourage user's $PAGER to display ANSI when supported
-  when useColorOnStdout setupPager
+  usecolor <- useColorOnStdout
+  when usecolor setupPager
   -- Search PATH for addon commands. Exclude any that match builtin command names.
   addons <- hledgerAddons <&> filter (not . (`elem` builtinCommandNames) . dropExtension)
 
@@ -269,6 +270,7 @@ main = withGhcDebug' $ do
     -- the command line contains a bad flag or wrongly present/missing flag value,
     -- cmdname will be "".
     args = [confcmdarg | not $ null confcmdarg] <> cliargswithcmdfirstwithoutclispecific
+    -- XXX Unknown flag: --depth while parsing these args for command name
     cmdname = stringopt "command" $ cmdargsParse "for command name" (mainmode addons) args
     badcmdprovided = null cmdname && not nocmdprovided
     isaddoncmd     = not (null cmdname) && cmdname `elem` addons

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -22,6 +22,7 @@ module Hledger.Cli.CliOptions (
   -- * cmdargs flags & modes
   inputflags,
   reportflags,
+  terminalflags,
   helpflags,
   helpflagstitle,
   flattreeflags,
@@ -223,17 +224,8 @@ reportflags = [
       ,"'now':      value today"
       ,"YYYY-MM-DD: value on given date"
       ])
-
-  -- general output-related
  ,flagReq ["commodity-style", "c"] (\s opts -> Right $ setopt "commodity-style" s opts) "S"
     "Override a commodity's display style.\nEg: -c '$1000.' or -c '1.000,00 EUR'"
-  -- This has special support in hledger-lib:colorOption, keep synced
- ,flagNone ["no-pager"] (setboolopt "no-pager") "don't use a pager for long output"
- ,flagReq  ["color","colour"] (\s opts -> Right $ setopt "color" s opts) "YN"
-   (unlines
-     ["Use ANSI color codes in text output? Can be"
-     ,"'y'/'yes'/'always', 'n'/'no'/'never' or 'auto'."
-     ])
  ,flagOpt "yes" ["pretty"] (\s opts -> Right $ setopt "pretty" s opts) "YN"
     "Use box-drawing characters in text output? Can be\n'y'/'yes' or 'n'/'no'.\nIf YN is specified, the equals is required."
  ]
@@ -250,6 +242,19 @@ helpflags = [
  ,flagReq  ["debug"]    (\s opts -> Right $ setopt "debug" s opts) "[1-9]" "show this much debug output (default: 1)"
  ]
 -- XXX why are these duplicated in defCommandMode below ?
+ <> terminalflags
+
+-- Low-level flags affecting terminal output.
+-- These are included in helpflags so they appear everywhere.
+terminalflags = [
+  flagNone ["no-pager"] (setboolopt "no-pager") "don't use a pager for long output"
+  -- This has special support in hledger-lib:colorOption, keep synced
+ ,flagReq  ["color","colour"] (\s opts -> Right $ setopt "color" s opts) "YN"
+   (unlines
+     ["Use ANSI color codes in text output? Can be"
+     ,"'y'/'yes'/'always', 'n'/'no'/'never' or 'auto'."
+     ])
+ ]
 
 -- | Flags for selecting flat/tree mode, used for reports organised by account.
 -- With a True argument, shows some extra help about inclusive/exclusive amounts.
@@ -269,7 +274,7 @@ confflags = [
   ,flagNone ["no-conf","n"] (setboolopt "no-conf") "ignore any config file"
   ]
 
--- | Common legacy flags that are accepted but not shown in --help.
+-- | Common legacy flags that are accepted but not shown in --help, when running the main mode.
 hiddenflagsformainmode :: [Flag RawOpts]
 hiddenflagsformainmode = [
    flagNone ["effective","aux-date"] (setboolopt "date2") "Ledger-compatible aliases for --date2"
@@ -280,7 +285,8 @@ hiddenflagsformainmode = [
   ,flagReq  ["rules-file"]           (\s opts -> Right $ setopt "rules" s opts) "RULESFILE" "was renamed to --rules"
   ]
 
--- Subcommands/addons add the conf flags, so they won't error if those are present.
+-- Hidden flags accepted but not shown, when running subcommand or addon command modes.
+-- Here we add the confflags, so their presence won't cause an error,
 hiddenflags :: [Flag RawOpts]
 hiddenflags = hiddenflagsformainmode ++ confflags
 

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -22,8 +22,8 @@ module Hledger.Cli.CliOptions (
   -- * cmdargs flags & modes
   inputflags,
   reportflags,
-  terminalflags,
   helpflags,
+  terminalflags,
   helpflagstitle,
   flattreeflags,
   confflags,
@@ -240,17 +240,17 @@ helpflags = [
   -- flagOpt would be more correct for --debug, showing --debug[=LVL] rather than --debug=[LVL] in help.
   -- But flagReq plus special handling in Cli.hs makes the = optional, removing a source of confusion.
  ,flagReq  ["debug"]    (\s opts -> Right $ setopt "debug" s opts) "[1-9]" "show this much debug output (default: 1)"
- ]
--- XXX why are these duplicated in defCommandMode below ?
+ ] -- XXX why are these duplicated in defCommandMode below ?
  <> terminalflags
 
 -- Low-level flags affecting terminal output.
 -- These are included in helpflags so they appear everywhere.
 terminalflags = [
-  flagNone ["no-pager"] (setboolopt "no-pager") "don't use a pager for long output"
+  flagReq  ["pager"] (\s opts -> Right $ setopt "pager" s opts) "YN"
+   "use pager for long output ? y/yes or n/no"
   -- This has special support in hledger-lib:colorOption, keep synced
  ,flagReq  ["color","colour"] (\s opts -> Right $ setopt "color" s opts) "YN"
-   "use ANSI color in terminal ? 'y'/'yes', 'n'/'no', or 'auto' (default)"
+   "use ANSI color ? y/yes, n/no, or auto (default)"
  ]
 
 -- | Flags for selecting flat/tree mode, used for reports organised by account.
@@ -542,6 +542,8 @@ data CliOpts = CliOpts {
     ,reportspec_      :: ReportSpec
     ,output_file_     :: Maybe FilePath
     ,output_format_   :: Maybe String
+    ,pageropt_        :: Maybe Bool     -- ^ --pager
+    ,coloropt_        :: Maybe YNA      -- ^ --color. Controls use of ANSI color and ANSI styles.
     ,debug_           :: Int            -- ^ debug level, set by @--debug[=N]@. See also 'Hledger.Utils.debugLevel'.
     ,no_new_accounts_ :: Bool           -- add
     ,width_           :: Maybe String   -- ^ the --width value provided, if any
@@ -563,6 +565,8 @@ defcliopts = CliOpts
     , reportspec_      = def
     , output_file_     = Nothing
     , output_format_   = Nothing
+    , pageropt_        = Nothing
+    , coloropt_        = Nothing
     , debug_           = 0
     , no_new_accounts_ = False
     , width_           = Nothing
@@ -621,6 +625,8 @@ rawOptsToCliOpts rawopts = do
              ,reportspec_      = rspec
              ,output_file_     = maybestringopt "output-file" rawopts
              ,output_format_   = maybestringopt "output-format" rawopts
+             ,pageropt_        = maybeynopt "pager" rawopts
+             ,coloropt_        = maybeynaopt "color" rawopts
              ,debug_           = posintopt "debug" rawopts
              ,no_new_accounts_ = boolopt "no-new-accounts" rawopts -- add
              ,width_           = maybestringopt "width" rawopts

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -228,6 +228,7 @@ reportflags = [
  ,flagReq ["commodity-style", "c"] (\s opts -> Right $ setopt "commodity-style" s opts) "S"
     "Override a commodity's display style.\nEg: -c '$1000.' or -c '1.000,00 EUR'"
   -- This has special support in hledger-lib:colorOption, keep synced
+ ,flagNone ["no-pager"] (setboolopt "no-pager") "don't use a pager for long output"
  ,flagReq  ["color","colour"] (\s opts -> Right $ setopt "color" s opts) "YN"
    (unlines
      ["Use ANSI color codes in text output? Can be"

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -493,7 +493,7 @@ showModeUsage =
 
 -- | Add some ANSI decoration to cmdargs' help output.
 highlightHelp
-  | not useColorOnStdout = id
+  | not useColorOnStdoutUnsafe = id   -- XXX unsafe boldening help headings - seems to work, even respecting config file
   | otherwise = unlines . zipWith (curry f) [1..] . lines
   where
     f (n,l)
@@ -606,8 +606,9 @@ rawOptsToCliOpts rawopts = do
               Nothing -> currentDay
               Just d  -> either (const err) fromEFDay $ fixSmartDateStrEither' currentDay (T.pack d)
                 where err = error' $ "Unable to parse date \"" ++ d ++ "\""
-  let iopts = rawOptsToInputOpts day rawopts
-  rspec <- either error' pure $ rawOptsToReportSpec day rawopts  -- PARTIAL:
+  usecolor <- useColorOnStdout
+  let iopts = rawOptsToInputOpts day usecolor rawopts
+  rspec <- either error' pure $ rawOptsToReportSpec day usecolor rawopts  -- PARTIAL:
   mcolumns <- readMay <$> getEnvSafe "COLUMNS"
   mtermwidth <-
 #ifdef mingw32_HOST_OS

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -250,10 +250,7 @@ terminalflags = [
   flagNone ["no-pager"] (setboolopt "no-pager") "don't use a pager for long output"
   -- This has special support in hledger-lib:colorOption, keep synced
  ,flagReq  ["color","colour"] (\s opts -> Right $ setopt "color" s opts) "YN"
-   (unlines
-     ["Use ANSI color codes in text output? Can be"
-     ,"'y'/'yes'/'always', 'n'/'no'/'never' or 'auto'."
-     ])
+   "use ANSI color in terminal ? 'y'/'yes', 'n'/'no', or 'auto' (default)"
  ]
 
 -- | Flags for selecting flat/tree mode, used for reports organised by account.

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -163,7 +163,7 @@ _banner_speed = drop 1 [""
 -- picking one that will contrast with the current terminal background colour.
 accent :: String -> String
 accent
-  | not useColorOnStdout          = id
+  | not useColorOnStdoutUnsafe    = id  -- XXX unsafe accenting the title banner - seems to work, even respecting config file
   | terminalIsLight == Just False = brightWhite
   | terminalIsLight == Just True  = brightBlack
   | otherwise                     = id

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -327,7 +327,7 @@ printCommandsList progversion installedaddons =
   seq (length $ dbg8 "uninstalledknownaddons" uninstalledknownaddons) $  -- for debug output
   seq (length $ dbg8 "installedknownaddons"   installedknownaddons)   $
   seq (length $ dbg8 "installedunknownaddons" installedunknownaddons) $
-  pager $ unlines $ map unplus $ filter (not.isuninstalledaddon) $
+  runPager $ unlines $ map unplus $ filter (not.isuninstalledaddon) $
   commandsList progversion installedunknownaddons
   where
     knownaddons = knownAddonCommands

--- a/hledger/Hledger/Cli/DocFiles.hs
+++ b/hledger/Hledger/Cli/DocFiles.hs
@@ -109,6 +109,7 @@ runInfoForTopic tool mtopic =
 -- less with any vertical whitespace squashed, case-insensitive searching, the $ regex metacharacter accessible as \$.
 less = "less -s -i --use-backslash"
 
+-- related: Hledger.Utils.IO.pager
 -- | Display plain text help for this tool, scrolled to the given topic if any, using the users $PAGER or "less".
 -- When a topic is provided we always use less, ignoring $PAGER.
 runPagerForTopic :: Tool -> Maybe Topic -> IO ()

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -130,7 +130,7 @@ writeOutput opts s = do
 writeOutputLazyText :: CliOpts -> TL.Text -> IO ()
 writeOutputLazyText opts s = do
   f <- outputFileFromOpts opts
-  maybe (pager.TL.unpack) TL.writeFile f s
+  maybe (pager . TL.unpack) TL.writeFile f s
 
 -- -- | Get a journal from the given string and options, or throw an error.
 -- readJournal :: CliOpts -> String -> IO Journal

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -123,13 +123,14 @@ writeOutput opts s = do
   f <- outputFileFromOpts opts
   (maybe putStr writeFile f) s
 
--- | Write some output to stdout or to a file selected by --output-file.
--- If the file exists it will be overwritten. This function operates on Lazy
--- Text values.
+-- | Write some output, to a file specified by --output-file if any,
+-- otherwise to stdout.
+-- If writing to a file and the file exists, it will be overwritten.
+-- If writing to stdout, a pager is used when appropriate and possible.
 writeOutputLazyText :: CliOpts -> TL.Text -> IO ()
 writeOutputLazyText opts s = do
   f <- outputFileFromOpts opts
-  (maybe TL.putStr TL.writeFile f) s
+  maybe (pager.TL.unpack) TL.writeFile f s
 
 -- -- | Get a journal from the given string and options, or throw an error.
 -- readJournal :: CliOpts -> String -> IO Journal

--- a/hledger/Hledger/Cli/Utils.hs
+++ b/hledger/Hledger/Cli/Utils.hs
@@ -130,7 +130,7 @@ writeOutput opts s = do
 writeOutputLazyText :: CliOpts -> TL.Text -> IO ()
 writeOutputLazyText opts s = do
   f <- outputFileFromOpts opts
-  maybe (pager . TL.unpack) TL.writeFile f s
+  maybe (runPager . TL.unpack) TL.writeFile f s
 
 -- -- | Get a journal from the given string and options, or throw an error.
 -- readJournal :: CliOpts -> String -> IO Journal

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -736,8 +736,8 @@ in `less` (and in its `more` compatibility mode).
 If you use a different pager, you might need to configure it similarly, to avoid seeing junk on screen.
 Or you can set the `NO_COLOR` environment variable described below.
 
-You can prevent the use of a pager by using the `--no-pager` flag,
-eg in your hledger config file.
+You can prevent the use of a pager by providing the `--no-pager` flag at the command line,
+or in a config file.
 
 Here are some notes about the various output formats.
 
@@ -769,6 +769,7 @@ You can override this in the usual ways.
 If the `NO_COLOR` environment variable is set, colour will be disabled by default.
 Or you can use the `--color/--colour` option with a `yes`/`always` value,
 or `no`/`never`, to force colour on or off.
+(This option doesn't work in a config file yet.)
 
 #### Box-drawing
 
@@ -936,6 +937,7 @@ To capture debug output in a log file instead, you can usually redirect stderr, 
 ```cli
 hledger bal --debug=3 2>hledger.log
 ```
+(This option doesn't work in a config file yet.)
 
 # Environment
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -721,6 +721,21 @@ The `-O` option can be combined with `-o` to override the file extension if need
 $ hledger balancesheet -o foo.txt -O csv    # write CSV to foo.txt
 ```
 
+## Paging
+
+On unix-like systems, when displaying large output in the terminal,
+hledger tries to use a pager when appropriate:
+the one specified by the `PAGER` environment variable,
+otherwise `less` if available, otherwise `more` if available.
+The pager shows one page of text at a time, and lets you scroll around to see more.
+While it is active, usually `SPACE` shows the next page, `q` quits, and `?` shows more features.
+
+The pager is expected to display ANSI color and text styling if possible.
+hledger adds `R` to the `LESS` and `MORE` environment variables to enable this
+in `less` (and in its `more` compatibility mode).
+If you use a different pager, you might need to configure it similarly, to avoid seeing junk on screen.
+Or you can set the `NO_COLOR` environment variable described below.
+
 Here are some notes about the various output formats.
 
 ### Text output
@@ -905,23 +920,6 @@ the [commodity directive](#commodity-directive).
 
 In some cases hledger will adjust number formatting to improve their parseability
 (such as adding [trailing decimal marks](#trailing-decimal-marks) when needed).
-
-## Paging
-
-When showing long output in the terminal, hledger will try to use
-the pager specified by the `PAGER` environment variable, or `less`, or `more`.
-(A pager is a helper program that shows one page at a time rather than scrolling everything off screen).
-Currently it does this only for help output, not for reports; specifically,
-
-- when listing commands, with `hledger`
-- when showing help with `hledger [CMD] --help`,
-- when viewing manuals with `hledger help` or `hledger --man`.
-
-Note the pager is expected to handle ANSI codes, which hledger uses eg for bold emphasis. 
-For the common pager `less` (and its `more` compatibility mode),
-we add `R` to the `LESS` and `MORE` environment variables to make this work.
-If you use a different pager, you might need to configure it similarly, to avoid seeing junk on screen (let us know).
-Otherwise, you can set the `NO_COLOR` environment variable to 1 to disable all ANSI output (see [Colour](#colour)).
 
 ## Debug output
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -736,6 +736,9 @@ in `less` (and in its `more` compatibility mode).
 If you use a different pager, you might need to configure it similarly, to avoid seeing junk on screen.
 Or you can set the `NO_COLOR` environment variable described below.
 
+You can prevent the use of a pager by using the `--no-pager` flag,
+eg in your hledger config file.
+
 Here are some notes about the various output formats.
 
 ### Text output

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -767,8 +767,8 @@ and help output uses bold text for emphasis.
 
 You can override this in the usual ways.
 If the `NO_COLOR` environment variable is set, colour will be disabled by default.
-Or you can use the `--color/--colour` option with a `yes`/`always` value,
-or `no`/`never`, to force colour on or off.
+Or you can use the `--color/--colour` option with a `y`/`yes` value,
+or `n`/`no`, to force colour on or off.
 (This option doesn't work in a config file yet.)
 
 #### Box-drawing
@@ -955,7 +955,7 @@ Default: `$HOME/.hledger.journal`.
 **NO_COLOR**
 If this environment variable exists (with any value, including empty),
 hledger will not use ANSI color codes in terminal output,
-unless overridden by an explicit `--color=y`/`--colour=y` option.
+unless overridden by an explicit `--color=y` or `--colour=y` option.
 
 # PART 2: DATA FORMATS
 


### PR DESCRIPTION
This is an impactful change, and I value the CLI and easy scriptability. But it has been working well for help output, and I for one am ready for it. Feedback, testing and problem reports welcome.

Doc:

## Paging

On unix-like systems, when displaying large output in the terminal,
hledger tries to use a pager when appropriate:
the one specified by the `PAGER` environment variable,
otherwise `less` if available, otherwise `more` if available.
The pager shows one page of text at a time, and lets you scroll around to see more.
While it is active, usually `SPACE` shows the next page, `q` quits, and `?` shows more features.

The pager is expected to display ANSI color and text styling if possible.
hledger adds `R` to the `LESS` and `MORE` environment variables to enable this
in `less` (and in its `more` compatibility mode).
If you use a different pager, you might need to configure it similarly, to avoid seeing junk on screen.
Or you can set the `NO_COLOR` environment variable described below.