### PR TITLE
;bin: git: make ensure_git more robust

### DIFF
--- a/bin/hledger-git
+++ b/bin/hledger-git
@@ -62,12 +62,11 @@ EOF
     fi
 }
 
-# TODO: also look in parent directories
 ensure_git_repo() {
-    if [[ ! -d "$DIR/.git" ]]; then
-        $GIT init "$DIR"
-        echo "Created git repo in $DIR"
-    fi
+  if [[ $($GIT -C "$DIR" rev-parse --is-inside-work-tree 2> /dev/null) != true ]];  then
+      $GIT init "$DIR"
+      echo "Created git repo in $DIR"
+  fi
 }
 
 # * Commands


### PR DESCRIPTION
Instead of manually checking for a .git directory, ask git to check whether
or not we are in a work tree using 'git rev-parse --is-inside-work-tree'.
This takes care of things like being in a subdirectory of a work tree, or
someone having GIT_DIR pointing somewhere other than .git, etc.
