### PR TITLE
Forbid solving for hashtables 1.3

### DIFF
--- a/hledger-lib/hledger-lib.cabal
+++ b/hledger-lib/hledger-lib.cabal
@@ -148,7 +148,7 @@ library
     , extra >=1.7.11
     , file-embed >=0.0.10
     , filepath
-    , hashtables >=1.2.3.1
+    , hashtables >=1.2.3.1 && <1.3 || >=1.4.0
     , lucid
     , megaparsec >=7.0.0 && <9.8
     , microlens >=0.4

--- a/hledger-lib/package.yaml
+++ b/hledger-lib/package.yaml
@@ -68,7 +68,7 @@ dependencies:
 - encoding >=0.10
 - file-embed >=0.0.10
 - filepath
-- hashtables >=1.2.3.1
+- hashtables >=1.2.3.1 && <1.3 || >=1.4.0
 - lucid
 - megaparsec >=7.0.0 && <9.8
 - microlens >=0.4

--- a/stack92.yaml.old
+++ b/stack92.yaml.old
@@ -15,6 +15,7 @@ extra-deps:
 - safe-0.3.21
 # for hledger-lib:
 - encoding-0.10
+- hashtables-1.4.2
 # for hledger:
 # for hledger-ui:
 - brick-2.3.1

--- a/stack94.yaml.old
+++ b/stack94.yaml.old
@@ -13,6 +13,7 @@ packages:
 extra-deps:
 - brick-2.3.1
 - encoding-0.10
+- hashtables-1.4.2
 - fsnotify-0.4.2.0
 - hfsevents-0.1.8
 - safe-0.3.21

--- a/stack96.yaml
+++ b/stack96.yaml
@@ -10,6 +10,7 @@ packages:
 
 extra-deps:
 - encoding-0.10
+- hashtables-1.4.2
 - vty-windows-0.2.0.1
 
 nix:

--- a/stack98.yaml
+++ b/stack98.yaml
@@ -10,6 +10,7 @@ packages:
 
 extra-deps:
 - encoding-0.10
+- hashtables-1.4.2
 
 nix:
   pure: false


### PR DESCRIPTION
On modern gccs, this sometimes causes build failures, see
https://github.com/gregorycollins/hashtables/issues/97
