### PR TITLE
fix:ui: Display All Transactions correctly

### DIFF
--- a/hledger-lib/Hledger/Utils/Text.hs
+++ b/hledger-lib/Hledger/Utils/Text.hs
@@ -211,7 +211,7 @@ fitText mminwidth mmaxwidth ellipsify rightside = clip . pad
     clip s =
       case mmaxwidth of
         Just w
-          | realLength s > w ->
+          | realLength s > max 0 w ->
             if rightside
               then textTakeWidth (w - T.length ellipsis) s <> ellipsis
               else ellipsis <> T.reverse (textTakeWidth (w - T.length ellipsis) $ T.reverse s)
@@ -287,5 +287,9 @@ tests_Text = testGroup "Text" [
      textUnbracket "[([]())]" @?= "[]()"
      textUnbracket "[([[[()]]])]" @?= ""
      textUnbracket "[([[[(]]])]" @?= "("
-     textUnbracket "[([[[)]]])]" @?= ")"
+     textUnbracket "[([[[)]]])]" @?= ")",
+   testCase "fitText" $ do
+     fitText Nothing (Just (-2)) True True "" @?= ""
+     fitText Nothing (Just 0) True True "" @?= ""
+     fitText Nothing (Just 6) True True "Test Text" @?= "Test.."
   ]

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -94,7 +94,7 @@ rsDraw UIState{aopts=_uopts@UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec}}
         -- allocating equally.
         descwidth = maxdescacctswidth `div` 2
         acctswidth = maxdescacctswidth - descwidth
-        colwidths = (datewidth,descwidth,acctswidth,changewidth,balwidth)
+        colwidths = (max 0 datewidth,max 0 descwidth,max 0 acctswidth,max 0 changewidth,max 0 balwidth)
 
       render $ defaultLayout toplabel bottomlabel $ renderList (rsDrawItem colwidths) True _rssList
 


### PR DESCRIPTION
Even if there there are no displayitems left, there are still blankitems in the List. With this the List is not technically empty and will therefore keep showing a selection.
This is fixed by actively removing the list selection if there are no displayitems left.

Also, if there are only blankitems left, the colwidths cacluation in the RegisterScreen produces negative widths. The fitText function would then see that the 0-length of the blankitems is greater than the negative widths and ellipsify.
This is fixed in the RegisterScreen by ensuring that no negative widths are passed and more generally in the fitText function by treating negative max widths as 0.

Fixes #2476