### PR TITLE
roi: more input sanity checks (fixes #2505)

### DIFF
--- a/hledger/Hledger/Cli/Commands/Roi.hs
+++ b/hledger/Hledger/Cli/Commands/Roi.hs
@@ -306,9 +306,9 @@ internalRateOfReturn styles showCashFlow prettyTables (OneSpan begin end valueBe
                       (0.000000000001,10000)
                       (interestSum end totalCF) of
         Root rate    -> return ((rate-1)*100)
-        NotBracketed -> error' $ "Error (NotBracketed): No solution for Internal Rate of Return (IRR).\n"
+        NotBracketed -> error' $ "Equation for Internal Rate of Return (IRR) can not be solved.\n"
                         ++       "  Possible causes: IRR is huge (>1000000%), balance of investment becomes negative at some point in time."
-        SearchFailed -> error' $ "Error (SearchFailed): Failed to find solution for Internal Rate of Return (IRR).\n"
+        SearchFailed -> error' $ "Equation for Internal Rate of Return (IRR) can not be solved.\n"
                         ++       "  Either search does not converge to a solution, or converges too slowly."
 
 type CashFlow = [(Day, MixedAmount)]

--- a/hledger/test/roi.test
+++ b/hledger/test/roi.test
@@ -212,7 +212,7 @@ $ hledger -f- roi --inv investment --pnl pnl -b 2017-06 -e 2018
 2019/11/01 Example
   Assets:Checking  1
   Income:Salary  -1
-$ hledger -f- roi -p 2019-11
+$ hledger -f- roi -p 2019-11 --pnl "^$"
 +---++------------+------------++---------------+----------+-------------+-----++-------++------------+----------+
 |   ||      Begin |        End || Value (begin) | Cashflow | Value (end) | PnL ||   IRR || TWR/period | TWR/year |
 +===++============+============++===============+==========+=============+=====++=======++============+==========+
@@ -236,7 +236,10 @@ $ hledger -f- roi -p 2019-11
   Assets:Checking    101 A
   Unrealized PnL
 $ hledger -f- roi -p 2019-11 --inv Investment --pnl PnL
->2 /Error: Amounts could not be converted to a single commodity: \["10 B","-9 B @@ 100 A","100 C"\]/
+>2
+hledger: Error: Period (2019-11-01,2019-12-01) has multiple commodities: A, B, C
+Consider using --value to force all costs to be in a single commodity.
+For example, "--value=end,<commodity> --infer-market-prices", where commodity is the one that you want to value the investment in.
 >= 1
 
 # ** 10. Forcing valuation via --value


### PR DESCRIPTION
This checks for:

- catch-all queries supplied to `--pnl`, which will cause no transactions to be classed as "investment" (root cause of #2505)

- mixed commodities in cashflow / pnl transactions, as we can't add apples to oranges to compute a sensible rate of return

At the moment both of these cases fail with undecipherable error from the bowels of IRR computation. Let's fail with a sensible error message instead, and provide a path to resolution, if possible
