### PR TITLE
fix 1825: Fix infinite memory usage by allowing old data to be garbage collected

### DIFF
--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -245,7 +245,9 @@ rsHandle ev = do
               where
                 p = reportPeriod ui
 
-            e | e `elem` [AppEvent FileChange, VtyEvent (EvKey (KChar 'g') [])] -> uiReload copts d ui >>= put'
+            e | e `elem` [AppEvent FileChange, VtyEvent (EvKey (KChar 'g') [])] -> do
+              ui' <- uiReload copts d ui
+              put' $ regenerateScreens (ajournal ui') d ui'
 
             VtyEvent (EvKey (KChar 'I') []) -> uiToggleBalanceAssertions d ui
             VtyEvent (EvKey (KChar 'a') []) -> suspendAndResume $ clearScreen >> setCursorPosition 0 0 >> add (cliOptsDropArgs copts) j >> uiReloadIfFileChanged copts d j ui

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -366,8 +366,8 @@ resetScreens d ui@UIState{astartupopts=origopts, ajournal=j, aScreen=s,aPrevScre
 -- (using the ui state's current options), preserving the screen navigation history.
 -- Note, does not save the reporting date.
 --
--- XXX Currently this does not properly regenerate the transaction screen or error screen,
--- which depend on state from their parent(s); those screens' handlers must do additional work, which is fragile.
+-- XXX Currently this does not properly regenerate the error screen,
+-- which depends on state from their parent(s); that screens' handler must do additional work, which is fragile.
 regenerateScreens :: Journal -> Day -> UIState -> UIState
 regenerateScreens j d ui@UIState{aScreen=s} = 
   let !ui' = ui{ajournal=j, aScreen=s'}
@@ -378,6 +378,6 @@ regenerateScreens j d ui@UIState{aScreen=s} =
         BS ass -> BS $! bsUpdate (aopts ui') d j ass
         IS ass -> IS $! isUpdate (aopts ui') d j ass
         RS rss -> RS $! rsUpdate (aopts ui') d j rss
-        TS tss -> TS $! tsUpdate tss
+        TS tss -> TS $! tsUpdate (aopts ui') d j tss
         ES _   -> s
   in ui'

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -370,4 +370,7 @@ resetScreens d ui@UIState{astartupopts=origopts, ajournal=j, aScreen=s,aPrevScre
 -- which depend on state from their parent(s); those screens' handlers must do additional work, which is fragile.
 regenerateScreens :: Journal -> Day -> UIState -> UIState
 regenerateScreens j d ui@UIState{aopts=opts, aScreen=s,aPrevScreens=ss} =
-  ui{ajournal=j, aScreen=screenUpdate opts d j s, aPrevScreens=map (screenUpdate opts d j) ss}
+  let !newScreen = screenUpdate opts d j s
+      !newPrevScreens = map (screenUpdate opts d j) ss
+      !newJournal = j
+  in ui{ajournal=newJournal, aScreen=newScreen, aPrevScreens=newPrevScreens}

--- a/hledger-ui/hledger-ui.m4.md
+++ b/hledger-ui/hledger-ui.m4.md
@@ -330,14 +330,10 @@ eg to toggle cleared mode, or to explore the history.
   ([#836](https://github.com/simonmichael/hledger/issues/836))
 - It may not detect changes made from outside a virtual machine, ie by an editor running on the host system.
 - It may not detect file changes on certain less common filesystems.
-- It may use increasing CPU and RAM over time, especially with large files.
-  (This is probably not --watch specific, you may be able to reproduce it by pressing `g` repeatedly.)
-  ([#1825](https://github.com/simonmichael/hledger/issues/1825))
 
 Tips/workarounds:
 
 - If --watch won't work for you, press `g` to reload data manually instead.
-- If --watch is leaking resources over time, quit and restart (or suspend and resume) hledger-ui when you're not using it.
 - When running hledger-ui inside a VM, also make file changes inside the VM.
 - When working with files mounted from another machine, make sure the system clocks on both machines are roughly in agreement.
 


### PR DESCRIPTION
Fixes #1825

... at least the increasing memory usage on each press of <kbd>g</kbd> is fixed by making new data structures and allowing the old data to be garbage collected. I'm not sure about CPU usage as that did not go up appreciably in my repro for this issue, and I haven't tested this long enough to know if it also solves the ‘leave running for days’ variant of the problem rather than the repeated manual refresh variant, but it seems likely it will.
