### PR TITLE
fix: balance: Clip account names in generateMultiBalanceAccount, not before (#2434)

### DIFF
--- a/hledger/test/balance/balance.test
+++ b/hledger/test/balance/balance.test
@@ -201,13 +201,29 @@ $ hledger -f- bal -MT -O html
   a      10
   a:aa   20
   b
+$ hledger -f- bal --count
+                   1  a
+                   1  a:aa
+                   1  b
+--------------------
+                   3  
+
+# ** 16. --count counts clipped postings.
 $ hledger -f- bal --count -1
                    2  a
                    1  b
 --------------------
                    3  
 
-# ** 16. Make sure that balance --flat --empty does not display implied
+# ** 17. --count counts inclusive postings with --tree.
+$ hledger -f- bal --count --tree
+                   2  a
+                   1    aa
+                   1  b
+--------------------
+                   3  
+
+# ** 18. Make sure that balance --flat --empty does not display implied
 # accounts (i.e. those with no postings, like "assets", here), but does show
 # accounts that have postings with zero balance (like "assets:bank:checking"
 # here).

--- a/hledger/test/incomestatement.test
+++ b/hledger/test/incomestatement.test
@@ -304,3 +304,29 @@ Income Statement ..
  Expenses        ||    
 -----------------++----
  expenses        ||  0 
+
+# ** 10. Clipping too far doesn't erase account types (#2434)
+<
+account sm:assets    ; type:A
+account sm:revenues  ; type:R
+
+2025-01-01
+    sm:revenues   -$1
+    sm:assets      $1
+
+2025-01-02
+    sm:revenues   A -2
+    sm:assets     A 2
+
+$ hledger -f - incomestatement -1 -N
+Income Statement 2025-01-01..2025-01-02
+
+          || 2025-01-01..2025-01-02 
+==========++========================
+ Revenues ||                        
+----------++------------------------
+ sm       ||                $1, A 2 
+==========++========================
+ Expenses ||                        
+----------++------------------------
+


### PR DESCRIPTION
Previously accounts were clipped in getPostings, however compound balance reports re-use the output of getPostings for the different subreports. This caused a problem when clipping erased the information needed to determine the account type, as would be used by e.g. incomestatement.

Add some extra tests for --count.