### PR TITLE
dev: add nix-shell support for commands from just

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# For use with direnv or nix-direnv
+use nix

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,39 @@
+{
+  # Get latest commits from https://status.nixos.org/
+  # Compute sha256 with `nix-prefetch-url --unpack https://github.com/NixOS/nixpkgs/archive/8eaee110344796db060382e15d3af0a9fc396e0e.tar.gz`
+  nixpkgs ? fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/8eaee110344796db060382e15d3af0a9fc396e0e.tar.gz";
+    sha256 = "1k5zyljqg8fp99hzgjkvkawhmbwlfsnz4viisfcfdjyky9zrc8c8";
+  },
+  pkgs ? import nixpkgs {
+    config = {
+      allowUnfree = true;
+    };
+  },
+}:
+{
+  shell = pkgs.mkShellNoCC {
+    packages = with pkgs; [
+      bash
+      cabal-install
+      dateutils
+      difftastic
+      fd
+      gh
+      ghc
+      ghcid
+      hlint
+      jj
+      just
+      pngquant
+      stack
+
+      haskellPackages.ghcitui
+      haskellPackages.hasktags
+      haskellPackages.profiterole
+      haskellPackages.profiteur
+      haskellPackages.quickbench
+      haskellPackages.shelltestrunner
+    ];
+  };
+}


### PR DESCRIPTION
This adds `nix-shell` support to hledger to run all the commands in the Justfile. I also added a `.envrc` file to support https://direnv.net/, it was so easy to do I thought it would be okay in the same PR.

Contributes to #2044.

Tested with:

```
$ nix-shell
[nix-shell:~/hledger]$ echo "Shake authors authorsv bench bench-throughput bench-throughput-dev bench-throughput-recent bin-short bloglog branches branchesv buildtimes cabalfilestest changelogs changelogs-catchup changelogs-finalise changelogs-reset chatlog commitlog compare-balance completions describe devtag-push doctest docupdatediag embedtest etags etags-clean etags-ls functest ghbin ghbin-download ghbin-open ghci ghci-doctest ghci-echo ghci-prof ghci-shake ghci-ui ghci-web ghci-web-test ghrel-notes ghrel-open ghrel-upload ghrun-open ghworkflows-open google-search-console hackageupload haddock haddock-and-open haddock-open haddocktest heap hledgerprof hlinttest installallas installallasdbg installas installasdbg installcommithook installrel installtest log-headtail log-push log-save maillog majorver manuals manuals-site modulediag modulediags modulediags-view oldest packagediags packagediags-view perfhelp perftest pkgtest push pushfaq quickprof redditlog rel relauthors relbranch reldate releasediag relnotes rels rels-major reltags reltags-push relver samplejournals scc sccv schedule showrelnotes site site-caching-open site-restart site-watch symlink-binary symlink-web-dirs tags test testbin testbin-bin testbin-notes testbin-open time timelog tldr-diff tools tootlog twih unittest unreleased usage ver worklog worklogdates" \
  | xargs -n1 sh -c 'echo === $0; just $0' \
  | tee just.log
```

I got the list from `just --summary` and removed the header commands (like BUILD) and the ghcid ones since they start a shell. I did run the ghcid ones separately and they work too.

I had none of the needed binaries installed. Log output after caches are hot. Also, I eluded not interesting parts like compilation output, unless the compilation failed.

