### PR TITLE
fix: budget: Respect --summary-only flag. (#2443)

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -951,7 +951,7 @@ budgetReportAsTable ropts@ReportOpts{..} (PeriodicReport spans items totrow) =
           (flip (concatTables SingleLine) $ Table rowhdrs colhdrs totalrows)  -- XXX ?
 
     colheadings = ["Commodity" | layout_ == LayoutBare]
-                  ++ map (reportPeriodName balanceaccum_ spans) spans
+                  ++ (if not summary_only_ then map (reportPeriodName balanceaccum_ spans) spans else [])
                   ++ ["  Total" | row_total_]
                   ++ ["Average" | average_]
 
@@ -1045,7 +1045,8 @@ budgetReportAsTable ropts@ReportOpts{..} (PeriodicReport spans items totrow) =
         -- | Get the data cells from a row or totals row, maybe adding
         -- the row total and/or row average depending on options.
         rowToBudgetCells :: PeriodicReportRow a BudgetCell -> [BudgetCell]
-        rowToBudgetCells (PeriodicReportRow _ as rowtot rowavg) = as
+        rowToBudgetCells (PeriodicReportRow _ as rowtot rowavg) =
+            (if not summary_only_ then as else [])
             ++ [rowtot | row_total_ && not (null as)]
             ++ [rowavg | average_   && not (null as)]
 
@@ -1152,7 +1153,7 @@ budgetReportAsSpreadsheet
   (addHeaderBorders $ map headerCell $
   "Account" :
   ["Commodity" | layout_ == LayoutBare ]
-   ++ concatMap (\spn -> [showDateSpan spn, "budget"]) colspans
+   ++ (if not summary_only_ then concatMap (\spn -> [showDateSpan spn, "budget"]) colspans else [])
    ++ concat [["Total"  ,"budget"] | row_total_]
    ++ concat [["Average","budget"] | average_]
   ) :
@@ -1196,7 +1197,7 @@ budgetReportAsSpreadsheet
       where
         cs = S.toList . mconcat . map maCommodities $ mapMaybe snd vals
         dopts = oneLineNoCostFmt{displayCommodity=layout_ /= LayoutBare, displayCommodityOrder=Just cs, displayMinWidth=Nothing}
-        vals = flattentuples rc as
+        vals = flattentuples rc (if not summary_only_ then as else [])
             ++ concat [[(rowTotalClass rc, rowtot),
                         (budgetTotalClass rc, budgettot)]
                             | row_total_]

--- a/hledger/test/balance/budget.test
+++ b/hledger/test/balance/budget.test
@@ -734,7 +734,7 @@ Budget performance in 2020-01-01..2020-02-29:
     expenses:rent                  $100
     income:gifts:cash
 
-~ monthly 2023-08
+~ monthly
     (income:employment)           $-100
     (income:gifts:cash)           $-100
 
@@ -761,3 +761,30 @@ Budget performance in 2023-08:
      cash     || 0 [0% of $-100] 
 --------------++-----------------
               || 0 [0% of $-200] 
+
+# ** 42. Multicolumn budget report with --row-total and --average
+$ hledger -f- bal --budget -M -e 2023-10 --row-total --average -N
+Budget performance in 2023Q3:
+
+                   ||                   Jul              Aug              Sep                 Total              Average 
+===================++====================================================================================================
+ <unbudgeted>      ||  $100                  0                0                 $100 [           0]   $33 [           0] 
+ income:employment ||     0 [  0% of $-100]  0 [0% of $-100]  0 [0% of $-100]      0 [ 0% of $-300]     0 [ 0% of $-100] 
+ income:gifts:cash || $-100 [100% of $-100]  0 [0% of $-100]  0 [0% of $-100]  $-100 [33% of $-300]  $-33 [33% of $-100] 
+
+# ** 43. Multicolumn budget report with --row-total, --average, and --summary-only
+$ hledger -f- bal --budget -M -e 2023-10 --row-total --average -N --summary-only
+Budget performance in 2023Q3:
+
+                   ||                Total              Average 
+===================++===========================================
+ <unbudgeted>      ||  $100 [           0]   $33 [           0] 
+ income:employment ||     0 [ 0% of $-300]     0 [ 0% of $-100] 
+ income:gifts:cash || $-100 [33% of $-300]  $-33 [33% of $-100] 
+
+# ** 44. Multicolumn csv report with --row-total, --average, and --summary-only
+$ hledger -f- bal --budget -M -e 2023-10 --row-total --average -N --summary-only -O csv
+"Account","Total","budget","Average","budget"
+"<unbudgeted>","$100","0","$33","0"
+"income:employment","0","$-300","0","$-100"
+"income:gifts:cash","$-100","$-300","$-33","$-100"


### PR DESCRIPTION
Budget reports will now respect the --summary-only flag.
