### PR TITLE
feat: prices: add the --quoted option to filter prices by the commodity they're quoted in

### DIFF
--- a/hledger/Hledger/Cli/Commands/Prices.txt
+++ b/hledger/Hledger/Cli/Commands/Prices.txt
@@ -8,6 +8,7 @@ reversing known prices.
 Flags:
      --show-reverse         also show the prices inferred by reversing known
                             prices
+     --quoted COMM          only show prices quoted in commodity matching COMM
 
 Price amounts are always displayed with their full precision, except for
 reverse prices which are limited to 8 decimal digits.


### PR DESCRIPTION
If you have prices of a commodity quoted in multiple currencies like:

```
hledger prices cur:EUR -p 2025-12-31              
P 2025-12-31 EUR CHF 0.93060
P 2025-12-31 EUR USD 1.17450
```

It's useful to be able to filter them on the currency they're quoted in:

```
hledger prices cur:EUR -p 2025-12-31 --quoted CHF
P 2025-12-31 EUR CHF 0.93060
```

```
hledger prices cur:EUR -p 2025-12-31 --quoted USD 
P 2025-12-31 EUR USD 1.17450
```

I'm not sure about the option name. `--quoted-in` might read better.