### PR TITLE
Widen balance amount column for long commodity names

### DIFF
--- a/hledger/Hledger/Cli/Commands/Balance.hs
+++ b/hledger/Hledger/Cli/Commands/Balance.hs
@@ -491,23 +491,55 @@ balanceReportAsCsv opts =
 
 -- | Render a single-column balance report as plain text.
 balanceReportAsText :: ReportOpts -> BalanceReport -> TB.Builder
-balanceReportAsText opts ((items, total)) = case layout_ opts of
+balanceReportAsText originalopts report@((items, total)) = case layout_ originalopts of
     LayoutBare | iscustom -> error' "Custom format not supported with commodity columns"  -- PARTIAL:
-    LayoutBare -> bareLayoutBalanceReportAsText opts ((items, total))
+    LayoutBare -> bareLayoutBalanceReportAsText originalopts report
     _ -> unlinesB ls <> unlinesB (if no_total_ opts then [] else [overline, totalLines])
   where
+    opts = widenDefaultBalanceLineFormat originalopts report
     (ls, sizes) = unzip $ map (balanceReportItemAsText opts) items
     -- abuse renderBalanceReportItem to render the total with similar format
-    (totalLines, _) = renderBalanceReportItem opts ("",0,total)
+    (totalLines, _totalSizes) = renderBalanceReportItem opts ("",0,total)
     -- with a custom format, extend the line to the full report width;
-    -- otherwise show the usual 20-char line for compatibility
-    iscustom = case format_ opts of
+    -- otherwise show the amount column's width.
+    iscustom = case format_ originalopts of
         OneLine       ((FormatField _ _ _ TotalField):_) -> False
         TopAligned    ((FormatField _ _ _ TotalField):_) -> False
         BottomAligned ((FormatField _ _ _ TotalField):_) -> False
         _ -> True
