### PR TITLE
feat: timeclock: Add support for multiple clocked in sessions (#2141)

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -231,6 +231,7 @@ rawOptsToInputOpts day usecoloronstdout postingaccttags rawopts =
                                }
       ,strict_            = boolopt "strict" rawopts
       ,_ioDay             = day
+      ,_oldtimeclock      = boolopt "oldtimeclock" rawopts
       }
 
 handleReadFnToTextReadFn :: (InputOpts -> FilePath -> Text -> ExceptT String IO Journal) -> InputOpts -> FilePath -> Handle -> ExceptT String IO Journal

--- a/hledger-lib/Hledger/Read/InputOptions.hs
+++ b/hledger-lib/Hledger/Read/InputOptions.hs
@@ -44,6 +44,7 @@ data InputOpts = InputOpts {
     ,strict_            :: Bool                 -- ^ do extra correctness checks ?
     ,_defer             :: Bool                 -- ^ internal flag: postpone checks, because we are processing multiple files ?
     ,_ioDay             :: Day                  -- ^ today's date, for use with forecast transactions  XXX this duplicates _rsDay, and should eventually be removed when it's not needed anymore.
+    ,_oldtimeclock      :: Bool                 -- ^ parse with the old timeclock pairing rules?
  } deriving (Eq, Ord, Show)
 
 definputopts :: InputOpts
@@ -66,6 +67,7 @@ definputopts = InputOpts
     , strict_            = False
     , _defer             = False
     , _ioDay             = nulldate
+    , _oldtimeclock      = False
     }
 
 -- | Get the Maybe the DateSpan to generate forecast options from.

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -283,6 +283,7 @@ hiddenflagsformainmode = [
   ,flagNone ["pretty-tables"]        (setopt "pretty" "always") "legacy flag that was renamed"
   ,flagNone ["anon"]                 (setboolopt "anon") "deprecated, renamed to --obfuscate"  -- #2133, handled by anonymiseByOpts
   ,flagNone ["obfuscate"]            (setboolopt "obfuscate") "slightly obfuscate hledger's output. Warning, does not give privacy. Formerly --anon."  -- #2133, handled by maybeObfuscate
+  ,flagNone ["timeclock-old"]        (setboolopt "oldtimeclock") "don't pair timeclock entries by account name"
   ,flagReq  ["rules-file"]           (\s opts -> Right $ setopt "rules" s opts) "RULESFILE" "was renamed to --rules"
   ]
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4606,12 +4606,19 @@ i 2015/03/30 09:00:00 some account  optional description after 2 spaces ; option
 o 2015/03/30 09:20:00
 i 2015/03/31 22:21:45 another:account
 o 2015/04/01 02:00:34
+i 2015/04/02 12:00:00 another:account  ; this demonstrates multple sessions being clocked in
+i 2015/04/02 13:00:00 some account
+o 2015/04/02 14:00:00
+o 2015/04/02 15:00:00 another:account
 ```
 
 hledger treats each clock-in/clock-out pair as a transaction posting
-some number of hours to an account. Or if the session spans more than
-one day, it is split into several transactions, one for each day. For
-the above time log, `hledger print` generates these journal entries:
+some number of hours to an account. Entries are paired by the account
+name if the same name is given for a clock-in/clock-out pair. If no 
+name is given for a clock-out, then it is paired with the most recent 
+clock-in entry. If the session spans more than one day, it is split into 
+several transactions, one for each day. For the above time log, 
+`hledger print` generates these journal entries:
 
 ```cli
 $ hledger -f t.timeclock print
@@ -4623,6 +4630,12 @@ $ hledger -f t.timeclock print
 
 2015-04-01 * 00:00-02:00
     (another:account)           2.01h
