### PR TITLE
fix: perform hard rounding in hledger close

### DIFF
--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -257,7 +257,7 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec0} j = do
 
   -- print them
   -- allow user-specified rounding with --round, like print
-  let styles = amountStylesSetRoundingFromRawOpts rawopts $ journalCommodityStyles j
+  let styles = amountStylesSetRoundingFromRawOpts rawopts $ journalCommodityStylesWith HardRounding j
   maybe (pure ()) (T.putStr . showTransaction . styleAmounts styles) mclosetxn
   maybe (pure ()) (T.putStr . showTransaction . styleAmounts styles) mopentxn
  

--- a/hledger/test/close.test
+++ b/hledger/test/close.test
@@ -275,3 +275,18 @@ $ hledger -f- close --clopen -e 2001 --round=hard -c '$1.0'
     equity:opening/closing balances
 
 >=
+
+# ** 20. close rounds amounts to display precision
+<
+commodity $1.00
+commodity JPY  1000.
+2025-06-12
+  assets:a  100000 JPY @ $0.006631
+  assets:a
+
+$ hledger -f- close -e 2026
+2025-12-31 closing balances  ; clopen:
+    assets:a                                $663.10 = $0.00
+    assets:a                            JPY -100000 = JPY 0
+    equity:opening/closing balances
+>=


### PR DESCRIPTION
Back in 2019 I bought some yen and recorded that with a "@-style" transaction. Now every time I use hledger-close it prints one of my accounts with 4 digit precision.

This particular fix is similar to #2407, so it shouldn't break much but some existing tests rely on the current rounding logic and thus fail.

P.S. Couldn't run tests myself -- don't have `fd` binary on my system and don't know what that is supposed to be. Didn't find a mention in the documentation either. I also don't have `ghc` in $PATH, only available as `stack ghc`.