### PR TITLE
Avoid double compilation in just test

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -404,9 +404,9 @@ test:
     @echo
     just embedtest
     @echo
-    just doctest
-    @echo
     just functest --hide
+    @echo
+    just doctest
     @echo
 
 # For quieter tests add --silent. It may hide troubleshooting info.


### PR DESCRIPTION
Rearrange the order of test execution to avoid double recompilation caused by different compilation settings in docstest