### PR TITLE
Fix nested tables and broken HTML on export

### DIFF
--- a/hledger/Hledger/Cli/CompoundBalanceCommand.hs
+++ b/hledger/Hledger/Cli/CompoundBalanceCommand.hs
@@ -16,6 +16,7 @@ module Hledger.Cli.CompoundBalanceCommand (
 
 import Control.Monad (guard)
 import Data.Bifunctor (second)
+import Data.Foldable (traverse_)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
@@ -36,7 +37,7 @@ import Hledger.Cli.Commands.Balance
 import Hledger.Cli.CliOptions
 import Hledger.Cli.Utils (unsupportedOutputFormatError, writeOutputLazyText)
 import Hledger.Write.Csv (CSV, printCSV, printTSV)
-import Hledger.Write.Html (htmlAsLazyText, styledTableHtml, Html)
+import Hledger.Write.Html (formatRow, htmlAsLazyText, Html)
 import Hledger.Write.Html.Attribute (stylesheet, tableStyle, alignleft)
 import Hledger.Write.Ods (printFods)
 import Hledger.Write.Spreadsheet qualified as Spr
@@ -339,7 +340,8 @@ compoundBalanceReportAsHtml ropts cbr =
       ]
     table_ $ do
       tr_ $ th_ [colspanattr, style_ alignleft] $ h2_ $ toHtml title
-      styledTableHtml $ NonEmpty.toList $ fmap (map (fmap L.toHtml)) cells
+      -- Do not use `styledTableHtml` here since that leads to nested `<table>`s.
+      traverse_ formatRow $ fmap (map (fmap L.toHtml)) cells
 
 -- | Render a compound balance report as Spreadsheet.
 compoundBalanceReportAsSpreadsheet ::


### PR DESCRIPTION
A HTML export results in a table which has a stylesheet and another table nested inside. This is not valid HTML and gets auto corrected by closing the first table and opening another table. The result is the heading of the table can expand further than the remaining table.

This results in a few notable changes (as seen below):

- The date is in a far bigger cell and it's very noticeable it's centered compared to the amounts
  (we may want to right align the date, though I don't have any particular thoughts about this)
- We no longer have two consecutive lines with black background and the start
- The table is as big as the heading (+ the default left margin)

Using the following small example journal:

```journal
D 1,000.00€

account foo  ; type: A
account bar  ; type: A

2025-01-01 Test
	foo   1,000.00€
	bar  -1,000.00€
```

We get the following difference:

Old | New
---|---
<img width="391" height="292" alt="Old" src="https://github.com/user-attachments/assets/e3b89005-a9fa-4961-b714-5b28b65fccbd" /> | <img width="391" height="292" alt="New" src="https://github.com/user-attachments/assets/b670c7c5-94dd-4bd1-8e47-c42fe45b7438" />

In case we do not want this new look, I still recommend fixing the tables But in this case this can simply be done by dropping the top table and only have the heading. I do not recommend this since the table not extending as far as the heading looks (especially on a longer list of accounts) rather weird.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
