### PR TITLE
lib: fix division by zero in roi when all assets are sold (fixes #2281)

### DIFF
--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -239,7 +239,9 @@ timeWeightedReturn styles showCashFlow prettyTables investmentsQuery trans mixed
                Left pnl' ->
                  -- PnL change
                  let valueAfterDate = valueOnDate + unMix pnl'
-                     unitCost' = valueAfterDate/unitBalance
+                     unitCost' =
+                       if unitBalance == 0 then initialUnitCost -- everything was sold, let's reset the cost to initial cost
+                       else valueAfterDate/unitBalance
                  in (valueOnDate, 0, unitCost', unitBalance))
           (0, 0, initialUnitCost, initialUnits)
           $ dbg3 "changes" changes


### PR DESCRIPTION
TWR computation works by computing the running total of "investment units" and their cost. If at some point we run out of units, we could divide by zero trying to compute new cost. Instead lets just reset the cost the the initial one as we have essentially went to the initial state (no units on hand, cost is an arbitrary chosen number 100).

This fixes #2281 