```
=== Shake
Shake: for heavier project scripting. See also Justfile
Usage:
./Shake.hs [CMD [ARGS]]  run CMD, compiling this script first if needed
./Shake    [CMD [ARGS]]  run CMD, using the compiled version of this script
./Shake [help]           show this help
./Shake cabalfiles [-c]  update */*.cabal files from */package.yaml
./Shake setversion [VER] [PKGS] [-c]
                         update versions in source files to */.version or VER
                         and update */*.cabal files
./Shake hledger-install-version    update some version strs in hledger-install
./Shake cmddocs [-c]     update all hledger's COMMAND.md and COMMAND.txt files,
                         used for --help, manuals etc. (run after changing
                         COMMAND.md or command options or general options)
./Shake manuals [-c]     update the packages' embedded info/man/txt manuals
./Shake changelogs [-c] [-n/--dry-run]
                         update CHANGES.md files, adding new commits & headings
./Shake docs [-c]        update all program docs (CLI help, manuals, changelogs)
./Shake site             update (render) the website, in ./site
./Shake build [PKGS]     build hledger packages and their embedded docs
./Shake clean            remove generated texts, manuals
./Shake Clean            also remove object files, Shake's cache
./Shake FILE             build any individual file
./Shake --help           list shake build options (--color, --rebuild, etc.
                         Keep shake option arguments adjacent to their flag.)

See comments in Shake.hs for more detailed descriptions.
Add -c/--commit to have commands commit their changes.
Add -B (on its own) to force rebuilding.
Add -V/-VV/-VVV/-VVVV to see more verbose output.
Add --skip-commands to try to avoid running external commands
(not a true dry run; some cmd calls may still run, code may do IO, etc).

=== authors
Commit authors (0):
=== authorsv
Commit authors (0):
=== bench
Running quick benchmarks (times are approximate, can be skewed):
Running 3 tests 1 times at 2026-03-16 22:28:41 CET:
 (error: hledger: readCreateProcessWithExitCode: posix_spawnp: does not exist (No such file or directory))  (error: hledger: readCreateProcessWithExitCode: posix_spawnp: does not exist (No such file or directory))  (error: hledger: readCreateProcessWithExitCode: posix_spawnp: does not exist (No such file or directory)) 
Best times:
+------------------------------------------------------++------+
|                                                      ||      |
+======================================================++======+
| hledger -f examples/10ktxns-1kaccts.journal print    || 0.00 |
| hledger -f examples/10ktxns-1kaccts.journal register || 0.00 |
| hledger -f examples/10ktxns-1kaccts.journal balance  || 0.00 |
+------------------------------------------------------++------+
=== bench-throughput
=== bench-throughput-dev
=== bench-throughput-recent

hledger-1.25:

hledger-1.28:

hledger-1.29:

hledger-1.32:

hledger-1.32.3:
=== bin-short
=== bloglog
=== branches
Recent branches:
=== branchesv
Recent branches (commits):
=== buildtimes
hledger-lib> CodeGen [Hledger.Data.Currency]: alloc=194405928 time=112.625
[...]
CodeGen [Paths_hledger]: alloc=15991384 time=12.379
=== cabalfilestest

checking hledger-lib.cabal:
These warnings may cause trouble when distributing the package:

checking hledger.cabal:
These warnings may cause trouble when distributing the package:

checking hledger-ui.cabal:
These warnings may cause trouble when distributing the package:

checking hledger-web.cabal:
These warnings may cause trouble when distributing the package:
PASSED
=== changelogs
doc/CHANGES.md: updated to 5396edb4
hledger-web/CHANGES.md: updated to 5396edb4
hledger-ui/CHANGES.md: updated to 5396edb4
hledger/CHANGES.md: updated to 5396edb4
hledger-lib/CHANGES.md: updated to 5396edb4
=== changelogs-catchup
You are currently on ibizaman/master branch. Please switch to the latest release branch.
=== changelogs-finalise
You are currently on ibizaman/master branch. Please switch to the latest release branch.
=== changelogs-reset
=== chatlog
=== commitlog
=== compare-balance
-------------------------------------------------------------------------------
comparing hledger -f examples/1txns-1accts.journal balance and ledger -f examples/1txns-1accts.journal balance --flat
[1m[93m/dev/fd/63[39m[0m[2m --- Text[0m
No changes.

-------------------------------------------------------------------------------
comparing hledger -f examples/10txns-10accts.journal balance and ledger -f examples/10txns-10accts.journal balance --flat
[1m[93m/dev/fd/63[39m[0m[2m --- Text[0m
No changes.

=== completions
make: Entering directory '/home/timi/hledger/hledger/shell-completion'
make: Leaving directory '/home/timi/hledger/hledger/shell-completion'
=== describe
hledger-1.24-4393-g5396edb49-dirty
=== devtag-push
Setting versions to 1.51.2.99..
hledger-web/package.yaml: hledger bounds are (improve if needed):
  - hledger-lib >=1.51.2.99 && <1.52
  - hledger >=1.51.2.99 && <1.52
hledger-ui/package.yaml: hledger bounds are (improve if needed):
  - hledger-lib >=1.51.2.99 && <1.52
  - hledger >=1.51.2.99 && <1.52
hledger/package.yaml: hledger bounds are (improve if needed):
- hledger-lib >=1.51.2.99 && <1.52
[ibizaman/master 8d30a66ba] ;pkg: set version to 1.51.2.99
 13 files changed, 22 insertions(+), 22 deletions(-)
=== doctest
Loading and searching for doctests in 65 files, plus any files they import:
PASSED
=== docupdatediag
[ibizaman/master cb1d6ed91] ;doc:doc-update.png: update
 1 file changed, 0 insertions(+), 0 deletions(-)
=== embedtest
Checking embedded file declarations:
config/openapi.yaml                     	declared in hledger-web/package.yaml
Hledger/Cli/Commands/Balancesheet.txt   	declared in hledger/package.yaml
[...]
embeddedfiles/hledger-web.info          	declared in hledger/package.yaml
ok
=== etags
=== etags-clean
=== etags-ls
=== functest
Excluding 351 test files

         Test Cases  Total 
 Passed  1236        1236  
 Failed  0           0     
 Total   1236        1236  
PASSED
=== ghbin
=== ghbin-download
=== ghbin-open
=== ghci
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/timi/hledger/.ghci
[  1 of 104] Compiling Hledger.Data.Currency ( hledger-lib/Hledger/Data/Currency.hs, interpreted )
[...]
[104 of 104] Compiling Hledger.Cli      ( hledger/Hledger/Cli.hs, interpreted )
Ok, 104 modules loaded.
ghci> Leaving GHCi.
=== ghci-doctest
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/timi/hledger/hledger-lib/.ghci
[1 of 2] Compiling Main             ( /home/timi/hledger/hledger-lib/test/doctests.hs, interpreted )
Ok, one module added.
Loaded GHCi configuration from /home/timi/.cache/stack/ghci-script/0d005671/ghci-script
hledger-lib> Leaving GHCi.
=== ghci-echo
stack exec -- ghci -rtsopts -Wall -Wno-incomplete-uni-patterns -Wno-missing-signatures -Wno-orphans -Wno-type-defaults -Wno-unused-do-bind -DDEVELOPMENT -DVERSION="1.51.2.99" -ihledger-lib -ihledger -ihledger-ui -ihledger-web -ihledger-web/app hledger/Hledger/Cli.hs
=== ghci-prof
=== ghci-shake
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/timi/hledger/.ghci
[1 of 2] Compiling Main             ( Shake.hs, interpreted )
Ok, one module loaded.
ghci> Leaving GHCi.
=== ghci-ui
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/timi/hledger/.ghci
[  1 of 122] Compiling Hledger.Data.Currency ( hledger-lib/Hledger/Data/Currency.hs, interpreted )
[  2 of 122] Compiling Hledger.UI.Theme ( hledger-ui/Hledger/UI/Theme.hs, interpreted )
hledger-ui/Hledger/UI/Theme.hs:22:1: error: [GHC-87110]
    Could not find module ‘Graphics.Vty’.
    Use :set -v to see a list of the files searched for.
   |
22 | import Graphics.Vty
   | ^^^^^^^^^^^^^^^^^^^

hledger-ui/Hledger/UI/Theme.hs:23:1: error: [GHC-87110]
    Could not find module ‘Brick’.
    Use :set -v to see a list of the files searched for.
   |
23 | import Brick
   | ^^^^^^^^^^^^
[...]
[106 of 122] Compiling Hledger.Cli      ( hledger/Hledger/Cli.hs, interpreted )
Failed, 105 modules loaded.
ghci> Leaving GHCi.
=== ghci-web
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/timi/hledger/.ghci
Failed, unloaded all modules.
ghci> Leaving GHCi.
=== ghci-web-test
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/timi/hledger/.ghci
Failed, unloaded all modules.
ghci> Leaving GHCi.
=== ghrel-notes
You are currently on ibizaman/master branch. Please switch to the latest release branch.
=== ghrel-open
=== ghrel-upload
You are currently on ibizaman/master branch. Please switch to the latest release branch.
=== ghrun-open
=== ghworkflows-open
=== google-search-console
=== hackageupload
hackageupload: in heads/ibizaman/master branch, please upload from the latest release branch.
Perhaps: git switch 
=== haddock
=== haddock-and-open
=== haddock-open
=== haddocktest
haddocktest PASSED
=== heap
building bin/hledgerprof...
=== hledgerprof
building bin/hledgerprof...
=== hlinttest
=== installallas
=== installallasdbg
bin/hledger-dbg
bin/hledger-ui-dbg
bin/hledger-web-dbg
=== installas
=== installasdbg
bin/hledger-dbg
=== installcommithook
=== installrel
=== installtest
=== log-headtail
...
=== log-push
```

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
