### PR TITLE
Make terminal width lookup more robust

### DIFF
--- a/hledger-lib/Hledger/Utils/IO.hs
+++ b/hledger-lib/Hledger/Utils/IO.hs
@@ -413,8 +413,30 @@ hasOutputFile = do
 
 -- Terminal size
 
+-- [NOTE: Alternative methods of getting the terminal size]
+-- terminal-size uses the TIOCGWINSZ ioctl to get the window size on Unix
+-- systems, which may not be completely portable according to people in
+-- #linux@liberachat.
+--
+-- If this turns out to be the case, supplementary coverage can be given by
+-- using the terminfo package.
+--
+-- Conversely, terminfo on its own is not a full solution, firstly because it
+-- only works on Unix (not Windows), and secondly since in some scenarios (eg
+-- stripped-down build systems) the terminfo database may be limited and lack
+-- the correct entries. (A hack that sometimes works but which isn't robust
+-- enough to be relied upon is to set TERM=dumb -- while this advice does appear
+-- in some places, it's not guaranteed to work)
+--
+-- In any case, $LINES/$COLUMNS should not be used as a source for the terminal
+-- size -- that is a bashism, and in particular they aren't updated as the
+-- terminal is resized.
+--
+-- See #2332 for details
+
 -- | An alternative to ansi-terminal's getTerminalSize, based on
 -- the more robust-looking terminal-size package.
+--
 -- Tries to get stdout's terminal's current height and width.
 getTerminalHeightWidth :: IO (Maybe (Int,Int))
 getTerminalHeightWidth = fmap (fmap unwindow) size

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -550,9 +550,8 @@ data CliOpts = CliOpts {
     ,no_new_accounts_ :: Bool           -- add
     ,width_           :: Maybe String   -- ^ the --width value provided, if any
     ,available_width_ :: Int            -- ^ estimated usable screen width, based on
-                                        -- 1. the COLUMNS env var, if set
-                                        -- 2. the width reported by the terminal, if supported
-                                        -- 3. the default (80)
+                                        -- 1. the width reported by the terminal, if supported
+                                        -- 2. the default (80)
     ,progstarttime_   :: POSIXTime      -- system POSIX time at start
  } deriving (Show)
 
@@ -615,9 +614,8 @@ rawOptsToCliOpts rawopts = do
   usecolor <- useColorOnStdout
   let iopts = rawOptsToInputOpts day usecolor postingaccttags rawopts
   rspec <- either error' pure $ rawOptsToReportSpec day usecolor rawopts  -- PARTIAL:
-  mcolumns <- readMay <$> getEnvSafe "COLUMNS"
   mtermwidth <- getTerminalWidth
-  let availablewidth = NE.head $ NE.fromList $ catMaybes [mcolumns, mtermwidth, Just defaultWidth]  -- PARTIAL: fromList won't fail because non-null list
+  let availablewidth = NE.head $ NE.fromList $ catMaybes [mtermwidth, Just defaultWidth]  -- PARTIAL: fromList won't fail because non-null list
   return defcliopts {
               rawopts_         = rawopts
              ,command_         = command
@@ -763,8 +761,7 @@ rulesFilePathFromOpts opts = do
   maybe (return Nothing) (fmap Just . expandPath d) $ mrules_file_ $ inputopts_ opts
 
 -- -- | Get the width in characters to use for console output.
--- -- This comes from the --width option, or the COLUMNS environment
--- -- variable, or (on posix platforms) the current terminal width, or 80.
+-- -- This comes from the --width option, or the current terminal width, or 80.
 -- -- Will raise a parse error for a malformed --width argument.
 -- widthFromOpts :: CliOpts -> Int
 -- widthFromOpts CliOpts{width_=Nothing, available_width_=w} = w
@@ -779,7 +776,7 @@ rulesFilePathFromOpts opts = do
 -- and also the description column width if specified (following the main width, comma-separated).
 -- The widths will be as follows:
 -- @
--- no --width flag - overall width is the available width (COLUMNS, or posix terminal width, or 80); description width is unspecified (auto)
+-- no --width flag - overall width is the available width (or terminal width, or 80); description width is unspecified (auto)
 -- --width W       - overall width is W, description width is auto
 -- --width W,D     - overall width is W, description width is D
 -- @

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -107,9 +107,7 @@ import String.ANSI
 import System.Console.CmdArgs hiding (Default,def)
 import System.Console.CmdArgs.Explicit
 import System.Console.CmdArgs.Text
-#ifndef mingw32_HOST_OS
-import System.Console.Terminfo
-#endif
+import Hledger.Utils.IO (getTerminalWidth)
 import System.Directory
 import System.Environment
 import System.Exit (exitSuccess)
@@ -618,13 +616,7 @@ rawOptsToCliOpts rawopts = do
   let iopts = rawOptsToInputOpts day usecolor postingaccttags rawopts
   rspec <- either error' pure $ rawOptsToReportSpec day usecolor rawopts  -- PARTIAL:
   mcolumns <- readMay <$> getEnvSafe "COLUMNS"
-  mtermwidth <-
-#ifdef mingw32_HOST_OS
-    return Nothing
-#else
-    (`getCapability` termColumns) <$> setupTermFromEnv
-    -- XXX Throws a SetupTermError if the terminfo database could not be read, should catch
-#endif
+  mtermwidth <- getTerminalWidth
   let availablewidth = NE.head $ NE.fromList $ catMaybes [mcolumns, mtermwidth, Just defaultWidth]  -- PARTIAL: fromList won't fail because non-null list
   return defcliopts {
               rawopts_         = rawopts

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -615,7 +615,7 @@ rawOptsToCliOpts rawopts = do
   let iopts = rawOptsToInputOpts day usecolor postingaccttags rawopts
   rspec <- either error' pure $ rawOptsToReportSpec day usecolor rawopts  -- PARTIAL:
   mtermwidth <- getTerminalWidth
-  let availablewidth = NE.head $ NE.fromList $ catMaybes [mtermwidth, Just defaultWidth]  -- PARTIAL: fromList won't fail because non-null list
+  let availablewidth = fromMaybe defaultWidth mtermwidth
   return defcliopts {
               rawopts_         = rawopts
              ,command_         = command

--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -65,7 +65,7 @@ aregistermode = hledgerCommandMode
 #else
       "terminal width"
 #endif
-      ++ " or $COLUMNS). -wN,M sets description width as well."
+      ++ "). -wN,M sets description width as well."
      )
   ,flagNone ["align-all"] (setboolopt "align-all") "guarantee alignment across all lines (slower)"
   ,outputFormatFlag ["txt","html","csv","tsv","json"]

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -67,7 +67,7 @@ registermode = hledgerCommandMode
 #else
       "terminal width"
 #endif
-      ++ " or $COLUMNS). -wN,M sets description width as well."
+      ++ "). -wN,M sets description width as well."
      )
   ,flagNone ["align-all"] (setboolopt "align-all") "guarantee alignment across all lines (slower)"
   ,flagReq  ["base-url"] (\s opts -> Right $ setopt "base-url" s opts) "URLPREFIX" "in html output, generate links to hledger-web, with this prefix. (Usually the base url shown by hledger-web; can also be relative.)"

--- a/hledger/hledger.cabal
+++ b/hledger/hledger.cabal
@@ -98,11 +98,6 @@ flag debug
   manual: True
   default: False
 
-flag terminfo
-  description: On POSIX systems, build with the terminfo lib for detecting terminal width
-  manual: False
-  default: True
-
 flag threaded
   description: Build with support for multithreaded execution
   manual: False
@@ -195,9 +190,6 @@ library
     , utility-ht >=0.0.13
     , wizards >=1.0
   default-language: Haskell2010
-  if (!(os(windows))) && (flag(terminfo))
-    build-depends:
-        terminfo
   if (flag(debug))
     cpp-options: -DDEBUG
 
@@ -247,9 +239,6 @@ executable hledger
     , utility-ht >=0.0.13
     , wizards >=1.0
   default-language: Haskell2010
-  if (!(os(windows))) && (flag(terminfo))
-    build-depends:
-        terminfo
   if (flag(debug))
     cpp-options: -DDEBUG
   if flag(threaded)
@@ -300,9 +289,6 @@ test-suite unittest
     , utility-ht >=0.0.13
     , wizards >=1.0
   default-language: Haskell2010
-  if (!(os(windows))) && (flag(terminfo))
-    build-depends:
-        terminfo
   if (flag(debug))
     cpp-options: -DDEBUG
 
@@ -353,8 +339,5 @@ benchmark bench
     , wizards >=1.0
   buildable: False
   default-language: Haskell2010
-  if (!(os(windows))) && (flag(terminfo))
-    build-depends:
-        terminfo
   if (flag(debug))
     cpp-options: -DDEBUG


### PR DESCRIPTION
On some systems, `TERM` is set to a value that doesn't have a valid terminfo entry. Rather than hackily fall back on a value for `TERM` that appears to work in most contexts (`TERM=dumb`) but which isn't guaranteed anywhere to be valid, use proper POSIX ioctls to get the tty width.
This has the added bonus of also working on Windows.
In fact, we already settled on computing the terminal size in this way in hledger-lib, so this commit centralizes the choice of the logic there.

Also added a note for alternative methods and their tradeoffs, in case this turns out to be fragile on some systems.

Additionally, `COLUMNS` is a bashism that isn't particularly usable for our purposes (for one thing, it isn't updated when the terminal is resized), so I removed its usages.

Finally, reducing our sources of truth for terminal width to 2 permitted removing the partial `NE.fromList` which I took advantage of.

Fixes: #2332
