### PR TITLE
Print export to HTML and FODS

### DIFF
--- a/hledger-lib/Hledger/Write/Spreadsheet.hs
+++ b/hledger-lib/Hledger/Write/Spreadsheet.hs
@@ -24,6 +24,7 @@ module Hledger.Write.Spreadsheet (
     rawTableContent,
     cellFromMixedAmount,
     cellsFromMixedAmount,
+    cellFromAmount,
     ) where
 
 import qualified Hledger.Data.Amount as Amt
@@ -234,6 +235,15 @@ cellsFromMixedAmount bopts (cls, mixedAmt) =
                 cellType = amountType bopts amt
             })
         (Amt.showMixedAmountLinesPartsB bopts mixedAmt)
+
+cellFromAmount ::
+    (Lines border) =>
+    AmountFormat -> (Class, (wb, Amount)) -> Cell border wb
+cellFromAmount bopts (cls, (str,amt)) =
+    (defaultCell str) {
+        cellClass = cls,
+        cellType = amountType bopts amt
+    }
 
 amountType :: AmountFormat -> Amount -> Type
 amountType bopts amt =

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -394,7 +394,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
             "html" -> (<>"\n") . L.renderText .
                       printHtml . map (map (fmap L.toHtml)) . budgetReportAsSpreadsheet ropts
             "fods" -> printFods IO.localeEncoding .
-                      Map.singleton "Hledger" . (,) (Just 1, Nothing) . budgetReportAsSpreadsheet ropts
+                      Map.singleton "Budget Report" . (,) (Just 1, Nothing) . budgetReportAsSpreadsheet ropts
             _      -> error' $ unsupportedOutputFormatError fmt
       writeOutputLazyText opts $ render budgetreport
 
@@ -407,7 +407,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
               "html" -> (<>"\n") . L.renderText . multiBalanceReportAsHtml ropts
               "json" -> (<>"\n") . toJsonText
               "fods" -> printFods IO.localeEncoding .
-                        Map.singleton "Hledger" . multiBalanceReportAsSpreadsheet ropts
+                        Map.singleton "Multi-period Balance Report" . multiBalanceReportAsSpreadsheet ropts
               _      -> const $ error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render report
 
@@ -420,7 +420,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
               "html" -> (<>"\n") . L.renderText .
                                    printHtml . map (map (fmap L.toHtml)) . balanceReportAsSpreadsheet ropts
               "json" -> (<>"\n") . toJsonText
-              "fods" -> printFods IO.localeEncoding . Map.singleton "Hledger" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts
+              "fods" -> printFods IO.localeEncoding . Map.singleton "Balance Report" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render report
   where

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -240,8 +240,7 @@ transactionToSpreadsheet ::
   AmountFormat -> Maybe Text -> [Text] ->
   Transaction -> [[Spr.Cell Spr.NumLines Text]]
 transactionToSpreadsheet fmt baseUrl query t =
-  map
-    (\p -> idx:d:d2:status:code:description:comment:p)
+  addRowSpanHeader (idx:d:d2:status:code:description:comment:[])
     (postingToSpreadsheet fmt baseUrl query =<< tpostings t)
   where
     cell = Spr.defaultCell
@@ -254,6 +253,20 @@ transactionToSpreadsheet fmt baseUrl query t =
     status = cell $ T.pack . show $ tstatus t
     code = cell $ tcode t
     comment = cell $ T.strip $ tcomment t
+
+addRowSpanHeader ::
+    [Spr.Cell border text] ->
+    [[Spr.Cell border text]] -> [[Spr.Cell border text]]
+addRowSpanHeader common rows =
+    case rows of
+        [] -> []
+        [row] -> [common++row]
+        _ ->
+            let setSpan spn cell = cell{Spr.cellSpan = spn} in
+            zipWith (++)
+                (map (setSpan $ Spr.SpanVertical $ length rows) common :
+                 repeat (map (setSpan Spr.Covered) common))
+                rows
 
 postingToSpreadsheet ::
   (Spr.Lines border) =>

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -71,7 +71,7 @@ registermode = hledgerCommandMode
      )
   ,flagNone ["align-all"] (setboolopt "align-all") "guarantee alignment across all lines (slower)"
   ,flagReq  ["base-url"] (\s opts -> Right $ setopt "base-url" s opts) "URLPREFIX" "in html output, generate links to hledger-web, with this prefix. (Usually the base url shown by hledger-web; can also be relative.)"
