### PR TITLE
Fix #2345: do not pre-load journal(s) at the start of run/repl, and honor reporting interval changes for --forecast

### DIFF
--- a/hledger/Hledger/Cli/Commands/Run.hs
+++ b/hledger/Hledger/Cli/Commands/Run.hs
@@ -43,6 +43,7 @@ import Hledger.Cli.DocFiles (runTldrForPage, runInfoForTopic, runManForTopic)
 import Hledger.Cli.Utils (journalTransform)
 import Text.Printf (printf)
 import System.Process (system)
+import Data.Maybe (isJust)
 
 -- | Command line options for this command.
 runmode = hledgerCommandMode
@@ -240,10 +241,9 @@ withJournalCached defaultJournalOverride cliopts cmd = do
             either error' (\j -> return (Map.insert (ioptsWithoutReportSpan,fp) j cache, j)) journal
       where
         -- InputOptions contain reportspan_ that is used to calculare forecast period,
-        -- that is used by journalFinalise to insert forecast transactions.addHeaderBorders
-        -- For the purposes of caching, we want to ignore this, as it is only used for forecast
-        -- and it is sufficient to include forecast_ in the InputOptions that we use as a key.
-        ioptsWithoutReportSpan = iopts { reportspan_ = emptydatespan }
+        -- that is used by journalFinalise to insert forecast transactions.
+        -- For the purposes of caching, we want to ignore this when --forecast is not given.
+        ioptsWithoutReportSpan = if isJust (forecast_ iopts) then iopts else iopts { reportspan_ = emptydatespan }
         -- Read stdin, or if we read it alread, use a cache
         -- readStdin :: InputOpts -> ExceptT String IO Journal
         readStdin = do

--- a/hledger/test/run.test
+++ b/hledger/test/run.test
@@ -164,3 +164,33 @@ readAndCacheJournalFile reading and caching -:
 readAndCacheJournalFile reading and caching sample.journal:
 readAndCacheJournalFile using cache for -:
 readAndCacheJournalFile using cache for sample.journal:
+
+# ** 12. Run commands with forecast properly honor reporting interval
+<
+2025-01-01  Buy beans
+    expenses:food   $2
+    assets         -$2
+
+~ every 14 days from 2025-01-01  Buy soylent green
+    expenses:food:not people   $1
+    assets                    -$1
+$ hledger run -f- -- echo "Till Feb" -- register --forecast -b 2025-01 -e 2025-02 -- echo "Till Mar" -- register --forecast -b 2025-01 -e 2025-03
+>
+Till Feb
+2025-01-01 Buy beans            expenses:food                   $2            $2
+                                assets                         $-2             0
+2025-01-15 Buy soylent green    ex:food:not people              $1            $1
+                                assets                         $-1             0
+2025-01-29 Buy soylent green    ex:food:not people              $1            $1
+                                assets                         $-1             0
+Till Mar
+2025-01-01 Buy beans            expenses:food                   $2            $2
+                                assets                         $-2             0
+2025-01-15 Buy soylent green    ex:food:not people              $1            $1
+                                assets                         $-1             0
+2025-01-29 Buy soylent green    ex:food:not people              $1            $1
+                                assets                         $-1             0
+2025-02-12 Buy soylent green    ex:food:not people              $1            $1
+                                assets                         $-1             0
+2025-02-26 Buy soylent green    ex:food:not people              $1            $1
+                                assets                         $-1             0

--- a/hledger/test/run.test
+++ b/hledger/test/run.test
@@ -150,7 +150,7 @@ Assets, depth 2:
 --------------------
                  $-1  
 
-# ** 0. Run caches input files, and re-parses files when InputOptions change
+# ** 11. Run caches input files, and re-parses files when InputOptions change
 <
 2017-01-01 groceries
    assets:cash  -$100
@@ -158,7 +158,6 @@ Assets, depth 2:
 $ hledger run --debug 1 -f- -- accounts -- balance -f sample.journal -- balance cash --forecast -- balance cash -f sample.journal --forecast -- register -- register -f sample.journal 2>&1 | grep readAndCacheJournalFile | sed -e "s#$(pwd)/##"
 >
 readAndCacheJournalFile reading and caching -:
-readAndCacheJournalFile using cache for -:
 readAndCacheJournalFile reading and caching sample.journal:
 readAndCacheJournalFile reading and caching -:
 readAndCacheJournalFile reading and caching sample.journal:


### PR DESCRIPTION
This fixes #2345 

Previosly: both "run" and "repl" did `withJournalCached` at the start to pre-load journal. The returned journal would be dropped on the floor, but when the command will ask for the same journal, it would already be in the cache. What's bad: there is no guarantee that _any_ command will actually ask for this same journal. We are not winning anything by preload, this was just side-effect of multiple refactors.

Now: no journals are preloaded, any reading/parsing will only occur when commands ask for it

Aslo previosly: InputOpts is used in the cache key, and I would blank out `reportspan_` there, thinking that as it is derived from (forecast_ :: Maybe DateSpan) which is also in InputOpts, it is sufficient to rely on `forecast_` changing. What's bad: actually, we are interested in distinguishing inputs with `--forecast` set and different reporting intervals

Now: `reportspan_` is only blanked out when `--forecast` is not set.

I've added one more test. 

Tests demonstrate both of these changes.