### PR TITLE
Hledger.Cli.CliOptions: Remove commented-out, unused functions

### DIFF
--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -898,18 +898,6 @@ getDirectoryContentsSafe :: FilePath -> IO [String]
 getDirectoryContentsSafe d =
     (filter (not . (`elem` [".",".."])) `fmap` getDirectoryContents d) `C.catch` (\(_::C.IOException) -> return [])
 
--- not used:
--- -- | Print debug info about arguments and options if --debug is present.
--- debugArgs :: [String] -> CliOpts -> IO ()
--- debugArgs args opts =
---   when ("--debug" `elem` args) $ do
---     progname <- getProgName
---     putStrLn $ "running: " ++ progname
---     putStrLn $ "raw args: " ++ show args
---     putStrLn $ "processed opts:\n" ++ show opts
---     d <- getCurrentDay
---     putStrLn $ "search query: " ++ (show $ queryFromOpts d $ reportopts_ opts)
-
 -- ** Lenses
 
 makeHledgerClassyLenses ''CliOpts

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -72,7 +72,6 @@ module Hledger.Cli.CliOptions (
   outputFileFromOpts,
   outputFormatFromOpts,
   defaultWidth,
-  -- widthFromOpts,
   replaceNumericFlags,
   ensureDebugFlagHasVal,
   -- | For register:
@@ -758,18 +757,6 @@ rulesFilePathFromOpts :: CliOpts -> IO (Maybe FilePath)
 rulesFilePathFromOpts opts = do
   d <- getCurrentDirectory
   maybe (return Nothing) (fmap Just . expandPath d) $ mrules_file_ $ inputopts_ opts
-
--- -- | Get the width in characters to use for console output.
--- -- This comes from the --width option, or the current terminal width, or 80.
--- -- Will raise a parse error for a malformed --width argument.
--- widthFromOpts :: CliOpts -> Int
--- widthFromOpts CliOpts{width_=Nothing, available_width_=w} = w
--- widthFromOpts CliOpts{width_=Just s}  =
---     case runParser (read `fmap` some digitChar <* eof :: ParsecT Void String Identity Int) "(unknown)" s of
---         Left e   -> usageError $ "could not parse width option: "++errorBundlePretty e
---         Right w  -> w
-
--- for register:
 
 -- | Get the width in characters to use for the register command's console output,
 -- and also the description column width if specified (following the main width, comma-separated).


### PR DESCRIPTION
While looking at `Hledger.Cli.CliOptions`, I noticed a couple of bits of dead
code which are duplicated elsewhere. I propose we remove them

- `debugArgs`:
  A variant of it is present as a local definition in `getHledgerCliOpts'`

- `widthFromOpts`:
  As noted in 5c289ac, it is unused elsewhere, and `registerWidthsFromOpts` is right next to it and implements nearly the exact same logic
