### PR TITLE
fix cur: filtering of multicommodity amounts in posting-based reports

### DIFF
--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -44,6 +44,7 @@ module Hledger.Query (
   queryIsReal,
   queryIsAmt,
   queryIsSym,
+  queryIsAmtOrSym,
   queryIsStartDateOnly,
   queryIsTransactionRelated,
   -- * accessors
@@ -684,6 +685,9 @@ queryIsAmt _         = False
 queryIsSym :: Query -> Bool
 queryIsSym (Sym _) = True
 queryIsSym _ = False
+
+queryIsAmtOrSym :: Query -> Bool
+queryIsAmtOrSym = liftA2 (||) queryIsAmt queryIsSym
 
 -- | Does this query specify a start date and nothing else (that would
 -- filter postings prior to the date) ?

--- a/hledger-web/Hledger/Web/Handler/MiscR.hs
+++ b/hledger-web/Hledger/Web/Handler/MiscR.hs
@@ -26,7 +26,6 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 import qualified Data.ByteString as BS
-import Data.FileEmbed (embedFile)
 import Yesod.Default.Handlers (getFaviconR, getRobotsR)
 
 import Hledger

--- a/hledger/test/query-expr.test
+++ b/hledger/test/query-expr.test
@@ -159,11 +159,18 @@ $ hledger -f- reg expr:'date:2023 OR date:2024'
 >=1
 
 # ** 12. #2371 boolean query with amt: or cur: which hledger <=1.42.1 gets wrong: register
-$ hledger -f sample2.journal reg expr:'(checking and amt:>0) or credit'
-2025-01-01 starting balances    assets:bank:checking   1000.00 USD   1000.00 USD
-                                li:credit card         -400.00 USD    600.00 USD
-2025-01-02 salary               assets:bank:checking   1000.00 USD   1600.00 USD
-2025-01-03 pay half of credi..  li:credit card          200.00 USD   1800.00 USD
+<
+2025-01-01
+    a          1
+    a        -20
+    a        300
+    b      -4000
+    z
+
+$ hledger -f - reg expr:'(a and amt:>0) or b'
+2025-01-01                      a                                1             1
+                                a                              300           301
+                                b                            -4000         -3699
 
 # ** 13. #2371 aregister
 $ hledger -f sample2.journal areg assets any:'(checking and amt:>0) or credit'


### PR DESCRIPTION
This is a fix for #2396. It adds a filterJournalAmounts pass to filter out any unmatched amounts from multicommodity amounts.

- **;dev: query-expr.test: a simpler test [# 2371]**
- **;lib: note an issue with filterQuery**
- **lib:Hledger.Query: queryIsAmtOrSym**
- **dev: refactor journalValueAndFilterPostingsWith a bit [# 2396]**
- **fix: cur: in posting-based reports filters multicommodity amounts again [# 2396]**
