### PR TITLE
fix: balance: preserve account declaration order with --empty --declared

### DIFF
--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -218,14 +218,15 @@ getPostings rspec@ReportSpec{_rsQuery=query, _rsReportOpts=ropts} j priceoracle 
 -- of 'Posting's.
 generateMultiBalanceAccount :: ReportSpec -> Journal -> PriceOracle -> Maybe DayPartition -> [Posting] -> Account BalanceData
 generateMultiBalanceAccount rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle colspans =
-    -- Add declared accounts if called with --declared and --empty
-    (if (declared_ ropts && empty_ ropts) then addDeclaredAccounts rspec j else id)
     -- Negate amounts if applicable
-    . (if invert_ ropts then fmap (mapBalanceData maNegate) else id)
+    (if invert_ ropts then fmap (mapBalanceData maNegate) else id)
     -- Mark which accounts are boring and which are interesting
     . markAccountBoring rspec
     -- Set account declaration info (for sorting purposes)
+    -- This must happen after addDeclaredAccounts so newly added accounts also get their info
     . mapAccounts (accountSetDeclarationInfo j)
+    -- Add declared accounts if called with --declared and --empty
+    . (if (declared_ ropts && empty_ ropts) then addDeclaredAccounts rspec j else id)
     -- Process changes into normal, cumulative, or historical amounts, plus value them
     . calculateReportAccount rspec j priceoracle colspans
     -- Clip account names


### PR DESCRIPTION
## Summary

Fixes #2564 - Account ordering regression with `--empty --declared`.

- **Root cause**: In `generateMultiBalanceAccount`, `accountSetDeclarationInfo` was applied *before* `addDeclaredAccounts` in the processing pipeline. Newly added declared accounts (zero-balance ones) never received their declaration info, causing `accountDeclarationOrderAndName` to assign them `maxBound` sort priority, pushing them to the bottom of reports.

- **Fix**: Reorder the pipeline so `addDeclaredAccounts` runs first, then `accountSetDeclarationInfo` is applied to all accounts (including the newly added ones), ensuring proper declaration order is preserved during sorting.

## Reproduction

```journal
account a
account b
account c

2025-01-01 txn
    a       1
    c      -1
```

**Before fix** (`hledger balance --empty --declared`):
```
                   1  a
                  -1  c
                   0  b    <-- wrong, should be between a and c
```

**After fix**:
```
                   1  a
                   0  b    <-- correct declaration order
                  -1  c
```

## Test plan

- [ ] Verify the reproduction case shows correct a, b, c ordering
- [ ] Run existing balance report tests to check for regressions
- [ ] Test with compound balance commands (bs, is, cf) that also use `generateMultiBalanceAccount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)