### PR TITLE
Add pipe fallback syntax for pivot components

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1447,7 +1447,11 @@ pivotAccount fieldortagname p =
 -- Pivoting on a tag when there are multiple values for that tag, returns the first value.
 -- Pivoting on the "type" tag normalises type values to their short spelling.
 pivotComponent :: Text -> Posting -> Text
-pivotComponent fieldortagname p
+pivotComponent fieldortagname p =
+  firstNonEmpty $ map (`pivotComponentSingle` p) $ T.splitOn "|" fieldortagname
+
+pivotComponentSingle :: Text -> Posting -> Text
+pivotComponentSingle fieldortagname p
   | fieldortagname == "code",        Just t <- ptransaction p = tcode t
   | fieldortagname `elem` descnames, Just t <- ptransaction p = tdescription t
   | fieldortagname == "payee",       Just t <- ptransaction p = transactionPayee t
@@ -1466,6 +1470,12 @@ pivotComponent fieldortagname p
     descnames = ["desc", "description"]   -- allow "description" for hledger <=1.30 compat
     commnames = ["cur","comm"]            -- allow either; cur is the query prefix, comm is more consistent
     unknown   = ""
+
+firstNonEmpty :: [Text] -> Text
+firstNonEmpty [] = ""
+firstNonEmpty (x:xs)
+  | T.null x = firstNonEmpty xs
+  | otherwise = x
 
 postingFindTag :: TagName -> Posting -> Maybe (TagName, TagValue)
 postingFindTag tagname p = find ((tagname==) . fst) $ postingAllTags p

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -5968,6 +5968,7 @@ PIVOTEXPR can be
 - any of these standard transaction or posting fields (their value is substituted): `status`, `code`, `desc`, `payee`, `note`, `acct`, `comm`/`cur`, `amt`, `cost`
 - or a tag name
 - or any combination of these, colon-separated.
+- within each colon-separated component, multiple field or tag names can be tried left-to-right with `|`, taking the first non-empty value.
 
 Some special cases:
 

--- a/hledger/test/pivot.test
+++ b/hledger/test/pivot.test
@@ -130,7 +130,17 @@ $ hledger -f- --pivot acct:kind:project bal ^expense -N
                   20  expenses:equipment:job2
                   25  expenses:fee:job2
 
-# ** 12. Pivot on the commodity symbol with "comm".
+# ** 12. fallback to another value with "|"
+<
+2024/01/01 Lunch
+    assets:bank account             30 USD
+    expenses:food                  -30 USD  ; mynotes: receipt
+$ hledger -f- --pivot mynotes|desc print
+2024-01-01 Lunch
+    receipt                                      30 USD
+    Lunch                                       -30 USD
+
+# ** 13. Pivot on the commodity symbol with "comm".
 <
 2025-01-01
     expenses   1 A
@@ -147,7 +157,7 @@ Balance changes in 2025:
 ---++----------
    || 1 A, 2 B 
 
-# ** 13. "cur" is accepted as a synonym. Postings with multiple commodities currently are lumped in the "" bucket, not pivoted fully.
+# ** 14. "cur" is accepted as a synonym. Postings with multiple commodities currently are lumped in the "" bucket, not pivoted fully.
 $ hledger -f- bal -Y assets --pivot=cur
 Balance changes in 2025:
 
@@ -157,7 +167,7 @@ Balance changes in 2025:
 --++------------
   || -1 A, -2 B 
 
-# ** 14. When commodities are being converted, the original commodity is shown.
+# ** 15. When commodities are being converted, the original commodity is shown.
 <
 2025-01-01
     expenses   1 A @ $10
@@ -174,7 +184,7 @@ Balance changes in 2025, converted to cost:
 ---++------
    || $210 
 
-# ** 15. The "" bucket looks a bit strange in this case..
+# ** 16. The "" bucket looks a bit strange in this case..
 $ hledger -f- bal -Y assets --pivot=comm -B
 Balance changes in 2025, converted to cost:
 
@@ -184,7 +194,7 @@ Balance changes in 2025, converted to cost:
 ---++-------
    || $-210 
 
-# ** 16. Pivot on amount.
+# ** 17. Pivot on amount.
 $ hledger -f- bal -Y --pivot=amt
 Balance changes in 2025:
 
@@ -196,7 +206,7 @@ Balance changes in 2025:
 ------++-----------------
       || $-210, 1 A, 2 B 
 
-# ** 17. Pivot on cost.
+# ** 18. Pivot on cost.
 $ hledger -f- bal -Y --pivot=cost
 Balance changes in 2025:
 


### PR DESCRIPTION
/claim #1640

This extends --pivot so each colon-separated component can try multiple field/tag names left-to-right with |, returning the first non-empty value. The existing colon-delimited composition from #2050 stays intact; this only adds the missing fallback behavior from the original issue proposal.

Validation:
- git diff --check
- static review of the changed pivot code and regression test (no Haskell toolchain is installed in this environment)