+
+2015-04-02 * 12:00-15:00  ; this demonstrates multiple sessions being clocked in
+    (another:account)           3.00h
+
+2015-04-02 * 13:00-14:00
+    (some account)           1.00h
 
 ```
 

--- a/hledger/test/errors/tcclockouttime.test
+++ b/hledger/test/errors/tcclockouttime.test
@@ -1,10 +1,8 @@
 $$$ hledger check -f tcclockouttime.timeclock
 >>>2 /hledger: Error: .*tcclockouttime.timeclock:5:1:
-  \| i 2022-01-01 00:01:00   
 5 \| o 2022-01-01 00:00:00   
-  \|   \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^
+  \| \^
 
-This clockout time \(2022-01-01 00:00:00\) is earlier than the previous clockin.
-Please adjust it to be later than 2022-01-01 00:01:00.
+Could not find previous clockin to match this clockout.
 /
 >>>= 1

--- a/hledger/test/errors/tcorderedactions.test
+++ b/hledger/test/errors/tcorderedactions.test
@@ -3,8 +3,6 @@ $$$ hledger check -f  tcorderedactions.timeclock
 8 \| i 2022-01-01 00:01:00   
   \| \^
 
-Expected a timeclock o entry but got i.
-Only one session may be clocked in at a time.
-Please alternate i and o, beginning with i.
+Encountered clockin entry for session "" that is already active.
 /
 >>>= 1

--- a/hledger/test/timeclock.test
+++ b/hledger/test/timeclock.test
@@ -3,7 +3,7 @@
 # ** 1. a timeclock session is parsed as a similarly-named transaction with one virtual posting.
 <
 i 2009/1/1 08:00:00
-o 2009/1/1 09:00:00 stuff on checkout record  is ignored
+o 2009/1/1 09:00:00
 
 i 2009/1/2 08:00:00 account name
 o 2009/1/2 09:00:00
@@ -43,19 +43,19 @@ $ hledger -f timeclock:- balance
 > /./
 >=
 
-# ** 4. For a log not starting with clock-out, print error
+# ** 4. For a log not starting with clock-in, print error
 <
 o 2020/1/1 08:00
 $ hledger -f timeclock:- balance
->2 /Expected a timeclock i entry/
+>2 /Could not find previous clockin to match this clockout./
 >= !0
 
-# ** 5. For two consecutive clock-ins, print error
+# ** 5. For two consecutive anonymous clock-ins, print error
 <
 i 2020/1/1 08:00
 i 2020/1/1 09:00
 $ hledger -f timeclock:- balance
->2 /Expected a timeclock o entry/
+>2 /Encountered clockin entry for session "" that is already active./
 >= !0
 
 # ** 6. Timeclock amounts are always rounded to two decimal places, 
@@ -87,6 +87,88 @@ $ hledger -f timeclock:- accounts
 acct 1
 acct 2
 
+# ** 9. Support multiple sessions simultaneously clocked in.
+<
+i 2025-03-10 08:00:00 multi:1  description 1
+i 2025-03-10 09:00:00 multi:2  description 2 ; note that these entries are both active
+o 2025-03-10 12:00:00 multi:1
+o 2025-03-10 15:00:00 multi:2
+$ hledger -f timeclock:- print
+>
+2025-03-10 * description 1
+    (multi:1)           4.00h
+
+2025-03-10 * description 2  ; note that these entries are both active
+    (multi:2)           6.00h
+
+>=
+
+# ** 10. Implicit clockouts apply to the correct session.
+# The first 'o' here applies to multi:3, the next explicitly to multi:1, and the third to multi:2.
+<
+i 2025-03-10 08:00:00 multi:1  description 1
+i 2025-03-10 09:00:00 multi:2  description 2
+i 2025-03-10 10:00:00 multi:3  description 3
+o 2025-03-10 11:00:00
+o 2025-03-10 12:00:00 multi:1
+o 2025-03-10 15:00:00
+$ hledger -f timeclock:- print
+>
+2025-03-10 * description 1
+    (multi:1)           4.00h
+
+2025-03-10 * description 2
+    (multi:2)           6.00h
+
+2025-03-10 * description 3
+    (multi:3)           1.00h
+
+>=
+
+# ** 11. Multiple active sessions can span multiple days.
+< 
+i 2025-03-11 19:00:00 multi:1
+i 2025-03-11 20:00:00 multi:2
+o 2025-03-12 08:00:00
+o 2025-03-12 09:00:00
+$ hledger -f timeclock:- print
+>
+2025-03-11 * 19:00-23:59
+    (multi:1)           5.00h
+
+2025-03-11 * 20:00-23:59
+    (multi:2)           4.00h
+
+2025-03-12 * 00:00-09:00
+    (multi:1)           9.00h
+
+2025-03-12 * 00:00-08:00
+    (multi:2)           8.00h
+
+>=
+
+# ** 12. The --timeclock-old flag reverts to the old behavior.
+<
+i 2009/1/1 08:00:00
+o 2009/1/1 09:00:00 stuff on checkout record  is ignored
+
+i 2009/1/2 08:00:00 account name
+o 2009/1/2 09:00:00
+i 2009/1/3 08:00:00 some:account name  and a description
+o 2009/1/3 09:00:00
+
+$ hledger --timeclock-old -f timeclock:- print
+>
+2009-01-01 * 08:00-09:00
+    ()           1.00h
+
+2009-01-02 * 08:00-09:00
+    (account name)           1.00h
+
+2009-01-03 * and a description
+    (some:account name)           1.00h
+
+>=
 
 ## TODO
 ## multi-day sessions get a new transaction for each day


### PR DESCRIPTION
As requested in #2141, this adds support for having multiple sessions clocked in. These are paired by account name if given on the out entry, and otherwise an out closes the most recent in entry.

Note that this breaks some backwards compatibility, in that we previously ignored the description on the clock out entry.

(Also, I tried to update the documentation with `Shake manuals`, but that seems to have made lots of other changes...not sure if I didn't do something correctly or if those files were just out of date.)

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
