### PR TITLE
;roi: optimize "one period per report interval" case a bit

### DIFF
--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -154,7 +154,9 @@ roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsReportOpts=ReportO
                , T.pack $ printf "%0.2f%%" $ smallIsZero annualizedTwr ]
 
   periodRows <- forM spans processSpan
-  totalRow <- processSpan fullPeriod
+  totalRow <- case periodRows of
+    [singleRow] -> return singleRow
+    _           -> processSpan fullPeriod
 
   let rowTitles = Tab.Group Tab.NoLine (map (Header . T.pack . show) (take (length periodRows) [1..]))
 


### PR DESCRIPTION
Fixes #2316 

`roi` computes returns per each reporting period, and then computes overall return for complete report interval.
When there is just one reporting period, there is no need to compute overall return as it would be exactly the same.
Lets optimize for this.