### PR TITLE
imp: add: Verify balance assertions on each posting (#2355)

### DIFF
--- a/hledger-lib/Hledger/Data/Balancing.hs
+++ b/hledger-lib/Hledger/Data/Balancing.hs
@@ -18,6 +18,8 @@ module Hledger.Data.Balancing
 , isTransactionBalanced
 , balanceTransaction
 , balanceTransactionHelper
+  -- * assertion validation
+, checkAssertions
   -- * journal balancing
 , journalBalanceTransactions
   -- * tests
@@ -146,6 +148,16 @@ transactionCheckBalanced BalancingOpts{commodity_styles_} t = errs
 -- | Legacy form of transactionCheckBalanced.
 isTransactionBalanced :: BalancingOpts -> Transaction -> Bool
 isTransactionBalanced bopts = null . transactionCheckBalanced bopts
+
+-- | Verify that any assertions in this transaction hold 
+-- when included in the larger journal.
+checkAssertions :: BalancingOpts -> Journal -> Transaction -> Either String Transaction
+checkAssertions bopts j t =
+  if (ignore_assertions_ bopts) || noassertions t then Right t else do
+    j' <- journalStyleAmounts j 
+    fmap (\_ -> t) $ journalBalanceTransactions defbalancingopts j'{jtxns = (t : (jtxns j')) }
+  where
+    noassertions = all (isNothing . pbalanceassertion) . tpostings
 
 -- | Balance this transaction, ensuring that its postings
 -- (and its balanced virtual postings) sum to 0,

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -231,16 +231,27 @@ confirmedTransactionWizard prevInput es@EntryState{..} stack@(currentStage : _) 
       confirmedTransactionWizard prevInput es{esPostings=init esPostings} (dropWhile notPrevAmountAndNotEnterDesc stack)
 
   EnterAmountAndComment txnParams account -> amountAndCommentWizard prevInput es >>= \case
-    Just (amt, comment) -> do
+    Just (amt, assertion, comment) -> do
       let p = nullposting{paccount=T.pack $ stripbrackets account
                           ,pamount=mixedAmount amt
                           ,pcomment=comment
                           ,ptype=accountNamePostingType $ T.pack account
+                          ,pbalanceassertion = assertion
                           }
           amountAndCommentString = showAmount amt ++ T.unpack (if T.null comment then "" else "  ;" <> comment)
           prevAmountAndCmnt' = replaceNthOrAppend (length esPostings) amountAndCommentString (prevAmountAndCmnt prevInput)
           es' = es{esPostings=esPostings++[p], esArgs=drop 1 esArgs}
-      confirmedTransactionWizard prevInput{prevAmountAndCmnt=prevAmountAndCmnt'} es' (EnterNewPosting txnParams (Just posting) : stack)
+          -- Include a dummy posting to balance the unfinished transation in assertion checking
+          dummytxn = nulltransaction{tpostings = esPostings ++ [p, post "" missingamt]
+                                     ,tdate = txnDate txnParams
+                                     ,tdescription = txnDesc txnParams }
+          validated = balanceTransaction defbalancingopts dummytxn >>= checkAssertions defbalancingopts esJournal
+      case validated of
+        Left err -> do
+          liftIO (hPutStrLn stderr err)
+          confirmedTransactionWizard prevInput es (EnterAmountAndComment txnParams account : stack)
+        Right _ -> 
+          confirmedTransactionWizard prevInput{prevAmountAndCmnt=prevAmountAndCmnt'} es' (EnterNewPosting txnParams (Just posting) : stack)
     Nothing -> confirmedTransactionWizard prevInput es (drop 1 stack)
 
   EndStage t -> do
@@ -352,13 +363,14 @@ amountAndCommentWizard PrevInput{..} EntryState{..} = do
                                   ""
                                   (T.pack s)
       nodefcommodityj = esJournal{jparsedefaultcommodity=Nothing}
-      amountandcommentp :: JournalParser Identity (Amount, Text)
+      amountandcommentp :: JournalParser Identity (Amount, Maybe BalanceAssertion, Text)
       amountandcommentp = do
         a <- amountp
         lift skipNonNewlineSpaces
+        assertion <- optional balanceassertionp
         c <- T.pack <$> fromMaybe "" `fmap` optional (char ';' >> many anySingle)
         -- eof
-        return (a,c)
+        return (a, assertion, c)
       balancingamt = maNegate . sumPostings $ filter isReal esPostings
       balancingamtfirstcommodity = mixed . take 1 $ amounts balancingamt
       showamt = wbUnpack . showMixedAmountB defaultFmt . mixedAmountSetPrecision


### PR DESCRIPTION
<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->

As requested in #2355, this verifies balance assertions during `hledger add`. Here's an example of the new workflow. With the following journal file:

```
2025-03-18 * Deposit
    Assets:Checking                     $20
    Income:Salary                      $-20
```

```
$ hledger add
Date [2025-03-19]:
Description: Food
Account 1: Expenses:Food
Amount  1: $15
Account 2: Assets:Checking
Amount  2 [$-15]: $-15 == $10
1:6:
  | 2025-03-19 Food
  |     Expenses:Food               $15
3 |     Assets:Checking            $-15 == $10
  |                                     ^^^^^^
  |                                  $0

Balance assertion failed in Assets:Checking
Across all commodities at this point, excluding subaccounts, ignoring costs,
the asserted balance is:        $10
but the calculated balance is:   $5
(difference: $5)
To troubleshoot, check this account's running balance with assertions disabled, eg:
hledger reg -I 'Assets:Checking$'
Amount  2 [$-15]: $-15  == $5
Account 3 (or . or enter to finish this transaction):
2025-03-19 Food
    Expenses:Food               $15
    Assets:Checking            $-15 == $5

Save this transaction to the journal ? [y]: y
Saved.
```

The only thing that might be odd here is including the "To troubleshoot..." lines. I left those in because it's not bad advice for tracking down why an assertion might be failing, but also it isn't really helpful and might be misleading in the middle of an `hledger add`, so I'm open to removing those lines here.