### PR TITLE
Help ui --watch catch changes from editors that overwrite files

### DIFF
--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -44,7 +44,7 @@ import Lens.Micro ((^.))
 import System.Directory (canonicalizePath)
 import System.Environment (withProgName)
 import System.FilePath (takeDirectory)
-import System.FSNotify (Event(Modified), watchDir, withManager, EventIsDirectory (IsFile))
+import System.FSNotify (Event(Added, Modified), watchDir, withManager, EventIsDirectory (IsFile))
 import Brick hiding (bsDraw)
 import Brick.BChan qualified as BC
 
@@ -305,9 +305,8 @@ runBrickUi uopts0@UIOpts{uoCliOpts=copts@CliOpts{inputopts_=_iopts,reportspec_=r
           d
           -- predicate: ignore changes not involving our files
           (\case
-            Modified f _ IsFile -> f `elem` files
-            -- Added    f _ -> f `elem` files
-            -- Removed  f _ -> f `elem` files
+            Added f _ IsFile -> f `elem` files -- for editors which write the whole file from scratch on saves
+            Modified f _ IsFile -> f `elem` files -- for editors which modify existing files in place
             -- we don't handle adding/removing journal files right now
             -- and there might be some of those events from tmp files
             -- clogging things up so let's ignore them

--- a/hledger-ui/hledger-ui.m4.md
+++ b/hledger-ui/hledger-ui.m4.md
@@ -327,8 +327,6 @@ eg to toggle cleared mode, or to explore the history.
 - It may not work at all for you, depending on platform or system configuration.
   On some unix systems, increasing fs.inotify.max_user_watches or fs.file-max parameters in /etc/sysctl.conf might help.
   ([#836](https://github.com/simonmichael/hledger/issues/836))
-- It may not detect file changes made by certain tools, such as Jetbrains IDEs or gedit.
-  ([#1617](https://github.com/simonmichael/hledger/issues/1617))
 - It may not detect changes made from outside a virtual machine, ie by an editor running on the host system.
 - It may not detect file changes on certain less common filesystems.
 - It may use increasing CPU and RAM over time, especially with large files.


### PR DESCRIPTION
Not all editors trigger the `Modified` event for files because they don't edit the bits of an existing file, they flush their internal buffer to a new temporary file, then clobber the existing file on disk. This means many editors trigger the `Added` event even when saving changes to an existing journal file.

Tested with `gedit`.

Closes #1617
