### PR TITLE
fix: csv: Make --summary-only work with csv output (#2411)

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -688,7 +688,7 @@ multiBalanceReportAsSpreadsheetParts fmt opts@ReportOpts{..} (PeriodicReport col
       LayoutBare -> headerCell "commodity" : dateHeaders
       _          -> dateHeaders
     dateHeaders =
-      map (headerDateSpanCell balance_base_url_ querystring_) colspans ++
+      (if not summary_only_ then map (headerDateSpanCell balance_base_url_ querystring_) colspans  else [] )++
       [hCell "rowtotal" "total" | multiBalanceHasTotalsColumn opts] ++
       [hCell "rowaverage" "average" | average_]
     fullRowAsTexts row =

--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -358,7 +358,7 @@ compoundBalanceReportAsSpreadsheet fmt accountLabel maybeBlank ropts cbr =
     dataHeaders =
       (guard (layout_ ropts /= LayoutTidy) >>) $
       map (Spr.headerCell . reportPeriodName (balanceaccum_ ropts) colspans)
-        colspans ++
+      (if not (summary_only_ ropts) then colspans else []) ++
       (guard (multiBalanceHasTotalsColumn ropts) >> [Spr.headerCell "Total"]) ++
       (guard (average_   ropts) >> [Spr.headerCell "Average"])
     headerrow = leadingHeaders ++ dataHeaders

--- a/hledger/test/balance/layout.test
+++ b/hledger/test/balance/layout.test
@@ -170,7 +170,27 @@ Yearly Income Statement 2012-01-01..2014-12-31
                           || USD        345982.46  115327.49 
                           || VACHR         337.26     112.42 
 
-# ** 14. Multicolumn budget report csv output with --layout=bare.
+# ** 14. Multicolumn balance report with --layout=bare, --row-total, --average, and --summary-only, with csv output
+$ hledger -f bcexample.hledger bal -Y assets.*etrade -3 -N --layout=bare --row-total --average --summary-only -O csv
+"account","commodity","total","average"
+"Assets:US:ETrade","GLD","70.00","23.33"
+"Assets:US:ETrade","ITOT","17.00","5.67"
+"Assets:US:ETrade","USD","5120.50","1706.83"
+"Assets:US:ETrade","VEA","36.00","12.00"
+"Assets:US:ETrade","VHT","294.00","98.00"
+
+# ** 15. Multicolumn income statement report with --layout=bare, --row-total, --average, and --summary-only, with csv output
+$ hledger -f bcexample.hledger is income expenses:food -Y -2 -N --layout=bare --row-total --average --summary-only -O csv
+"Yearly Income Statement 2012-01-01..2014-12-31","","",""
+"Account","Commodity","Total","Average"
+"Revenues","","",""
+"Income:US","IRAUSD","52000.00","17333.33"
+"Income:US","USD","365071.44","121690.48"
+"Income:US","VACHR","337.26","112.42"
+"Expenses","","",""
+"Expenses:Food","USD","19088.98","6362.99"
+
+# ** 16. Multicolumn budget report csv output with --layout=bare.
 $ hledger -f bcexample.hledger bal -Y assets.*etrade -3 -O csv --layout=bare --budget
 "Account","Commodity","2012","budget","2013","budget","2014","budget"
 "<unbudgeted>","GLD","0","0","70.00","0","0","0"
@@ -184,7 +204,7 @@ $ hledger -f bcexample.hledger bal -Y assets.*etrade -3 -O csv --layout=bare --b
 "Total:","VEA","12.00","0","10.00","0","14.00","0"
 "Total:","VHT","106.00","0","18.00","0","170.00","0"
 
-# ** 15. Multicolumn balance report with --layout=bare and null commodity
+# ** 17. Multicolumn balance report with --layout=bare and null commodity
 <
 2018/1/1
   (a)          1
@@ -206,7 +226,7 @@ Balance changes in 2018:
        || EUR           1 
 
 
-# ** 16. Multicolumn balance report with --layout=bare --transpose.
+# ** 18. Multicolumn balance report with --layout=bare --transpose.
 $ hledger -f bcexample.hledger bal -Y assets.*etrade -1 --average --layout=bare --transpose
 Balance changes in 2012-01-01..2014-12-31:
 
@@ -218,7 +238,7 @@ Balance changes in 2012-01-01..2014-12-31:
  2014      ||      0  -11.00  4881.44   14.00  170.00 |     0  -11.00  4881.44  14.00  170.00 
  Average   ||  23.33    5.67  1706.83   12.00   98.00 | 23.33    5.67  1706.83  12.00   98.00 
 
-# ** 17. Multicolumn budget report with --layout=bare --transpose.
+# ** 19. Multicolumn budget report with --layout=bare --transpose.
 <
 ~ daily from 2016/1/1
     expenses:food     $10
@@ -260,7 +280,7 @@ Budget performance in 2016-12-01..2016-12-03:
  2016-12-03 || -51 [204% of -25]  51 [204% of 25]  11 [110% of 10]     0 [       15] 
    Total    || -75 [100% of -75]  75 [100% of 75]  30 [100% of 30]     5 [11% of 45] 
 
-# ** 18. Compound balance report output with --layout=bare.
+# ** 20. Compound balance report output with --layout=bare.
 $ hledger -f bcexample.hledger bs -3 --layout=bare
 Balance Sheet 2014-10-11
 
@@ -303,7 +323,7 @@ Balance Sheet 2014-10-11
                       || VEA                   36.00 
                       || VHT                  294.00 
 
-# ** 19. Multicolumn balance report csv output with --layout=tidy
+# ** 21. Multicolumn balance report csv output with --layout=tidy
 $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv --layout=tidy
 "account","period","start_date","end_date","commodity","value"
 "Assets:US:ETrade","2012","2012-01-01","2012-12-31","GLD","0"
@@ -322,7 +342,7 @@ $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O csv --layout=tidy
 "Assets:US:ETrade","2014","2014-01-01","2014-12-31","VEA","14.00"
 "Assets:US:ETrade","2014","2014-01-01","2014-12-31","VHT","170.00"
 
-# ** 20.
+# ** 22.
 $ hledger -f bcexample.hledger bal -T -Y assets.*etrade -3 -O tsv --layout=tidy
 account	period	start_date	end_date	commodity	value
 Assets:US:ETrade	2012	2012-01-01	2012-12-31	GLD	0
@@ -341,7 +361,7 @@ Assets:US:ETrade	2014	2014-01-01	2014-12-31	USD	4881.44
 Assets:US:ETrade	2014	2014-01-01	2014-12-31	VEA	14.00
 Assets:US:ETrade	2014	2014-01-01	2014-12-31	VHT	170.00
 
-# ** 21. Single column balance report csv output with --layout=tidy
+# ** 23. Single column balance report csv output with --layout=tidy
 $ hledger -f bcexample.hledger bal -T assets.*etrade -3 -O csv --layout=tidy
 "account","period","start_date","end_date","commodity","value"
 "Assets:US:ETrade","2012-01-01..2014-10-11","2012-01-01","2014-10-11","GLD","70.00"
@@ -350,7 +370,7 @@ $ hledger -f bcexample.hledger bal -T assets.*etrade -3 -O csv --layout=tidy
 "Assets:US:ETrade","2012-01-01..2014-10-11","2012-01-01","2014-10-11","VEA","36.00"
 "Assets:US:ETrade","2012-01-01..2014-10-11","2012-01-01","2014-10-11","VHT","294.00"
 
-# ** 22.
+# ** 24.
 $ hledger -f bcexample.hledger bal -T assets.*etrade -3 -O tsv --layout=tidy
 account	period	start_date	end_date	commodity	value
 Assets:US:ETrade	2012-01-01..2014-10-11	2012-01-01	2014-10-11	GLD	70.00
@@ -359,7 +379,7 @@ Assets:US:ETrade	2012-01-01..2014-10-11	2012-01-01	2014-10-11	USD	5120.50
 Assets:US:ETrade	2012-01-01..2014-10-11	2012-01-01	2014-10-11	VEA	36.00
 Assets:US:ETrade	2012-01-01..2014-10-11	2012-01-01	2014-10-11	VHT	294.00
 
-# ** 23. Should omit commodity from totals row when the sum is zero with --layout=bare. (#1789)
+# ** 25. Should omit commodity from totals row when the sum is zero with --layout=bare. (#1789)
 <
 2021-01-01 Test
     Assets:Bank           INR 1.00
@@ -371,7 +391,7 @@ $ hledger -f - bal --layout=bare
  ----- 
      0                      
 
-# ** 24. The same with -M. (#1789)
+# ** 26. The same with -M. (#1789)
 $ hledger -f - bal --layout=bare -M
 Balance changes in 2021-01:
 


### PR DESCRIPTION
Don't display date headers with --summary-only in csv output.