-  ,outputFormatFlag ["txt","csv","tsv","json"]
+  ,outputFormatFlag ["txt","csv","tsv","html","fods","json"]
   ,outputFileFlag
   ])
   cligeneralflagsgroups1

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -673,7 +673,7 @@ Here are those commands and the formats currently supported:
 | balancesheetequity | Y   | Y    | Y       | Y    |           |     | Y    |
 | cashflow           | Y   | Y    | Y       | Y    |           |     | Y    |
 | incomestatement    | Y   | Y    | Y       | Y    |           |     | Y    |
-| print              | Y   |      | Y       |      | Y         | Y   | Y    |
+| print              | Y   | Y    | Y       | Y    | Y         | Y   | Y    |
 | register           | Y   | Y    | Y       | Y    |           |     | Y    |
 
 <!--

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -669,10 +669,10 @@ Here are those commands and the formats currently supported:
 |--------------------|-----|------|---------|------|-----------|-----|------|
 | aregister          | Y   | Y    | Y       |      |           |     | Y    |
 | balance            | Y   | Y    | Y       | Y    |           |     | Y    |
-| balancesheet       | Y   | Y    | Y       |      |           |     | Y    |
-| balancesheetequity | Y   | Y    | Y       |      |           |     | Y    |
-| cashflow           | Y   | Y    | Y       |      |           |     | Y    |
-| incomestatement    | Y   | Y    | Y       |      |           |     | Y    |
+| balancesheet       | Y   | Y    | Y       | Y    |           |     | Y    |
+| balancesheetequity | Y   | Y    | Y       | Y    |           |     | Y    |
+| cashflow           | Y   | Y    | Y       | Y    |           |     | Y    |
+| incomestatement    | Y   | Y    | Y       | Y    |           |     | Y    |
 | print              | Y   |      | Y       |      | Y         | Y   | Y    |
 | register           | Y   | Y    | Y       | Y    |           |     | Y    |
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -775,8 +775,21 @@ are disabled automatically.
 
 ### FODS output
 
-[FODS] is the OpenDocument spreadsheet format used by LibreOffice and OpenOffice.
-It is a good format to use if you are exporting to their spreadsheet app.
+[FODS] is the OpenDocument Spreadsheet format as plain XML,
+as accepted by LibreOffice and OpenOffice.
+If you use their spreadsheet applications,
+this is better than CSV because it works across locales
+(decimal point vs. decimal comma,
+character encoding stored in XML header, thus no problems with umlauts),
+it supports fixed header rows and columns,
+cell types (string vs. number vs. date),
+separation of number and currency
+(currency is displayed but the cell type
+is still a number accessible for computation),
+styles (bold), borders.
+Btw. you can still extract CSV from FODS/ODS
+using various utilities like `libreoffice --headless` or
+[ods2csv](https://hackage.haskell.org/package/ods2csv).
 
 [FODS]: https://en.wikipedia.org/wiki/OpenDocument
 

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -676,10 +676,10 @@ Output
        --------------------------------------------------------------------------------------------
        aregister               Y       Y        Y                                           Y
        balance                 Y       Y        Y           Y                               Y
-       balancesheet            Y       Y        Y                                           Y
-       balancesheetequity      Y       Y        Y                                           Y
-       cashflow                Y       Y        Y                                           Y
-       incomestatement         Y       Y        Y                                           Y
+       balancesheet            Y       Y        Y           Y                               Y
+       balancesheetequity      Y       Y        Y           Y                               Y
+       cashflow                Y       Y        Y           Y                               Y
+       incomestatement         Y       Y        Y           Y                               Y
        print                   Y                Y                    Y              Y       Y
        register                Y       Y        Y           Y                               Y
 


### PR DESCRIPTION
As in `balance` and `register` and friends I generate CSV, HTML, FODS from the same Spreadsheet structure. This means that HTML output deviates from the text output of `print`. It presents data in a table and not in the journal format.