### PR TITLE
Implement `encoding` in .rules

### DIFF
--- a/hledger-lib/Hledger/Read/JournalReader.hs
+++ b/hledger-lib/Hledger/Read/JournalReader.hs
@@ -194,7 +194,7 @@ reader :: MonadIO m => Reader m
 reader = Reader
   {rFormat     = Journal'
   ,rExtensions = ["journal", "j", "hledger", "ledger"]
-  ,rReadFn     = parse
+  ,rReadFn     = handleReadFnToTextReadFn parse
   ,rParser    = journalp  -- no need to add command line aliases like journalp'
                            -- when called as a subparser I think
   }

--- a/hledger-lib/Hledger/Read/TimeclockReader.hs
+++ b/hledger-lib/Hledger/Read/TimeclockReader.hs
@@ -79,7 +79,7 @@ reader :: MonadIO m => Reader m
 reader = Reader
   {rFormat     = Timeclock
   ,rExtensions = ["timeclock"]
-  ,rReadFn     = parse
+  ,rReadFn     = handleReadFnToTextReadFn parse
   ,rParser    = timeclockfilep
   }
 

--- a/hledger-lib/Hledger/Read/TimedotReader.hs
+++ b/hledger-lib/Hledger/Read/TimedotReader.hs
@@ -68,7 +68,7 @@ reader :: MonadIO m => Reader m
 reader = Reader
   {rFormat     = Timedot
   ,rExtensions = ["timedot"]
-  ,rReadFn     = parse
+  ,rReadFn     = handleReadFnToTextReadFn parse
   ,rParser    = timedotp
   }
 

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -301,7 +301,7 @@ tests_PostingsReport = testGroup "PostingsReport" [
       ,"postings report with cleared option" ~:
        do
         let opts = defreportopts{cleared_=True}
-        j <- readJournal' sample_journal_str
+        j <- readJournal'' sample_journal_str
         (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` unlines
          ["2008/06/03 eat & shop           expenses:food                    $1           $1"
          ,"                                expenses:supplies                $1           $2"
@@ -313,7 +313,7 @@ tests_PostingsReport = testGroup "PostingsReport" [
       ,"postings report with uncleared option" ~:
        do
         let opts = defreportopts{uncleared_=True}
-        j <- readJournal' sample_journal_str
+        j <- readJournal'' sample_journal_str
         (postingsReportAsText opts $ postingsReport opts (queryFromOpts date1 opts) j) `is` unlines
          ["2008/01/01 income               assets:bank:checking             $1           $1"
          ,"                                income:salary                   $-1            0"
@@ -325,7 +325,7 @@ tests_PostingsReport = testGroup "PostingsReport" [
 
       ,"postings report sorts by date" ~:
        do
-        j <- readJournal' $ unlines
+        j <- readJournal'' $ unlines
             ["2008/02/02 a"
             ,"  b  1"
             ,"  c"

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -140,7 +140,7 @@ library
     , deepseq
     , directory >=1.2.6.1
     , doclayout >=0.3 && <0.6
-    , encoding >=0.8.10
+    , encoding >=0.9
     , extra >=1.6.3
     , file-embed >=0.0.10
     , filepath

--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -140,6 +140,7 @@ library
     , deepseq
     , directory >=1.2.6.1
     , doclayout >=0.3 && <0.6
+    , encoding >=0.8.10
     , extra >=1.6.3
     , file-embed >=0.0.10
     , filepath

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -59,6 +59,7 @@ dependencies:
 - Decimal >=0.5.1
 - directory >=1.2.6.1
 - doclayout >=0.3 && <0.6
+- encoding >=0.8.10
 - file-embed >=0.0.10
 - filepath
 - hashtables >=1.2.3.1

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -59,7 +59,7 @@ dependencies:
 - Decimal >=0.5.1
 - directory >=1.2.6.1
 - doclayout >=0.3 && <0.6
-- encoding >=0.8.10
+- encoding >=0.9
 - file-embed >=0.0.10
 - filepath
 - hashtables >=1.2.3.1

--- a/hledger-web/Hledger/Web/Test.hs
+++ b/hledger-web/Hledger/Web/Test.hs
@@ -131,7 +131,7 @@ hledgerWebTest = do
     rawopts = [("forecast","")]
     iopts = rawOptsToInputOpts d usecolor True $ mkRawOpts rawopts
     f = "fake"  -- need a non-null filename so forecast transactions get index 0
-  pj <- readJournal' (T.pack $ unlines  -- PARTIAL: readJournal' should not fail
+  pj <- readJournal'' (T.pack $ unlines  -- PARTIAL: readJournal'' should not fail
     ["~ monthly"
     ,"    assets    10"
     ,"    income"

--- a/hledger-web/Hledger/Web/Widget/Common.hs
+++ b/hledger-web/Hledger/Web/Widget/Common.hs
@@ -66,7 +66,7 @@ writeJournalTextIfValidAndChanged f t = mapExceptT liftIO $ do
   -- formatdirectivep, #1194) writeFileWithBackupIfChanged require them.
   -- XXX klunky. Any equivalent of "hSetNewlineMode h universalNewlineMode" for form posts ?
   let t' = T.replace "\r" "" t
-  j <- readJournal definputopts (Just f) t'
+  j <- readJournal definputopts (Just f) =<< liftIO (inputToHandle t')
   _ <- liftIO $ j `seq` writeFileWithBackupIfChanged f t'  -- Only write backup if the journal didn't error
   return ()
 

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -387,8 +387,8 @@ tests_Commands = testGroup "Commands" [
         let
           ignoresourcepos j = j{jtxns=map (\t -> t{tsourcepos=nullsourcepospair}) (jtxns j)}
           sameParse str1 str2 = do
-            j1 <- ignoresourcepos <$> readJournal' str1  -- PARTIAL:
-            j2 <- ignoresourcepos <$> readJournal' str2  -- PARTIAL:
+            j1 <- ignoresourcepos <$> readJournal'' str1  -- PARTIAL:
+            j2 <- ignoresourcepos <$> readJournal'' str2  -- PARTIAL:
             j1 @?= j2{jlastreadtime=jlastreadtime j1, jfiles=jfiles j1} --, jparsestate=jparsestate j1}
         sameParse
            ("2008/12/07 One\n  alpha  $-1\n  beta  $1\n" <>
@@ -405,19 +405,19 @@ tests_Commands = testGroup "Commands" [
            )
 
     ,testCase "preserves \"virtual\" posting type" $ do
-      j <- readJournal' "apply account test\n2008/12/07 One\n  (from)  $-1\n  (to)  $1\n"  -- PARTIAL:
+      j <- readJournal'' "apply account test\n2008/12/07 One\n  (from)  $-1\n  (to)  $1\n"  -- PARTIAL:
       let p = headErr $ tpostings $ headErr $ jtxns j  -- PARTIAL headErrs succeed because txns & postings provided
       paccount p @?= "test:from"
       ptype p @?= VirtualPosting
     ]
 
   ,testCase "alias directive" $ do
-    j <- readJournal' "!alias expenses = equity:draw:personal\n1/1\n (expenses:food)  1\n"  -- PARTIAL:
+    j <- readJournal'' "!alias expenses = equity:draw:personal\n1/1\n (expenses:food)  1\n"  -- PARTIAL:
     let p = headErr $ tpostings $ headErr $ jtxns j  -- PARTIAL headErrs succeed because txns & postings provided
     paccount p @?= "equity:draw:personal:food"
 
   ,testCase "Y default year directive" $ do
-    j <- readJournal' defaultyear_journal_txt  -- PARTIAL:
+    j <- readJournal'' defaultyear_journal_txt  -- PARTIAL:
     tdate (headErr $ jtxns j) @?= fromGregorian 2009 1 1  -- PARTIAL headErr succeeds because defaultyear_journal_txt has a txn
 
   ,testCase "ledgerAccountNames" $
@@ -450,7 +450,7 @@ tests_Commands = testGroup "Commands" [
 -- t1 = LocalTime date1 midday
 
 {-
-samplejournal = readJournal' sample_journal_str
+samplejournal = readJournal'' sample_journal_str
 
 sample_journal_str = unlines
  ["; A sample journal file."

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -459,7 +459,7 @@ ensureOneNewlineTerminated = (<>"\n") . T.dropWhileEnd (=='\n')
 -- | Convert a string of journal data into a register report.
 registerFromString :: T.Text -> IO TL.Text
 registerFromString s = do
-  j <- readJournal' s
+  j <- readJournal'' s
   return . postingsReportAsText opts $ postingsReport rspec j
       where
         ropts = defreportopts{empty_=True}

--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -1227,7 +1227,7 @@ tests_Balance = testGroup "Balance" [
 
    testGroup "balanceReportAsText" [
     testCase "unicode in balance layout" $ do
-      j <- readJournal' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
+      j <- readJournal'' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
       let rspec = defreportspec{_rsReportOpts=defreportopts{no_total_=True}}
       TB.toLazyText (balanceReportAsText (_rsReportOpts rspec) (balanceReport rspec{_rsDay=fromGregorian 2008 11 26} j))
         @?=

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -304,7 +304,7 @@ tests_Register = testGroup "Register" [
 
    testGroup "postingsReportAsText" [
     testCase "unicode in register layout" $ do
-      j <- readJournal' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
+      j <- readJournal'' "2009/01/01 * медвежья шкура\n  расходы:покупки  100\n  актив:наличные\n"
       let rspec = defreportspec
       (TL.unpack . postingsReportAsText defcliopts $ postingsReport rspec j)
         @?=

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -106,7 +106,7 @@ For more about how to do that on your system, see [Common tasks > Setting LEDGER
 
 ## Text encoding
 
-Data files containing non-ascii characters must use UTF-8 encoding.
+Data files containing non-ascii characters must use UTF-8 encoding, with the exception being `csv` files (see [`encoding`](#encoding) below).
 An optional [byte order mark (BOM)](https://www.unicode.org/faq/utf_bom.html#BOM) is allowed, at the beginning of the file (only).
 
 Also, your system should be configured with a locale that can decode UTF-8 text.
@@ -114,8 +114,6 @@ On some unix systems, you may need set the `LANG` environment variable, eg.
 You can read more about this in [Unicode characters](#unicode-characters), below.
 
 On unix systems you can check a file's encoding with the `file` command.
-If you need to import from a UTF-16-encoded CSV file, say,
-you can convert it to UTF-8 with the `iconv` command. 
 
 ## Data formats
 
@@ -3269,6 +3267,64 @@ This is most often useful when getting a csv from a bank as they are sometimes
 in an old encoding.
 
 If none is given, `utf8` is assumed.
+
+The encoding will be checked case-insensitive with some alternative spellings also allowed.
+The full list of valid encodings is:
+- ASCII
+- UTF8
+- UTF16
+- UTF32
+- ISO88591
+- ISO88592
+- ISO88593
+- ISO88594
+- ISO88595
+- ISO88596
+- ISO88597
+- ISO88598
+- ISO88599
+- ISO885910
+- ISO885911
+- ISO885913
+- ISO885914
+- ISO885915
+- ISO885916
+- CP1250
+- CP1251
+- CP1252
+- CP1253
+- CP1254
+- CP1255
+- CP1256
+- CP1257
+- CP1258
+- KOI8R
+- KOI8U
+- GB18030
+- MacOSRoman
+- JISX0201
+- JISX0208
+- ISO2022JP
+- ShiftJIS
+- CP437
+- CP737
+- CP775
+- CP850
+- CP852
+- CP855
+- CP857
+- CP860
+- CP861
+- CP862
+- CP863
+- CP864
+- CP865
+- CP866
+- CP869
+- CP874
+- CP932
+
+Alternate spellings may be found in the [source code of `encoding`](https://hackage.haskell.org/package/encoding/docs/src/Data.Encoding.html#encodingFromStringExplicit)
 
 ## `separator`
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3210,6 +3210,7 @@ The following kinds of rule can appear in the rules file, in any order.
 |                                                 |                                                                                                |
 |-------------------------------------------------|------------------------------------------------------------------------------------------------|
 | [**`source`**](#source)                         | optionally declare which file to read data from                                                |
+| [**`encoding`**](#encoding)                     | optionally declare which encoding the data has                                                 |
 | [**`separator`**](#separator)                   | declare the field separator, instead of relying on file extension                              |
 | [**`skip`**](#skip)                             | skip one or more header lines at start of file                                                 |
 | [**`date-format`**](#date-format)               | declare how to parse CSV dates/date-times                                                      |
@@ -3255,6 +3256,19 @@ source Checking1*.csv
 ```
 
 See also ["Working with CSV > Reading files specified by rule"](#reading-files-specified-by-rule).
+
+## `encoding`
+
+```rules
+encoding ENCODING
+```
+
+Specifying `encoding` followed by a valid encoding tells HLedger how to convert a
+csv to be able to make use of it.
+This is most often useful when getting a csv from a bank as they are sometimes
+in an old encoding.
+
+If none is given, `utf8` is assumed.
 
 ## `separator`
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,6 +35,10 @@ extra-deps:
 # # to silence a warning
 # - wizards-1.0.3@rev:3
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 nix:
   pure: false
   packages: [perl gmp ncurses zlib]

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,10 +12,11 @@ packages:
 
 # To minimise problems, use the versions shipped with GHC 9.10.1 when possible.
 # See https://github.com/haskell/unix/issues/329.
-# extra-deps:
+extra-deps:
 # - base-compat-0.14.0
 
-# # for hledger-lib
+# for hledger-lib
+- encoding-0.9          # not yet in stackage
 # - Cabal-3.12.0.0
 # - Cabal-syntax-3.12.0.0
 # #- directory-1.3.8.3

--- a/stack8.10.yaml
+++ b/stack8.10.yaml
@@ -51,6 +51,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -fplugin Debug.Breakpoint
 

--- a/stack8.10.yaml
+++ b/stack8.10.yaml
@@ -31,6 +31,7 @@ extra-deps:
 - text-builder-0.6.7
 - text-builder-dev-0.3.3.2
 - isomorphism-class-0.1.0.7
+- encoding-0.9          # not yet in stackage
 # for hledger:
 # silence a warning
 - wizards-1.0.3@rev:3

--- a/stack9.0.yaml
+++ b/stack9.0.yaml
@@ -40,6 +40,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -fplugin Debug.Breakpoint
 

--- a/stack9.0.yaml
+++ b/stack9.0.yaml
@@ -22,6 +22,7 @@ extra-deps:
 - text-builder-0.6.7
 - text-builder-dev-0.3.3.2
 - isomorphism-class-0.1.0.7
+- encoding-0.9
 # for hledger:
 # for hledger-ui:
 - bimap-0.5.0

--- a/stack9.12.yaml
+++ b/stack9.12.yaml
@@ -18,7 +18,8 @@ packages:
 extra-deps:
 # - base-compat-0.14.0
 
-# # for hledger-lib
+ # for hledger-lib
+- encoding-0.9          # not yet in stackage
 # - Cabal-3.12.0.0
 # - Cabal-syntax-3.12.0.0
 # #- directory-1.3.8.3

--- a/stack9.12.yaml
+++ b/stack9.12.yaml
@@ -42,6 +42,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -Wno-x-partial
 #   "$locals": -fplugin Debug.Breakpoint

--- a/stack9.2.yaml
+++ b/stack9.2.yaml
@@ -30,6 +30,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -fplugin Debug.Breakpoint
 

--- a/stack9.2.yaml
+++ b/stack9.2.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - megaparsec-9.3.0
 - safe-0.3.21
 # for hledger-lib:
+- encoding-0.9
 # for hledger:
 # for hledger-ui:
 - brick-2.3.1

--- a/stack9.4.yaml
+++ b/stack9.4.yaml
@@ -16,6 +16,7 @@ extra-deps:
 - vty-crossplatform-0.4.0.0
 - vty-unix-0.2.0.0
 - vty-windows-0.2.0.2
+- encoding-0.9
 
 nix:
   pure: false

--- a/stack9.4.yaml
+++ b/stack9.4.yaml
@@ -22,6 +22,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -fplugin Debug.Breakpoint
 

--- a/stack9.6.yaml
+++ b/stack9.6.yaml
@@ -11,6 +11,7 @@ packages:
 extra-deps:
 - base-compat-0.14.0
 - vty-windows-0.2.0.1   # not yet in stackage
+- encoding-0.9          # not yet in stackage
 
 nix:
   pure: false

--- a/stack9.6.yaml
+++ b/stack9.6.yaml
@@ -17,6 +17,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -fplugin Debug.Breakpoint
 

--- a/stack9.8.yaml
+++ b/stack9.8.yaml
@@ -16,6 +16,10 @@ nix:
   pure: false
   packages: [perl gmp ncurses zlib]
 
+flags:
+  encoding:
+    systemEncoding: false # See https://github.com/dmwit/encoding/issues/26
+
 # ghc-options:
 #   "$locals": -Wno-x-partial
 #   "$locals": -fplugin Debug.Breakpoint

--- a/stack9.8.yaml
+++ b/stack9.8.yaml
@@ -10,6 +10,7 @@ packages:
 
 extra-deps:
 - base-compat-0.14.0
+- encoding-0.9          # not yet in stackage
 
 nix:
   pure: false


### PR DESCRIPTION
<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
An implementation for `encoding` in rules file:
The cases are:
- [X] `-f *.rules`
- [x] `-f *.csv`
- [x] `-f *.csv --rules *.rules`

The second and third case are effectively the same. The problem is that for them we call a `Reader`s `rReadFn` value taking the contents rather then the filepath / handle.
So we either would have to change `Reader` to take a `FilePath` instead of `Text`, which would break how we do Tests,
or we add an extra field  `rGetContents :: FilePath -> IO Text`.
I would rather get some feedback on this before I implement a potentially bigger change.

If implemented this PR should:
- fix #1777 