-    overlinewidth = if iscustom then sum (map maximum' $ transpose sizes) else 20
+    isdefault = format_ originalopts == defaultBalanceLineFormat
+    overlinewidth
+      | iscustom  = sum (map maximum' $ transpose sizes)
+      | isdefault = defaultBalanceAmountColumnWidth originalopts report
+      | otherwise = 20
     overline   = TB.fromText $ T.replicate overlinewidth "-"
+
+-- | The default balance format historically used a 20-character amount
+-- column. Keep that as the minimum, but widen it when any rendered amount
+-- needs more room.
+widenDefaultBalanceLineFormat :: ReportOpts -> BalanceReport -> ReportOpts
+widenDefaultBalanceLineFormat opts report
+  | format_ opts == defaultBalanceLineFormat = opts{format_ = setTotalMinWidth amountwidth defaultBalanceLineFormat}
+  | otherwise = opts
+  where
+    amountwidth = defaultBalanceAmountColumnWidth opts report
+    setTotalMinWidth w (BottomAligned (FormatField l _ m TotalField : rest)) =
+      BottomAligned (FormatField l (Just w) m TotalField : rest)
+    setTotalMinWidth _ fmt = fmt
+
+defaultBalanceAmountColumnWidth :: ReportOpts -> BalanceReport -> Int
+defaultBalanceAmountColumnWidth opts ((items, total)) =
+    maximum' $ 20 : map renderedAmountWidth visibleAmounts
+  where
+    visibleAmounts =
+      map (\(_,_,_,amt) -> amt) items ++
+      [total | not (no_total_ opts)]
+    renderedAmountWidth =
+      wbWidth . showMixedAmountB noCostFmt
+        { displayCommodity = layout_ opts /= LayoutBare
+        , displayMinWidth = Just 0
+        , displayColour = False
+        }
 
 -- | Render a single-column balance report as plain text with a separate commodity column (--layout=bare)
 bareLayoutBalanceReportAsText :: ReportOpts -> BalanceReport -> TB.Builder

--- a/hledger/Hledger/Cli/Commands/Balance.md
+++ b/hledger/Hledger/Cli/Commands/Balance.md
@@ -245,7 +245,7 @@ Some example formats:
 - `%(total)`         - the account's total
 - `%-20.20(account)` - the account's name, left justified, padded to 20 characters and clipped at 20 characters
 - `%,%-50(account)  %25(total)` - account name padded to 50 characters, total padded to 20 characters, with multiple commodities rendered on one line
-- `%20(total)  %2(depth_spacer)%-(account)` - the default format for the single-column balance report
+- `%20(total)  %2(depth_spacer)%-(account)` - the default format for the single-column balance report. The total field keeps this 20-character width as a minimum, but widens automatically when displayed amounts need more room.
 
 [valuation]: #valuation
 [valuation date(s)]: #valuation-date

--- a/hledger/test/balance/1148.test
+++ b/hledger/test/balance/1148.test
@@ -1,0 +1,25 @@
+# * balance: long commodity names widen the default amount column (#1148)
+
+<
+2024-01-01
+  assets:short     1 "short"
+  equity:opening
+
+2024-01-02
+  assets:long      1 "a very very long commodity"
+  equity:opening
+$ hledger -f- balance assets --flat --no-total
+1 "a very very long commodity"  assets:long
+                       1 short  assets:short
+
+# Wide quantities also widen the default amount column.
+
+<
+2024-01-01
+  assets:big       12345678901234567890.00 USD
+  assets:small     1.00 USD
+  equity:opening
+$ hledger -f- balance --no-total
+ 12345678901234567890.00 USD  assets:big
+                    1.00 USD  assets:small
+-12345678901234567891.00 USD  equity:opening

--- a/hledger/test/balance/bcexample.test
+++ b/hledger/test/balance/bcexample.test
@@ -10,14 +10,14 @@ $ hledger -f bcexample.journal bal -t -1 --color=always
 309.950000000000 VBMPX
              36.00 VEA
             294.00 VHT  Assets
-        [31m-2891.85 USD[m  Liabilities
-        [31m-3077.70 USD[m  Equity
-    [31m-52000.00 IRAUSD[m
-      [31m-365071.44 USD[m
-       [31m-337.26 VACHR[m  Income
-     52000.00 IRAUSD
-       260911.70 USD  Expenses
---------------------
+          [31m-2891.85 USD[m  Liabilities
+          [31m-3077.70 USD[m  Equity
+      [31m-52000.00 IRAUSD[m
+        [31m-365071.44 USD[m
+         [31m-337.26 VACHR[m  Income
+       52000.00 IRAUSD
+         260911.70 USD  Expenses
+----------------------
              70.00 GLD
             17.00 ITOT
 489.957000000000 RGAGX

--- a/hledger/test/journal/precision.test
+++ b/hledger/test/journal/precision.test
@@ -217,7 +217,7 @@ $ hledger -f - bal -N
 $ hledger -f - bal -N
 811.210000000000000000000000000 CNY
                         -113.50 USD  a
-0.000000000000000000000000018 CNY  z
+  0.000000000000000000000000018 CNY  z
 
 # ** 16. Before hledger 1.50, an inexactly balanced entry like this could be accepted,
 # because of a commodity directive reducing the display/balance-checking precision.
@@ -269,4 +269,3 @@ $ hledger -f - check --txn-balancing=old
 $ hledger -f - reg cur:USD
 2025-01-01                      a                        1.000 USD     1.000 USD
                                 z                       -2.000 USD    -1.000 USD
-


### PR DESCRIPTION
Fixes #1148.

## Summary
- widen the default single-column balance amount field to the widest visible rendered amount
- keep the historic 20-character minimum for ordinary reports
- add a shell regression for long quoted commodity names in flat balance output

## Tests
- `stack build hledger:exe:hledger`
- `stack exec -- shelltest --execdir --hide hledger/test/balance/1148.test`
- `stack exec -- shelltest --execdir --hide hledger/test/balance/1148.test hledger/test/balance/layout.test hledger/test/balance/balance.test`