### PR TITLE
consistent console error output independent of GHC version

### DIFF
--- a/hledger-lib/Hledger/Read/RulesReader.hs
+++ b/hledger-lib/Hledger/Read/RulesReader.hs
@@ -942,7 +942,7 @@ readJournalFromCsv merulesfile csvfile csvhandle sep = do
     skiplines <- case getDirective "skip" rules of
                       Nothing -> return 0
                       Just "" -> return 1
-                      Just s  -> maybe (throwError $ "could not parse skip value: " ++ show s) return . readMay $ T.unpack s
+                      Just s  -> maybe (throwError $ "could not parse skip value: " ++ T.unpack s) return . readMay $ T.unpack s
     let csvlines2 = dbg9 "csvlines2" $ drop skiplines csvlines1
 
     -- convert back to text and parse as csv records
@@ -1117,7 +1117,7 @@ transactionFromCsvRecord timesarezoned mtzin tzout sourcepos rules record = t
     mdateformat = rule "date-format"
     parsedate = parseDateWithCustomOrDefaultFormats timesarezoned mtzin tzout mdateformat
     mkdateerror datefield datevalue mdateformat' = T.unpack $ T.unlines
-      ["error: could not parse \""<>datevalue<>"\" as a date using date format "
+      ["could not parse \""<>datevalue<>"\" as a date using date format "
         <>maybe "\"YYYY/M/D\", \"YYYY-M-D\" or \"YYYY.M.D\"" (T.pack . show) mdateformat'
       ,showRecord record
       ,"the "<>datefield<>" rule is:   "<>(fromMaybe "required, but missing" $ field datefield)
@@ -1147,7 +1147,7 @@ transactionFromCsvRecord timesarezoned mtzin tzout sourcepos rules record = t
         Just s  -> either statuserror id $ runParser (statusp <* eof) "" s
           where
             statuserror err = error' . T.unpack $ T.unlines
-              ["error: could not parse \""<>s<>"\" as a cleared status (should be *, ! or empty)"
+              ["could not parse status value \""<>s<>"\" (should be *, ! or empty)"
               ,"the parse error is:      "<>T.pack (customErrorBundlePretty err)
               ]
     code        = maybe "" singleline' $ fieldval "code"
@@ -1362,7 +1362,7 @@ parseAmount rules record currency s =
   where
     journalparsestate = nulljournal{jparsedecimalmark=parseDecimalMark rules}
     mkerror e = error' . T.unpack $ T.unlines
-      ["error: could not parse \"" <> s <> "\" as an amount"
+      ["could not parse \"" <> s <> "\" as an amount"
       ,showRecord record
       ,showRules rules record
       -- ,"the default-currency is: "++fromMaybe "unspecified" (getDirective "default-currency" rules)
@@ -1395,7 +1395,7 @@ parseBalanceAmount rules record currency n s =
   where
     journalparsestate = nulljournal{jparsedecimalmark=parseDecimalMark rules}
     mkerror n' s' e = error' . T.unpack $ T.unlines
-      ["error: could not parse \"" <> s' <> "\" as balance"<> T.pack (show n') <> " amount"
+      ["could not parse \"" <> s' <> "\" as balance"<> T.pack (show n') <> " amount"
       ,showRecord record
       ,showRules rules record
       -- ,"the default-currency is: "++fromMaybe "unspecified" mdefaultcurrency

--- a/hledger-lib/Hledger/Utils/IO.hs
+++ b/hledger-lib/Hledger/Utils/IO.hs
@@ -26,6 +26,7 @@ module Hledger.Utils.IO (
   ansiFormatWarning,
   exitOnExceptions,
   exitWithError,
+  printError,
 
   -- * Time
   getCurrentLocalTime,
@@ -254,11 +255,16 @@ exitOnExceptions = flip catches
   where
     rstrip = reverse . dropWhile isSpace . reverse
 
--- | Print an error message on stderr, with a standard program name prefix,
--- and styling the first line with ansiFormatError if that's allowed;
+-- | Print an error message with printError, 
 -- then exit the program with a non-zero exit code.
 exitWithError :: String -> IO ()
-exitWithError msg = do
+exitWithError msg = printError msg >> exitFailure
+
+-- | Print an error message to stderr,
+-- with a standard program name prefix,
+-- and styling the first line with ansiFormatError if that's allowed.
+printError :: String -> IO ()
+printError msg = do
   progname <- getProgName
   usecolor <- useColorOnStderr
   let
@@ -269,8 +275,6 @@ exitWithError msg = do
       -- Use a stupid heuristic for now: add it again unless already there.
       <> (if "Error:" `isPrefixOf` msg then "" else "Error: ")
   hPutStrLn stderr $ style $ prefix <> msg
-  exitFailure
-
 
 -- Time
 

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -76,7 +76,7 @@ writeChan = BC.writeBChan
 
 
 hledgerUiMain :: IO ()
-hledgerUiMain = withGhcDebug' $ withProgName "hledger-ui.log" $ do  -- force Hledger.Utils.Debug.* to log to hledger-ui.log
+hledgerUiMain = exitOnExceptions $ withGhcDebug' $ withProgName "hledger-ui.log" $ do  -- force Hledger.Utils.Debug.* to log to hledger-ui.log
   when (ghcDebugMode == GDPauseAtStart) $ ghcDebugPause'
 
 #if MIN_VERSION_base(4,20,0)

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -37,7 +37,6 @@ import Network.Wai.Handler.Warp (runSettings, runSettingsSocket, defaultSettings
 import Network.Wai.Handler.Launch (runHostPortFullUrl)
 import System.Directory (removeFile)
 import System.Environment ( getArgs, withArgs )
-import System.Exit (exitFailure)
 import System.IO (hFlush, stdout)
 import System.PosixCompat.Files (getFileStatus, isSocket)
 import Text.Printf (printf)
@@ -162,10 +161,10 @@ web opts j = do
                   when (isSocket sockstat) $ removeFile s
               )
               (\sock -> Network.Wai.Handler.Warp.runSettingsSocket warpsettings sock app)
-            else do
-              putStrLn "Unix domain sockets are not available on your operating system"
-              putStrLn "Please try again without --socket"
-              exitFailure
+            else error $ unlines
+              ["Unix domain sockets are not available on your operating system."
+              ,"Please try again without --socket."
+              ]
 
         Nothing -> Network.Wai.Handler.Warp.runSettings warpsettings app
 

--- a/hledger-web/Hledger/Web/Main.hs
+++ b/hledger-web/Hledger/Web/Main.hs
@@ -62,7 +62,7 @@ hledgerWebDev =
 
 -- Run normally.
 hledgerWebMain :: IO ()
-hledgerWebMain = withGhcDebug' $ do
+hledgerWebMain = exitOnExceptions $ withGhcDebug' $ do
   when (ghcDebugMode == GDPauseAtStart) $ ghcDebugPause'
 
 #if MIN_VERSION_base(4,20,0)

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -200,7 +200,7 @@ confflagsmode = defMode{
 -- implementing that would simplify hledger's CLI processing a lot.
 --
 main :: IO ()
-main = withGhcDebug' $ do
+main = exitOnExceptions $ withGhcDebug' $ do
 
 #if MIN_VERSION_base(4,20,0)
   -- Control ghc 9.10+'s stack traces.

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -457,7 +457,7 @@ main = exitOnExceptions $ withGhcDebug' $ do
         system shellcmd >>= exitWith
 
     -- deprecated command found
-    -- cmdname == "convert" = error' (modeHelp oldconvertmode) >> exitFailure
+    -- cmdname == "convert" = error' (modeHelp oldconvertmode)
 
     -- 6.7. something else (shouldn't happen) - show an error
     | otherwise -> usageError $

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -435,7 +435,7 @@ hledgerCommandMode :: CommandHelpStr -> [Flag RawOpts] -> [(String, [Flag RawOpt
   -> [Flag RawOpts] -> ([Arg RawOpts], Maybe (Arg RawOpts)) -> Mode RawOpts
 hledgerCommandMode helpstr unnamedflaggroup namedflaggroups hiddenflaggroup argsdescr =
   case parseCommandHelp helpstr of
-    Nothing -> error' $ "Could not parse command doc:\n"++helpstr++"\n"  -- PARTIAL:
+    Nothing -> error' $ "could not parse command doc:\n"++helpstr++"\n"  -- PARTIAL:
     Just CommandHelp{cmdName, mcmdShortName, cmdHelpPreamble, cmdHelpPostamble} ->
       (defCommandMode $ cmdName : maybeToList mcmdShortName) {
          modeHelp        = cmdHelpPreamble

--- a/hledger/Hledger/Cli/Commands/Diff.hs
+++ b/hledger/Hledger/Cli/Commands/Diff.hs
@@ -21,7 +21,6 @@ import Data.Either (partitionEithers)
 import qualified Data.Text.IO as T
 import Lens.Micro (set)
 import Safe (headDef)
-import System.Exit (exitFailure)
 
 import Hledger
 import Hledger.Cli.CliOptions
@@ -114,6 +113,4 @@ diff CliOpts{file_=[f1, f2], reportspec_=ReportSpec{_rsQuery=Acct acctRe}} _ = d
   putStrLn "These transactions are in the second file only:\n"
   mapM_ (T.putStr . showTransaction) unmatchedtxn2
 
-diff _ _ = do
-  putStrLn "Please specify two input files. Usage: hledger diff -f FILE1 -f FILE2 FULLACCOUNTNAME"
-  exitFailure
+diff _ _ = error' "Please specify two input files. Usage: hledger diff -f FILE1 -f FILE2 FULLACCOUNTNAME"

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -31,7 +31,6 @@ import qualified Data.Text.Lazy.Builder as TB
 import Lens.Micro ((^.), _Just, has)
 import Safe (lastMay, minimumDef)
 import System.Console.CmdArgs.Explicit
-import System.Exit (exitFailure)
 
 import Hledger
 import Hledger.Write.Beancount (accountNameToBeancount, showTransactionBeancount, showBeancountMetadata)
@@ -124,7 +123,7 @@ print' opts j = do
       -- XXX should match similarly to register --match
       case journalSimilarTransaction opts j' (dbg1 "finding best match for description" $ T.pack desc) of
         Just t  -> printEntries opts j'{jtxns=[t]}
-        Nothing -> putStrLn "no matches found." >> exitFailure
+        Nothing -> error' $ "no transactions found with descriptions like " <> show desc
 
 printEntries :: CliOpts -> Journal -> IO ()
 printEntries opts@CliOpts{rawopts_=rawopts, reportspec_=rspec} j =

--- a/hledger/Hledger/Cli/Commands/Register.hs
+++ b/hledger/Hledger/Cli/Commands/Register.hs
@@ -41,7 +41,6 @@ import qualified Lucid
 import Data.List (sortBy)
 import Data.Char (toUpper)
 import Data.List.Extra (intersect)
-import System.Exit (exitFailure)
 import qualified System.IO as IO
 
 registermode = hledgerCommandMode
@@ -88,7 +87,7 @@ register opts@CliOpts{rawopts_=rawopts, reportspec_=rspec} j
   | Just desc <- maybestringopt "match" rawopts = do
       let ps = [p | (_,_,_,p,_) <- rpt]
       case similarPosting ps desc of
-        Nothing -> putStrLn "no matches found." >> exitFailure
+        Nothing -> error' $ "no postings found with description like " <> show desc
         Just p  -> TL.putStr $ postingsReportAsText opts [pri]
                   where pri = (Just (postingDate p)
                               ,Nothing

--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -16,7 +16,6 @@ module Hledger.Cli.Commands.Roi (
 ) where
 
 import Control.Monad
-import System.Exit
 import Data.Time.Calendar
 import Text.Printf
 import Data.Bifunctor (second)
@@ -92,9 +91,8 @@ roi CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsReportOpts=ReportO
     filteredj = filterJournalTransactions investmentsQuery j
     trans = dbg3 "investments" $ jtxns filteredj
 
-  when (null trans) $ do
-    putStrLn "No relevant transactions found. Check your investments query"
-    exitFailure
+  when (null trans) $
+    error' "No relevant transactions found. Check your investments query"
 
   let (fullPeriod, spans) = reportSpan filteredj rspec
 

--- a/hledger/test/csv.test
+++ b/hledger/test/csv.test
@@ -779,7 +779,6 @@ $  ./csvtest.sh
 6 \| %amount 150\|acct2
   \| \^
 line of conditional table should have 2 values, but this one has only 1
-
 /
 >=1
 # XXX regex needed for error tests with ghc 9.10, https://gitlab.haskell.org/ghc/ghc/-/issues/25116
@@ -803,7 +802,6 @@ $  ./csvtest.sh
   \| \^
 start of conditional block found, but no assignment rules afterward
 \(assignment rules in a conditional block should be indented\)
-
 /
 >=1
 # XXX
@@ -830,7 +828,6 @@ $  ./csvtest.sh
   \|   \^\^\^\^\^\^\^\^\^\^\^\^
 unexpected "myaccount2 a"
 expecting conditional block
-
 /
 >=1
 # XXX
@@ -879,7 +876,6 @@ $  ./csvtest.sh
   \| \^
 start of conditional block found, but no assignment rules afterward
 \(assignment rules in a conditional block should be indented\)
-
 /
 >=1
 # XXX

--- a/hledger/test/errors/accounts.test
+++ b/hledger/test/errors/accounts.test
@@ -9,6 +9,5 @@ account "a" has not been declared.
 Consider adding an account directive. Examples:
 
 account a
-
 /
 >>>= 1

--- a/hledger/test/errors/commodities.test
+++ b/hledger/test/errors/commodities.test
@@ -10,6 +10,5 @@ Consider adding a commodity directive. Examples:
 
 commodity A1000.00
 commodity 1.000,00 A
-
 /
 >>>= 1

--- a/hledger/test/errors/csvamountparse.test
+++ b/hledger/test/errors/csvamountparse.test
@@ -1,5 +1,5 @@
 $$$ hledger check -f  csvamountparse.csv
->>>2 /hledger: Error: error: could not parse "badamount" as an amount
+>>>2 /hledger: Error: could not parse "badamount" as an amount
 CSV record: "2022-01-03","badamount"
 the amount rule is: %2
 the date rule is: %1

--- a/hledger/test/errors/csvbalanceparse.test
+++ b/hledger/test/errors/csvbalanceparse.test
@@ -1,5 +1,5 @@
 $$$ hledger check -f  csvbalanceparse.csv
->>>2 /hledger: Error: error: could not parse "badbalance" as balance1 amount
+>>>2 /hledger: Error: could not parse "badbalance" as balance1 amount
 CSV record: "2022-01-03","badbalance"
 the balance rule is: %2
 the date rule is: %1

--- a/hledger/test/errors/csvbalanceparse.test
+++ b/hledger/test/errors/csvbalanceparse.test
@@ -10,7 +10,5 @@ the parse error is:      1:11:
   \|           \^
 unexpected end of input
 expecting '\+', '-', or number
-
-
 /
 >>>= 1

--- a/hledger/test/errors/csvbalancetypeparse.test
+++ b/hledger/test/errors/csvbalancetypeparse.test
@@ -3,7 +3,5 @@ $$$ hledger check -f  csvbalancetypeparse.csv
 CSV record: "2022-01-01","1"
 the balance rule is: %2
 the date rule is: %1
-
-
 /
 >>>= 1

--- a/hledger/test/errors/csvdateformat.test
+++ b/hledger/test/errors/csvdateformat.test
@@ -1,5 +1,5 @@
 $$$ hledger print -f  csvdateformat.csv
->>>2 /hledger: Error: error: could not parse "a" as a date using date format "YYYY\/M\/D", "YYYY-M-D" or "YYYY.M.D"
+>>>2 /hledger: Error: could not parse "a" as a date using date format "YYYY\/M\/D", "YYYY-M-D" or "YYYY.M.D"
 CSV record: "a","b"
 the date rule is:   %1
 the date-format is: unspecified

--- a/hledger/test/errors/csvdateparse.test
+++ b/hledger/test/errors/csvdateparse.test
@@ -1,5 +1,5 @@
 $$$ hledger check -f  csvdateparse.csv
->>>2 /hledger: Error: error: could not parse "baddate" as a date using date format "%Y-%m-%d"
+>>>2 /hledger: Error: could not parse "baddate" as a date using date format "%Y-%m-%d"
 CSV record: "baddate","b"
 the date rule is:   %1
 the date-format is: %Y-%m-%d

--- a/hledger/test/errors/csvdaterule.test
+++ b/hledger/test/errors/csvdaterule.test
@@ -1,6 +1,5 @@
 $$$ hledger check -f  csvdaterule.csv
 >>>2 /hledger: Error: offset=0:
 Please specify \(at top level\) the date field. Eg: date %1
-
 /
 >>>= 1

--- a/hledger/test/errors/csvifblocknonempty.test
+++ b/hledger/test/errors/csvifblocknonempty.test
@@ -5,6 +5,5 @@ $$$ hledger check -f  csvifblocknonempty.csv
   \| \^
 start of conditional block found, but no assignment rules afterward
 \(assignment rules in a conditional block should be indented\)
-
 /
 >>>= 1

--- a/hledger/test/errors/csviftablenonempty.test
+++ b/hledger/test/errors/csviftablenonempty.test
@@ -4,6 +4,5 @@ $$$ hledger check -f  csviftablenonempty.csv
 2 \| if,date,description,comment
   \| \^
 start of conditional table found, but no assignment rules afterward
-
 /
 >>>= 1

--- a/hledger/test/errors/csviftablevaluecount.test
+++ b/hledger/test/errors/csviftablevaluecount.test
@@ -4,6 +4,5 @@ $$$ hledger check -f  csviftablevaluecount.csv
 4 \| one,val1
   \| \^
 line of conditional table should have 2 values, but this one has only 1
-
 /
 >>>= 1

--- a/hledger/test/errors/csvskipvalue.test
+++ b/hledger/test/errors/csvskipvalue.test
@@ -1,4 +1,4 @@
 $$$ hledger check -f  csvskipvalue.csv
->>>2 /hledger: Error: could not parse skip value: "badval"
+>>>2 /hledger: Error: could not parse skip value: badval
 /
 >>>= 1

--- a/hledger/test/errors/csvstatusparse.test
+++ b/hledger/test/errors/csvstatusparse.test
@@ -6,7 +6,5 @@ the parse error is:      1:1:
   \| \^
 unexpected 'b'
 expecting '!', '\*', or end of input
-
-
 /
 >>>= 1

--- a/hledger/test/errors/csvstatusparse.test
+++ b/hledger/test/errors/csvstatusparse.test
@@ -1,5 +1,5 @@
 $$$ hledger print -f  csvstatusparse.csv
->>>2 /hledger: Error: error: could not parse "badstatus" as a cleared status \(should be \*, ! or empty\)
+>>>2 /hledger: Error: could not parse status value "badstatus" \(should be \*, ! or empty\)
 the parse error is:      1:1:
   \|
 1 \| badstatus

--- a/hledger/test/errors/parseable-dates.test
+++ b/hledger/test/errors/parseable-dates.test
@@ -5,6 +5,5 @@ $$$ hledger check -f parseable-dates.j
   \| \^\^\^\^\^\^\^\^\^
 
 This is not a valid date, please fix it.
-
 /
 >>>= 1

--- a/hledger/test/errors/parseable-regexps.test
+++ b/hledger/test/errors/parseable-regexps.test
@@ -6,6 +6,5 @@ $$$ hledger check -f parseable-regexps.j
 
 This regular expression is invalid or unsupported, please correct it:
 \(
-
 /
 >>>= 1

--- a/hledger/test/errors/parseable.test
+++ b/hledger/test/errors/parseable.test
@@ -5,6 +5,5 @@ $$$ hledger check -f parseable.j
   \|  \^
 unexpected newline
 expecting date separator or digit
-
 /
 >>>= 1

--- a/hledger/test/errors/payees.test
+++ b/hledger/test/errors/payees.test
@@ -9,6 +9,5 @@ payee "p" has not been declared.
 Consider adding a payee directive. Examples:
 
 payee p
-
 /
 >>>= 1

--- a/hledger/test/journal/directive-account.test
+++ b/hledger/test/journal/directive-account.test
@@ -79,7 +79,6 @@ $ hledger -f- accounts
   \|         \^
 unexpected '\('
 expecting account name without brackets
-
 /
 >=1
 # XXX regex needed for error tests with ghc 9.10, https://gitlab.haskell.org/ghc/ghc/-/issues/25116
@@ -95,7 +94,6 @@ $ hledger -f- accounts
   \|         \^
 unexpected '\['
 expecting account name without brackets
-
 /
 >=1
 # XXX regex needed for error tests with ghc 9.10, https://gitlab.haskell.org/ghc/ghc/-/issues/25116

--- a/hledger/test/journal/parse-errors.test
+++ b/hledger/test/journal/parse-errors.test
@@ -12,7 +12,6 @@ $ hledger -f - print
   \|     \^
 unexpected newline
 expecting date separator or digit
-
 /
 >=1
 # XXX regex needed for error tests with ghc 9.10, https://gitlab.haskell.org/ghc/ghc/-/issues/25116

--- a/hledger/test/run.test
+++ b/hledger/test/run.test
@@ -6,7 +6,7 @@
    assets:cash  -$100
    expenses:food
 $ hledger run -f- aregister cash
->2 /hledger: aregister: openFile: does not exist \(No such file or directory\)/
+>2 /hledger: Error: aregister: openFile: does not exist \(No such file or directory\)/
 >=1
 
 # ** 2. Run refuses to read input file and commands from stdin


### PR DESCRIPTION
- **fix:cli,ui,web: consistent console error output independent of GHC version [#2367]**

Hledger.Utils.IO helpers have been updated and new ones have been
added (exitOnExceptions, exitWithError) to allow consistent display of
program errors whether compiled with GHC <9.10, GHC 9.10, or GHC >9.10.
The trailing newlines added by GHC 9.10 are gone,
and so is the "uncaught exception" output added by GHC 9.12.
