### PR TITLE
Apply amt:/cur: queries after valuation, not before (to fix boolean queries)

### DIFF
--- a/hledger-lib/Hledger/Reports/EntriesReport.hs
+++ b/hledger-lib/Hledger/Reports/EntriesReport.hs
@@ -38,8 +38,9 @@ entriesReport rspec@ReportSpec{_rsReportOpts=ropts} =
       sortBy (comparing $ transactionDateFn ropts)
     . map  (if invert_ ropts then transactionNegate else id)
     . jtxns
-    . journalApplyValuationFromOpts (setDefaultConversionOp NoConversionOp rspec)
+    -- #2371: filter after valuation not before - even though it's safe to do here - for consistency with postingsReport
     . filterJournalTransactions (filterQuery (not.queryIsDepth) $ _rsQuery rspec)
+    . journalApplyValuationFromOpts (setDefaultConversionOp NoConversionOp rspec)
 
 tests_EntriesReport = testGroup "EntriesReport" [
   testGroup "entriesReport" [

--- a/hledger/test/journal/amounts-and-commodities.test
+++ b/hledger/test/journal/amounts-and-commodities.test
@@ -297,42 +297,27 @@ $ hledger -f- print cur: amt:1112
 
 >=
 
+# ** 22. cur: and amt: match currency before cost/value conversion #1625 (balance)
 <
-P 2021-01-01 A  1000 B
+P 2021-01-01 A  10 B
 2021-01-01
   (a)    1 A
 
-2021-01-02
-  (a)   10 A
+$ hledger -f- balance -NBV cur:A
+                10 B  a
 
-2021-01-03
-  (a)   10 A @ 0.1 B
+# ** 23. #1625 (register)
+$ hledger -f- register -BV cur:A
+2021-01-01                      (a)                           10 B          10 B
 
-2021-01-04
-  (a)    1 B @ 0.001 A
-
-2021-01-05
-  (a)    1 B
-
-# ** 22. balance report cur: and amt: query matches currency before valuation/cost
-$ hledger -f- balance -N -V -B cur:A "amt:<5"
-              1000 B  a
->=
-
-# ** 23. register report cur: and amt: query matches currency before valuation/cost
-$ hledger -f- register -V -B cur:A "amt:<5"
-2021-01-01                      (a)                         1000 B        1000 B
->=
-
-# ** 24. aregister report cur: and amt: query matches currency before valuation/cost
-$ hledger -f- aregister a -V -B cur:A "amt:<5"
+# ** 24. #1625 (aregister)
+$ hledger -f- aregister a -BV cur:A
 Transactions in a and subaccounts (matching query):
-2021-01-01                      a                           1000 B        1000 B
->=
+2021-01-01                      a                             10 B          10 B
 
-# ** 25. print report cur: and amt: query matches currency before valuation/cost
-$ hledger -f- print -V -B a cur:A "amt:<5"
+# ** 25. #1625 (print)
+$ hledger -f- print -BV cur:A
 2021-01-01
-    (a)          1000 B
+    (a)            10 B
 
 >=

--- a/hledger/test/journal/amounts-and-commodities.test
+++ b/hledger/test/journal/amounts-and-commodities.test
@@ -297,26 +297,64 @@ $ hledger -f- print cur: amt:1112
 
 >=
 
-# ** 22. cur: and amt: match currency before cost/value conversion #1625 (balance)
+# # ** 22. cur: and amt: match currency before cost/value conversion #1625 (balance)
+# <
+# P 2021-01-01 A  10 B
+# 2021-01-01
+#   (a)    1 A
+
+# $ hledger -f- balance -NBV cur:A
+#                 10 B  a
+
+# # ** 23. #1625 (register)
+# $ hledger -f- register -BV cur:A
+# 2021-01-01                      (a)                           10 B          10 B
+
+# # ** 24. #1625 (aregister)
+# $ hledger -f- aregister a -BV cur:A
+# Transactions in a and subaccounts (matching query):
+# 2021-01-01                      a                             10 B          10 B
+
+# # ** 25. #1625 (print)
+# $ hledger -f- print -BV cur:A
+# 2021-01-01
+#     (a)            10 B
+
+# >=
+
+# ** 22. cur: and amt: match currency after cost/value conversion #2371 (balance)
 <
 P 2021-01-01 A  10 B
 2021-01-01
   (a)    1 A
 
-$ hledger -f- balance -NBV cur:A
+$ hledger -f- balance -NV cur:A
+
+# ** 23. #2371 (balance 2)
+$ hledger -f- balance -NV cur:B
                 10 B  a
 
-# ** 23. #1625 (register)
-$ hledger -f- register -BV cur:A
+# ** 24. #2371 (register)
+$ hledger -f- register -V cur:A
+
+# ** 25. #2371 (register 2)
+$ hledger -f- register -V cur:B
 2021-01-01                      (a)                           10 B          10 B
 
-# ** 24. #1625 (aregister)
-$ hledger -f- aregister a -BV cur:A
+# ** 26. #2371 (aregister)
+$ hledger -f- aregister a -V cur:A
+Transactions in a and subaccounts (matching query):
+
+# ** 27. #2371 (aregister 2)
+$ hledger -f- aregister a -V cur:B
 Transactions in a and subaccounts (matching query):
 2021-01-01                      a                             10 B          10 B
 
-# ** 25. #1625 (print)
-$ hledger -f- print -BV cur:A
+# ** 28. #2371 (print)
+$ hledger -f- print -V cur:A
+
+# ** 29. #2371 (print 2)
+$ hledger -f- print -V cur:B
 2021-01-01
     (a)            10 B
 

--- a/hledger/test/query-expr.test
+++ b/hledger/test/query-expr.test
@@ -158,3 +158,15 @@ $ hledger -f- reg expr:'date:2023 OR date:2024'
 >2 /using date: in OR expressions is not supported/
 >=1
 
+# ** 12. #2371 boolean query which hledger <=1.42.1 gets wrong: register
+$ hledger -f sample2.journal reg expr:'(checking and amt:>0) or credit'
+2025-01-01 starting balances    assets:bank:checking   1000.00 USD   1000.00 USD
+                                li:credit card         -400.00 USD    600.00 USD
+2025-01-02 salary               assets:bank:checking   1000.00 USD   1600.00 USD
+2025-01-03 pay half of credi..  li:credit card          200.00 USD   1800.00 USD
+
+# # ** 13. aregister
+# $ hledger -f sample2.journal areg expr:'(checking and amt:>0) or credit'
+
+# # ** 14. print
+# $ hledger -f sample2.journal reg expr:'(checking and amt:>0) or credit'

--- a/hledger/test/sample2.journal
+++ b/hledger/test/sample2.journal
@@ -1,0 +1,1 @@
+../../examples/sample2.journal


### PR DESCRIPTION
This is a draft for discussion. It reverses #1625 (matching amt:/cur: before valuation) to fix #2371 (some boolean queries not working). 

Here's the current description:

> Until now, at least since #1625 (2021), cur: and amt: matched the
> pre-cost/value-conversion commodity symbols and amounts.
> 
> To do that, we were separating the cur:/amt: parts from the rest of
> the report query. But with boolean queries #1989 (2023), it's not
> possible to do that reliably without changing the query's meaning (?).
> 
> So we no longer do that, which means that cur: and amt: now match the
> post valuation amounts. This is a breaking change for reports:
> 
> - register and all balance reports (using journalValueAndFilterPostingsWith)
>   and aregister, hledger-ui & hledger-web register views (using accountTransactionsReport)
>   no longer pre-filter by amt:/cur:. amt:/cur: with these reports now
>   match the post-valuation amounts and commodity symbols, not the
>   pre-valuation ones.
> 
> - print, codes, descriptions, notes, hledger-web journal view (using entriesReport)
>   now apply all queries after valuation, not before it
>   (for consistency with the above).

- [Old and new amt:/cur: tests](https://github.com/simonmichael/hledger/blob/eeb701140df47260125cf7d26bd746482f89abd8/hledger/test/journal/amounts-and-commodities.test#L300-L361)
- [fixed boolean query test](https://github.com/simonmichael/hledger/blob/eeb701140df47260125cf7d26bd746482f89abd8/hledger/test/query-expr.test#L161-L166)


This fixes boolean queries, or at least some of them. There are other cases where reports transform the report query (eg with filterQuery), which have not been fully audited. A common case is removing the depth: limit from the query. It's not yet clear if these cases can also break boolean queries - more auditing, testing and producing repros will help.

"Early amt:/cur:" (before valuation) has been the status quo for years. So this needs more thought and ideas about whether and how to preserve compatibility. As it stands, this would break some existing reports, and might make those reports hard or impossible to produce at all (testing needed).

Some options to consider ?

1. Try to match with amt:/cur: both before and after valuation.
   (We do this with acct:, trying to match both before and after account name aliasing.)
   Even if advisable, I'm not sure how feasible it would be to make this robust.
   Eg, where A amounts have been converted to value in B:
   - `reg -V cur:A` matches the B amounts (because they were formerly A)
   - `reg -V cur:B` also matches the B amounts
   - `reg -V expr:'(cur:A AND cash) OR checking'` is still problematic; cur:A is part of a more complex query, can't extract and prefilter with it

2. Keep the old behaviour for simple queries, but disable it when a problematic boolean query is detected (one with amt:/cur: in subexpressions).
   Inconsistent behaviour would probably be bad.
   Eg: 
   - `reg -V expr:'cur:A AND cash'` cur:A is in a top level AND, can extract it and prefilter with it (and exclude it from the postfilter so it doesn't exclude the B result)
   - `reg -V expr:'(cur:A AND cash) OR checking'` cur:A is in a subquery, can't extract/prefilter with it; must leave it in the postfilter (it will exclude the B result)

3. Disallow amt:/cur: in boolean queries or subqueries.
   (We already disallow date: in OR subexpressions.)
   This might be over-restrictive.
   Eg:
   - `reg -V expr:'cur:A AND cash'` "Error: amt: and cur: are not supported in boolean queries"
   - `reg -V expr:'(cur:A AND cash) OR checking'` "Error: amt: and cur: must be part of a top-level AND query"
   - `reg -V cur:A cash` works as before

4. Think harder about 
   - more safe/limited/reasonable ways to extract the amt:/cur: queries for pre-filtering, preserving the old behaviour without altering boolean queries.
   - why those reports were doing that pre-filtering, and if it's really needed. Reports often make a variant of the user's query, eg removing a depth limit, or changing the period in order to calculate starting balances, while preserving the rest of the query as-is.
   - how to ease the transition, if behaviour is changed
  