### PR TITLE
fix:lib: Accounts with no postings were showing out of order in balance when using --empty --declared

### DIFF
--- a/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
+++ b/hledger-lib/Hledger/Reports/MultiBalanceReport.hs
@@ -218,14 +218,14 @@ getPostings rspec@ReportSpec{_rsQuery=query, _rsReportOpts=ropts} j priceoracle 
 -- of 'Posting's.
 generateMultiBalanceAccount :: ReportSpec -> Journal -> PriceOracle -> Maybe DayPartition -> [Posting] -> Account BalanceData
 generateMultiBalanceAccount rspec@ReportSpec{_rsReportOpts=ropts} j priceoracle colspans =
+    -- Set account declaration info (for sorting purposes)
+    mapAccounts (accountSetDeclarationInfo j)
     -- Add declared accounts if called with --declared and --empty
-    (if (declared_ ropts && empty_ ropts) then addDeclaredAccounts rspec j else id)
+    . (if (declared_ ropts && empty_ ropts) then addDeclaredAccounts rspec j else id)
     -- Negate amounts if applicable
     . (if invert_ ropts then fmap (mapBalanceData maNegate) else id)
     -- Mark which accounts are boring and which are interesting
     . markAccountBoring rspec
-    -- Set account declaration info (for sorting purposes)
-    . mapAccounts (accountSetDeclarationInfo j)
     -- Process changes into normal, cumulative, or historical amounts, plus value them
     . calculateReportAccount rspec j priceoracle colspans
     -- Clip account names

--- a/hledger/test/balance/balance.test
+++ b/hledger/test/balance/balance.test
@@ -259,3 +259,19 @@ $ hledger -f sample.journal balance -b 1000-01-01 -e 1000-01-02
 $ hledger -f- balance
 --------------------
                    0  
+
+# ** 21. Ordering of accounts with no postings is preserved when --declared and --empty are used
+<
+account a
+account b
+account c
+
+2025-01-01 txn
+    a       1
+    c      -1
+$ hledger -f - balance --empty --declared
+                   1  a
+                   0  b
+                  -1  c
+--------------------
+                   0  

--- a/hledger/test/incomestatement.test
+++ b/hledger/test/incomestatement.test
@@ -330,3 +330,28 @@ Income Statement 2025-01-01..2025-01-02
  Expenses ||                        
 ----------++------------------------
 
+# ** 11. With --declared and --empty, account declaration order is preserved
+<
+account revenues:b
+account revenues:a
+account expenses:y
+account expenses:x
+
+2025-01-01 txn
+    revenues:a      -1
+    expenses:x       1
+
+$ hledger -f - incomestatement -N --empty --declared
+Income Statement 2025-01-01
+
+            || 2025-01-01 
+============++============
+ Revenues   ||            
+------------++------------
+ revenues:b ||          0 
+ revenues:a ||          1 
+============++============
+ Expenses   ||            
+------------++------------
+ expenses:y ||          0 
+ expenses:x ||          1 


### PR DESCRIPTION
Fixes #2564

The fix was adding account declaration info after all accounts had been added back.

The commands below were impacted, as far as I can tell.

I'm not sure if there's tests in layers other than `shelltest` that I should have added. If so, let me know and I can add them =]

# Impacted commands

## balance

<pre><code><
account a
account b
account c

2025-01-01 txn
    a       1
    c      -1
$ hledger -f - balance --empty --declared
</code></pre>

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><pre>
                   1  a
                  -1  c
                   0  b
--------------------
                   0  
</pre></td>
<td><pre>
                   1  a
                   0  b
                  -1  c
--------------------
                   0  
</pre></td>
</tr>
</table>

## incomestatement

<pre><code><
account revenues:b
account revenues:a
account expenses:y
account expenses:x

2025-01-01 txn
    revenues:a      -1
    expenses:x       1

$ hledger -f - incomestatement -N --empty --declared
</code></pre>

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><pre>
============++============
 Revenues   ||            
------------++------------
 revenues:a ||          1 
 revenues:b ||          0 
============++============
 Expenses   ||            
------------++------------
 expenses:x ||          1 
 expenses:y ||          0 
</pre></td>
<td><pre>
============++============
 Revenues   ||            
------------++------------
 revenues:b ||          0 
 revenues:a ||          1 
============++============
 Expenses   ||            
------------++------------
 expenses:y ||          0 
 expenses:x ||          1 
</pre></td>
</tr>
</table>