### PR TITLE
dev: lib: Use strict data in Hledger.Data.Types.

### DIFF
--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -23,6 +23,7 @@ For more detailed documentation on each type, see the corresponding modules.
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE StrictData           #-}
 
 module Hledger.Data.Types (
   module Hledger.Data.Types,


### PR DESCRIPTION
This reduces memory usage and results in speedups in some commands.

```
Running 5 tests 3 times with 2 executables at 2025-04-28 22:11:48 AEST:

Best times:
+-------------------------------------------------------++------------------+-------------------------+
|                                                       || ./hledger-master | ./hledger-master-strict |
+=======================================================++==================+=========================+
| -f examples/10ktxns-1kaccts.journal print             ||             0.87 |                    0.87 |
| -f examples/10ktxns-1kaccts.journal register          ||             3.06 |                    2.80 |
| -f examples/10ktxns-1kaccts.journal balance           ||             0.81 |                    0.84 |
| -f examples/10ktxns-1kaccts.journal balance --weekly  ||             8.25 |                    7.50 |
| -f examples/100ktxns-1kaccts.journal balance --yearly ||            11.26 |                   11.02 |
+-------------------------------------------------------++------------------+-------------------------+
```

```
$ for i in hledger-master hledger-master-strict; do
      echo $i;
      ./$i -f examples/100ktxns-1kaccts.journal balance --yearly +RTS -s > /dev/null;
  done
hledger-master
  43,526,689,224 bytes allocated in the heap
   4,818,428,448 bytes copied during GC
     376,952,048 bytes maximum residency (13 sample(s))
       3,414,800 bytes maximum slop
            1041 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     10559 colls,     0 par    1.633s   1.641s     0.0002s    0.0030s
  Gen  1        13 colls,     0 par    1.533s   1.536s     0.1182s    0.3198s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    7.415s  (  7.424s elapsed)
  GC      time    3.166s  (  3.178s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   10.582s  ( 10.603s elapsed)

  Alloc rate    5,870,393,914 bytes per MUT second

  Productivity  70.1% of total user, 70.0% of total elapsed

hledger-master-strict
  43,894,946,560 bytes allocated in the heap
   4,628,407,808 bytes copied during GC
     277,673,352 bytes maximum residency (14 sample(s))
       3,221,848 bytes maximum slop
             756 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     10647 colls,     0 par    1.519s   1.526s     0.0001s    0.0034s
  Gen  1        14 colls,     0 par    1.341s   1.345s     0.0961s    0.1797s

  TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    7.619s  (  7.629s elapsed)
  GC      time    2.861s  (  2.872s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   10.480s  ( 10.501s elapsed)

  Alloc rate    5,761,202,708 bytes per MUT second

  Productivity  72.7% of total user, 72.6% of total elapsed
```