### PR TITLE
FODS documentation

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -394,7 +394,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
             "html" -> (<>"\n") . L.renderText .
                       printHtml . map (map (fmap L.toHtml)) . budgetReportAsSpreadsheet ropts
             "fods" -> printFods IO.localeEncoding .
-                      Map.singleton "Hledger" . (,) (Just 1, Nothing) . budgetReportAsSpreadsheet ropts
+                      Map.singleton "Budget Report" . (,) (Just 1, Nothing) . budgetReportAsSpreadsheet ropts
             _      -> error' $ unsupportedOutputFormatError fmt
       writeOutputLazyText opts $ render budgetreport
 
@@ -407,7 +407,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
               "html" -> (<>"\n") . L.renderText . multiBalanceReportAsHtml ropts
               "json" -> (<>"\n") . toJsonText
               "fods" -> printFods IO.localeEncoding .
-                        Map.singleton "Hledger" . multiBalanceReportAsSpreadsheet ropts
+                        Map.singleton "Multi-period Balance Report" . multiBalanceReportAsSpreadsheet ropts
               _      -> const $ error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render report
 
@@ -420,7 +420,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
               "html" -> (<>"\n") . L.renderText .
                                    printHtml . map (map (fmap L.toHtml)) . balanceReportAsSpreadsheet ropts
               "json" -> (<>"\n") . toJsonText
-              "fods" -> printFods IO.localeEncoding . Map.singleton "Hledger" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts
+              "fods" -> printFods IO.localeEncoding . Map.singleton "Balance Report" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render report
   where

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -71,7 +71,7 @@ registermode = hledgerCommandMode
      )
   ,flagNone ["align-all"] (setboolopt "align-all") "guarantee alignment across all lines (slower)"
   ,flagReq  ["base-url"] (\s opts -> Right $ setopt "base-url" s opts) "URLPREFIX" "in html output, generate links to hledger-web, with this prefix. (Usually the base url shown by hledger-web; can also be relative.)"
-  ,outputFormatFlag ["txt","csv","tsv","json"]
+  ,outputFormatFlag ["txt","csv","tsv","html","fods","json"]
   ,outputFileFlag
   ])
   cligeneralflagsgroups1

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -669,10 +669,10 @@ Here are those commands and the formats currently supported:
 |--------------------|-----|------|---------|------|-----------|-----|------|
 | aregister          | Y   | Y    | Y       |      |           |     | Y    |
 | balance            | Y   | Y    | Y       | Y    |           |     | Y    |
-| balancesheet       | Y   | Y    | Y       |      |           |     | Y    |
-| balancesheetequity | Y   | Y    | Y       |      |           |     | Y    |
-| cashflow           | Y   | Y    | Y       |      |           |     | Y    |
-| incomestatement    | Y   | Y    | Y       |      |           |     | Y    |
+| balancesheet       | Y   | Y    | Y       | Y    |           |     | Y    |
+| balancesheetequity | Y   | Y    | Y       | Y    |           |     | Y    |
+| cashflow           | Y   | Y    | Y       | Y    |           |     | Y    |
+| incomestatement    | Y   | Y    | Y       | Y    |           |     | Y    |
 | print              | Y   |      | Y       |      | Y         | Y   | Y    |
 | register           | Y   | Y    | Y       | Y    |           |     | Y    |
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -775,8 +775,21 @@ are disabled automatically.
 
 ### FODS output
 
-[FODS] is the OpenDocument spreadsheet format used by LibreOffice and OpenOffice.
-It is a good format to use if you are exporting to their spreadsheet app.
+[FODS] is the OpenDocument Spreadsheet format as plain XML,
+as accepted by LibreOffice and OpenOffice.
+If you use their spreadsheet applications,
+this is better than CSV because it works across locales
+(decimal point vs. decimal comma,
+character encoding stored in XML header, thus no problems with umlauts),
+it supports fixed header rows and columns,
+cell types (string vs. number vs. date),
+separation of number and currency
+(currency is displayed but the cell type
+is still a number accessible for computation),
+styles (bold), borders.
+Btw. you can still extract CSV from FODS/ODS
+using various utilities like `libreoffice --headless` or
+[ods2csv](https://hackage.haskell.org/package/ods2csv).
 
 [FODS]: https://en.wikipedia.org/wiki/OpenDocument
 

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -676,10 +676,10 @@ Output
        --------------------------------------------------------------------------------------------
        aregister               Y       Y        Y                                           Y
        balance                 Y       Y        Y           Y                               Y
-       balancesheet            Y       Y        Y                                           Y
-       balancesheetequity      Y       Y        Y                                           Y
-       cashflow                Y       Y        Y                                           Y
-       incomestatement         Y       Y        Y                                           Y
+       balancesheet            Y       Y        Y           Y                               Y
+       balancesheetequity      Y       Y        Y           Y                               Y
+       cashflow                Y       Y        Y           Y                               Y
+       incomestatement         Y       Y        Y           Y                               Y
        print                   Y                Y                    Y              Y       Y
        register                Y       Y        Y           Y                               Y
 


### PR DESCRIPTION
some extensions to documentation regarding FODS export

How can I regenerate `hledger.txt`? `just` only lists targets for Haddock generation.
Why is it checked into the Repo, since it seems to be generated?