### PR TITLE
commodities/payees/tags: used/declared flags, like accounts

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -79,6 +79,7 @@ module Hledger.Data.Amount (
   amountUnstyled,
   commodityStylesFromAmounts,
   -- canonicalStyleFrom,
+  getAmounts,
 
   -- ** rendering
   AmountFormat(..),
@@ -565,6 +566,13 @@ instance HasAmounts Amount where
                 -- dbg0 "old      style"
                 olds)
           Nothing -> olds
+
+-- | Get an amount and its attached cost amount if any. Returns one or two amounts.
+getAmounts :: Amount -> [Amount]
+getAmounts a@Amount{acost} = a : case acost of
+  Nothing            -> []
+  Just (UnitCost  c) -> [c]
+  Just (TotalCost c) -> [c]
 
 -- AmountStyle helpers
 
@@ -1094,13 +1102,17 @@ mixedAmountSetStyles = styleAmounts
 -- v4
 instance HasAmounts MixedAmount where
   styleAmounts styles = mapMixedAmountUnsafe (styleAmounts styles)
+  -- getAmounts = concatMap getAmounts . amounts
 
 instance HasAmounts BalanceData where
   styleAmounts styles balance@BalanceData{bdexcludingsubs,bdincludingsubs} =
     balance{bdexcludingsubs=styleAmounts styles bdexcludingsubs, bdincludingsubs=styleAmounts styles bdincludingsubs}
+  -- getAmounts BalanceData{bdexcludingsubs, bdincludingsubs} =
+  --   getAmounts bdexcludingsubs <> getAmounts bdincludingsubs
 
 instance HasAmounts a => HasAmounts (PeriodData a) where
   styleAmounts styles = fmap (styleAmounts styles)
+  -- getAmounts 
 
 instance HasAmounts a => HasAmounts (Account a) where
   styleAmounts styles acct@Account{adata} =

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -435,7 +435,7 @@ postingStatus Posting{pstatus=s, ptransaction=mt} = case s of
 postingAllTags :: Posting -> [Tag]
 postingAllTags p = ptags p ++ maybe [] ttags (ptransaction p)
 
