### PR TITLE
;cln: unittest.hs: remove bothersome PackageImports

### DIFF
--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -176,7 +176,6 @@ test-suite doctest
   type: exitcode-stdio-1.0
   main-is: doctests.hs
   hs-source-dirs:
-      ./
       test
   ghc-options: -Wall -Wno-incomplete-uni-patterns -Wno-missing-signatures -Wno-orphans -Wno-type-defaults -Wno-unused-do-bind
   build-depends:
@@ -239,7 +238,6 @@ test-suite unittest
   type: exitcode-stdio-1.0
   main-is: unittest.hs
   hs-source-dirs:
-      ./
       test
   ghc-options: -Wall -Wno-incomplete-uni-patterns -Wno-missing-signatures -Wno-orphans -Wno-type-defaults -Wno-unused-do-bind
   build-depends:

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -115,10 +115,6 @@ when:
 #   dependencies:
 #   - ghc-debug-stub >=0.6.0.0 && <0.7
 
-source-dirs: 
-#- other/ledger-parse
-- .
-
 library:
   exposed-modules:
   - Hledger
@@ -186,6 +182,10 @@ library:
   - Text.WideString
 #  other-modules:
 #  - Ledger.Parser.Text
+  source-dirs: 
+  #- other/ledger-parse
+  - .
+
 
 # "cabal test hledger-lib" currently fails, see doctest suite below
 tests:

--- a/hledger-lib/test/unittest.hs
+++ b/hledger-lib/test/unittest.hs
@@ -2,9 +2,7 @@
 Run the hledger-lib package's unit tests using the tasty test runner.
 -}
 
--- package-qualified import to avoid cabal missing-home-modules warning (and double-building ?)
-{-# LANGUAGE PackageImports #-}
-import "hledger-lib" Hledger (tests_Hledger)
+import Hledger (tests_Hledger)
 import System.Environment (setEnv)
 import Test.Tasty (defaultMain)
 

--- a/hledger/test/unittest.hs
+++ b/hledger/test/unittest.hs
@@ -3,9 +3,6 @@ Run the hledger package's unit tests using the tasty test runner
 (by running the test command limited to Hledger.Cli tests).
 -}
 
--- cabal missing-home-modules workaround from hledger-lib, seems not needed here
--- {-# LANGUAGE PackageImports #-}
--- import "hledger" Hledger.Cli (tests_Hledger_Cli)
 import Hledger.Cli (tests_Hledger_Cli)
 import System.Environment (setEnv)
 import Test.Tasty (defaultMain)


### PR DESCRIPTION
When running `cd hledger-lib && ghci test/unittest.hs`, ghci complains with:

```
  test/unittest.hs:7:1: error:
      Could not find module ‘Hledger’
      It is not a module in the current program, or in any known package.
    |
  7 | import "hledger-lib" Hledger (tests_Hledger)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Failed, no modules loaded.
```

I suspect the "hledger-lib" package-qualified import isn't really necessary anymore. After removing it, above ghci command works as expected.

This instance of PackageImports was introduced in commit c7574b8005a84c6116a2871313ce8417b492a823 (2019).