### PR TITLE
run less more robustly; don't add --quit-at-eof

### DIFF
--- a/hledger-lib/Hledger/Utils/IO.hs
+++ b/hledger-lib/Hledger/Utils/IO.hs
@@ -752,18 +752,29 @@ lessVarValue mHLEDGER_LESS mLESS usecolor =
        (_, Just lessvar) -> if extralessopts `isInfixOf` lessvar then lessvar else unwords [lessvar, extralessopts]
        _ -> extralessopts
 
--- | hledger's preferred less options, for a consistent pleasant UX.
+-- keep synced: hledger.m4.md > Paging
+-- | hledger's preferred less options, which it will append to the user's LESS environment variable.
+-- The thinking here is: "Many people don't have their LESS optimised to get the best experience from modern less, as I didn't.
+-- Also as they use hledger on different machines, LESS is likely not consistent. 
+-- So let's add some settings that I have found reasonably robust, compatible, and good for usability.
+-- That will help provide a consistent good experience when viewing hledger's long outputs.
+-- And power users can prevent this by setting exactly the options they want in HLEDGER_LESS."
+-- Here's what they mean: https://manned.org/man/less#head5
+--
+-- Flags that might break older less versions (causing hledger to fall back to unpaged output) are avoided here.
+-- Such as --mouse and --wheel-lines (less >=530, 2018) and --use-color (less >=551, 2019).
+-- --hilite-unread (less >=443, 2011) is useful and considered old enough.
+--
 lessOptions = unwords [
    "--chop-long-lines"
   ,"--hilite-unread"
   ,"--ignore-case"
   ,"--no-init"
-  ,"--quit-at-eof"
   ,"--quit-if-one-screen"
   ,"--shift=8"
   ,"--squeeze-blank-lines"
   ,"--use-backslash"
-  ]
+  ] 
 
 -- | Additional less options to use if we are showing colour on stdout.
 lessColourOptions = unwords [

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -756,21 +756,23 @@ If you see junk characters, you might need to configure your pager to handle ANS
 Or you could disable colour as described above.
 
 If you are using the [`less` pager](https://www.greenwoodsoftware.com/less/faq.html),
-hledger automatically appends a number of options to the `LESS` variable
-to enable ANSI colour and a number of other conveniences.
-(At the time of writing:
+hledger tries to provide a consistently pleasant experience by running it with some extra options added to your `LESS` environment variable:
+
 --chop-long-lines
 --hilite-unread
 --ignore-case
 --no-init
---quit-at-eof
 --quit-if-one-screen
---RAW-CONTROL-CHARS
 --shift=8
 --squeeze-blank-lines
 --use-backslash
-).
-If these don't work well, you can set your preferred options in the `HLEDGER_LESS` variable, which will be used instead.
+
+and when colour output is enabled:
+
+--RAW-CONTROL-CHARS
+
+You can prevent this by setting your preferred options in the `HLEDGER_LESS` variable, which will be used instead of `LESS`.
+
 
 ### HTML output
 


### PR DESCRIPTION
This adds more robust handling of various less and pager failure mode. Generally when anything goes wrong, it should always fall back to printing the output unpaged.

Based on feedback from chat, I have removed --quit-at-eof from the options that hledger adds to LESS when using less as pager. It meant that when you scrolled to the bottom of long output, you would often end up exiting less by accident, so you couldn't scroll back up. Now when less is invoked (because output is longer than the window), you'll always see its end of output indicator at the bottom and you'll always have to press q to exit. 

Of course you can override this default by setting your preferred less options in HLEDGER_LESS (or by setting PAGER to something else or by using --pager=no).

Related: #2544