### PR TITLE
feat: csv: allow multiple matchers on the same line

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3741,10 +3741,13 @@ If you have trouble with it, see "Regular expressions" in the hledger manual (<h
 When an if block has multiple matchers, each on its own line,
 
 - By default they are OR'd (any of them can match).
-- Matcher lines beginning with `&` (and optional space) are AND'ed with the matcher above (all in the AND'ed group must match).
+- Matcher lines beginning with `&` (or `&&`, *since 1.42*) are AND'ed with the matcher above (all in the AND'ed group must match).
+- Matcher lines beginning with `& !` (*since 1.41*, or `&& !`, *since 1.42*) are first negated and then AND'ed with the matcher above.
 
-*(Since 1.41:)*
-You can use a negated `!` matcher on a `&` line, meaning AND NOT.
+You can also combine multiple matchers one the same line separated by `&&` (AND) or `&& !` (AND NOT).
+Eg `%description amazon && %date 2025-01-01` will match only when the
+description field contains "amazon" and the date field equals 2025-01-01.
+*Added in 1.42.*
 
 ### Match groups
 
@@ -3779,9 +3782,9 @@ they can express many matchers and field assignments in a more compact tabular f
 ```rules
 if,HLEDGERFIELD1,HLEDGERFIELD2,...
 MATCHERA,VALUE1,VALUE2,...
-MATCHERB,VALUE1,VALUE2,...
-; Comment line that explains MATCHERC
-MATCHERC,VALUE1,VALUE2,...
+MATCHERB && MATCHERC,VALUE1,VALUE2,...  (*since 1.42*)
+; Comment line that explains MATCHERD
+MATCHERD,VALUE1,VALUE2,...
 <empty line>
 ```
 
@@ -3796,8 +3799,8 @@ You can use the comment lines in the table body.
 The table must be terminated by an empty line (or end of file).
 
 An if table like the above is interpreted as follows:
-try all of the matchers; 
-whenever a matcher succeeds, assign all of the values on that line to the corresponding hledger fields;
+try all of the lines with matchers; 
+whenever a line with matchers succeeds, assign all of the values on that line to the corresponding hledger fields;
 If multiple lines match, later lines will override fields assigned by the earlier ones - just like the sequence of `if` blocks would behave.
 
 If table presented above is equivalent to this sequence of if blocks:
@@ -3808,13 +3811,13 @@ if MATCHERA
   HLEDGERFIELD2 VALUE2
   ...
 
-if MATCHERB
+if MATCHERB && MATCHERC
   HLEDGERFIELD1 VALUE1
   HLEDGERFIELD2 VALUE2
   ...
 
-; Comment line which explains MATCHERC
-if MATCHERC
+; Comment line which explains MATCHERD
+if MATCHERD
   HLEDGERFIELD1 VALUE1
   HLEDGERFIELD2 VALUE2
   ...


### PR DESCRIPTION



### Description
If blocks and If tables now allow multiple matchers on the same line. The only requirement is that the first (n-1) matchers end with a '$' (i.e. end of string marker).

Example `if block` with two matchers on the same line:

	if %date ^2025-02-22$ & %description amazon
	    account2 expenses:books

Example `if table` with two matchers on the same line:

	if|account2
	%date ^2025-02-22$ & %description amazon | expenses:books
	


### Justification
I make heavy use of `if tables`.  Example:

```
if|account2|comment2
%description ^CARTE ../../.. AUCHAN SUPERMAR 4 CB | expenses:food:supermarket|
%description ^CARTE ../../.. CARREFOUR.FR CB | expenses:food:supermarket|
...
```

But then sometimes I need to match 2 separate fields, usually `%date` and `%description`, and  I will have to fall back to using an `if block`:

```
if
%description ^VIR INST STICHTING MOLLIE PAYMENTS$
& %date ^2024-06-20$
  account2 expenses:food:supermarket
```

My rules files would look much nicer like this:
```
if|account2|comment2
%description ^CARTE ../../.. AUCHAN SUPERMAR 4 CB | expenses:food:supermarket|
%description ^CARTE ../../.. CARREFOUR.FR CB | expenses:food:supermarket|
%description ^VIR INST STICHTING MOLLIE PAYMENTS$ & %date ^2024-06-20$ | expenses:food:supermarket|
...
```

That's what this MR accomplishes.

### Alternative solution

Instead of using field matchers, I could use whole record matchers like so:

``` 
if|account2|comment2
%description ^CARTE ../../.. AUCHAN SUPERMAR 4 CB | expenses:food:supermarket|
%description ^CARTE ../../.. CARREFOUR.FR CB | expenses:food:supermarket|
2024-06-20,VIR INST STICHTING MOLLIE PAYMENTS | expenses:food:supermarket|
```

This works, but I suspect whole record matchers are slower to execute than field matchers. I have some csv files where dates are in `%d/%m/%Y` format, and matching whole records with dates seemed very slow. I also just like my matchers to be as restrictive as possible, so using `^` and `$` on field matchers, so that I'm sure I'm not accidentally matching a record I didn't mean to.

### Discussion

Hello @simonmichael, let me know if this is a feature you would like to include. This MR is more a prove of concept; the implementation is probably not very efficient, and the documentation needs updating. Thanks.