### PR TITLE
fix: balance: Correctly handle empty journals (#2452)

### DIFF
--- a/hledger-lib/Hledger/Data/PeriodData.hs
+++ b/hledger-lib/Hledger/Data/PeriodData.hs
@@ -9,12 +9,18 @@ Report periods are assumed to be contiguous, and represented only by start dates
 -}
 module Hledger.Data.PeriodData
 ( periodDataFromList
+, periodDataToList
 
 , lookupPeriodData
+, lookupPeriodDataLE
 , insertPeriodData
 , opPeriodData
 , mergePeriodData
 , padPeriodData
+
+, periodDataToDateSpans
+, maybePeriodDataToDateSpans
+, dateSpansToPeriodData
 
 , tests_PeriodData
 ) where
@@ -24,18 +30,17 @@ import Data.Foldable1 (Foldable1(..))
 #else
 import Control.Applicative (liftA2)
 #endif
+import Data.Bifunctor (first)
 import qualified Data.IntMap.Strict as IM
-import qualified Data.IntSet as IS
 #if !MIN_VERSION_base(4,20,0)
 import Data.List (foldl')
 #endif
 import Data.Time (Day(..), fromGregorian)
 
-import Test.Tasty (testGroup)
-import Test.Tasty.HUnit ((@?=), testCase)
-
 import Hledger.Data.Amount
+import Hledger.Data.Dates
 import Hledger.Data.Types
+import Hledger.Utils
 
 
 instance Show a => Show (PeriodData a) where
@@ -44,7 +49,7 @@ instance Show a => Show (PeriodData a) where
         showString "PeriodData"
       . showString "{ pdpre = " . shows h
       . showString ", pdperiods = "
-      . showString "fromList " . shows (map (\(day, x) -> (ModifiedJulianDay $ toInteger day, x)) $ IM.toList ds)
+      . showString "fromList " . shows (map (\(day, x) -> (intToDay day, x)) $ IM.toList ds)
       . showChar '}'
 
 instance Foldable PeriodData where
@@ -73,18 +78,29 @@ instance Monoid a => Monoid (PeriodData a) where
 
 -- | Construct an 'PeriodData' from a list.
 periodDataFromList :: a -> [(Day, a)] -> PeriodData a
-periodDataFromList h = PeriodData h . IM.fromList . map (\(d, a) -> (fromInteger $ toModifiedJulianDay d, a))
+periodDataFromList h = PeriodData h . IM.fromList . map (\(d, a) -> (dayToInt d, a))
 
--- | Get account balance information to the period containing a given 'Day'.
+-- | Convert 'PeriodData' to a list of pairs.
+periodDataToList :: PeriodData a -> (a, [(Day, a)])
+periodDataToList (PeriodData h as) = (h, map (\(s, e) -> (intToDay s, e)) $ IM.toList as)
+
+
+-- | Get account balance information to the period containing a given 'Day',
+-- and the historical data if this day lies in the historical period.
 lookupPeriodData :: Day -> PeriodData a -> a
-lookupPeriodData d (PeriodData h as) =
-    maybe h snd $ IM.lookupLE (fromInteger $ toModifiedJulianDay d) as
+lookupPeriodData d pd@(PeriodData h _) = maybe h snd $ lookupPeriodDataLE d pd
+
+-- | Get account balance information for the period containing a given 'Day',
+-- along with the start of the period, or 'Nothing' if this day lies in the
+-- historical period.
+lookupPeriodDataLE :: Day -> PeriodData a -> Maybe (Day, a)
+lookupPeriodDataLE d (PeriodData _ as) = first intToDay <$> IM.lookupLE (dayToInt d) as
 
 -- | Add account balance information to the appropriate location in 'PeriodData'.
 insertPeriodData :: Semigroup a => Maybe Day -> a -> PeriodData a -> PeriodData a
 insertPeriodData mday b balances = case mday of
     Nothing  -> balances{pdpre = pdpre balances <> b}
-    Just day -> balances{pdperiods = IM.insertWith (<>) (fromInteger $ toModifiedJulianDay day) b $ pdperiods balances}
+    Just day -> balances{pdperiods = IM.insertWith (<>) (dayToInt day) b $ pdperiods balances}
 
 -- | Merges two 'PeriodData', using the given operation to combine their balance information.
 --
@@ -103,10 +119,38 @@ mergePeriodData only1 only2 f = \(PeriodData h1 as1) (PeriodData h2 as2) ->
   where
     merge = IM.mergeWithKey (\_ x y -> Just $ f x y) (fmap only1) (fmap only2)
 
--- | Pad out the datemap of an 'PeriodData' so that every key from a set is present.
-padPeriodData :: Monoid a => IS.IntSet -> PeriodData a -> PeriodData a
-padPeriodData keys bal = bal{pdperiods = pdperiods bal <> IM.fromSet (const mempty) keys}
+-- | Pad out the datemap of an 'PeriodData' so that every key from another 'PeriodData' is present.
+padPeriodData :: a -> PeriodData b -> PeriodData a -> PeriodData a
+padPeriodData x pad bal = bal{pdperiods = pdperiods bal <> (x <$ pdperiods pad)}
 
+
+-- | Convert 'PeriodData Day' to a list of 'DateSpan's.
+periodDataToDateSpans :: PeriodData Day -> [DateSpan]
+periodDataToDateSpans = map (\(s, e) -> DateSpan (toEFDay s) (toEFDay e)) . snd . periodDataToList
+  where toEFDay = Just . Exact
+
+-- Convert a periodic report 'Maybe (PeriodData Day)' to a list of 'DateSpans',
+-- replacing the empty case with an appropriate placeholder.
+maybePeriodDataToDateSpans :: Maybe (PeriodData Day) -> [DateSpan]
+maybePeriodDataToDateSpans = maybe [DateSpan Nothing Nothing] periodDataToDateSpans
+
+-- | Convert a list of 'DateSpan's to a 'PeriodData Day', or 'Nothing' if it is not well-formed.
+-- PARTIAL:
+dateSpansToPeriodData :: [DateSpan] -> Maybe (PeriodData Day)
+-- Handle the cases of partitions which would arise from journals with no transactions
+dateSpansToPeriodData []                           = Nothing
+dateSpansToPeriodData [DateSpan Nothing  Nothing]  = Nothing
+dateSpansToPeriodData [DateSpan Nothing  (Just _)] = Nothing
+dateSpansToPeriodData [DateSpan (Just _) Nothing]  = Nothing
+-- Handle properly defined reports
+dateSpansToPeriodData (x:xs) = Just $ periodDataFromList (fst $ boundaries x) (map boundaries (x:xs))
+  where
+    boundaries spn = makeJust (spanStart spn, spanEnd spn)
+    makeJust (Just a, Just b)  = (a, b)
+    makeJust ab = error' $ "dateSpansToPeriodData: expected all spans to have start and end dates, but one has " ++ show ab
+
+intToDay = ModifiedJulianDay . toInteger
+dayToInt = fromInteger . toModifiedJulianDay
 
 -- tests
 

--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -46,8 +46,6 @@ module Hledger.Data.Posting (
   postingDate,
   postingDate2,
   postingDateOrDate2,
-  isPostingInDateSpan,
-  isPostingInDateSpan',
   -- * account name operations
   accountNamesFromPostings,
   -- * comment/tag operations
@@ -107,7 +105,7 @@ import Hledger.Utils
 import Hledger.Data.Types
 import Hledger.Data.Amount
 import Hledger.Data.AccountName
-import Hledger.Data.Dates (nulldate, spanContainsDate)
+import Hledger.Data.Dates (nulldate)
 import Hledger.Data.Valuation
 
 
@@ -443,15 +441,6 @@ transactionAllTags t = ttags t ++ concatMap ptags (tpostings t)
 relatedPostings :: Posting -> [Posting]
 relatedPostings p@Posting{ptransaction=Just t} = filter (/= p) $ tpostings t
 relatedPostings _ = []
-
--- | Does this posting fall within the given date span ?
-isPostingInDateSpan :: DateSpan -> Posting -> Bool
-isPostingInDateSpan = isPostingInDateSpan' PrimaryDate
-
--- --date2-sensitive version, separate for now to avoid disturbing multiBalanceReport.
-isPostingInDateSpan' :: WhichDate -> DateSpan -> Posting -> Bool
-isPostingInDateSpan' PrimaryDate   s = spanContainsDate s . postingDate
-isPostingInDateSpan' SecondaryDate s = spanContainsDate s . postingDate2
 
 isEmptyPosting :: Posting -> Bool
 isEmptyPosting = mixedAmountLooksZero . pamount

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -43,8 +43,7 @@ import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty((:|)))
 import qualified Data.HashSet as HS
 import qualified Data.IntMap.Strict as IM
-import qualified Data.IntSet as IS
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Ord (Down(..))
 import Data.Semigroup (sconcat)
 import Data.These (these)
@@ -163,7 +162,7 @@ compoundBalanceReportWith rspec' j priceoracle subreportspecs = cbr
         subreportTotal (_, sr, increasestotal) =
             (if increasestotal then id else fmap maNegate) $ prTotals sr
 
-    cbr = CompoundPeriodicReport "" colspans subreports overalltotals
+    cbr = CompoundPeriodicReport "" (maybePeriodDataToDateSpans colspans) subreports overalltotals
 
 
 -- | Remove any date queries and insert queries from the report span.
@@ -217,7 +216,7 @@ getPostings rspec@ReportSpec{_rsQuery=query, _rsReportOpts=ropts} j priceoracle 
 
 -- | Generate the 'Account' for the requested multi-balance report from a list
 -- of 'Posting's.
-generateMultiBalanceAccount :: ReportSpec -> Journal -> PriceOracle -> [DateSpan] -> [Posting] -> Account BalanceData
+generateMultiBalanceAccount :: ReportSpec -> Journal -> PriceOracle -> Maybe (PeriodData Day) -> [Posting] -> Account BalanceData
 generateMultiBalanceAccount rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle colspans =
     -- Add declared accounts if called with --declared and --empty
     (if (declared_ ropts && empty_ ropts) then addDeclaredAccounts rspec j else id)
@@ -263,8 +262,10 @@ addDeclaredAccounts rspec j acct =
 -- | Gather the account balance changes into a regular matrix, then
 -- accumulate and value amounts, as specified by the report options.
 -- Makes sure all report columns have an entry.
-calculateReportAccount :: ReportSpec -> Journal -> PriceOracle -> [DateSpan] -> [Posting] -> Account BalanceData
-calculateReportAccount rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle colspans ps =  -- PARTIAL:
+calculateReportAccount :: ReportSpec -> Journal -> PriceOracle -> Maybe (PeriodData Day) -> [Posting] -> Account BalanceData
+calculateReportAccount _ _ _ Nothing _ =
+    accountFromBalances "root" $ periodDataFromList mempty [(nulldate, mempty)]
+calculateReportAccount rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle (Just colspans) ps =
     mapPeriodData rowbals changesAcct
   where
     -- The valued row amounts to be displayed: per-period changes,
@@ -291,23 +292,17 @@ calculateReportAccount rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle colsp
         avalue = periodDataValuation ropts j priceoracle colspans
 
     changesAcct = dbg5With (\x -> "calculateReportAccount changesAcct\n" ++ showAccounts x) .
-        mapPeriodData (padPeriodData intervalStarts) $
+        mapPeriodData (padPeriodData mempty colspans) $
         accountFromPostings getIntervalStartDate ps
 
-    getIntervalStartDate p = intToDay <$> IS.lookupLE (dayToInt $ getPostingDate p) intervalStarts
+    getIntervalStartDate p = fst <$> lookupPeriodDataLE (getPostingDate p) colspans
     getPostingDate = postingDateOrDate2 (whichDate (_rsReportOpts rspec))
-
-    intervalStarts = IS.fromList . map dayToInt $ case mapMaybe spanStart colspans of
-      [] -> [nulldate]  -- Deal with the case of the empty journal
-      xs -> xs
-    dayToInt = fromInteger . toModifiedJulianDay
-    intToDay = ModifiedJulianDay . toInteger
 
 -- | The valuation function to use for the chosen report options.
 -- This can call error in various situations.
-periodDataValuation :: ReportOpts -> Journal -> PriceOracle -> [DateSpan]
+periodDataValuation :: ReportOpts -> Journal -> PriceOracle -> PeriodData Day
                     -> PeriodData BalanceData -> PeriodData BalanceData
-periodDataValuation ropts j priceoracle colspans =
+periodDataValuation ropts j priceoracle periodEnds =
     opPeriodData valueBalanceData balanceDataPeriodEnds
   where
     valueBalanceData :: Day -> BalanceData -> BalanceData
@@ -316,18 +311,9 @@ periodDataValuation ropts j priceoracle colspans =
     valueMixedAmount :: Day -> MixedAmount -> MixedAmount
     valueMixedAmount = mixedAmountApplyValuationAfterSumFromOptsWith ropts j priceoracle
 
+    -- The end date of a period is one before the beginning of the next period
     balanceDataPeriodEnds :: PeriodData Day
-    balanceDataPeriodEnds = dbg5 "balanceDataPeriodEnds" $ case colspans of  -- FIXME: Change colspans to nonempty list
-        [DateSpan Nothing Nothing] -> periodDataFromList nulldate [(nulldate, nulldate)]  -- Empty journal
-        h:ds                       -> periodDataFromList (makeJustFst $ boundaries h) $ map (makeJust . boundaries) (h:ds)
-        []                         -> error' "balanceDataPeriodEnds: Shouldn't have empty colspans"  -- PARTIAL: Shouldn't occur
-      where
-        boundaries spn = (spanStart spn, spanEnd spn)
-
-        makeJust (Just x, Just y) = (x, addDays (-1) y)
-        makeJust _    = error' "balanceDataPeriodEnds: expected all non-initial spans to have start and end dates"
-        makeJustFst (Just x, _) = addDays (-1) x
-        makeJustFst _ = error' "balanceDataPeriodEnds: expected initial span to have an end date"
+    balanceDataPeriodEnds = dbg5 "balanceDataPeriodEnds" $ addDays (-1) <$> periodEnds
 
 -- | Mark which nodes of an 'Account' are boring, and so should be omitted from reports.
 markAccountBoring :: ReportSpec -> Account BalanceData -> Account BalanceData
@@ -381,7 +367,7 @@ markAccountBoring ReportSpec{_rsQuery=query,_rsReportOpts=ropts}
 -- | Build a report row.
 --
 -- Calculate the column totals. These are always the sum of column amounts.
-generateMultiBalanceReport :: ReportOpts -> [DateSpan] -> Account BalanceData -> MultiBalanceReport
+generateMultiBalanceReport :: ReportOpts -> Maybe (PeriodData Day) -> Account BalanceData -> MultiBalanceReport
 generateMultiBalanceReport ropts colspans =
     reportPercent ropts . generatePeriodicReport makeMultiBalanceReportRow bdincludingsubs id ropts colspans
 
@@ -391,9 +377,9 @@ generateMultiBalanceReport ropts colspans =
 generatePeriodicReport :: Show c =>
     (forall a. ReportOpts -> (BalanceData -> MixedAmount) -> a -> Account b -> PeriodicReportRow a c)
     -> (b -> MixedAmount) -> (c -> MixedAmount)
-    -> ReportOpts -> [DateSpan] -> Account b -> PeriodicReport DisplayName c
+    -> ReportOpts -> Maybe (PeriodData Day) -> Account b -> PeriodicReport DisplayName c
 generatePeriodicReport makeRow treeAmt flatAmt ropts colspans acct =
-    PeriodicReport colspans (buildAndSort acct) totalsrow
+    PeriodicReport (maybePeriodDataToDateSpans colspans) (buildAndSort acct) totalsrow
   where
     -- Build report rows and sort them
     buildAndSort = dbg5 "generatePeriodicReport buildAndSort" . case accountlistmode_ ropts of

--- a/hledger-lib/Hledger/Reports/PostingsReport.hs
+++ b/hledger-lib/Hledger/Reports/PostingsReport.hs
@@ -209,12 +209,12 @@ mkpostingsReportItem showdate showdesc wd mperiod p b =
 -- | Convert a list of postings into summary postings, one per interval,
 -- aggregated to the specified depth if any.
 -- Each summary posting will have a non-Nothing interval end date.
-summarisePostingsByInterval :: WhichDate -> Maybe Int -> Bool -> [DateSpan] -> [Posting] -> [SummaryPosting]
+summarisePostingsByInterval :: WhichDate -> Maybe Int -> Bool -> Maybe (PeriodData Day) -> [Posting] -> [SummaryPosting]
 summarisePostingsByInterval wd mdepth showempty colspans =
     concatMap (\(s,ps) -> summarisePostingsInDateSpan s wd mdepth showempty ps)
     -- Group postings into their columns. We try to be efficient, since
     -- there can possibly be a very large number of intervals (cf #1683)
-    . groupByDateSpan showempty (postingDateOrDate2 wd) colspans
+    . groupByDateSpan showempty (postingDateOrDate2 wd) (maybePeriodDataToDateSpans colspans)
 
 -- | Given a date span (representing a report interval) and a list of
 -- postings within it, aggregate the postings into one summary posting per
@@ -416,7 +416,7 @@ tests_PostingsReport = testGroup "PostingsReport" [
     -}
 
   ,testCase "summarisePostingsByInterval" $
-    summarisePostingsByInterval PrimaryDate Nothing False [DateSpan Nothing Nothing] [] @?= []
+    summarisePostingsByInterval PrimaryDate Nothing False Nothing [] @?= []
 
   -- ,tests_summarisePostingsInDateSpan = [
     --  "summarisePostingsInDateSpan" ~: do

--- a/hledger-lib/Hledger/Reports/ReportOptions.hs
+++ b/hledger-lib/Hledger/Reports/ReportOptions.hs
@@ -677,7 +677,7 @@ journalApplyValuationFromOptsWith rspec@ReportSpec{_rsReportOpts=ropts} j priceo
           _          -> spanEnd <=< latestSpanContaining (historical : spans)
 
     historical = DateSpan Nothing $ (fmap Exact . spanStart) =<< headMay spans
-    spans = snd $ reportSpanBothDates j rspec
+    spans = maybePeriodDataToDateSpans . snd $ reportSpanBothDates j rspec
     styles = journalCommodityStyles j
     err = error' "journalApplyValuationFromOpts: expected all spans to have an end date"
 
@@ -778,18 +778,18 @@ sortKeysDescription = "date, desc, account, amount, absamount"  -- 'description'
 -- (or non-future market price date, when doing an end value report) is used.
 -- If none of these things are present, the null date span is returned.
 -- The report sub-periods caused by a report interval, if any, are also returned.
-reportSpan :: Journal -> ReportSpec -> (DateSpan, [DateSpan])
+reportSpan :: Journal -> ReportSpec -> (DateSpan, Maybe (PeriodData Day))
 reportSpan = reportSpanHelper False
 -- Note: In end value reports, the report end date and valuation date are the same.
 -- If valuation date ever needs to be different, journalApplyValuationFromOptsWith is the place.
 
 -- | Like reportSpan, but considers both primary and secondary dates, not just one or the other.
-reportSpanBothDates :: Journal -> ReportSpec -> (DateSpan, [DateSpan])
+reportSpanBothDates :: Journal -> ReportSpec -> (DateSpan, Maybe (PeriodData Day))
 reportSpanBothDates = reportSpanHelper True
 
-reportSpanHelper :: Bool -> Journal -> ReportSpec -> (DateSpan, [DateSpan])
+reportSpanHelper :: Bool -> Journal -> ReportSpec -> (DateSpan, Maybe (PeriodData Day))
 reportSpanHelper bothdates j ReportSpec{_rsQuery=query, _rsReportOpts=ropts, _rsDay=today} =
-  (enlargedreportspan, if not (null intervalspans) then intervalspans else [enlargedreportspan])
+  (enlargedreportspan, dateSpansToPeriodData $ if not (null intervalspans) then intervalspans else [enlargedreportspan])
   where
     -- The date span specified by -b/-e/-p options and query args if any.
     requestedspan = dbg3 "requestedspan" $

--- a/hledger/Hledger/Cli/Commands/Stats.hs
+++ b/hledger/Hledger/Cli/Commands/Stats.hs
@@ -57,7 +57,7 @@ stats opts@CliOpts{rawopts_=rawopts, reportspec_=rspec, progstarttime_} j = do
       l = ledgerFromJournal q j
       intervalspans = snd $ reportSpanBothDates j rspec
       ismultiperiod = length intervalspans > 1
-      (ls, txncounts) = unzip $ map (showLedgerStats verbose l today) intervalspans
+      (ls, txncounts) = unzip . map (showLedgerStats verbose l today) $ maybePeriodDataToDateSpans intervalspans
       numtxns = sum txncounts
       txt = (if ismultiperiod then id else TL.init) $ TB.toLazyText $ unlinesB ls
   writeOutputLazyText opts txt

--- a/hledger/test/balance/balance.test
+++ b/hledger/test/balance/balance.test
@@ -239,3 +239,23 @@ $ hledger -f sample.journal balance --flat --empty
 --------------------
                    0  
 
+# ** 19. Shows zero if period starts after all transactions
+$ hledger -f sample.journal balance -b 3000-01-01
+--------------------
+                   0  
+
+# ** 20. Shows zero if period ends before all transactions
+$ hledger -f sample.journal balance -e 1000-01-01
+--------------------
+                   0  
+
+# ** 20. Shows zero if period starts and ends before all transactions
+$ hledger -f sample.journal balance -b 1000-01-01 -e 1000-01-02
+--------------------
+                   0  
+
+# ** 19. Shows zero on empty journal
+<
+$ hledger -f- balance
+--------------------
+                   0  

--- a/hledger/test/close.test
+++ b/hledger/test/close.test
@@ -235,10 +235,9 @@ $ hledger -f- close
 >=
 
 # ** 16. "override the closing date ... by specifying a report period, where last day of the report period will be the closing date"
-# With no data to close in the period, this is currently giving an error. XXX
-$ hledger -f- close -e 100000-01-01
->2 /Error: balanceDataPeriodEnds: expected initial span to have an end date/
->=1
+$ hledger -f- close -e 10000
+> /9999-12-31 closing balances/
+>=
 
 # ** 17. close (and print) should add trailing decimal marks when needed to posting amounts and costs.
 <


### PR DESCRIPTION
Eliminate several partial functions.

There is more work to be done creating fewer error states in the function `splitSpan`, but I'll leave this to a separate PR.