### PR TITLE
perf: some journal reading optimisations

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -602,7 +602,7 @@ journalAccountType Journal{jaccounttypes} = accountNameType jaccounttypes
 
 -- | Add a map of all known account types to the journal.
 journalAddAccountTypes :: Journal -> Journal
-journalAddAccountTypes j = j{jaccounttypes = journalAccountTypes j}
+journalAddAccountTypes j = j{jaccounttypes = journalAccountTypes j} `seq` j
 
 -- | An account type inherited from the parent account(s),
 -- and whether it was originally declared by an account directive (true) or inferred from an account name (false).
@@ -640,7 +640,7 @@ journalDeclaredAccountTypes Journal{jdeclaredaccounttypes} =
 -- (including those inherited from parent accounts).
 -- If the same tag exists on posting and account, the latter is ignored.
 journalPostingsAddAccountTags :: Journal -> Journal
-journalPostingsAddAccountTags j = journalMapPostings addtags j
+journalPostingsAddAccountTags j = journalMapPostings addtags j `seq` j
   where addtags p = p `postingAddTags` (journalInheritedAccountTags j $ paccount p)
 
 -- | Remove all tags from the journal's postings except those provided by their account.
@@ -858,13 +858,14 @@ filterJournalTransactionsByAccount apats j@Journal{jtxns=ts} = j{jtxns=filter tm
 -- post-parse finalisation.
 journalReverse :: Journal -> Journal
 journalReverse j =
-  j {jfiles            = reverse $ jfiles j
-    ,jdeclaredaccounts = reverse $ jdeclaredaccounts j
-    ,jtxns             = reverse $ jtxns j
-    ,jtxnmodifiers     = reverse $ jtxnmodifiers j
-    ,jperiodictxns     = reverse $ jperiodictxns j
-    ,jpricedirectives  = reverse $ jpricedirectives j
-    }
+  let j' = j {jfiles            = reverse $ jfiles j
+              ,jdeclaredaccounts = reverse $ jdeclaredaccounts j
+              ,jtxns             = reverse $ jtxns j
+              ,jtxnmodifiers     = reverse $ jtxnmodifiers j
+              ,jperiodictxns     = reverse $ jperiodictxns j
+              ,jpricedirectives  = reverse $ jpricedirectives j
+              }
+  in j' `seq` j'
 
 -- | Set this journal's last read time, ie when its files were last read.
 journalSetLastReadTime :: POSIXTime -> Journal -> Journal
@@ -907,7 +908,8 @@ journalStyleAmounts :: Journal -> Either String Journal
 journalStyleAmounts = fmap journalapplystyles . journalInferCommodityStyles
   where
     journalapplystyles j@Journal{jpricedirectives=pds} =
-      journalMapPostings (styleAmounts styles) j{jpricedirectives=map fixpricedirective pds}
+      let j' = journalMapPostings (styleAmounts styles) j{jpricedirectives=map fixpricedirective pds}
+      in j' `seq` j'
       where
         styles = journalCommodityStylesWith NoRounding j  -- defer rounding, in case of print --round=none
         fixpricedirective pd@PriceDirective{pdamount=a} = pd{pdamount=styleAmounts styles a}
@@ -941,7 +943,8 @@ journalInferCommodityStyles :: Journal -> Either String Journal
 journalInferCommodityStyles j =
   case commodityStylesFromAmounts $ journalStyleInfluencingAmounts False j of
     Left e   -> Left e
-    Right cs -> Right j{jinferredcommoditystyles = dbg7 "journalInferCommodityStyles" cs}
+    Right cs -> let j' = j{jinferredcommoditystyles = dbg7 "journalInferCommodityStyles" cs}
+                 in j' `seq` Right j'
 
 -- -- | Apply this journal's historical price records to unpriced amounts where possible.
 -- journalApplyPriceDirectives :: Journal -> Journal
@@ -968,12 +971,13 @@ journalInferCommodityStyles j =
 -- been balanced and posting amounts have appropriate prices attached.
 journalInferMarketPricesFromTransactions :: Journal -> Journal
 journalInferMarketPricesFromTransactions j =
-  j{jinferredmarketprices =
+  let j' = j{jinferredmarketprices =
        dbg4With (("jinferredmarketprices:\n"<>) . showMarketPrices) $
        map priceDirectiveToMarketPrice .
        concatMap postingPriceDirectivesFromCost $
        journalPostings j
-   }
+    }
+  in j' `seq` j'
 
 -- | Convert all this journal's amounts to cost using their attached prices, if any.
 journalToCost :: ConversionOp -> Journal -> Journal


### PR DESCRIPTION
Hi @simonmichael 

In an attempt to try to investigate possibilities to speed up journal reading and parsing, which appears to be the performance bottleneck, I gave a try to analyze it using opencode and glm-4.7 LLM.

It proposed some non-invasive fixes that, on my system, improved the performance of the balance and income statement command by roughly 5-15%.

Unit tests are passing.

Can you please check and let me know if it makes sense to include.