### PR TITLE
Support plus-joined pivot components

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -1441,13 +1441,22 @@ pivotAccount :: Text -> Posting -> Text
 pivotAccount fieldortagname p =
   T.intercalate ":" [pivotComponent x p | x <- T.splitOn ":" fieldortagname]
 
+-- | Resolve one colon-delimited pivot component. A component may contain
+-- plus-delimited fields/tags, whose non-empty values are joined with spaces.
+pivotComponent :: Text -> Posting -> Text
+pivotComponent fieldortagname p
+  | [_] <- fields = pivotFieldOrTag fieldortagname p
+  | otherwise     = T.intercalate " " . filter (not . T.null) $ map (`pivotFieldOrTag` p) fields
+  where
+    fields = T.splitOn "+" fieldortagname
+
 -- | Get the value of the given field or tag for this posting.
 -- "comm" and "cur" are accepted as synonyms meaning the commodity symbol.
 -- Pivoting on an unknown field or tag, or on commodity when there are multiple commodities, returns "".
 -- Pivoting on a tag when there are multiple values for that tag, returns the first value.
 -- Pivoting on the "type" tag normalises type values to their short spelling.
-pivotComponent :: Text -> Posting -> Text
-pivotComponent fieldortagname p
+pivotFieldOrTag :: Text -> Posting -> Text
+pivotFieldOrTag fieldortagname p
   | fieldortagname == "code",        Just t <- ptransaction p = tcode t
   | fieldortagname `elem` descnames, Just t <- ptransaction p = tdescription t
   | fieldortagname == "payee",       Just t <- ptransaction p = transactionPayee t

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -7614,6 +7614,10 @@ substituted): \f[CR]status\f[R], \f[CR]code\f[R], \f[CR]desc\f[R],
 or a tag name
 .IP \(bu 2
 or any combination of these, colon\-separated.
+.IP \(bu 2
+within each colon\-separated component, multiple fields or tags can be
+joined with \f[CR]+\f[R]; their non\-empty values are concatenated with
+spaces.
 .PP
 Some special cases:
 .IP \(bu 2
@@ -7682,6 +7686,16 @@ Hierarchical reports can be generated with multiple pivot values:
 .EX
 $ hledger balance Income:Dues \-\-pivot kind:member
               \-2 EUR  Lifetime:John Doe
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+              \-2 EUR
+.EE
+.PP
+Multiple pivot values can also be shown in the same hierarchy level by
+joining them with \f[CR]+\f[R]:
+.IP
+.EX
+$ hledger balance Income:Dues \-\-pivot kind+member
+              \-2 EUR  Lifetime John Doe
 \-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
               \-2 EUR
 .EE

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -7387,6 +7387,9 @@ grouping and display.  PIVOTEXPR can be
      'comm'/'cur', 'amt', 'cost'
    * or a tag name
    * or any combination of these, colon-separated.
+   * within each colon-separated component, multiple fields or tags can
+     be joined with '+'.  Their non-empty values are concatenated with
+     spaces.
 
    Some special cases:
 
@@ -7441,6 +7444,14 @@ $ hledger balance --pivot member acct:.
 
 $ hledger balance Income:Dues --pivot kind:member
               -2 EUR  Lifetime:John Doe
+--------------------
+              -2 EUR
+
+   Multiple pivot values can also be shown in the same hierarchy level by
+joining them with '+':
+
+$ hledger balance Income:Dues --pivot kind+member
+              -2 EUR  Lifetime John Doe
 --------------------
               -2 EUR
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -5968,6 +5968,7 @@ PIVOTEXPR can be
 - any of these standard transaction or posting fields (their value is substituted): `status`, `code`, `desc`, `payee`, `note`, `acct`, `comm`/`cur`, `amt`, `cost`
 - or a tag name
 - or any combination of these, colon-separated.
+- within each colon-separated component, multiple fields or tags can be joined with `+`; their non-empty values are concatenated with spaces.
 
 Some special cases:
 
@@ -6018,6 +6019,13 @@ Hierarchical reports can be generated with multiple pivot values:
 ```cli
 $ hledger balance Income:Dues --pivot kind:member
               -2 EUR  Lifetime:John Doe
+--------------------
+              -2 EUR
+```
+Multiple pivot values can also be shown in the same hierarchy level by joining them with `+`:
+```cli
+$ hledger balance Income:Dues --pivot kind+member
+              -2 EUR  Lifetime John Doe
 --------------------
               -2 EUR
 ```

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -5743,6 +5743,9 @@ Pivoting
 
      * or any combination of these, colon-separated.
 
+     * within each colon-separated component, multiple fields or tags  can  be
+       joined with +; their non-empty values are concatenated with spaces.
+
      Some special cases:
 
      * Colons appearing in PIVOTEXPR or in a pivoted tag value will generate ac-
@@ -5796,6 +5799,14 @@ Pivoting
 
             $ hledger balance Income:Dues --pivot kind:member
                           -2 EUR  Lifetime:John Doe
+            --------------------
+                          -2 EUR
+
+     Multiple pivot values can also be shown in the same hierarchy level by
+     joining them with +:
+
+            $ hledger balance Income:Dues --pivot kind+member
+                          -2 EUR  Lifetime John Doe
             --------------------
                           -2 EUR
 

--- a/hledger/test/pivot.test
+++ b/hledger/test/pivot.test
@@ -130,6 +130,18 @@ $ hledger -f- --pivot acct:kind:project bal ^expense -N
                   20  expenses:equipment:job2
                   25  expenses:fee:job2
 
+# ** 11b. pivot on multiple tags joined with spaces
+<
+2023-01-01 compound purchase
+        expenses  10 ; project: job1, kind: equipment
+        expenses  20 ; project: job2
+        expenses  25 ; kind: fee
+        assets
+$ hledger -f- --pivot kind+project bal ^expense -N
+                  10  equipment job1
+                  25  fee
+                  20  job2
+
 # ** 12. Pivot on the commodity symbol with "comm".
 <
 2025-01-01


### PR DESCRIPTION
Refs #1640.

This implements the non-duplicative `+` portion of the pivot enhancement proposal: within each existing colon-delimited pivot component, `TAG1+TAG2+...` resolves each field/tag, drops empty values, and joins the remaining values with spaces. Colon composition continues to work as before, so expressions can mix hierarchy and same-level labels.

Changes:
- add plus-joined pivot component resolution in `pivotComponent`
- add a regression case for `--pivot kind+project`
- update the manual source plus generated text/man/info outputs

Verification:
- `git diff --check`

I could not run the Haskell test suite locally in this environment because no `ghc`/`stack`/`cabal` toolchain is installed and the local Docker daemon is not running.