--- | Tags for this transaction including any from its postings.
+-- | Tags for this transaction including any from its postings (which includes any from the postings' accounts).
 transactionAllTags :: Transaction -> [Tag]
 transactionAllTags t = ttags t ++ concatMap ptags (tpostings t)
 

--- a/hledger-lib/Hledger/Query.hs
+++ b/hledger-lib/Hledger/Query.hs
@@ -813,8 +813,14 @@ inAccountQuery (QueryOptInAcct a     : _) = Just . Acct $ accountNameToAccountRe
 -- matching things with queries
 
 matchesCommodity :: Query -> CommoditySymbol -> Bool
-matchesCommodity (Sym r) = regexMatchText r
-matchesCommodity _ = const True
+matchesCommodity (Sym r)          s = regexMatchText r s
+matchesCommodity (Any)            _ = True
+matchesCommodity (None)           _ = False
+matchesCommodity (Or qs)          s = any (`matchesCommodity` s) qs
+matchesCommodity (And qs)         s = all (`matchesCommodity` s) qs
+matchesCommodity (AnyPosting qs)  s = all (`matchesCommodity` s) qs
+matchesCommodity (AllPostings qs) s = all (`matchesCommodity` s) qs
+matchesCommodity _                _ = False
 
 -- | Does the match expression match this (simple) amount ?
 matchesAmount :: Query -> Amount -> Bool

--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -388,16 +388,16 @@ journalFinalise iopts@InputOpts{auto_,balancingopts_,infer_costs_,infer_equity_,
       -- XXX how to force debug output here ?
        -- >>= Right . dbg0With (concatMap (T.unpack.showTransaction).jtxns)
        -- >>= \j -> deepseq (concatMap (T.unpack.showTransaction).jtxns $ j) (return j)
-      <&> dbg9With (lbl "amounts after styling, forecasting, auto-posting".showJournalAmountsDebug)
+      <&> dbg9With (lbl "amounts after styling, forecasting, auto-posting".showJournalPostingAmountsDebug)
       >>= (\j -> if checkordereddates then journalCheckOrdereddates j $> j else Right j)  -- check ordereddates before assertions. The outer parentheses are needed.
       >>= journalBalanceTransactions balancingopts_{ignore_assertions_=not checkassertions}  -- infer balance assignments and missing amounts, and maybe check balance assertions.
-      <&> dbg9With (lbl "amounts after transaction-balancing".showJournalAmountsDebug)
-      -- <&> dbg9With (("journalFinalise amounts after styling, forecasting, auto postings, transaction balancing"<>).showJournalAmountsDebug)
+      <&> dbg9With (lbl "amounts after transaction-balancing".showJournalPostingAmountsDebug)
+      -- <&> dbg9With (("journalFinalise amounts after styling, forecasting, auto postings, transaction balancing"<>).showJournalPostingAmountsDebug)
       >>= journalInferCommodityStyles                    -- infer commodity styles once more now that all posting amounts are present
       -- >>= Right . dbg0With (pshow.journalCommodityStyles)
       >>= (if infer_costs_  then journalTagCostsAndEquityAndMaybeInferCosts verbose_tags_ True else pure)  -- With --infer-costs, infer costs from equity postings where possible
       <&> (if infer_equity_ then journalInferEquityFromCosts verbose_tags_ else id)          -- With --infer-equity, infer equity postings from costs where possible
-      <&> dbg9With (lbl "amounts after equity-inferring".showJournalAmountsDebug)
+      <&> dbg9With (lbl "amounts after equity-inferring".showJournalPostingAmountsDebug)
       <&> journalInferMarketPricesFromTransactions       -- infer market prices from commodity-exchanging transactions
       -- <&> dbg6Msg fname  -- debug logging
       <&> dbgJournalAcctDeclOrder (fname <> ": acct decls           : ")

--- a/hledger/Hledger/Cli/CliOptions.hs
+++ b/hledger/Hledger/Cli/CliOptions.hs
@@ -81,6 +81,8 @@ module Hledger.Cli.CliOptions (
 
   -- * Other utils
   topicForMode,
+  UsedOrDeclared(..),
+  usedOrDeclaredFromOpts,
 
 --  -- * Convenience re-exports
 --  module Data.String.Here,
@@ -814,6 +816,29 @@ registerWidthsFromOpts CliOpts{width_=Just s}  =
           descwidth <- optional (char ',' >> read `fmap` some digitChar)
           eof
           return (totalwidth, descwidth)
+
+-- A common choice for filtering lists of declarable things.
+data UsedOrDeclared
+  = Used
+  | Declared
+  | Undeclared
+  | Unused
+  deriving (Show, Eq)
+
+-- Get the flag of this kind from opts, or raise an error if there's more than one.
+usedOrDeclaredFromOpts :: CliOpts -> Maybe UsedOrDeclared
+usedOrDeclaredFromOpts CliOpts{rawopts_=rawopts} =
+  case ( boolopt "used"       rawopts
+       , boolopt "declared"   rawopts
+       , boolopt "undeclared" rawopts
+       , boolopt "unused"     rawopts
+       ) of
+    (False, False, False, False) -> Nothing
+    (True, False, False, False) -> Just Used
+    (False, True, False, False) -> Just Declared
+    (False, False, True, False) -> Just Undeclared
+    (False, False, False, True) -> Just Unused
+    _ -> error' "please pick at most one of --used, --declared, --undeclared, --unused"
 
 -- Other utils
 

--- a/hledger/Hledger/Cli/Commands/Accounts.md
+++ b/hledger/Hledger/Cli/Commands/Accounts.md
@@ -1,39 +1,34 @@
 ## accounts 
 
-List account names.
+List the account names used or declared in the journal.
 
 ```flags
 Flags:
-  -u --used                 show only accounts used by transactions
-  -d --declared             show only accounts declared by account directive
-     --unused               show only accounts declared but not used
-     --undeclared           show only accounts used but not declared
+  -u --used                 list accounts used
+  -d --declared             list accounts declared
+     --undeclared           list accounts used but not declared
+     --unused               list accounts declared but not used
+     --find                 list the first account matched by the first
+                            argument (a case-insensitive infix regexp)
      --types                also show account types when known
      --positions            also show where accounts were declared
      --directives           show as account directives, for use in journals
-     --find                 find the first account matched by the first
-                            argument (a case-insensitive infix regexp or
-                            account name)
   -l --flat                 list/tree mode: show accounts as a flat list
                             (default)
   -t --tree                 list/tree mode: show accounts as a tree
      --drop=N               flat mode: omit N leading account name parts
 ```
 
-This command lists account names.
-By default it shows all known accounts, either used in transactions or declared with account directives.
+This command lists account names - all of them by default.
+or just the ones which have been used in transactions,
+or declared with `account` directives,
+or used but not declared,
+or declared but not used,
+or just the first account name matched by a pattern.
 
-With query arguments, only matched account names and account names referenced by matched postings are shown.
+You can add query arguments to select a subset of transactions or accounts.
 
-Or it can show just
-the used accounts (`--used`/`-u`),
-the declared accounts (`--declared`/`-d`),
-the accounts declared but not used (`--unused`),
-the accounts used but not declared (`--undeclared`),
-or the first account matched by an account name pattern, if any (`--find`).
-
-It shows a flat list by default. With `--tree`, it uses indentation to
-show the account hierarchy.
+It shows a flat list by default. With `--tree`, it uses indentation to show the account hierarchy.
 In flat mode you can add `--drop N` to omit the first few account name components.
 Account names can be depth-clipped with `depth:N` or `--depth N` or `-N`.
 
@@ -44,8 +39,7 @@ With `--positions`, it also shows the file and line number of each
 account's declaration, if any, and the account's overall declaration order;
 these may be useful when troubleshooting account display order.
 
-With `--directives`, it adds the `account` keyword, showing
-valid account directives which can be pasted into a journal file.
+With `--directives`, it shows valid account directives which could be pasted into a journal file.
 This is useful together with `--undeclared` when updating your account declarations
 to satisfy `hledger check accounts`.
 

--- a/hledger/Hledger/Cli/Commands/Accounts.txt
+++ b/hledger/Hledger/Cli/Commands/Accounts.txt
@@ -1,34 +1,29 @@
 accounts
 
-List account names.
+List the account names used or declared in the journal.
 
 Flags:
-  -u --used                 show only accounts used by transactions
-  -d --declared             show only accounts declared by account directive
-     --unused               show only accounts declared but not used
-     --undeclared           show only accounts used but not declared
+  -u --used                 list accounts used
+  -d --declared             list accounts declared
+     --undeclared           list accounts used but not declared
+     --unused               list accounts declared but not used
+     --find                 list the first account matched by the first
+                            argument (a case-insensitive infix regexp)
      --types                also show account types when known
      --positions            also show where accounts were declared
      --directives           show as account directives, for use in journals
-     --find                 find the first account matched by the first
-                            argument (a case-insensitive infix regexp or
-                            account name)
   -l --flat                 list/tree mode: show accounts as a flat list
                             (default)
   -t --tree                 list/tree mode: show accounts as a tree
      --drop=N               flat mode: omit N leading account name parts
 
-This command lists account names. By default it shows all known
-accounts, either used in transactions or declared with account
-directives.
+This command lists account names - all of them by default. or just the
+ones which have been used in transactions, or declared with account
+directives, or used but not declared, or declared but not used, or just
+the first account name matched by a pattern.
 
-With query arguments, only matched account names and account names
-referenced by matched postings are shown.
-
-Or it can show just the used accounts (--used/-u), the declared accounts
-(--declared/-d), the accounts declared but not used (--unused), the
-accounts used but not declared (--undeclared), or the first account
-matched by an account name pattern, if any (--find).
+You can add query arguments to select a subset of transactions or
+accounts.
 
 It shows a flat list by default. With --tree, it uses indentation to
 show the account hierarchy. In flat mode you can add --drop N to omit
@@ -42,10 +37,10 @@ With --positions, it also shows the file and line number of each
 account's declaration, if any, and the account's overall declaration
 order; these may be useful when troubleshooting account display order.
 
-With --directives, it adds the account keyword, showing valid account
-directives which can be pasted into a journal file. This is useful
-together with --undeclared when updating your account declarations to
-satisfy hledger check accounts.
+With --directives, it shows valid account directives which could be
+pasted into a journal file. This is useful together with --undeclared
+when updating your account declarations to satisfy
+hledger check accounts.
 
 The --find flag can be used to look up a single account name, in the
 same way that the aregister command does. It returns the

--- a/hledger/Hledger/Cli/Commands/Add.txt
+++ b/hledger/Hledger/Cli/Commands/Add.txt
@@ -57,3 +57,27 @@ Examples:
   hledger add today 'best buy' expenses:supplies '$20'
 
 There is a detailed tutorial at https://hledger.org/add.html.
+
+add and balance assertions
+
+Since hledger 1.43, whenever you enter a posting amount, add will
+re-check all balance assertions in the journal, and if any of them fail,
+it will report the problem and ask for the amount again.
+
+You can also add a new balance assertion, following the amount as in
+journal format.
+
+The new transaction's date, and the new posting's posting date if any
+(entered in a comment following the amount), will influence assertion
+checking.
+
+You can use -I/--ignore-assertions to disable assertion checking
+temporarily.
+
+add and balance assignments
+
+Balance assignments are not recalculated during a hledger add session.
+When add runs, it sees the journal with all balance assignments already
+processed and converted to assertions. So if you add a new posting which
+is dated earlier than a balance assignment, it will break the assertion
+and be rejected. You can make it work by using hledger add -I.

--- a/hledger/Hledger/Cli/Commands/Commodities.md
+++ b/hledger/Hledger/Cli/Commands/Commodities.md
@@ -1,9 +1,19 @@
 ## commodities
 
-List all commodity/currency symbols used or declared in the journal.
+List the commodity symbols used or declared in the journal.
 
 ```flags
 Flags:
-no command-specific flags
+     --used                 list commodities used
+     --declared             list commodities declared
+     --undeclared           list commodities used but not declared
+     --unused               list commodities declared but not used
 ```
 
+This command lists commodity symbols/names - all of them by default,
+or just the ones which have been used in transactions or `P` directives,
+or declared with `commodity` directives,
+or used but not declared,
+or declared but not used.
+
+You can add cur: query arguments to further limit the commodities.

--- a/hledger/Hledger/Cli/Commands/Commodities.txt
+++ b/hledger/Hledger/Cli/Commands/Commodities.txt
@@ -1,6 +1,16 @@
 commodities
 
-List all commodity/currency symbols used or declared in the journal.
+List the commodity symbols used or declared in the journal.
 
 Flags:
-no command-specific flags
+     --used                 list commodities used
+     --declared             list commodities declared
+     --undeclared           list commodities used but not declared
+     --unused               list commodities declared but not used
+
+This command lists commodity symbols/names - all of them by default, or
+just the ones which have been used in transactions or P directives, or
+declared with commodity directives, or used but not declared, or
+declared but not used.
+
+You can add cur: query arguments to further limit the commodities.

--- a/hledger/Hledger/Cli/Commands/Descriptions.md
+++ b/hledger/Hledger/Cli/Commands/Descriptions.md
@@ -1,6 +1,6 @@
 ## descriptions
 
-List the unique descriptions that appear in transactions.
+List the unique descriptions used in transactions.
 
 ```flags
 Flags:

--- a/hledger/Hledger/Cli/Commands/Descriptions.txt
+++ b/hledger/Hledger/Cli/Commands/Descriptions.txt
@@ -1,6 +1,6 @@
 descriptions
 
-List the unique descriptions that appear in transactions.
+List the unique descriptions used in transactions.
 
 Flags:
 no command-specific flags

--- a/hledger/Hledger/Cli/Commands/Payees.md
+++ b/hledger/Hledger/Cli/Commands/Payees.md
@@ -1,23 +1,25 @@
 ## payees
 
-List the unique payee/payer names that appear in transactions.
+List the payee/payer names used or declared in the journal.
 
 ```flags
 Flags:
-     --declared             show payees declared with payee directives
-     --used                 show payees referenced by transactions
+     --used                 list payees used
+     --declared             list payees declared
+     --undeclared           list payees used but not declared
+     --unused               list payees declared but not used
 ```
 
-This command lists unique payee/payer names which have been 
-declared with payee directives (--declared), 
-used in transaction descriptions (--used), 
-or both (the default).
+This command lists unique payee/payer names - all of them by default,
+or just the ones which have been used in transaction descriptions,
+or declared with `payee` directives,
+or used but not declared,
+or declared but not used.
 
-The payee/payer is the part of the transaction description before a | character 
+The payee/payer name is the part of the transaction description before a | character
 (or if there is no |, the whole description).
 
-You can add query arguments to select a subset of transactions. This implies --used.
-
+You can add query arguments to select a subset of transactions or payees.
 
 Example:
 ```cli

--- a/hledger/Hledger/Cli/Commands/Payees.txt
+++ b/hledger/Hledger/Cli/Commands/Payees.txt
@@ -1,20 +1,23 @@
 payees
 
-List the unique payee/payer names that appear in transactions.
+List the payee/payer names used or declared in the journal.
 
 Flags:
-     --declared             show payees declared with payee directives
-     --used                 show payees referenced by transactions
+     --used                 list payees used
+     --declared             list payees declared
+     --undeclared           list payees used but not declared
+     --unused               list payees declared but not used
 
-This command lists unique payee/payer names which have been declared
-with payee directives (--declared), used in transaction descriptions
-(--used), or both (the default).
+This command lists unique payee/payer names - all of them by default, or
+just the ones which have been used in transaction descriptions, or
+declared with payee directives, or used but not declared, or declared
+but not used.
 
-The payee/payer is the part of the transaction description before a |
-character (or if there is no |, the whole description).
+The payee/payer name is the part of the transaction description before a
+| character (or if there is no |, the whole description).
 
-You can add query arguments to select a subset of transactions. This
-implies --used.
+You can add query arguments to select a subset of transactions or
+payees.
 
 Example:
 

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -60,7 +60,7 @@ printmode = hledgerCommandMode
    flagReq  ["match","m"] (\s opts -> Right $ setopt "match" s opts) arg
     ("fuzzy search for one recent transaction with description closest to "++arg)
   ,flagReq  ["base-url"] (\s opts -> Right $ setopt "base-url" s opts) "URLPREFIX" "in html output, generate links to hledger-web, with this prefix. (Usually the base url shown by hledger-web; can also be relative.)"
-  ,flagNone ["location"] (setboolopt "location") "add file/line number tags to print output"
+  ,flagNone ["location"] (setboolopt "location") "add tags showing file paths and line numbers"
   ,outputFormatFlag ["txt","beancount","csv","tsv","html","fods","json","sql"]
   ,outputFileFlag
   ])
@@ -113,9 +113,9 @@ print' opts@CliOpts{rawopts_=rawopts} j = do
   let
     -- lbl = lbl_ "print'"
     j' = j
-      -- & dbg9With (lbl "amounts before setting full precision".showJournalAmountsDebug)
+      -- & dbg9With (lbl "amounts before setting full precision".showJournalPostingAmountsDebug)
       & journalMapPostingAmounts mixedAmountSetFullPrecision
-      -- & dbg9With (lbl "amounts after  setting full precision: ".showJournalAmountsDebug)
+      -- & dbg9With (lbl "amounts after  setting full precision: ".showJournalPostingAmountsDebug)
       & if boolopt "location" rawopts then journalMapTransactions addLocationTag else id
 
   case maybestringopt "match" $ rawopts_ opts of

--- a/hledger/Hledger/Cli/Commands/Print.md
+++ b/hledger/Hledger/Cli/Commands/Print.md
@@ -25,7 +25,7 @@ Flags:
      --base-url=URLPREFIX   in html output, generate links to hledger-web,
                             with this prefix. (Usually the base url shown by
                             hledger-web; can also be relative.)
-     --location             add file/line number tags to print output
+     --location             add tags showing file paths and line numbers
   -O --output-format=FMT    select the output format. Supported formats:
                             txt, beancount, csv, tsv, html, fods, json, sql.
   -o --output-file=FILE     write output to FILE. A file extension matching

--- a/hledger/Hledger/Cli/Commands/Print.txt
+++ b/hledger/Hledger/Cli/Commands/Print.txt
@@ -24,7 +24,7 @@ Flags:
      --base-url=URLPREFIX   in html output, generate links to hledger-web,
                             with this prefix. (Usually the base url shown by
                             hledger-web; can also be relative.)
-     --location             add file/line number tags to print output
+     --location             add tags showing file paths and line numbers
   -O --output-format=FMT    select the output format. Supported formats:
                             txt, beancount, csv, tsv, html, fods, json, sql.
   -o --output-file=FILE     write output to FILE. A file extension matching

--- a/hledger/Hledger/Cli/Commands/Tags.hs
+++ b/hledger/Hledger/Cli/Commands/Tags.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 
 module Hledger.Cli.Commands.Tags (
   tagsmode
@@ -12,47 +13,73 @@ import Data.List.Extra (nubSort)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Safe
-import System.Console.CmdArgs.Explicit as C
+import System.Console.CmdArgs.Explicit
+
 import Hledger
 import Hledger.Cli.CliOptions
 
+
 tagsmode = hledgerCommandMode
   $(embedFileRelative "Hledger/Cli/Commands/Tags.txt")
-  [flagNone ["values"] (setboolopt "values") "list tag values instead of tag names"
-  ,flagNone ["parsed"] (setboolopt "parsed") "show tags/values in the order they were parsed, including duplicates"
+  [
+   flagNone ["used"]         (setboolopt "used")       "list tags used"
+  ,flagNone ["declared"]     (setboolopt "declared")   "list tags declared"
+  ,flagNone ["undeclared"]   (setboolopt "undeclared") "list tags used but not declared"
+  ,flagNone ["unused"]       (setboolopt "unused")     "list tags declared but not used"
+  ,flagNone ["values"]       (setboolopt "values")     "list tag values instead of tag names"
+  ,flagNone ["parsed"]       (setboolopt "parsed")     "show them in the order they were parsed (mostly), including duplicates"
   ]
   cligeneralflagsgroups1
   hiddenflags
-  ([], Just $ argsFlag "[TAGREGEX [QUERY...]]")
+  ([], Just $ argsFlag "[TAGREGEX [QUERY..]]")
 
 tags :: CliOpts -> Journal -> IO ()
-tags CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
+tags opts@CliOpts{rawopts_=rawopts, reportspec_=rspec@ReportSpec{_rsQuery=_q, _rsReportOpts=ropts}} j = do
   let today = _rsDay rspec
       args = listofstringopt "args" rawopts
-  -- first argument is a tag name pattern, others are a hledger query: hledger tags [TAGREGEX [QUERYARGS..]]
+  -- For convenience/power, the first argument is a tag name regex, 
+  -- separate from the main query arguments: hledger tags [TAGREGEX [QUERYARGS..]]
+  -- So we have to re-parse the query here. Overcomplicated ?
   mtagpat <- mapM (either Fail.fail pure . toRegexCI . T.pack) $ headMay args
   let
-    querystr = map T.pack $ drop 1 args
     values   = boolopt "values" rawopts
     parsed   = boolopt "parsed" rawopts
-    empty    = empty_ $ _rsReportOpts rspec
+    empty    = empty_ ropts
+    querystr = map T.pack $ drop 1 args
   query <- either usageError (return . fst) $ parseQueryList today querystr
   let
-    q = simplifyQuery $ And [queryFromFlags $ _rsReportOpts rspec, query]
-    matchedtxns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
-    -- also list tags from matched account declarations, but not if there is
-    -- a query for something transaction-related, like date: or amt:.
-    matchedaccts = dbg4 "accts" $
-      if dbg4 "queryIsTransactionRelated" $ queryIsTransactionRelated $ dbg4 "q" q
+    q = simplifyQuery $ And [queryFromFlags ropts, query]
+    txns = filter (q `matchesTransaction`) $ jtxns $ journalApplyValuationFromOpts rspec j
+    accts =
+      -- also search for tags in matched account declarations,
+      -- unless there is a query for something transaction-specific, like date: or amt:.
+      if dbg5 "queryIsTransactionRelated" $ queryIsTransactionRelated $ dbg4 "q" q
       then []
       else filter (matchesAccountExtra (journalAccountType j) (journalInheritedAccountTags j) q) $
            map fst $ jdeclaredaccounts j
-    tagsorvalues =
+
+    used       = dbg5 "used"       $ concatMap (journalAccountTags j) accts ++ concatMap transactionAllTags txns
+    declared'  = dbg5 "declared"   $ filter (q `matchesTag`) $ map (,"") $ journalTagsDeclared j
+    (usednames, declarednames) = (map fst used, map fst declared')
+    unused     = dbg5 "unused"     $ filter (not . (`elem` usednames) . fst) declared'
+    undeclared = dbg5 "undeclared" $ filter (not . (`elem` declarednames) . fst) used
+    all'       = dbg5 "all"        $ declared' <> used
+
+    tags' =
+      case usedOrDeclaredFromOpts opts of
+        Nothing         -> all'
+        Just Used       -> used
+        Just Declared   -> declared'
+        Just Undeclared -> undeclared
+        Just Unused     -> unused
+
+    results =
       (if parsed then id else nubSort)
       [ r
-      | (t,v) <- concatMap (journalAccountTags j) matchedaccts ++ concatMap transactionAllTags matchedtxns
+      | (t,v) <- tags'
       , maybe True (`regexMatchText` t) mtagpat
       , let r = if values then v else t
       , not (values && T.null v && not empty)
       ]
-  mapM_ T.putStrLn tagsorvalues
+
+  mapM_ T.putStrLn results

--- a/hledger/Hledger/Cli/Commands/Tags.md
+++ b/hledger/Hledger/Cli/Commands/Tags.md
@@ -1,32 +1,39 @@
 ## tags
 
-List the tags used in the journal, or their values.
-<!-- same section name as Journal > Tags; if reordering this and that, update all #tags[-1] links -->
+List the tag names used or declared in the journal, or their values.
+<!-- This section has the same name as Journal > Tags; 
+     if reordering this and that, update all #tags[-1] links -->
 
 ```flags
 Flags:
+     --used                 list tags used
+     --declared             list tags declared
+     --undeclared           list tags used but not declared
+     --unused               list tags declared but not used
      --values               list tag values instead of tag names
-     --parsed               show tags/values in the order they were parsed,
+     --parsed               show them in the order they were parsed (mostly),
                             including duplicates
 ```
 
-This command lists the tag names used in the journal,
-whether on transactions, postings, or account declarations.
+This command lists tag names - all of them by default,
+or just the ones which have been used on transactions/postings/accounts,
+or declared with `tag` directives,
+or used but not declared,
+or declared but not used.
 
-With a TAGREGEX argument, only tag names matching this regular expression
-(case insensitive, infix matched) are shown.
+You can add one TAGREGEX argument, to show only tags whose name is
+matched by this case-insensitive, infix-matching regular expression.
 
-With QUERY arguments, only transactions and accounts matching this query are considered.
-If the query involves transaction fields (date:, desc:, amt:, ...),
-the search is restricted to the matched transactions and their accounts.
+After that, you can add query arguments to filter the 
+transactions, postings, or accounts providing tags.
 
-With the --values flag, the tags' unique non-empty values are listed instead.
-With -E/--empty, blank/empty values are also shown.
+With `--values`, the tags' unique non-empty values are listed instead.
 
-With --parsed, tags or values are shown in the order they were parsed, with duplicates included.
+With `-E`/`--empty`, blank/empty values are also shown.
+
+With `--parsed`, tags or values are shown in the order they were parsed, with duplicates included.
 (Except, tags from account declarations are always shown first.)
 
-Tip: remember,
-accounts also acquire tags from their parents,
-postings also acquire tags from their account and transaction,
-transactions also acquire tags from their postings.
+Remember that accounts also acquire tags from their parents;
+postings also acquire tags from their account and transaction;
+and transactions also acquire tags from their postings.

--- a/hledger/Hledger/Cli/Commands/Tags.txt
+++ b/hledger/Hledger/Cli/Commands/Tags.txt
@@ -1,30 +1,34 @@
 tags
 
-List the tags used in the journal, or their values.
+List the tag names used or declared in the journal, or their values.
 
 Flags:
+     --used                 list tags used
+     --declared             list tags declared
+     --undeclared           list tags used but not declared
+     --unused               list tags declared but not used
      --values               list tag values instead of tag names
-     --parsed               show tags/values in the order they were parsed,
+     --parsed               show them in the order they were parsed (mostly),
                             including duplicates
 
-This command lists the tag names used in the journal, whether on
-transactions, postings, or account declarations.
+This command lists tag names - all of them by default, or just the ones
+which have been used on transactions/postings/accounts, or declared with
+tag directives, or used but not declared, or declared but not used.
 
-With a TAGREGEX argument, only tag names matching this regular
-expression (case insensitive, infix matched) are shown.
+You can add one TAGREGEX argument, to show only tags whose name is
+matched by this case-insensitive, infix-matching regular expression.
 
-With QUERY arguments, only transactions and accounts matching this query
-are considered. If the query involves transaction fields (date:, desc:,
-amt:, ...), the search is restricted to the matched transactions and
-their accounts.
+After that, you can add query arguments to filter the transactions,
+postings, or accounts providing tags.
 
-With the --values flag, the tags' unique non-empty values are listed
-instead. With -E/--empty, blank/empty values are also shown.
+With --values, the tags' unique non-empty values are listed instead.
+
+With -E/--empty, blank/empty values are also shown.
 
 With --parsed, tags or values are shown in the order they were parsed,
 with duplicates included. (Except, tags from account declarations are
 always shown first.)
 
-Tip: remember, accounts also acquire tags from their parents, postings
-also acquire tags from their account and transaction, transactions also
-acquire tags from their postings.
+Remember that accounts also acquire tags from their parents; postings
+also acquire tags from their account and transaction; and transactions
+also acquire tags from their postings.

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -8942,14 +8942,15 @@ if any (entered in a comment following the amount), will influence
 assertion checking.
 .PP
 You can use \f[CR]\-I\f[R]/\f[CR]\-\-ignore\-assertions\f[R] to disable
-this assertion checking.
+assertion checking temporarily.
 .SS add and balance assignments
-You can\[aq]t add new postings which are dated earlier than a balance
-assignment, currently.
-It\[aq]s because balance assignments are performed once, before
-\f[CR]add\f[R]; by the time \f[CR]add\f[R] runs, all amounts in the
-journal are explicit, and assignments have become assertions.
-(#2406).
+Balance assignments are not recalculated during a \f[CR]hledger add\f[R]
+session.
+When \f[CR]add\f[R] runs, it sees the journal with all balance
+assignments already processed and converted to assertions.
+So if you add a new posting which is dated earlier than a balance
+assignment, it will break the assertion and be rejected.
+You can make it work by using \f[CR]hledger add \-I\f[R].
 .SS import
 Import new transactions from one or more data files to the main journal.
 .IP
@@ -9186,39 +9187,32 @@ A new CSV record generates a journal entry identical to one(s) already
 in the journal.
 .SH Basic report commands
 .SS accounts
-List account names.
+List the account names used or declared in the journal.
 .IP
 .EX
 Flags:
-  \-u \-\-used                 show only accounts used by transactions
-  \-d \-\-declared             show only accounts declared by account directive
-     \-\-unused               show only accounts declared but not used
-     \-\-undeclared           show only accounts used but not declared
+  \-u \-\-used                 list accounts used
+  \-d \-\-declared             list accounts declared
+     \-\-undeclared           list accounts used but not declared
+     \-\-unused               list accounts declared but not used
+     \-\-find                 list the first account matched by the first
+                            argument (a case\-insensitive infix regexp)
      \-\-types                also show account types when known
      \-\-positions            also show where accounts were declared
      \-\-directives           show as account directives, for use in journals
-     \-\-find                 find the first account matched by the first
-                            argument (a case\-insensitive infix regexp or
-                            account name)
   \-l \-\-flat                 list/tree mode: show accounts as a flat list
                             (default)
   \-t \-\-tree                 list/tree mode: show accounts as a tree
      \-\-drop=N               flat mode: omit N leading account name parts
 .EE
 .PP
-This command lists account names.
-By default it shows all known accounts, either used in transactions or
-declared with account directives.
+This command lists account names \- all of them by default.
+or just the ones which have been used in transactions, or declared with
+\f[CR]account\f[R] directives, or used but not declared, or declared but
+not used, or just the first account name matched by a pattern.
 .PP
-With query arguments, only matched account names and account names
-referenced by matched postings are shown.
-.PP
-Or it can show just the used accounts
-(\f[CR]\-\-used\f[R]/\f[CR]\-u\f[R]), the declared accounts
-(\f[CR]\-\-declared\f[R]/\f[CR]\-d\f[R]), the accounts declared but not
-used (\f[CR]\-\-unused\f[R]), the accounts used but not declared
-(\f[CR]\-\-undeclared\f[R]), or the first account matched by an account
-name pattern, if any (\f[CR]\-\-find\f[R]).
+You can add query arguments to select a subset of transactions or
+accounts.
 .PP
 It shows a flat list by default.
 With \f[CR]\-\-tree\f[R], it uses indentation to show the account
@@ -9237,9 +9231,8 @@ each account\[aq]s declaration, if any, and the account\[aq]s overall
 declaration order; these may be useful when troubleshooting account
 display order.
 .PP
-With \f[CR]\-\-directives\f[R], it adds the \f[CR]account\f[R] keyword,
-showing valid account directives which can be pasted into a journal
-file.
+With \f[CR]\-\-directives\f[R], it shows valid account directives which
+could be pasted into a journal file.
 This is useful together with \f[CR]\-\-undeclared\f[R] when updating
 your account declarations to satisfy \f[CR]hledger check accounts\f[R].
 .PP
@@ -9322,14 +9315,24 @@ $ hledger codes \-E
 126
 .EE
 .SS commodities
-List all commodity/currency symbols used or declared in the journal.
+List the commodity symbols used or declared in the journal.
 .IP
 .EX
 Flags:
-no command\-specific flags
+     \-\-used                 list commodities used
+     \-\-declared             list commodities declared
+     \-\-undeclared           list commodities used but not declared
+     \-\-unused               list commodities declared but not used
 .EE
+.PP
+This command lists commodity symbols/names \- all of them by default, or
+just the ones which have been used in transactions or \f[CR]P\f[R]
+directives, or declared with \f[CR]commodity\f[R] directives, or used
+but not declared, or declared but not used.
+.PP
+You can add cur: query arguments to further limit the commodities.
 .SS descriptions
-List the unique descriptions that appear in transactions.
+List the unique descriptions used in transactions.
 .IP
 .EX
 Flags:
@@ -9379,23 +9382,26 @@ Petrol
 Snacks
 .EE
 .SS payees
-List the unique payee/payer names that appear in transactions.
+List the payee/payer names used or declared in the journal.
 .IP
 .EX
 Flags:
-     \-\-declared             show payees declared with payee directives
-     \-\-used                 show payees referenced by transactions
+     \-\-used                 list payees used
+     \-\-declared             list payees declared
+     \-\-undeclared           list payees used but not declared
+     \-\-unused               list payees declared but not used
 .EE
 .PP
-This command lists unique payee/payer names which have been declared
-with payee directives (\-\-declared), used in transaction descriptions
-(\-\-used), or both (the default).
+This command lists unique payee/payer names \- all of them by default,
+or just the ones which have been used in transaction descriptions, or
+declared with \f[CR]payee\f[R] directives, or used but not declared, or
+declared but not used.
 .PP
-The payee/payer is the part of the transaction description before a |
-character (or if there is no |, the whole description).
+The payee/payer name is the part of the transaction description before a
+| character (or if there is no |, the whole description).
 .PP
-You can add query arguments to select a subset of transactions.
-This implies \-\-used.
+You can add query arguments to select a subset of transactions or
+payees.
 .PP
 Example:
 .IP
@@ -9483,37 +9489,43 @@ Runtime stats       : 0.12 s elapsed, 8266 txns/s, 4 MB live, 16 MB alloc
 This command supports the \-o/\-\-output\-file option (but not
 \-O/\-\-output\-format).
 .SS tags
-List the tags used in the journal, or their values.
+List the tag names used or declared in the journal, or their values.
 .IP
 .EX
 Flags:
+     \-\-used                 list tags used
+     \-\-declared             list tags declared
+     \-\-undeclared           list tags used but not declared
+     \-\-unused               list tags declared but not used
      \-\-values               list tag values instead of tag names
-     \-\-parsed               show tags/values in the order they were parsed,
+     \-\-parsed               show them in the order they were parsed (mostly),
                             including duplicates
 .EE
 .PP
-This command lists the tag names used in the journal, whether on
-transactions, postings, or account declarations.
+This command lists tag names \- all of them by default, or just the ones
+which have been used on transactions/postings/accounts, or declared with
+\f[CR]tag\f[R] directives, or used but not declared, or declared but not
+used.
 .PP
-With a TAGREGEX argument, only tag names matching this regular
-expression (case insensitive, infix matched) are shown.
+You can add one TAGREGEX argument, to show only tags whose name is
+matched by this case\-insensitive, infix\-matching regular expression.
 .PP
-With QUERY arguments, only transactions and accounts matching this query
-are considered.
-If the query involves transaction fields (date:, desc:, amt:, ...), the
-search is restricted to the matched transactions and their accounts.
+After that, you can add query arguments to filter the transactions,
+postings, or accounts providing tags.
 .PP
-With the \-\-values flag, the tags\[aq] unique non\-empty values are
+With \f[CR]\-\-values\f[R], the tags\[aq] unique non\-empty values are
 listed instead.
-With \-E/\-\-empty, blank/empty values are also shown.
 .PP
-With \-\-parsed, tags or values are shown in the order they were parsed,
-with duplicates included.
+With \f[CR]\-E\f[R]/\f[CR]\-\-empty\f[R], blank/empty values are also
+shown.
+.PP
+With \f[CR]\-\-parsed\f[R], tags or values are shown in the order they
+were parsed, with duplicates included.
 (Except, tags from account declarations are always shown first.)
 .PP
-Tip: remember, accounts also acquire tags from their parents, postings
-also acquire tags from their account and transaction, transactions also
-acquire tags from their postings.
+Remember that accounts also acquire tags from their parents; postings
+also acquire tags from their account and transaction; and transactions
+also acquire tags from their postings.
 .SH Standard report commands
 .SS print
 Show full journal entries, representing transactions.
@@ -9541,7 +9553,7 @@ Flags:
      \-\-base\-url=URLPREFIX   in html output, generate links to hledger\-web,
                             with this prefix. (Usually the base url shown by
                             hledger\-web; can also be relative.)
-     \-\-location             add file/line number tags to print output
+     \-\-location             add tags showing file paths and line numbers
   \-O \-\-output\-format=FMT    select the output format. Supported formats:
                             txt, beancount, csv, tsv, html, fods, json, sql.
   \-o \-\-output\-file=FILE     write output to FILE. A file extension matching

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -8614,8 +8614,8 @@ journal format.
 (entered in a comment following the amount), will influence assertion
 checking.
 
-   You can use '-I'/'--ignore-assertions' to disable this assertion
-checking.
+   You can use '-I'/'--ignore-assertions' to disable assertion checking
+temporarily.
 
 
 File: hledger.info,  Node: add and balance assignments,  Next: import,  Prev: add and balance assertions,  Up: Data entry commands
@@ -8623,10 +8623,12 @@ File: hledger.info,  Node: add and balance assignments,  Next: import,  Prev: ad
 26.3 add and balance assignments
 ================================
 
-You can't add new postings which are dated earlier than a balance
-assignment, currently.  It's because balance assignments are performed
-once, before 'add'; by the time 'add' runs, all amounts in the journal
-are explicit, and assignments have become assertions.  (#2406).
+Balance assignments are not recalculated during a 'hledger add' session.
+When 'add' runs, it sees the journal with all balance assignments
+already processed and converted to assertions.  So if you add a new
+posting which is dated earlier than a balance assignment, it will break
+the assertion and be rejected.  You can make it work by using 'hledger
+add -I'.
 
 
 File: hledger.info,  Node: import,  Prev: add and balance assignments,  Up: Data entry commands
@@ -8890,35 +8892,30 @@ File: hledger.info,  Node: accounts,  Next: codes,  Up: Basic report commands
 27.1 accounts
 =============
 
-List account names.
+List the account names used or declared in the journal.
 
 Flags:
-  -u --used                 show only accounts used by transactions
-  -d --declared             show only accounts declared by account directive
-     --unused               show only accounts declared but not used
-     --undeclared           show only accounts used but not declared
+  -u --used                 list accounts used
+  -d --declared             list accounts declared
+     --undeclared           list accounts used but not declared
+     --unused               list accounts declared but not used
+     --find                 list the first account matched by the first
+                            argument (a case-insensitive infix regexp)
      --types                also show account types when known
      --positions            also show where accounts were declared
      --directives           show as account directives, for use in journals
-     --find                 find the first account matched by the first
-                            argument (a case-insensitive infix regexp or
-                            account name)
   -l --flat                 list/tree mode: show accounts as a flat list
                             (default)
   -t --tree                 list/tree mode: show accounts as a tree
      --drop=N               flat mode: omit N leading account name parts
 
-   This command lists account names.  By default it shows all known
-accounts, either used in transactions or declared with account
-directives.
+   This command lists account names - all of them by default.  or just
+the ones which have been used in transactions, or declared with
+'account' directives, or used but not declared, or declared but not
+used, or just the first account name matched by a pattern.
 
-   With query arguments, only matched account names and account names
-referenced by matched postings are shown.
-
-   Or it can show just the used accounts ('--used'/'-u'), the declared
-accounts ('--declared'/'-d'), the accounts declared but not used
-('--unused'), the accounts used but not declared ('--undeclared'), or
-the first account matched by an account name pattern, if any ('--find').
+   You can add query arguments to select a subset of transactions or
+accounts.
 
    It shows a flat list by default.  With '--tree', it uses indentation
 to show the account hierarchy.  In flat mode you can add '--drop N' to
@@ -8932,10 +8929,10 @@ depth-clipped with 'depth:N' or '--depth N' or '-N'.
 account's declaration, if any, and the account's overall declaration
 order; these may be useful when troubleshooting account display order.
 
-   With '--directives', it adds the 'account' keyword, showing valid
-account directives which can be pasted into a journal file.  This is
-useful together with '--undeclared' when updating your account
-declarations to satisfy 'hledger check accounts'.
+   With '--directives', it shows valid account directives which could be
+pasted into a journal file.  This is useful together with '--undeclared'
+when updating your account declarations to satisfy 'hledger check
+accounts'.
 
    The '--find' flag can be used to look up a single account name, in
 the same way that the 'aregister' command does.  It returns the
@@ -9014,10 +9011,20 @@ File: hledger.info,  Node: commodities,  Next: descriptions,  Prev: codes,  Up: 
 27.3 commodities
 ================
 
-List all commodity/currency symbols used or declared in the journal.
+List the commodity symbols used or declared in the journal.
 
 Flags:
-no command-specific flags
+     --used                 list commodities used
+     --declared             list commodities declared
+     --undeclared           list commodities used but not declared
+     --unused               list commodities declared but not used
+
+   This command lists commodity symbols/names - all of them by default,
+or just the ones which have been used in transactions or 'P' directives,
+or declared with 'commodity' directives, or used but not declared, or
+declared but not used.
+
+   You can add cur: query arguments to further limit the commodities.
 
 
 File: hledger.info,  Node: descriptions,  Next: files,  Prev: commodities,  Up: Basic report commands
@@ -9025,7 +9032,7 @@ File: hledger.info,  Node: descriptions,  Next: files,  Prev: commodities,  Up: 
 27.4 descriptions
 =================
 
-List the unique descriptions that appear in transactions.
+List the unique descriptions used in transactions.
 
 Flags:
 no command-specific flags
@@ -9081,21 +9088,24 @@ File: hledger.info,  Node: payees,  Next: prices,  Prev: notes,  Up: Basic repor
 27.7 payees
 ===========
 
-List the unique payee/payer names that appear in transactions.
+List the payee/payer names used or declared in the journal.
 
 Flags:
-     --declared             show payees declared with payee directives
-     --used                 show payees referenced by transactions
+     --used                 list payees used
+     --declared             list payees declared
+     --undeclared           list payees used but not declared
+     --unused               list payees declared but not used
 
-   This command lists unique payee/payer names which have been declared
-with payee directives (-declared), used in transaction descriptions
-(-used), or both (the default).
+   This command lists unique payee/payer names - all of them by default,
+or just the ones which have been used in transaction descriptions, or
+declared with 'payee' directives, or used but not declared, or declared
+but not used.
 
-   The payee/payer is the part of the transaction description before a |
-character (or if there is no |, the whole description).
+   The payee/payer name is the part of the transaction description
+before a | character (or if there is no |, the whole description).
 
-   You can add query arguments to select a subset of transactions.  This
-implies -used.
+   You can add query arguments to select a subset of transactions or
+payees.
 
    Example:
 
@@ -9187,34 +9197,40 @@ File: hledger.info,  Node: tags,  Prev: stats,  Up: Basic report commands
 27.10 tags
 ==========
 
-List the tags used in the journal, or their values.
+List the tag names used or declared in the journal, or their values.
 
 Flags:
+     --used                 list tags used
+     --declared             list tags declared
+     --undeclared           list tags used but not declared
+     --unused               list tags declared but not used
      --values               list tag values instead of tag names
-     --parsed               show tags/values in the order they were parsed,
+     --parsed               show them in the order they were parsed (mostly),
                             including duplicates
 
-   This command lists the tag names used in the journal, whether on
-transactions, postings, or account declarations.
+   This command lists tag names - all of them by default, or just the
+ones which have been used on transactions/postings/accounts, or declared
+with 'tag' directives, or used but not declared, or declared but not
+used.
 
-   With a TAGREGEX argument, only tag names matching this regular
-expression (case insensitive, infix matched) are shown.
+   You can add one TAGREGEX argument, to show only tags whose name is
+matched by this case-insensitive, infix-matching regular expression.
 
-   With QUERY arguments, only transactions and accounts matching this
-query are considered.  If the query involves transaction fields (date:,
-desc:, amt:, ...), the search is restricted to the matched transactions
-and their accounts.
+   After that, you can add query arguments to filter the transactions,
+postings, or accounts providing tags.
 
-   With the -values flag, the tags' unique non-empty values are listed
-instead.  With -E/-empty, blank/empty values are also shown.
+   With '--values', the tags' unique non-empty values are listed
+instead.
 
-   With -parsed, tags or values are shown in the order they were parsed,
-with duplicates included.  (Except, tags from account declarations are
-always shown first.)
+   With '-E'/'--empty', blank/empty values are also shown.
 
-   Tip: remember, accounts also acquire tags from their parents,
-postings also acquire tags from their account and transaction,
-transactions also acquire tags from their postings.
+   With '--parsed', tags or values are shown in the order they were
+parsed, with duplicates included.  (Except, tags from account
+declarations are always shown first.)
+
+   Remember that accounts also acquire tags from their parents; postings
+also acquire tags from their account and transaction; and transactions
+also acquire tags from their postings.
 
 
 File: hledger.info,  Node: Standard report commands,  Next: Advanced report commands,  Prev: Basic report commands,  Up: Top
@@ -9262,7 +9278,7 @@ Flags:
      --base-url=URLPREFIX   in html output, generate links to hledger-web,
                             with this prefix. (Usually the base url shown by
                             hledger-web; can also be relative.)
-     --location             add file/line number tags to print output
+     --location             add tags showing file paths and line numbers
   -O --output-format=FMT    select the output format. Supported formats:
                             txt, beancount, csv, tsv, html, fods, json, sql.
   -o --output-file=FILE     write output to FILE. A file extension matching
@@ -13113,116 +13129,116 @@ Node: web310211
 Node: Data entry commands310339
 Node: add310600
 Node: add and balance assertions313075
-Node: add and balance assignments313792
-Node: import314266
-Node: Import preview315324
-Node: Overlap detection316272
-Node: First import319158
-Node: Importing balance assignments320353
-Node: Import and commodity styles321408
-Node: Import special cases321846
-Node: Basic report commands323181
-Node: accounts323482
-Node: codes326415
-Node: commodities327437
-Node: descriptions327681
-Node: files328148
-Node: notes328445
-Node: payees328957
-Node: prices329741
-Node: stats330633
-Node: tags332374
-Node: Standard report commands333681
-Node: print333986
-Node: print explicitness336797
-Node: print amount style337717
-Node: print parseability338955
-Node: print other features339874
-Node: print output format340835
-Node: aregister344120
-Node: aregister and posting dates348673
-Node: register349574
-Node: Custom register output356815
-Node: balancesheet358000
-Node: balancesheetequity362965
-Node: cashflow368300
-Node: incomestatement373113
-Node: Advanced report commands377962
-Node: balance378170
-Node: balance features383591
-Node: Simple balance report385694
-Node: Balance report line format387504
-Node: Filtered balance report389864
-Node: List or tree mode390383
-Node: Depth limiting391896
-Node: Dropping top-level accounts392663
-Node: Showing declared accounts393173
-Node: Sorting by amount393903
-Node: Percentages394757
-Node: Multi-period balance report395464
-Node: Balance change end balance398216
-Node: Balance report modes399853
-Node: Calculation mode400532
-Node: Accumulation mode401236
-Node: Valuation mode402337
-Node: Combining balance report modes403681
-Node: Budget report405711
-Node: Using the budget report408011
-Node: Budget date surprises410287
-Node: Selecting budget goals411651
-Node: Budgeting vs forecasting412599
-Node: Balance report layout414276
-Node: Wide layout415481
-Node: Tall layout417886
-Node: Bare layout419192
-Node: Tidy layout421256
-Node: Balance report output422800
-Node: Some useful balance reports423574
-Node: roi424834
-Node: Spaces and special characters in --inv and --pnl427081
-Node: Semantics of --inv and --pnl427807
-Node: IRR and TWR explained429894
-Node: Chart commands433305
-Node: activity433486
-Node: Data generation commands433983
-Node: close434189
-Node: close --clopen436752
-Node: close --close438926
-Node: close --open439450
-Node: close --assert439700
-Node: close --assign440027
-Node: close --retain440706
-Node: close customisation441563
-Node: close and balance assertions443207
-Node: close examples444729
-Node: Retain earnings444966
-Node: Migrate balances to a new file445469
-Node: More detailed close examples446831
-Node: rewrite447053
-Node: Re-write rules in a file449625
-Node: Diff output format450935
-Node: rewrite vs print --auto452208
-Node: Maintenance commands452922
-Node: check453141
-Node: Basic checks454223
-Node: Strict checks455244
-Node: Other checks456181
-Node: Custom checks457933
-Node: diff458388
-Node: setup459596
-Node: test462463
-Node: PART 5 COMMON TASKS463366
-Node: Getting help463599
-Node: Constructing command lines464508
-Node: Starting a journal file465346
-Node: Setting LEDGER_FILE466730
-Node: Setting opening balances467988
-Node: Recording transactions471310
-Node: Reconciling472035
-Node: Reporting474424
-Node: Migrating to a new file478538
-Node: BUGS478987
-Node: Troubleshooting479955
+Node: add and balance assignments313799
+Node: import314360
+Node: Import preview315418
+Node: Overlap detection316366
+Node: First import319252
+Node: Importing balance assignments320447
+Node: Import and commodity styles321502
+Node: Import special cases321940
+Node: Basic report commands323275
+Node: accounts323576
+Node: codes326222
+Node: commodities327244
+Node: descriptions328001
+Node: files328461
+Node: notes328758
+Node: payees329270
+Node: prices330182
+Node: stats331074
+Node: tags332815
+Node: Standard report commands334352
+Node: print334657
+Node: print explicitness337471
+Node: print amount style338391
+Node: print parseability339629
+Node: print other features340548
+Node: print output format341509
+Node: aregister344794
+Node: aregister and posting dates349347
+Node: register350248
+Node: Custom register output357489
+Node: balancesheet358674
+Node: balancesheetequity363639
+Node: cashflow368974
+Node: incomestatement373787
+Node: Advanced report commands378636
+Node: balance378844
+Node: balance features384265
+Node: Simple balance report386368
+Node: Balance report line format388178
+Node: Filtered balance report390538
+Node: List or tree mode391057
+Node: Depth limiting392570
+Node: Dropping top-level accounts393337
+Node: Showing declared accounts393847
+Node: Sorting by amount394577
+Node: Percentages395431
+Node: Multi-period balance report396138
+Node: Balance change end balance398890
+Node: Balance report modes400527
+Node: Calculation mode401206
+Node: Accumulation mode401910
+Node: Valuation mode403011
+Node: Combining balance report modes404355
+Node: Budget report406385
+Node: Using the budget report408685
+Node: Budget date surprises410961
+Node: Selecting budget goals412325
+Node: Budgeting vs forecasting413273
+Node: Balance report layout414950
+Node: Wide layout416155
+Node: Tall layout418560
+Node: Bare layout419866
+Node: Tidy layout421930
+Node: Balance report output423474
+Node: Some useful balance reports424248
+Node: roi425508
+Node: Spaces and special characters in --inv and --pnl427755
+Node: Semantics of --inv and --pnl428481
+Node: IRR and TWR explained430568
+Node: Chart commands433979
+Node: activity434160
+Node: Data generation commands434657
+Node: close434863
+Node: close --clopen437426
+Node: close --close439600
+Node: close --open440124
+Node: close --assert440374
+Node: close --assign440701
+Node: close --retain441380
+Node: close customisation442237
+Node: close and balance assertions443881
+Node: close examples445403
+Node: Retain earnings445640
+Node: Migrate balances to a new file446143
+Node: More detailed close examples447505
+Node: rewrite447727
+Node: Re-write rules in a file450299
+Node: Diff output format451609
+Node: rewrite vs print --auto452882
+Node: Maintenance commands453596
+Node: check453815
+Node: Basic checks454897
+Node: Strict checks455918
+Node: Other checks456855
+Node: Custom checks458607
+Node: diff459062
+Node: setup460270
+Node: test463137
+Node: PART 5 COMMON TASKS464040
+Node: Getting help464273
+Node: Constructing command lines465182
+Node: Starting a journal file466020
+Node: Setting LEDGER_FILE467404
+Node: Setting opening balances468662
+Node: Recording transactions471984
+Node: Reconciling472709
+Node: Reporting475098
+Node: Migrating to a new file479212
+Node: BUGS479661
+Node: Troubleshooting480629
 
 End Tag Table
 

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -6923,13 +6923,15 @@ Data entry commands
        (entered in a comment following the amount), will  influence  assertion
        checking.
 
-       You can use -I/--ignore-assertions to disable this assertion checking.
+       You  can  use -I/--ignore-assertions to disable assertion checking tem-
+       porarily.
 
    add and balance assignments
-       You  can't  add new postings which are dated earlier than a balance as-
-       signment, currently.  It's because balance  assignments  are  performed
-       once,  before add; by the time add runs, all amounts in the journal are
-       explicit, and assignments have become assertions.  (#2406).
+       Balance assignments are not recalculated during a hledger add  session.
+       When add runs, it sees the journal with all balance assignments already
+       processed  and  converted  to  assertions.  So if you add a new posting
+       which is dated earlier than a balance assignment, it will break the as-
+       sertion and be rejected.  You can make it work by using hledger add -I.
 
    import
        Import new transactions from one or more data files to the  main  jour-
@@ -7132,35 +7134,30 @@ Data entry commands
 
 Basic report commands
    accounts
-       List account names.
+       List the account names used or declared in the journal.
 
               Flags:
-                -u --used                 show only accounts used by transactions
-                -d --declared             show only accounts declared by account directive
-                   --unused               show only accounts declared but not used
-                   --undeclared           show only accounts used but not declared
+                -u --used                 list accounts used
+                -d --declared             list accounts declared
+                   --undeclared           list accounts used but not declared
+                   --unused               list accounts declared but not used
+                   --find                 list the first account matched by the first
+                                          argument (a case-insensitive infix regexp)
                    --types                also show account types when known
                    --positions            also show where accounts were declared
                    --directives           show as account directives, for use in journals
-                   --find                 find the first account matched by the first
-                                          argument (a case-insensitive infix regexp or
-                                          account name)
                 -l --flat                 list/tree mode: show accounts as a flat list
                                           (default)
                 -t --tree                 list/tree mode: show accounts as a tree
                    --drop=N               flat mode: omit N leading account name parts
 
-       This command lists account names.  By default it shows  all  known  ac-
-       counts,  either  used  in  transactions or declared with account direc-
-       tives.
+       This command lists account names - all of them by default.  or just the
+       ones which have been used in transactions, or declared with account di-
+       rectives, or used but not declared, or declared but not used,  or  just
+       the first account name matched by a pattern.
 
-       With query arguments, only matched account names and account names ref-
-       erenced by matched postings are shown.
-
-       Or it can show just the used accounts  (--used/-u),  the  declared  ac-
-       counts  (--declared/-d), the accounts declared but not used (--unused),
-       the accounts used but not declared (--undeclared), or the first account
-       matched by an account name pattern, if any (--find).
+       You  can  add query arguments to select a subset of transactions or ac-
+       counts.
 
        It shows a flat list by default.  With --tree, it uses  indentation  to
        show  the account hierarchy.  In flat mode you can add --drop N to omit
@@ -7174,14 +7171,14 @@ Basic report commands
        count's  declaration, if any, and the account's overall declaration or-
        der; these may be useful when troubleshooting account display order.
 
-       With --directives, it adds the account keyword, showing  valid  account
-       directives which can be pasted into a journal file.  This is useful to-
-       gether  with  --undeclared  when  updating your account declarations to
-       satisfy hledger check accounts.
+       With --directives, it shows valid account  directives  which  could  be
+       pasted  into a journal file.  This is useful together with --undeclared
+       when updating your account declarations to satisfy  hledger  check  ac-
+       counts.
 
-       The --find flag can be used to look up a single account  name,  in  the
-       same  way that the aregister command does.  It returns the alphanumeri-
-       cally-first matched account name, or if none can  be  found,  it  fails
+       The  --find  flag  can be used to look up a single account name, in the
+       same way that the aregister command does.  It returns the  alphanumeri-
+       cally-first  matched  account  name,  or if none can be found, it fails
        with a non-zero exit code.
 
        Examples:
@@ -7205,13 +7202,13 @@ Basic report commands
               Flags:
               no command-specific flags
 
-       This  command prints the value of each transaction's code field, in the
-       order transactions were parsed.  The transaction code  is  an  optional
-       value  written  in  parentheses between the date and description, often
+       This command prints the value of each transaction's code field, in  the
+       order  transactions  were  parsed.  The transaction code is an optional
+       value written in parentheses between the date  and  description,  often
        used to store a cheque number, order number or similar.
 
        Transactions aren't required to have a code, and missing or empty codes
-       will not be shown by default.  With the -E/--empty flag, they  will  be
+       will  not  be shown by default.  With the -E/--empty flag, they will be
        printed as blank lines.
 
        You can add a query to select a subset of transactions.
@@ -7246,19 +7243,29 @@ Basic report commands
               126
 
    commodities
-       List all commodity/currency symbols used or declared in the journal.
+       List the commodity symbols used or declared in the journal.
 
               Flags:
-              no command-specific flags
+                   --used                 list commodities used
+                   --declared             list commodities declared
+                   --undeclared           list commodities used but not declared
+                   --unused               list commodities declared but not used
+
+       This command lists commodity symbols/names - all of them by default, or
+       just the ones which have been used in transactions or P directives,  or
+       declared  with  commodity  directives, or used but not declared, or de-
+       clared but not used.
+
+       You can add cur: query arguments to further limit the commodities.
 
    descriptions
-       List the unique descriptions that appear in transactions.
+       List the unique descriptions used in transactions.
 
               Flags:
               no command-specific flags
 
        This command lists the unique descriptions that appear in transactions,
-       in  alphabetic order.  You can add a query to select a subset of trans-
+       in alphabetic order.  You can add a query to select a subset of  trans-
        actions.
 
        Example:
@@ -7269,7 +7276,7 @@ Basic report commands
               Person A
 
    files
-       List all files included in the journal.  With a  REGEX  argument,  only
+       List  all  files  included in the journal.  With a REGEX argument, only
        file names matching the regular expression (case sensitive) are shown.
 
               Flags:
@@ -7282,8 +7289,8 @@ Basic report commands
               no command-specific flags
 
        This command lists the unique notes that appear in transactions, in al-
-       phabetic  order.   You  can  add a query to select a subset of transac-
-       tions.  The note is the part of the transaction description after  a  |
+       phabetic order.  You can add a query to select  a  subset  of  transac-
+       tions.   The  note is the part of the transaction description after a |
        character (or if there is no |, the whole description).
 
        Example:
@@ -7293,21 +7300,24 @@ Basic report commands
               Snacks
 
    payees
-       List the unique payee/payer names that appear in transactions.
+       List the payee/payer names used or declared in the journal.
 
               Flags:
-                   --declared             show payees declared with payee directives
-                   --used                 show payees referenced by transactions
+                   --used                 list payees used
+                   --declared             list payees declared
+                   --undeclared           list payees used but not declared
+                   --unused               list payees declared but not used
 
-       This  command  lists  unique payee/payer names which have been declared
-       with payee directives (--declared), used  in  transaction  descriptions
-       (--used), or both (the default).
+       This command lists unique payee/payer names - all of them  by  default,
+       or  just  the ones which have been used in transaction descriptions, or
+       declared with payee directives, or used but not declared,  or  declared
+       but not used.
 
-       The  payee/payer  is the part of the transaction description before a |
-       character (or if there is no |, the whole description).
+       The  payee/payer name is the part of the transaction description before
+       a | character (or if there is no |, the whole description).
 
-       You can add query arguments to select a subset of  transactions.   This
-       implies --used.
+       You can add query arguments to select a subset of transactions or  pay-
+       ees.
 
        Example:
 
@@ -7385,34 +7395,39 @@ Basic report commands
        put-format).
 
    tags
-       List the tags used in the journal, or their values.
+       List the tag names used or declared in the journal, or their values.
 
               Flags:
+                   --used                 list tags used
+                   --declared             list tags declared
+                   --undeclared           list tags used but not declared
+                   --unused               list tags declared but not used
                    --values               list tag values instead of tag names
-                   --parsed               show tags/values in the order they were parsed,
+                   --parsed               show them in the order they were parsed (mostly),
                                           including duplicates
 
-       This command lists the tag names used in the journal, whether on trans-
-       actions, postings, or account declarations.
+       This command lists tag names - all of them by default, or just the ones
+       which  have  been  used  on transactions/postings/accounts, or declared
+       with tag directives, or used but not  declared,  or  declared  but  not
+       used.
 
-       With  a TAGREGEX argument, only tag names matching this regular expres-
-       sion (case insensitive, infix matched) are shown.
+       You  can  add  one  TAGREGEX  argument, to show only tags whose name is
+       matched by this case-insensitive, infix-matching regular expression.
 
-       With QUERY arguments, only  transactions  and  accounts  matching  this
-       query are considered.  If the query involves transaction fields (date:,
-       desc:, amt:, ...), the search is restricted to the matched transactions
-       and their accounts.
+       After that, you can add query arguments  to  filter  the  transactions,
+       postings, or accounts providing tags.
 
-       With  the  --values  flag, the tags' unique non-empty values are listed
-       instead.  With -E/--empty, blank/empty values are also shown.
+       With --values, the tags' unique non-empty values are listed instead.
 
-       With --parsed, tags or values are shown in the order they were  parsed,
-       with  duplicates included.  (Except, tags from account declarations are
+       With -E/--empty, blank/empty values are also shown.
+
+       With  --parsed, tags or values are shown in the order they were parsed,
+       with duplicates included.  (Except, tags from account declarations  are
        always shown first.)
 
-       Tip: remember, accounts also acquire tags from their parents,  postings
-       also acquire tags from their account and transaction, transactions also
-       acquire tags from their postings.
+       Remember  that  accounts also acquire tags from their parents; postings
+       also acquire tags from their account and transaction; and  transactions
+       also acquire tags from their postings.
 
 Standard report commands
    print
@@ -7440,7 +7455,7 @@ Standard report commands
                    --base-url=URLPREFIX   in html output, generate links to hledger-web,
                                           with this prefix. (Usually the base url shown by
                                           hledger-web; can also be relative.)
-                   --location             add file/line number tags to print output
+                   --location             add tags showing file paths and line numbers
                 -O --output-format=FMT    select the output format. Supported formats:
                                           txt, beancount, csv, tsv, html, fods, json, sql.
                 -o --output-file=FILE     write output to FILE. A file extension matching

--- a/hledger/test/check-payees.test
+++ b/hledger/test/check-payees.test
@@ -1,18 +1,19 @@
-# check payees succeeds when all payees are declared:
+# * check payees
+# ** 1. check payees succeeds when all payees are declared:
 <
 payee foo
 2020-01-01 foo
 2020-01-02 foo | some description
 $ hledger -f - check payees
 
-# and otherwise fails:
+# ** 2. and otherwise fails:
 <
 2020-01-01 foo
 $ hledger -f - check payees
 >2 /payee "foo" has not been declared/
 >=1
 
-# or:
+# ** 3. or:
 <
 payee foo
 2020-01-01 the payee | foo

--- a/hledger/test/commodities.test
+++ b/hledger/test/commodities.test
@@ -1,0 +1,73 @@
+# * commodities command
+# "This command lists commodity symbols/names - all of them by default,
+# or just the ones which have been used in transactions or `P` directives,
+# or declared with `commodity` directives,
+# or used but not declared,
+# or declared but not used."
+
+# ** 1. all commodities
+<
+commodity 1. CA
+commodity 1. CB
+commodity 1. CC
+commodity 1. CD
+commodity 1. CE
+
+D 1. DH
+
+P 2025-01-01 CA 1 CB
+P 2025-01-01 PI 1 PJ
+
+2025-01-01
+  a        1 CC @ 1 CD
+  b        1 TK @ 1 TL
+  d
+
+$ hledger -f - commodities
+CA
+CB
+CC
+CD
+CE
+DH
+PI
+PJ
+TK
+TL
+
+# ** 2. used
+$ hledger -f - commodities --used
+CA
+CB
+CC
+CD
+PI
+PJ
+TK
+TL
+
+# ** 3. declared
+$ hledger -f - commodities --declared
+CA
+CB
+CC
+CD
+CE
+
+# ** 4. undeclared
+$ hledger -f - commodities --undeclared
+PI
+PJ
+TK
+TL
+
+# ** 5. unused
+$ hledger -f - commodities --unused
+CE
+
+# ** 6. with a query
+$ hledger -f - commodities --used expr:"cur:CA or cur:'P.*'"
+CA
+PI
+PJ
+

--- a/hledger/test/payees.test
+++ b/hledger/test/payees.test
@@ -1,6 +1,6 @@
-# payees command
+# * payees command
 
-# basic payees report
+# ** 1. basic payees report
 <
 payee qux
 
@@ -13,21 +13,20 @@ payee qux
 2018/1/3 foo
   a
 
-# declared and used payees, the default
 $ hledger -f - payees
 bar
 foo
 qux
 
-# used payees
+# ** 2. used payees
 $ hledger -f - payees --used
 bar
 foo
 
-# declared payees
+# ** 3. declared payees
 $ hledger -f - payees --declared
 qux
 
-# payees used in transactions matched by a query
+# ** 4. payees used in transactions matched by a query
 $ hledger -f - payees date:2018-01-03
 foo

--- a/hledger/test/tags.test
+++ b/hledger/test/tags.test
@@ -1,5 +1,19 @@
 # * tags command
 
+# ** 1. show account tags even when there are no transactions (#1857)
+<
+account a   ; t1:
+
+$ hledger -f- tags
+t1
+
+# ** 2. show all tags
+<
+tag t1
+tag t3
+tag t4
+tag t7
+
 account a     ; t1:v1, an account tag
 account b:bb  ; t2:v2, an unused account, depth 2
 
@@ -9,7 +23,6 @@ account b:bb  ; t2:v2, an unused account, depth 2
 2000/1/2      ; t5:v4, a reused value
   (c)      1  ; t6:v6, an undeclared account
 
-# ** 1. show all tags
 $ hledger -f- tags
 t1
 t2
@@ -17,8 +30,35 @@ t3
 t4
 t5
 t6
+t7
 
-# ** 2. show all tag values
+# ** . used
+$ hledger -f- tags --used
+t1
+t2
+t3
+t4
+t5
+t6
+
+# ** . declared
+$ hledger -f- tags --declared
+t1
+t3
+t4
+t7
+
+# ** . undeclared
+$ hledger -f- tags --undeclared
+t2
+t5
+t6
+
+# ** . unused
+$ hledger -f- tags --unused
+t7
+
+# ** . show (non empty) values
 $ hledger -f- tags --values
 v1
 v2
@@ -26,14 +66,14 @@ v3
 v4
 v6
 
-# ** 3. show tags matching a regex
+# ** . show tags matching a regex
 $ hledger -f- tags '[1-4]'
 t1
 t2
 t3
 t4
 
-# ** 4. show tags matching (a regex and) a hledger query.
+# ** . show tags matching (a regex and) a hledger query.
 # If the query is applicable to both transactions and account declarations,
 # both are searched for tags.
 $ hledger -f- tags . b c
@@ -41,16 +81,10 @@ t2
 t5
 t6
 
-# ** 5. If the query involves transaction attributes,
-# only accounts used by the matched transactions will contribute tags.
+# ** . If the query involves transaction attributes,
+# only the matched transactions and accounts they use will contribute tags.
 $ hledger -f- tags . date:2000/1/1
 t1
 t3
 t4
 
-# ** 6. show account tags even when there are no transactions (#1857)
-<
-account a   ; t1:
-
-$ hledger -f- tags
-t1


### PR DESCRIPTION
- **dev: Hledger.Query.matchesCommodity: check all query types, not just cur:**
  And default to False (unlike the other match functions. Ok ?)
  

- **imp: commodities/payees/tags: used/declared flags, like accounts**
  And general cleanup of options and help across
  the accounts, commodities, payees, tags commands.
  

- **;doc: update command docs**
  

- **;doc: update embedded manuals**
  