### PR TITLE
fix: Ensure valuation happens after filtration (#2385)

### DIFF
--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -590,19 +590,11 @@ journalValueAndFilterPostings rspec j = journalValueAndFilterPostingsWith rspec 
 
 -- | Like 'journalValueAndFilterPostings', but takes a 'PriceOracle' as an argument.
 journalValueAndFilterPostingsWith :: ReportSpec -> Journal -> PriceOracle -> Journal
-journalValueAndFilterPostingsWith rspec@ReportSpec{_rsQuery=q, _rsReportOpts=ropts} j =
-    -- Filter by the remainder of the query
-      filterJournal reportq
-    -- Apply valuation and costing
-    . journalApplyValuationFromOptsWith rspec
-    -- Filter by amount and currency, so it matches pre-valuation/costing
-      (if queryIsNull amtsymq then j else filterJournalAmounts amtsymq j)
+journalValueAndFilterPostingsWith rspec@ReportSpec{_rsQuery=q, _rsReportOpts=ropts} =
+    journalApplyValuationFromOptsWith rspec . filterJournal q
   where
     -- with -r, replace each posting with its sibling postings
     filterJournal = if related_ ropts then filterJournalRelatedPostings else filterJournalPostings
-    amtsymq = dbg3 "amtsymq" $ filterQuery queryIsAmtOrSym q
-    reportq = dbg3 "reportq" $ filterQuery (not . queryIsAmtOrSym) q
-    queryIsAmtOrSym = liftA2 (||) queryIsAmt queryIsSym
 
 -- | Convert this journal's postings' amounts to cost and/or to value, if specified
 -- by options (-B/--cost/-V/-X/--value etc.). Strip prices if not needed. This

--- a/hledger/test/journal/costs.test
+++ b/hledger/test/journal/costs.test
@@ -624,3 +624,23 @@ $ hledger -f- print
     Assets:BOG:Personal                209.60 GEL
 
 >=
+
+# ** 42. Make sure --cost interacts properly with interval reports with an early end date (#2385)
+<
+2025-03-02
+    expenses   $1
+    assets
+
+2025-04-02
+    expenses   $2
+    assets
+
+$ hledger -f- balance -M -X $ -e 2025-04 -N
+Balance changes in 2025-03, valued at period ends:
+
+          || Mar 
+==========++=====
+ assets   || $-1 
+ expenses ||  $1 
+>=0
+


### PR DESCRIPTION
With the change to `StrictData`, valuation of postings past the report end date sometimes encounters error conditions. These were previously ignored because the thunks were never actually evaluated (because they were past the end date of the report).