### PR TITLE
imp: support zed & sublime edit file at position

### DIFF
--- a/hledger-ui/Hledger/UI/Editor.hs
+++ b/hledger-ui/Hledger/UI/Editor.hs
@@ -81,6 +81,11 @@ runEditor mpos f = editFileAtPositionCommand mpos f >>= runCommand >>= waitForPr
 -- vi & variants    Just (line, _)        vi +LINE FILE
 --                  Just ('-' : _, _)     vi +     FILE
 --                  Nothing               vi       FILE
+-- 
+-- zed & sublime    Just (line, Just col) zed FILE:LINE:COL
+--                  Just (line, Nothing)  zed FILE:LINE
+--                  Just ('-' : _, _)     zed FILE
+--                  Nothing               zed FILE
 --
 -- (other PROG)     _                     PROG FILE
 --
@@ -125,6 +130,10 @@ editFileAtPositionCommand mpos f = do
           Nothing -> [f']
           Just ('-' : _, _) -> [f']
           Just (l, _) -> ['+' : l, f']
+        e | e `elem` ["zed", "subl"] -> case mpos' of
+          Nothing -> [f']
+          Just ('-' : _, _) -> [f']
+          Just (l, mc) -> [join ':' [Just f', Just l, mc]]
         _ -> [f']
   return $ unwords $ cmd:args
 
@@ -142,4 +151,3 @@ getEditCommand = do
   let defaultEditor = Just $ if os == "mingw32" then "notepad.exe" else "emacsclient -a '' -nw"
   let Just cmd = hledger_ui_editor_env <|> editor_env <|> defaultEditor
   return cmd
-


### PR DESCRIPTION
This adds support for opening a file from the UI at the right position if one is using Zed or Sublime Text.

I didn't see a mention about this in other parts of the documentation so I haven't added anything extra in the docs.

<!--
Thanks for your pull request! We appreciate it. 
If you're a new developer, FOSS contributor, or hledger contributor, welcome.

Much of our best design work and knowledge sharing happens during code review,
so be prepared for more work ahead, especially if your PR is large.
To minimise waste, and get your hledger PRs accepted quickly,
please check the guidelines in the developer docs:

https://hledger.org/PULLREQUESTS.html
https://hledger.org/COMMITS.html

You don't need to master our commit conventions, but do add at least one prefix and colon
to the commit message summary. The most common prefixes are:

- feat: for user-visible features
- fix:  for user-visible fixes
- imp:  for user-visible improvements
- ;doc:  for documentation improvements  (; at the start enables quicker/cheaper CI tests)
- dev:  for internal improvements

-->
