### PR TITLE
imp: areg: Do not abbreviate other accounts in machine-readable output (#1995)

### DIFF
--- a/hledger-ui/Hledger/UI/UIScreens.hs
+++ b/hledger-ui/Hledger/UI/UIScreens.hs
@@ -42,6 +42,7 @@ where
 import Brick.Widgets.List (listMoveTo, listSelectedElement, list)
 import Data.List
 import Data.Maybe
+import qualified Data.Text as T
 import Data.Time.Calendar (Day, diffDays)
 import Safe
 import qualified Data.Vector as V
@@ -280,11 +281,11 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
     -- pre-render the list items, helps calculate column widths
     displayitems = map displayitem items'
       where
-        displayitem (t, _, _issplit, otheracctsstr, change, bal) =
+        displayitem (t, _, _issplit, otheraccts, change, bal) =
           RegisterScreenItem{rsItemDate          = showDate $ transactionRegisterDate wd (_rsQuery rspec') thisacctq t
                             ,rsItemStatus        = tstatus t
                             ,rsItemDescription   = tdescription t
-                            ,rsItemOtherAccounts = otheracctsstr
+                            ,rsItemOtherAccounts = T.intercalate ", " . map accountSummarisedName $ nub otheraccts
                                                     -- _   -> "<split>"  -- should do this if accounts field width < 30
                             ,rsItemChangeAmount  = showamt change
                             ,rsItemBalanceAmount = showamt bal


### PR DESCRIPTION
The `aregister` report always abbreviates "other accounts" in the transaction by taking just the first two characters of all account components but the last one. Thus `asset:cash:bank:checking` always becomes `as:ca:ba:checking`. This is a reasonable strategy when outputting to text/terminal, as space is likely to be limited, but is less useful when outputting to machine-readable formats (CSV, HTML, FODS, etc).

#### This change makes `aregister` output unabridged account names to machine-readable formats:
- Do not turn "other accounts" into a comma-delimited string when the report is constructed, but pass `AccountName`s up to the caller. This requires modifying the `AccountTransactionsReportItem` type to contain `[AccountName]` rather than `Text`.

- Move the account name summarization (`Hledger.Data.AccountName.accountSummarizedName`) closer to the rendering of the report, so that different report formats can choose their own summarization strategy. The summarization algorithm for `aregister` isn't changed even though eg. `register` uses a different one.

- Continue to summarize as before for terminal/text output (ie. human-readable). Do not summarize any more for machine-readable output (csv/html/fods).

> [!WARNING]
> This has the potential to be a breaking change for users, if they are relying on abbreviated account names in their CSV/etc output. Is this a concern?

#### Other approaches I considered:
1. Instead of converting other accounts into `[AccountName]` and doing summarization in the caller, pass the desired summarization strategy into `accountTransactionsReportItem`. This felt like poor encapsulation, as rendering details would leak into report construction. I thought that instead the report builder should provide structured data, and the renderer should decide how to present them.

2. Collect user preferences for summarization on the command line. This would still leave (1) unresolved, since you'd need to then decide when to apply the preference, in the renderer, or in the report builder. I also thought that not abridging the account names in machine output is the "sensible" default, since that way you provide the full output and allow the post-processing tool to take its own approach to presentation. One further complication is that there are several confusing approaches to summarization (shorten/elide/ellipsize), which can be used in combination with each other, so figuring out a way to present the right options to the user is non-trivial.

I realize that "sensible" is subjective, and that adding a flag instead may be necessary to preserve established workflows. I'm open to implementing such a flag, with input on how best to name it/what it should control.

#### Testing notes
- I was able to verify through manual testing that `areg` on the command line continues to produce abbreviated account names, while CSV & FODS reports had full account names.
- JSON output appears to have the full structured transactions/postings even for summary reports like `aregister`, so the full account names are unchanged.
- I was unable to test HTML output for some reason. Both the build off my branch, off `master`, and even release v1.43.2, produced a header row but no other rows of the html table. This appears to be a regression, as release v1.42.2 produces html output just fine.