### PR TITLE
Regular-expression limited depth limits

### DIFF
--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -175,11 +175,11 @@ clipAccounts d a = a{asubs=subs}
 -- | Remove subaccounts below the specified depth, aggregating their balance at the depth limit
 -- (accounts at the depth limit will have any sub-balances merged into their exclusive balance).
 -- If the depth is Nothing, return the original accounts
-clipAccountsAndAggregate :: Maybe Int -> [Account] -> [Account]
-clipAccountsAndAggregate Nothing  as = as
-clipAccountsAndAggregate (Just d) as = combined
+clipAccountsAndAggregate :: DepthSpec -> [Account] -> [Account]
+clipAccountsAndAggregate (DepthSpec Nothing []) as = as
+clipAccountsAndAggregate d                      as = combined
     where
-      clipped  = [a{aname=clipOrEllipsifyAccountName (Just d) $ aname a} | a <- as]
+      clipped  = [a{aname=clipOrEllipsifyAccountName d $ aname a} | a <- as]
       combined = [a{aebalance=maSum $ map aebalance same}
                  | same@(a:_) <- groupOn aname clipped]
 {-

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -44,6 +44,7 @@ import Data.List (intercalate, sortBy)
 --The stored values don't represent large virtual data structures to be lazily computed.
 import qualified Data.Map as M
 import Data.Ord (comparing)
+import Data.Semigroup (Min(..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Calendar (Day)
@@ -155,6 +156,19 @@ instance Default Interval where def = NoInterval
 type Payee = Text
 
 type AccountName = Text
+
+-- A specification indicating how to depth-limit
+data DepthSpec = DepthSpec {
+  dsFlatDepth    :: Maybe Int,
+  dsRegexpDepths :: [(Regexp, Int)]
+  } deriving (Eq,Show)
+
+-- Semigroup instance consider all regular expressions, but take the minimum of the simple flat depths
+instance Semigroup DepthSpec where
+    DepthSpec d1 l1 <> DepthSpec d2 l2 = DepthSpec (getMin <$> (Min <$> d1) <> (Min <$> d2)) (l1 ++ l2)
+
+instance Monoid DepthSpec where
+    mempty = DepthSpec Nothing []
 
 data AccountType =
     Asset

--- a/hledger-lib/Hledger/Reports/BalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/BalanceReport.hs
@@ -149,7 +149,7 @@ tests_BalanceReport = testGroup "BalanceReport" [
        mixedAmount (usd 0))
 
     ,testCase "with --depth=N" $
-     (defreportspec{_rsReportOpts=defreportopts{depth_=Just 1}}, samplejournal) `gives`
+     (defreportspec{_rsReportOpts=defreportopts{depth_=DepthSpec (Just 1) []}}, samplejournal) `gives`
       ([
        ("expenses",    "expenses",     0, mixedAmount (usd 2))
        ,("income",      "income",      0, mixedAmount (usd (-2)))
@@ -222,7 +222,7 @@ tests_BalanceReport = testGroup "BalanceReport" [
        ]
 
       ,testCase "accounts report with account pattern o and --depth 1" ~:
-       defreportopts{patterns_=["o"],depth_=Just 1} `gives`
+       defreportopts{patterns_=["o"],depth_=(Just 1, [])} `gives`
        ["                  $1  expenses"
        ,"                 $-2  income"
        ,"--------------------"

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -130,7 +130,7 @@ asDrawHelper UIState{aScreen=scr, aopts=uopts, ajournal=j, aMode=mode} ropts scr
                   ,uiShowStatus copts $ statuses_ ropts
                   ,if real_ ropts then ["real"] else []
                   ]
-                mdepth = depth_ ropts
+                mdepth = dsFlatDepth $ depth_ ropts
                 curidx = case ass ^. assList . listSelectedL of
                           Nothing -> "-"
                           Just i -> show (i + 1)

--- a/hledger-ui/Hledger/UI/UIScreens.hs
+++ b/hledger-ui/Hledger/UI/UIScreens.hs
@@ -256,7 +256,7 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
     -- adjust the report options and report spec, carefully as usual to avoid screwups (#1523)
     ropts' = ropts {
         -- ignore any depth limit, as in postingsReport; allows register's total to match accounts screen
-        depth_=Nothing
+        depth_=mempty
         -- do not strip prices so we can toggle costs within the ui
       , show_costs_=True
       -- XXX aregister also has this, needed ?

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -201,7 +201,7 @@ reportflags = [
  ,flagNone ["pending","P"]   (setboolopt "pending")  "include only pending postings/transactions"
  ,flagNone ["cleared","C"]   (setboolopt "cleared")  "include only cleared postings/transactions\n(-U/-P/-C can be combined)"
  ,flagNone ["real","R"]      (setboolopt "real")     "include only non-virtual postings"
- ,flagReq  ["depth"]         (\s opts -> Right $ setopt "depth" s opts) "NUM" "or -NUM: show only top NUM levels of accounts"
+ ,flagReq  ["depth"]         (\s opts -> Right $ setopt "depth" s opts) "DEPTHEXP" "if a number (or -NUM): show only top NUM levels of accounts. If REGEXP=NUM, only apply limiting to accounts matching the regular expression."
  ,flagNone ["empty","E"]     (setboolopt "empty") "Show zero items, which are normally hidden.\nIn hledger-ui & hledger-web, do the opposite."
 
   -- valuation

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -98,7 +98,7 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
     thisacctq = Acct $ (if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex) acct
     ropts' = (_rsReportOpts rspec) {
         -- ignore any depth limit, as in postingsReport; allows register's total to match balance reports (cf #1468)
-        depth_=Nothing
+        depth_=DepthSpec Nothing []
       , balanceaccum_ =
           case balanceaccum_ $ _rsReportOpts rspec of
             PerPeriod -> Historical

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -5098,7 +5098,36 @@ Examples:
 With the `--depth NUM` option (short form: `-NUM`), 
 reports will show accounts only to the specified depth, hiding deeper subaccounts.
 Use this when you want a summary with less detail.
-This flag has the same effect as a `depth:` query argument: `depth:2`, `--depth=2` or `-2` are equivalent.
+This flag has the same effect as a `depth:` query argument: `depth:2`,
+`--depth=2` or `-2` are equivalent.
+
+In place of a single number which limits the depth for all accounts, you can
+also provide separate depth limits for different accounts using regular
+expressions.
+For example, `--depth assets=2` (or, equivalently: `depth:assets=2`)
+will collapse accounts matching the regular expression `assets` to depth 2.
+So `assets:bank:savings` would be collapsed to `assets:bank`, while
+`liabilities:bank:credit card` would not be affected.
+This can be combined with a flat depth to collapse other accounts not matching
+the regular expression, so `--depth assets=2 --depth 1` would collapse
+`assets:bank:savings` to `assets:bank` and `liabilities:bank:credit card` to
+`liabilities`.
+
+You can supply multiple depth arguments and they will all be applied, so
+`--depth assets=2 --depth liabilities=3 --depth 1` would collapse:
+
+- accounts matching `assets` to depth 2,
+- accounts matching `liabilities` to depth 3,
+- all other accounts to depth 1.
+
+If an account is matched by more than one regular expression depth argument
+then the more specific one will used.
+For example, if `--depth assets=1 --depth assets:bank:savings=2` is provided,
+then `assets:bank:savings` will be collapsed to depth 2 rather than depth 1.
+This is because `assets:bank:savings` matches at level 3 in the account name,
+while `assets` matches at level 1.
+The same would be true with the argument `--depth assets=1 --depth savings=2`.
+
 
 # Queries
 
@@ -5191,8 +5220,10 @@ Examples:\
 **`date2:PERIODEXPR`**\
 Match secondary dates within the specified period (independent of the `--date2` flag).
 
-**`depth:N`**\
-Match (or display, depending on command) accounts at or above this depth.
+**`depth:[REGEXP=]N`**\
+Match (or display, depending on command) accounts at or above this depth,
+optionally only for accounts matching a provided regular expression.
+See [Depth](#depth) for detailed rules.
 
 **`expr:"TERM AND NOT (TERM OR TERM)"`** (eg)\
 Match with a boolean combination of queries (which must be enclosed in quotes).

--- a/hledger/test/balance/depth.test
+++ b/hledger/test/balance/depth.test
@@ -7,11 +7,35 @@ $ hledger -f sample.journal balance --no-total --depth 1
                  $-2  income
                   $1  liabilities
 
-# ** 2. Depth 0 aggregates everything into one line
+# ** 2. If more than one flat depth, take the later one, when the later is smaller
+$ hledger -f sample.journal balance --no-total --depth 2 --depth 1
+                 $-1  assets
+                  $2  expenses
+                 $-2  income
+                  $1  liabilities
+
+# ** 3. If more than one flat depth, take the later one, when the later is bigger
+$ hledger -f sample.journal balance --no-total --depth 1 --depth 2
+                  $1  assets:bank
+                 $-2  assets:cash
+                  $1  expenses:food
+                  $1  expenses:supplies
+                 $-1  income:gifts
+                 $-1  income:salary
+                  $1  liabilities:debts
+
+# ** 4. If more than one flat depth when supplied with query terms, take the smaller one, even if it's not last
+$ hledger -f sample.journal balance --no-total depth:1 depth:2
+                 $-1  assets
+                  $2  expenses
+                 $-2  income
+                  $1  liabilities
+
+# ** 5. Depth 0 aggregates everything into one line
 $ hledger -f sample.journal balance --no-total --depth 0 assets
                  $-1  ...
 
-# ** 3. Ditto in a multi-column balance report.
+# ** 6. Ditto in a multi-column balance report.
 $ hledger -f sample.journal balance -M -e 2008/2 --depth 0 assets
 Balance changes in 2008-01:
 
@@ -20,3 +44,50 @@ Balance changes in 2008-01:
  ... ||  $1 
 -----++-----
      ||  $1 
+
+# ** 7. Aggregate at different levels for regular expressions
+$ hledger -f sample.journal balance --no-total --depth assets=1 --depth 2
+                 $-1  assets
+                  $1  expenses:food
+                  $1  expenses:supplies
+                 $-1  income:gifts
+                 $-1  income:salary
+                  $1  liabilities:debts
+
+# ** 8. If two regexps match, use the more specific one
+$ hledger -f sample.journal balance --no-total --depth assets:bank=2 --depth assets=1 assets
+                 $-2  assets
+                  $1  assets:bank
+
+# ** 9. If a regexp matches, don't use the flat depth
+$ hledger -f sample.journal balance --no-total --depth assets=2 --depth 1
+                  $1  assets:bank
+                 $-2  assets:cash
+                  $2  expenses
+                 $-2  income
+                  $1  liabilities
+
+# ** 10. Aggregate at different levels for regular expressions for tree mode
+$ hledger -f sample.journal balance --no-total --depth assets=1 --depth 2 --tree
+                 $-1  assets
+                  $2  expenses
+                  $1    food
+                  $1    supplies
+                 $-2  income
+                 $-1    gifts
+                 $-1    salary
+                  $1  liabilities:debts
+
+# ** 11. If a regexp matches, don't use the flat depth in tree mode
+$ hledger -f sample.journal balance --no-total --depth assets=2 --depth 1 --tree
+                 $-1  assets
+                  $1    bank
+                 $-2    cash
+                  $2  expenses
+                 $-2  income
+                  $1  liabilities
+
+# ** 12. If two regexps match, use the more specific one in tree mode
+$ hledger -f sample.journal balance --no-total --depth assets:bank=2 --depth assets=1 --tree assets
+                 $-1  assets
+                  $1    bank


### PR DESCRIPTION
Previously depth-limiting was universal across all accounts, e.g. all
accounts are clipped to depth 2. However, sometimes you want certain
accounts clipped to a different depth than others, e.g. all expenses to
depth 3, while all assets to depth 2. This commit enables depth-limiting
to optionally include a regular expression, which limits the accounts it
applies to.

More than one depth limit can be passed, and they are applied to each
account name by the following rules:
- If one or more regular-expression depth limit applies, use the
  smallest one
- If no regular-expression depth limits apply, and a flat depth limit is
  supplied, use that
- Otherwise, do not do any depth limiting

For example, this will clip all accounts matching "assets" to depth 3,
all accounts matching "expenses" to depth 2, and all other accounts to
depth 1.
--depth assets=3 --depth expenses=2 --depth 1