### PR TITLE
aregister: respect display order when picking the first-matched account

### DIFF
--- a/hledger/Hledger/Cli/Commands/Aregister.hs
+++ b/hledger/Hledger/Cli/Commands/Aregister.hs
@@ -88,9 +88,13 @@ aregister opts@CliOpts{rawopts_=rawopts,reportspec_=rspec} j = do
       []     -> error' $ help <> ".\nPlease provide an account name or a (case-insensitive, infix, regexp) pattern."
       (a:as) -> return (a, map T.pack as)
   let
-    -- keep synced with findMatchedByArgument's matching
+    -- related: findMatchedByArgument
+    -- Here, we select the first matched according to display order -
+    -- ie the first declared if the accounts are declaraed, otherwise the alphanumerically first.
     acct = fromMaybe (error' $ help <> ",\nbut " ++ show apat++" did not match any account.")   -- PARTIAL:
-           . firstMatch $ journalAccountNamesDeclaredOrImplied j
+           . firstMatch $
+            sortAccountNamesByDeclaration j False $
+            journalAccountNamesDeclaredOrImplied j
     firstMatch = case toRegexCI $ T.pack apat of
         Right re -> find (regexMatchText re)
         Left  _  -> const Nothing

--- a/hledger/Hledger/Cli/Commands/Aregister.md
+++ b/hledger/Hledger/Cli/Commands/Aregister.md
@@ -42,9 +42,10 @@ As a quick rule of thumb:
 
 Note this command's non-standard, and required, first argument; it specifies the account whose register will be shown.
 You can write the account's name, or (to save typing) a case-insensitive infix regular expression matching the name,
-which selects the alphabetically first matched account.
-(For example, if you have `assets:personal checking` and `assets:business checking`,
-`hledger areg checking` would select `assets:business checking`.)
+which selects the first matched account (in [display order](hledger.md#account-display-order) if any, otherwise alphabetically).
+For example, if you have `assets:personal checking` and `assets:business checking`,
+`hledger areg checking` will select `assets:business checking`
+(unless you used `account` directives to change their display order).
 
 Transactions involving subaccounts of this account will also be shown.
 `aregister` ignores depth limits, so its final total will always match 


### PR DESCRIPTION

This is more consistent with the accounts and balance reports,
and allows more customisation of what 'areg SHORTNAME' matches.
