### PR TITLE
fix: balance: Don't display zero rows with --no-elide (#2454)

### DIFF
--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -417,6 +417,8 @@ buildReportRows makeRow ropts = mkRows True (-drop_ ropts) 0
     -- Build the row for an account at a given depth with some number of boring parents
     mkRows :: Bool -> Int -> Int -> Account b -> [PeriodicReportRow DisplayName c]
     mkRows isRoot d boringParents acct
+        -- Account is boring and has no interesting children at any depth, so we stop
+        | allBoring acct                 = []
         -- Account is a boring root account, and should be bypassed entirely
         | aboring acct && isRoot         = buildSubrows d 0
         -- Account is boring and has been dropped, so should be skipped and move up the hierarchy
@@ -430,6 +432,7 @@ buildReportRows makeRow ropts = mkRows True (-drop_ ropts) 0
         buildSubrows i b = concatMap (mkRows False i b) $ asubs acct
 
     canOmitParents = flat_ ropts || not (no_elide_ ropts)
+    allBoring a = aboring a && all allBoring (asubs a)
     balance = case accountlistmode_ ropts of
         ALTree -> bdincludingsubs
         ALFlat -> bdexcludingsubs

--- a/hledger/test/balance/no-total-no-elide.test
+++ b/hledger/test/balance/no-total-no-elide.test
@@ -66,13 +66,17 @@ $ hledger -f - balance --tree --no-total --empty
                    1  a
                    0    aa:aaa
 
-# ** 7. But displayed with --no-elide
+# ** 7. But displayed with --no-elide --empty
 $ hledger -f - balance --tree --no-total --empty --no-elide
                    1  a
                    0    aa
                    0      aaa
 
-# ** 8. Same as 5 for multiperiod
+# ** 8. But not displayed with --no-elide and no --empty
+$ hledger -f - balance --tree --no-total --no-elide
+                   1  a
+
+# ** 9. Same as 5 for multiperiod
 $ hledger -f - balance --tree --no-total -Y
 Balance changes in 2020:
 
@@ -80,7 +84,7 @@ Balance changes in 2020:
 ===++======
  a ||    1 
 
-# ** 9. Same as 6 for mulitperiod
+# ** 10. Same as 6 for mulitperiod
 $ hledger -f - balance --tree --no-total -Y --empty
 Balance changes in 2020:
 
@@ -89,7 +93,7 @@ Balance changes in 2020:
  a        ||    1 
    aa:aaa ||    0 
 
-# ** 10. Same as 7 for multiperiod
+# ** 11. Same as 7 for multiperiod
 $ hledger -f - balance --tree --no-total -Y --empty --no-elide
 Balance changes in 2020:
 
@@ -99,13 +103,13 @@ Balance changes in 2020:
    aa    ||    0 
      aaa ||    0 
 
-# ** 11. In flat mode, display all zero-balance accounts, including non-leaves
+# ** 12. In flat mode, display all zero-balance accounts, including non-leaves
 $ hledger -f - balance --flat --no-total --empty
                    1  a
                    0  a:aa
                    0  a:aa:aaa
 
-# ** 12. Same as 11 for multiperiod
+# ** 13. Same as 11 for multiperiod
 $ hledger -f - balance --flat --no-total -Y --empty
 Balance changes in 2020:
 


### PR DESCRIPTION
Zero rows with --no-elide should only be displayed if either --empty is called or they have non-zero children at some depth.