### PR TITLE
Aregister: support option --cumulative

### DIFF
--- a/hledger-lib/Hledger/Write/Ods.hs
+++ b/hledger-lib/Hledger/Write/Ods.hs
@@ -13,6 +13,7 @@ module Hledger.Write.Ods (
     ) where
 
 import Prelude hiding (Applicative(..))
+import Control.Monad (guard)
 import Control.Applicative (Applicative(..))
 
 import qualified Data.Text.Lazy as TL
@@ -38,7 +39,7 @@ import Hledger.Data.Types (acommodity, aquantity, astyle, asprecision)
 
 printFods ::
     IO.TextEncoding ->
-    Map Text ((Maybe Int, Maybe Int), [[Cell Spr.NumLines Text]]) -> TL.Text
+    Map Text ((Int, Int), [[Cell Spr.NumLines Text]]) -> TL.Text
 printFods encoding tables =
     let fileOpen customStyles =
           map (map (\c -> case c of '\'' -> '"'; _ -> c)) $
@@ -87,14 +88,14 @@ printFods encoding tables =
           "    <config:config-item-map-entry>" :
           "     <config:config-item-map-named config:name='Tables'>" :
           (fold $
-           flip Map.mapWithKey tableNames $ \tableName (mTopRow,mLeftColumn) ->
+           flip Map.mapWithKey tableNames $ \tableName (topRow,leftColumn) ->
              printf "      <config:config-item-map-entry config:name='%s'>" tableName :
-             (flip foldMap mLeftColumn $ \leftColumn ->
+             ((guard (leftColumn>0) >>) $
                 "       <config:config-item config:name='HorizontalSplitMode' config:type='short'>2</config:config-item>" :
                 printf "       <config:config-item config:name='HorizontalSplitPosition' config:type='int'>%d</config:config-item>" leftColumn :
                 printf "       <config:config-item config:name='PositionRight' config:type='int'>%d</config:config-item>" leftColumn :
                 []) ++
-             (flip foldMap mTopRow $ \topRow ->
+             ((guard (topRow>0) >>) $
                 "       <config:config-item config:name='VerticalSplitMode' config:type='short'>2</config:config-item>" :
                 printf "       <config:config-item config:name='VerticalSplitPosition' config:type='int'>%d</config:config-item>" topRow :
                 printf "       <config:config-item config:name='PositionBottom' config:type='int'>%d</config:config-item>" topRow :

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -121,7 +121,7 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
            | fmt=="tsv"  = printTSV . accountTransactionsReportAsCsv wd (_rsQuery rspec') thisacctq
            | fmt=="fods" =
                 printFods IO.localeEncoding . Map.singleton "Aregister" .
-                (,) (Just 1, Nothing) .
+                (,) (1,0) .
                 accountTransactionsReportAsSpreadsheet oneLineNoCostFmt wd (_rsQuery rspec') thisacctq
            | fmt=="json" = toJsonText
            | otherwise   = error' $ unsupportedOutputFormatError fmt  -- PARTIAL:

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -48,11 +48,11 @@ aregistermode = hledgerCommandMode
   ([
    flagNone ["txn-dates"] (setboolopt "txn-dates") 
      "filter strictly by transaction date, not posting date. Warning: this can show a wrong running balance."
-   ,flagNone ["no-elide"] (setboolopt "no-elide") "don't show only 2 commodities per amount"
-  --  flagNone ["cumulative"] (setboolopt "cumulative")
-  --    "show running total from report start date (default)"
-  -- ,flagNone ["historical","H"] (setboolopt "historical")
-  --    "show historical running total/balance (includes postings before report start date)\n "
+  ,flagNone ["no-elide"] (setboolopt "no-elide") "don't show only 2 commodities per amount"
+  ,flagNone ["cumulative"] (setboolopt "cumulative")
+     "show running total from report start date"
+  ,flagNone ["historical","H"] (setboolopt "historical")
+     "show historical running total/balance (includes postings before report start date) (default)\n "
   -- ,flagNone ["average","A"] (setboolopt "average")
   --    "show running average of posting amounts instead of total (implies --empty)"
   -- ,flagNone ["related","r"] (setboolopt "related") "show postings' siblings instead"
@@ -97,8 +97,10 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     ropts' = (_rsReportOpts rspec) {
         -- ignore any depth limit, as in postingsReport; allows register's total to match balance reports (cf #1468)
         depth_=Nothing
-        -- always show historical balance
-      , balanceaccum_= Historical
+      , balanceaccum_ =
+          case balanceaccum_ $ _rsReportOpts rspec of
+            PerPeriod -> Historical
+            ba -> ba
       , querystring_ = querystr
       }
     wd = whichDate ropts'

--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -12,6 +12,7 @@ Flags:
                             balance.
      --no-elide             don't show only 2 commodities per amount
      --cumulative           show running total from report start date
+     --no-header            omit header row in table output
   -w --width=N              set output width (default: terminal width or
                             $COLUMNS). -wN,M sets description width as well.
      --align-all            guarantee alignment across all lines (slower)
@@ -73,6 +74,11 @@ For performance reasons, column widths are chosen based on the first 1000 lines;
 this means unusually wide values in later lines can cause visual discontinuities
 as column widths are adjusted. If you want to ensure perfect alignment, 
 at the cost of more time and memory, use the `--align-all` flag.
+
+By default, `aregister` shows a header above the data.
+However, when reporting in a language different from English,
+it is easier to omit this header and prepend your own one.
+For this purpose, use the `--no-header` option.
 
 This command also supports the
 [output destination](hledger.html#output-destination) and

--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -11,6 +11,7 @@ Flags:
                             date. Warning: this can show a wrong running
                             balance.
      --no-elide             don't show only 2 commodities per amount
+     --cumulative           show running total from report start date
   -w --width=N              set output width (default: terminal width or
                             $COLUMNS). -wN,M sets description width as well.
      --align-all            guarantee alignment across all lines (slower)
@@ -22,8 +23,9 @@ Flags:
 
 `aregister` shows the overall transactions affecting a particular account (and
 any subaccounts). Each report line represents one transaction in this account.
-Transactions before the report start date are always included in the running balance
-(`--historical` mode is always on).
+Transactions before the report start date are included in the running balance
+(`--historical` mode is the default).
+You can suppress this behaviour using the `--cumulative` option.
 
 This is a more "real world", bank-like view than the [`register`](#register) 
 command (which shows individual postings, possibly from multiple accounts,
@@ -75,7 +77,7 @@ at the cost of more time and memory, use the `--align-all` flag.
 This command also supports the
 [output destination](hledger.html#output-destination) and
 [output format](hledger.html#output-format) options.
-The output formats supported are `txt`, `csv`, `tsv` (*Added in 1.32*), and `json`.
+The output formats supported are `txt`, `csv`, `tsv` (*Added in 1.32*), `html`, `fods` (*Added in 1.41*) and `json`.
 
 ### aregister and posting dates
 

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -394,7 +394,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
             "html" -> (<>"\n") . L.renderText .
                       printHtml . map (map (fmap L.toHtml)) . budgetReportAsSpreadsheet ropts
             "fods" -> printFods IO.localeEncoding .
-                      Map.singleton "Budget Report" . (,) (Just 1, Nothing) . budgetReportAsSpreadsheet ropts
+                      Map.singleton "Budget Report" . (,) (1,0) . budgetReportAsSpreadsheet ropts
             _      -> error' $ unsupportedOutputFormatError fmt
       writeOutputLazyText opts $ render budgetreport
 
@@ -420,7 +420,7 @@ balance opts@CliOpts{reportspec_=rspec} j = case balancecalc_ ropts of
               "html" -> (<>"\n") . L.renderText .
                                    printHtml . map (map (fmap L.toHtml)) . balanceReportAsSpreadsheet ropts
               "json" -> (<>"\n") . toJsonText
-              "fods" -> printFods IO.localeEncoding . Map.singleton "Balance Report" . (,) (Just 1, Nothing) . balanceReportAsSpreadsheet ropts
+              "fods" -> printFods IO.localeEncoding . Map.singleton "Balance Report" . (,) (1,0) . balanceReportAsSpreadsheet ropts
               _      -> error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
         writeOutputLazyText opts $ render report
   where
@@ -718,12 +718,12 @@ multiBalanceReportAsHtml ropts mbr =
 -- Returns the heading row, 0 or more body rows, and the totals row if enabled.
 multiBalanceReportAsSpreadsheet ::
   ReportOpts -> MultiBalanceReport ->
-  ((Maybe Int, Maybe Int), [[Ods.Cell Ods.NumLines Text]])
+  ((Int, Int), [[Ods.Cell Ods.NumLines Text]])
 multiBalanceReportAsSpreadsheet ropts mbr =
   let (header,body,total) =
             multiBalanceReportAsSpreadsheetParts oneLineNoCostFmt ropts mbr
   in  (if transpose_ ropts then swap *** Ods.transpose else id) $
-      ((Just 1, case layout_ ropts of LayoutWide _ -> Just 1; _ -> Nothing),
+      ((1, case layout_ ropts of LayoutWide _ -> 1; _ -> 0),
             header : body ++ total)
 
 

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -146,7 +146,7 @@ printEntries opts@CliOpts{rawopts_=rawopts, reportspec_=rspec} j =
                 styleAmounts styles
            | fmt=="fods" =
                 printFods IO.localeEncoding . Map.singleton "Print" .
-                (,) (Just 1, Nothing) .
+                (,) (1,0) .
                 entriesReportAsSpreadsheet oneLineNoCostFmt baseUrl query .
                 styleAmounts styles
            | otherwise = error' $ unsupportedOutputFormatError fmt  -- PARTIAL:

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -108,7 +108,7 @@ register opts@CliOpts{rawopts_=rawopts, reportspec_=rspec} j
                 postingsReportAsSpreadsheet oneLineNoCostFmt baseUrl query
            | fmt=="fods" =
                 printFods IO.localeEncoding . Map.singleton "Register" .
-                (,) (Just 1, Nothing) .
+                (,) (1,0) .
                 postingsReportAsSpreadsheet oneLineNoCostFmt baseUrl query
            | otherwise   = error' $ unsupportedOutputFormatError fmt  -- PARTIAL:
       where fmt = outputFormatFromOpts opts
@@ -119,6 +119,8 @@ postingsReportAsCsv :: PostingsReport -> CSV
 postingsReportAsCsv =
   Spr.rawTableContent . postingsReportAsSpreadsheet machineFmt Nothing []
 
+-- ToDo: --layout=bare etc.
+-- ToDo: Text output does not show headers, but Spreadsheet does
 postingsReportAsSpreadsheet ::
   AmountFormat -> Maybe Text -> [Text] ->
   PostingsReport -> [[Spr.Cell Spr.NumLines Text]]

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -343,7 +343,7 @@ compoundBalanceReportAsHtml ropts cbr =
 compoundBalanceReportAsSpreadsheet ::
   AmountFormat -> T.Text -> Maybe T.Text ->
   ReportOpts -> CompoundPeriodicReport DisplayName MixedAmount ->
-  (T.Text, ((Maybe Int, Maybe Int), NonEmpty [Spr.Cell Spr.NumLines T.Text]))
+  (T.Text, ((Int, Int), NonEmpty [Spr.Cell Spr.NumLines T.Text]))
 compoundBalanceReportAsSpreadsheet fmt accountLabel maybeBlank ropts cbr =
   let
     CompoundPeriodicReport title colspans subreports totalrow = cbr
@@ -397,5 +397,5 @@ compoundBalanceReportAsSpreadsheet fmt accountLabel maybeBlank ropts cbr =
         & addTotalBorders    -- marking the first row for special styling
 
   in  (title,
-        ((Just 1, Just 1),
+        ((1,1),
             headerrow :| concatMap subreportrows subreports ++ totalrows))


### PR DESCRIPTION
This addresses #2077.

Now I translate `PerPeriod` to `Historical`, since `PerPeriod` is the default. This is a way to have different defaults for `aregister` (Historical) and `register` (Cumulative).