### PR TITLE
Fix 1.50's far-future periodic report bug

### DIFF
--- a/hledger-lib/Hledger/Data/Account.hs
+++ b/hledger-lib/Hledger/Data/Account.hs
@@ -387,7 +387,7 @@ tests_Account = testGroup "Account" [
       testCase "no postings, no days" $
         accountFromPostings undefined [] @?= accountTree "root" []
      ,testCase "no postings, only 2000-01-01" $
-         allAccounts (all (\d -> (ModifiedJulianDay $ toInteger d) == fromGregorian 2000 01 01) . M.keys . pdperiods . adata)
+         allAccounts (all (== fromGregorian 2000 01 01) . M.keys . pdperiods . adata)
                      (accountFromPostings undefined []) @? "Not all adata have exactly 2000-01-01"
     ]
   ]

--- a/hledger-lib/Hledger/Data/DayPartition.hs
+++ b/hledger-lib/Hledger/Data/DayPartition.hs
@@ -128,7 +128,7 @@ unionDayPartitions (DayPartition (PeriodData h as)) (DayPartition (PeriodData h'
 dayPartitionStartEnd :: DayPartition -> (Day, Day)
 dayPartitionStartEnd (DayPartition (PeriodData _ ds)) =
   -- Guaranteed not to error because the IntMap is non-empty.
-  (intToDay . fst $ M.findMin ds, snd $ M.findMax ds)
+  (fst $ M.findMin ds, snd $ M.findMax ds)
 
 -- | Find the start and end dates of the period within a 'DayPartition' which contains a given day.
 -- If the day is after the end of the last period, it is assumed to be within the last period.
@@ -240,8 +240,6 @@ intervalBoundaryBefore i d =
   case dayPartitionToNonEmpty <$> splitSpan True i (DateSpan (Just $ Exact d) (Just . Exact $ addDays 1 d)) of
     Just ((start, _) :| _ ) -> start
     _ -> d
-
-intToDay = ModifiedJulianDay . toInteger
 
 
 -- tests:

--- a/hledger-lib/Hledger/Data/Json.hs
+++ b/hledger-lib/Hledger/Data/Json.hs
@@ -26,7 +26,6 @@ import           Data.Maybe (fromMaybe)
 import Data.Text.Lazy qualified    as TL
 import Data.Text.Lazy.Builder qualified as TB
 import Data.Map qualified as M
-import Data.Time (Day (..))
 import           Text.Megaparsec (Pos, SourcePos, mkPos, unPos)
 
 import           Hledger.Data.Types
@@ -161,7 +160,7 @@ instance ToJSON BalanceData
 instance ToJSON a => ToJSON (PeriodData a) where
   toJSON a = object
     [ "pdpre" .= pdpre a
-    , "pdperiods" .= map (\(d, x) -> (ModifiedJulianDay (toInteger d), x)) (M.toList $ pdperiods a)
+    , "pdperiods" .= (M.toList $ pdperiods a)
     ]
 
 instance ToJSON a => ToJSON (Account a) where
@@ -227,7 +226,7 @@ instance FromJSON BalanceData
 instance FromJSON a => FromJSON (PeriodData a) where
   parseJSON = withObject "PeriodData" $ \v -> PeriodData
     <$> v .: "pdpre"
-    <*> (M.fromList . map (\(d, x) -> (fromInteger $ toModifiedJulianDay d, x)) <$> v .: "pdperiods")
+    <*> (M.fromList <$> v .: "pdperiods")
 
 -- XXX The ToJSON instance replaces subaccounts with just names.
 -- Here we should try to make use of those to reconstruct the

--- a/hledger-lib/Hledger/Data/Types.hs
+++ b/hledger-lib/Hledger/Data/Types.hs
@@ -754,10 +754,9 @@ data Account a = Account {
 -- The report periods are typically all the same length, but need not be.
 --
 -- Report periods are represented only by their start dates, used as the keys of a Map.
--- (As integers, like the one inside the Day type, representing days before/after 1858-11-17.)
 data PeriodData a = PeriodData {
-   pdpre     :: a                -- ^ data for the period before the report
-  ,pdperiods :: M.Map Integer a  -- ^ data for each period within the report
+   pdpre     :: a            -- ^ data for the period before the report
+  ,pdperiods :: M.Map Day a  -- ^ data for each period within the report
   } deriving (Eq, Ord, Functor, Generic)
 
 -- | Data that's useful in "balance" reports:

--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -454,7 +454,7 @@ makeMultiBalanceReportRow = makePeriodicReportRow nullmixedamt sumAndAverageMixe
 -- | Build a report row.
 --
 -- Calculate the column totals. These are always the sum of column amounts.
-makePeriodicReportRow :: c -> (M.Map Integer c -> (c, c))
+makePeriodicReportRow :: c -> (M.Map Day c -> (c, c))
                       -> ReportOpts -> (b -> c)
                       -> a -> Account b -> PeriodicReportRow a c
 makePeriodicReportRow nullEntry totalAndAverage ropts balance name acct =


### PR DESCRIPTION
This fixes a periodic report regression with far future dates, discussed in #2477 and #2479.

- **fix:PeriodData: use Integer keys to avoid date wraparound bugs**
- **fix:PeriodData: simplify, use Day keys**
