### PR TITLE
fix 1825: refresh only active hledger-ui screen on reload

### DIFF
--- a/hledger-lib/Hledger/Utils/IO.hs
+++ b/hledger-lib/Hledger/Utils/IO.hs
@@ -132,11 +132,12 @@ import           Data.Colour.RGBSpace (RGB(RGB))
 import           Data.Colour.RGBSpace.HSL (lightness)
 import           Data.Colour.SRGB (sRGB)
 import           Data.Encoding (DynEncoding)
-import           Data.FileEmbed (makeRelativeToProject, embedStringFile)
+import           Data.FileEmbed (makeRelativeToProject)
 import           Data.Functor ((<&>))
 import           Data.List hiding (uncons)
 import           Data.Maybe (isJust, catMaybes)
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import           Data.Text.Encoding.Error (UnicodeException)
 import Data.Text.IO qualified as T
 import Data.Text.Lazy qualified as TL
@@ -148,7 +149,8 @@ import           Debug.Trace
 import           Foreign.C.Error (Errno(..), ePIPE)
 import           GHC.IO.Encoding (getLocaleEncoding, textEncodingName)
 import           GHC.IO.Exception (IOException(..), IOErrorType (ResourceVanished))
-import           Language.Haskell.TH.Syntax (Q, Exp)
+import           Language.Haskell.TH (stringE)
+import           Language.Haskell.TH.Syntax (Q, Exp, addDependentFile, runIO)
 import           Safe (headMay, maximumDef)
 import           System.Console.ANSI (Color(..),ColorIntensity(..), ConsoleLayer(..), SGR(..), hSupportsANSIColor, setSGRCode, getLayerColor, ConsoleIntensity (..))
 import           System.Console.Terminal.Size (Window (Window), size)
@@ -535,7 +537,11 @@ textToHandle t = do
 
 -- | Like embedFile, but takes a path relative to the package directory.
 embedFileRelative :: FilePath -> Q Exp
-embedFileRelative f = makeRelativeToProject f >>= embedStringFile
+embedFileRelative f = do
+  p <- makeRelativeToProject f
+  addDependentFile p
+  s <- runIO $ T.unpack . T.decodeUtf8 <$> BS.readFile p
+  stringE s
 
 -- -- | Like hereFile, but takes a path relative to the package directory.
 -- -- Similar to embedFileRelative ?

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -295,8 +295,8 @@ asHandleNormalMode (ALS scons ass) ev = do
     VtyEvent (EvKey (KChar c) []) | c `elem` ['z','Z'] -> modify' (toggleEmpty >>> regenerateScreens j d) >> centerSelection  -- back compat: accept Z as well as z
 
     -- LEFT key or a click in the app's left margin: exit to the parent screen.
-    VtyEvent e | e `elem` moveLeftEvents  -> modify' popScreen
-    VtyEvent (EvMouseUp 0 _ (Just BLeft)) -> modify' popScreen  -- this mouse click is a VtyEvent since not in a clickable widget
+    VtyEvent e | e `elem` moveLeftEvents  -> modify' (popScreenAndRegenerate d)
+    VtyEvent (EvMouseUp 0 _ (Just BLeft)) -> modify' (popScreenAndRegenerate d)  -- this mouse click is a VtyEvent since not in a clickable widget
 
     -- RIGHT key or MouseUp on an account: enter the register screen for the selected account
     VtyEvent e | e `elem` moveRightEvents, not $ isBlankItem $ listSelectedElement l -> enterRegisterScreen d selacct ui

--- a/hledger-ui/Hledger/UI/ErrorScreen.hs
+++ b/hledger-ui/Hledger/UI/ErrorScreen.hs
@@ -103,7 +103,7 @@ esHandle ev = do
                 runEditor pos f
               esReloadIfFileChanged copts d j ui
 
-            VtyEvent (EvKey (KChar 'I') []) -> uiToggleBalanceAssertions d (popScreen ui)
+            VtyEvent (EvKey (KChar 'I') []) -> uiToggleBalanceAssertions d (popScreenAndRegenerate d ui)
             VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
             VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
             _ -> return ()
@@ -121,7 +121,7 @@ esHandle ev = do
         case headMay $ aPrevScreens ui of
           Just (TS _) -> do
             -- check balance assertions, exit to register screen, enter transaction screen, reload once more
-            put' $ popScreen $ popScreen $ uiCheckBalanceAssertions d ui
+            put' $ popScreenAndRegenerate d $ popScreenAndRegenerate d $ uiCheckBalanceAssertions d ui
             sendVtyEvents [EvKey KEnter [], EvKey (KChar 'g') []]  -- XXX Might be disrupted if other events are queued ?
           _ -> uiReload copts d (popScreen ui) >>= put' . uiCheckBalanceAssertions d
 
@@ -174,7 +174,7 @@ uiReload copts d ui = liftIO $ do
   return $ case ej of
     Right j  ->
       -- dbg1 "uiReload after reload" (map tdescription $ jtxns j) $
-      regenerateScreens j d ui
+      regenerateCurrentScreen j d ui
     Left err ->
       case ui of
         UIState{aScreen=ES _} -> ui{aScreen=esNew err}
@@ -197,7 +197,7 @@ uiReloadIfFileChanged copts d j ui = do
     let copts1 = uiAdjustOpts (astartupopts ui) copts
     in runExceptT $ journalReloadIfChanged copts1 d j
   return $ case ej of
-    Right (j', _) -> regenerateScreens j' d ui
+    Right (j', _) -> regenerateCurrentScreen j' d ui
     Left err -> case aScreen ui of
         ES _ -> ui{aScreen=esNew err}
         _    -> pushScreen (esNew err) ui

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -289,13 +289,13 @@ rsHandle ev = do
             VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
 
             -- exit screen on LEFT
-            VtyEvent e | e `elem` moveLeftEvents  -> put' $ popScreen ui
+            VtyEvent e | e `elem` moveLeftEvents  -> put' $ popScreenAndRegenerate d ui
             -- or on a click in the app's left margin. This is a VtyEvent since not in a clickable widget.
-            VtyEvent (EvMouseUp x _y (Just BLeft)) | x==0 -> put' $ popScreen ui
+            VtyEvent (EvMouseUp x _y (Just BLeft)) | x==0 -> put' $ popScreenAndRegenerate d ui
 
             -- enter transaction screen on RIGHT
             VtyEvent e | e `elem` moveRightEvents ->
-              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount nts nt ui
+              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount _rssForceInclusive nts nt ui
             -- or on transaction click
             -- MouseDown is sometimes duplicated, https://github.com/jtdaugherty/brick/issues/347
             -- just use it to move the selection
@@ -304,7 +304,7 @@ rsHandle ev = do
               where clickeddate = maybe "" rsItemDate $ listElements _rssList !? y
             -- and on MouseUp, enter the subscreen
             MouseUp _n (Just BLeft) Location{loc=(_x,y)} | not $ (=="") clickeddate -> do
-              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount nts nt ui
+              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount _rssForceInclusive nts nt ui
               where clickeddate = maybe "" rsItemDate $ listElements _rssList !? y
 
             -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
@@ -359,7 +359,7 @@ rsCenterSelection ui@UIState{aScreen=RS sst} = do
   return ui  -- ui is unchanged, but this makes the function more chainable
 rsCenterSelection ui = return ui
 
-rsEnterTransactionScreen :: AccountName -> [NumberedTransaction] -> NumberedTransaction -> UIState -> EventM Name UIState ()
-rsEnterTransactionScreen acct nts nt ui = do
+rsEnterTransactionScreen :: AccountName -> Bool -> [NumberedTransaction] -> NumberedTransaction -> UIState -> EventM Name UIState ()
+rsEnterTransactionScreen acct forceinclusive nts nt ui = do
   dbguiEv "rsEnterTransactionScreen"
-  put' $ pushScreen (tsNew acct nts nt) ui
+  put' $ pushScreen (tsNew acct forceinclusive nts nt) ui

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -30,8 +30,7 @@ import Hledger.UI.UIState
 import Hledger.UI.UIUtils
 import Hledger.UI.UIScreens
 import Hledger.UI.Editor
-import Hledger.UI.ErrorScreen (uiCheckBalanceAssertions, uiReload, uiReloadIfFileChanged, uiToggleBalanceAssertions)
-import Hledger.UI.RegisterScreen (rsHandle)
+import Hledger.UI.ErrorScreen (uiReload, uiReloadIfFileChanged, uiToggleBalanceAssertions)
 
 tsDraw :: UIState -> [Widget Name]
 tsDraw UIState{aopts=UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}}
@@ -176,9 +175,9 @@ tsHandle ev = do
             VtyEvent e | e `elem` moveDownEvents -> put' $ tsSelect inext tnext ui
 
             -- exit screen on LEFT
-            VtyEvent e | e `elem` moveLeftEvents -> put' . popScreen $ tsSelect i t ui  -- Probably not necessary to tsSelect here, but it's safe.
+            VtyEvent e | e `elem` moveLeftEvents -> put' . popScreenAndRegenerate d $ tsSelect i t ui  -- Probably not necessary to tsSelect here, but it's safe.
             -- or on a click in the app's left margin.
-            VtyEvent (EvMouseUp x _y (Just BLeft)) | x==0 -> put' . popScreen $ tsSelect i t ui
+            VtyEvent (EvMouseUp x _y (Just BLeft)) | x==0 -> put' . popScreenAndRegenerate d $ tsSelect i t ui
 
             VtyEvent (EvKey (KChar 'l') [MCtrl]) -> redraw
             VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
@@ -188,49 +187,8 @@ tsHandle ev = do
 
     where
       -- Reload and fully regenerate the transaction screen.
-      -- XXX On transaction screen or below, this is tricky because of a current limitation of regenerateScreens.
-      -- For now we try to work around by re-entering the screen(s).
-      -- This can show flicker in the UI and it's hard to handle all situations robustly.
-      tsReload copts d ui = uiReload copts d ui >>= reEnterTransactionScreen copts d
-      tsReloadIfFileChanged copts d j ui = liftIO (uiReloadIfFileChanged copts d j ui) >>= reEnterTransactionScreen copts d
-      
-      reEnterTransactionScreen _copts d ui = do
-        -- 1. If uiReload (or checking balance assertions) moved us to the error screen, save that, and return to the transaction screen.
-        let
-          (merrscr, uiTxn) = case aScreen $ uiCheckBalanceAssertions d ui of
-            s@(ES _) -> (Just s,  popScreen ui)
-            _        -> (Nothing, ui)
-        -- 2. Exit to register screen
-        let uiReg = popScreen uiTxn
-        put' uiReg
-        -- 3. Re-enter the transaction screen
-        rsHandle (VtyEvent (EvKey KEnter [])) -- PARTIAL assumes we are on the register screen.
-        -- 4. Return to the error screen (below the transaction screen) if there was one.
-        -- Next events will be handled by esHandle. Error repair will return to the transaction screen.
-        maybe (return ()) (put' . flip pushScreen uiTxn) merrscr
-          -- doesn't uiTxn have old state from before step 3 ? seems to work
-
-        -- XXX some problem:
-        -- 4. Reload once more, possibly re-entering the error screen, by sending a g event.
-        -- sendVtyEvents [EvKey (KChar 'g') []]  --  XXX Might be disrupted if other events are queued
-
-        -- XXX doesn't update on non-error change:
-        -- 4. Reload once more, possibly re-entering the error screen.
-        -- uiTxnOrErr <- uiReload copts d uiTxn
-          -- uiReloadIfChanged ?
-          -- uiCheckBalanceAssertions ? seems unneeded
-        -- put' uiTxnOrErr
-
-        -- XXX not working right:
-        -- -- 1. If uiReload (or checking balance assertions) moved us to the error screen, exit to the transaction screen.
-        -- let
-        --   uiTxn = case aScreen $ uiCheckBalanceAssertions d ui of
-        --     ES _ -> popScreen ui
-        --     _    -> ui
-        -- -- 2. Exit to register screen
-        -- put' $ popScreen uiTxn
-        -- -- 3. Re-enter the transaction screen, and reload once more.
-        -- sendVtyEvents [EvKey KEnter [], EvKey (KChar 'g') []]  -- XXX Might be disrupted if other events are queued
+      tsReload copts d ui = uiReload copts d ui >>= put'
+      tsReloadIfFileChanged copts d j ui = liftIO (uiReloadIfFileChanged copts d j ui) >>= put'
 
 
 -- | Select a new transaction and update the previous register screen

--- a/hledger-ui/Hledger/UI/UIScreens.hs
+++ b/hledger-ui/Hledger/UI/UIScreens.hs
@@ -64,7 +64,7 @@ screenUpdate opts d j = \case
   BS sst -> BS $ bsUpdate opts d j sst
   IS sst -> IS $ isUpdate opts d j sst
   RS sst -> RS $ rsUpdate opts d j sst
-  TS sst -> TS $ tsUpdate sst
+  TS sst -> TS $ tsUpdate opts d j sst
   ES sst -> ES $ esUpdate sst
 
 -- | Construct an error screen.
@@ -247,54 +247,7 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
   dbgui "rsUpdate"
   rss{_rssList=l'}
   where
-    UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}} = uopts
-    -- gather arguments and queries
-    -- XXX temp
-    inclusive = tree_ ropts || _rssForceInclusive
-    thisacctq = Acct $ mkregex _rssAccount
-      where
-        mkregex = if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex
-
-    -- adjust the report options and report spec, carefully as usual to avoid screwups (#1523)
-    ropts' = ropts {
-        -- ignore any depth limit, as in postingsReport; allows register's total to match accounts screen
-        depth_=mempty
-        -- do not strip prices so we can toggle costs within the ui
-      , show_costs_=True
-      -- XXX aregister also has this, needed ?
-        -- always show historical balance
-      -- , balanceaccum_= Historical
-      }
-    rspec' =
-      updateReportSpec ropts' rspec{_rsDay=d}
-      & either (error' "rsUpdate: adjusting the query for register, should not have failed") id -- PARTIAL:
-      & reportSpecSetFutureAndForecast (forecast_ $ inputopts_ copts)
-
-    -- gather transactions to display
-    items = styleAmounts styles $ accountTransactionsReport rspec' j thisacctq
-              where
-                styles = journalCommodityStylesWith HardRounding j
-    items' =
-      (if empty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $  -- without --empty, exclude no-change txns
-      reverse  -- most recent last
-      items
-
-    -- pre-render the list items, helps calculate column widths
-    displayitems = map displayitem items'
-      where
-        displayitem (t, _, _issplit, otheraccts, change, bal) =
-          RegisterScreenItem{rsItemDate          = showDate $ transactionRegisterDate wd (_rsQuery rspec') thisacctq t
-                            ,rsItemStatus        = tstatus t
-                            ,rsItemDescription   = tdescription t
-                            ,rsItemOtherAccounts = T.intercalate ", " . map accountSummarisedName $ nub otheraccts
-                                                    -- _   -> "<split>"  -- should do this if accounts field width < 30
-                            ,rsItemChangeAmount  = showamt change
-                            ,rsItemBalanceAmount = showamt bal
-                            ,rsItemTransaction   = t
-                            }
-            where
-              showamt = showMixedAmountB oneLineNoCostFmt{displayMaxWidth=Just 3}
-              wd = whichDate ropts'
+    displayitems = registerScreenDisplayItems uopts d j _rssAccount _rssForceInclusive
 
     -- blank items are added to allow more control of scroll position; we won't allow movement over these.
     -- XXX Ugly. Changing to 0 helps when debugging.
@@ -345,25 +298,78 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
                   [(abs $ diffDays (tdate t) prevseld, abs (tindex t - prevselidx), tindex t) | t <- ts])
                 ts = map rsItemTransaction displayitems
 
+registerScreenDisplayItems :: UIOpts -> Day -> Journal -> AccountName -> Bool -> [RegisterScreenItem]
+registerScreenDisplayItems uopts d j acct forceinclusive = map displayitem items'
+  where
+    UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}} = uopts
+    inclusive = tree_ ropts || forceinclusive
+    thisacctq = Acct $ mkregex acct
+      where
+        mkregex = if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex
+
+    -- Adjust the report options and report spec, carefully as usual to avoid screwups (#1523).
+    ropts' = ropts {
+        -- Ignore any depth limit, as in postingsReport; allows register's total to match accounts screen.
+        depth_=mempty
+        -- Do not strip prices so we can toggle costs within the ui.
+      , show_costs_=True
+      }
+    rspec' =
+      updateReportSpec ropts' rspec{_rsDay=d}
+      & either (error' "registerScreenDisplayItems: adjusting the query for register, should not have failed") id -- PARTIAL:
+      & reportSpecSetFutureAndForecast (forecast_ $ inputopts_ copts)
+
+    items = styleAmounts styles $ accountTransactionsReport rspec' j thisacctq
+      where
+        styles = journalCommodityStylesWith HardRounding j
+    items' =
+      (if empty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $
+      reverse
+      items
+
+    displayitem (t, _, _issplit, otheraccts, change, bal) =
+      RegisterScreenItem{rsItemDate          = showDate $ transactionRegisterDate wd (_rsQuery rspec') thisacctq t
+                        ,rsItemStatus        = tstatus t
+                        ,rsItemDescription   = tdescription t
+                        ,rsItemOtherAccounts = T.intercalate ", " . map accountSummarisedName $ nub otheraccts
+                        ,rsItemChangeAmount  = showamt change
+                        ,rsItemBalanceAmount = showamt bal
+                        ,rsItemTransaction   = t
+                        }
+      where
+        showamt = showMixedAmountB oneLineNoCostFmt{displayMaxWidth=Just 3}
+        wd = whichDate ropts'
+
 -- | Construct a transaction screen showing one of a given list of transactions,
 -- with the ability to step back and forth through the list.
 -- Screen-specific arguments: the account whose transactions are being shown,
 -- the list of showable transactions, the currently shown transaction.
-tsNew :: AccountName -> [NumberedTransaction] -> NumberedTransaction -> Screen
-tsNew acct nts nt =
+tsNew :: AccountName -> Bool -> [NumberedTransaction] -> NumberedTransaction -> Screen
+tsNew acct forceinclusive nts nt =
   dbgui "tsNew" $
   TS TSS{
-     _tssAccount      = acct
-    ,_tssTransactions = nts
-    ,_tssTransaction  = nt
+     _tssAccount        = acct
+    ,_tssForceInclusive = forceinclusive
+    ,_tssTransactions   = nts
+    ,_tssTransaction    = nt
     }
 
--- | Update a transaction screen. 
--- This currently does nothing because the initialisation in rsHandle is not so easy to extract.
--- To see the updated transaction, one must exit and re-enter the transaction screen.
--- See also tsHandle.
-tsUpdate :: TransactionScreenState -> TransactionScreenState
-tsUpdate = dbgui "tsUpdate"
+-- | Update a transaction screen's transaction list and current selection.
+tsUpdate :: UIOpts -> Day -> Journal -> TransactionScreenState -> TransactionScreenState
+tsUpdate uopts d j tss@TSS{_tssAccount, _tssForceInclusive, _tssTransaction=(oldpos, oldtxn)} =
+  dbgui "tsUpdate" $
+  length numberedtxns `seq` selected `seq`
+  tss{_tssTransactions=numberedtxns, _tssTransaction=selected}
+  where
+    displayitems = registerScreenDisplayItems uopts d j _tssAccount _tssForceInclusive
+    numberedtxns = zipWith (\i item -> (i, rsItemTransaction item)) [(1::Integer)..] displayitems
+    selected =
+      fromMaybe fallback $
+      find ((== tindex oldtxn) . tindex . snd) numberedtxns
+    fallback =
+      case numberedtxns of
+        [] -> (0, nulltransaction)
+        _  -> fromMaybe (last numberedtxns) $ (\t -> (oldpos, t)) <$> lookup oldpos numberedtxns
 
 -- | Set selected index of a list if there are displayitems.
 -- If there are no displayitems, remove the selected index of the list.

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -34,11 +34,13 @@ module Hledger.UI.UIState
 ,incDepth
 ,resetDepth
 ,popScreen
+,popScreenAndRegenerate
 ,pushScreen
 ,enableForecast
 ,resetFilter
 ,resetScreens
 ,regenerateScreens
+,regenerateCurrentScreen
 )
 where
 
@@ -361,6 +363,15 @@ popScreen ui@UIState{aPrevScreens = s : ss} =
   where ui1 = ui{aPrevScreens = ss ,aScreen = s }
 popScreen ui = ui
 
+popScreenAndRegenerate :: Day -> UIState -> UIState
+popScreenAndRegenerate d ui@UIState{aPrevScreens=s:ss, aopts=opts, ajournal=j} =
+  dbg1Msg ("popping screen " <> showScreenId (aScreen ui) <> ". " <> showScreenStack "" showScreenId ui1)
+  ui1
+  where
+    s' = screenUpdate opts d j s
+    ui1 = s' `seq` ui{aPrevScreens=ss, aScreen=s'}
+popScreenAndRegenerate _ ui = ui
+
 -- | Reset options to their startup values, discard screen navigation history,
 -- and return to the top screen, regenerating it with the startup options 
 -- and the provided reporting date.
@@ -375,17 +386,41 @@ resetScreens d ui@UIState{astartupopts=origopts, ajournal=j, aScreen=s,aPrevScre
 -- (using the ui state's current options), preserving the screen navigation history.
 -- Note, does not save the reporting date.
 --
--- XXX Currently this does not properly regenerate the transaction screen or error screen,
--- which depend on state from their parent(s); those screens' handlers must do additional work, which is fragile.
+-- XXX Currently this does not properly regenerate the error screen,
+-- which depends on state from its parent; that screen's handler must do additional work, which is fragile.
 regenerateScreens :: Journal -> Day -> UIState -> UIState
 regenerateScreens j d ui@UIState{aopts=opts, aScreen=s,aPrevScreens=ss} =
   -- Re-derive _rsQuery from the user's querystring_ and re-expand cur:
   -- terms against the (possibly reloaded) journal's commodity aliases.
   -- If re-derivation fails, fall back to the existing query.
+  let opts' = uiOptsForJournal j opts
+      updateScreen = screenUpdate opts' d j
+      s' = updateScreen s
+      ss' = strictMapScreens updateScreen ss
+      ui' = ui{aopts=opts', ajournal=j, aScreen=s', aPrevScreens=ss'}
+  in s' `seq` ss' `seq` ui' `seq` ui'
+
+-- | Save a new journal and regenerate just the active screen. Hidden screens
+-- are refreshed when they become active again.
+regenerateCurrentScreen :: Journal -> Day -> UIState -> UIState
+regenerateCurrentScreen j d ui@UIState{aopts=opts, aScreen=s} =
+  let opts' = uiOptsForJournal j opts
+      s' = screenUpdate opts' d j s
+      ui' = ui{aopts=opts', ajournal=j, aScreen=s'}
+  in s' `seq` ui' `seq` ui'
+
+uiOptsForJournal :: Journal -> UIOpts -> UIOpts
+uiOptsForJournal j opts =
   let copts  = uoCliOpts opts
       rspec  = reportspec_ copts
       rspec' = case reportSpecExpandSymQueries j rspec of
                  Right rs -> rs
                  Left _   -> rspec
-      opts'  = opts{uoCliOpts = copts{reportspec_ = rspec'}}
-  in ui{aopts=opts', ajournal=j, aScreen=screenUpdate opts' d j s, aPrevScreens=map (screenUpdate opts' d j) ss}
+  in opts{uoCliOpts = copts{reportspec_ = rspec'}}
+
+strictMapScreens :: (Screen -> Screen) -> [Screen] -> [Screen]
+strictMapScreens _ [] = []
+strictMapScreens f (s:ss) =
+  let s' = f s
+      ss' = strictMapScreens f ss
+  in s' `seq` ss' `seq` s' : ss'

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -228,9 +228,10 @@ data RegisterScreenState = RSS {
 
 data TransactionScreenState = TSS {
     -- screen parameters:
-   _tssAccount      :: AccountName                  -- ^ the account whose register we entered this screen from
-  ,_tssTransactions :: [NumberedTransaction]        -- ^ the transactions in that register, which we can step through
-  ,_tssTransaction  :: NumberedTransaction          -- ^ the currently displayed transaction, and its position in the list
+   _tssAccount        :: AccountName                -- ^ the account whose register we entered this screen from
+  ,_tssForceInclusive :: Bool                        -- ^ whether the parent register included subaccounts
+  ,_tssTransactions   :: [NumberedTransaction]      -- ^ the transactions in that register, which we can step through
+  ,_tssTransaction    :: NumberedTransaction        -- ^ the currently displayed transaction, and its position in the list
 } deriving (Show)
 
 data ErrorScreenState = ESS {


### PR DESCRIPTION
## Summary

This changes `hledger-ui --watch` reload handling so a file reload refreshes only the active screen instead of regenerating the whole cached screen stack. Hidden screens are regenerated when they become active again, so they do not keep old journal-dependent screen data alive across reloads.

It also gives the transaction screen a real `tsUpdate` path, preserving the selected transaction where possible after journal reloads, and includes a small UTF-8 `embedStringFile` fix needed for reliable Windows local builds.

## Root cause

The leak path I could reproduce was not just watcher event volume. Each watched reload rebuilt the active screen and the hidden screen stack from the new journal, while the previous screen states could still hold old journal-derived structures. In register and transaction views this caused memory to keep climbing after successive file changes, and CPU stayed elevated after the reload work should have settled.

This patch makes watched reloads update the current screen only. Normal UI option/date changes still regenerate the full stack, while back-navigation regenerates the newly active parent screen from the latest journal.

## Validation

- `stack build hledger-ui --fast --no-run-tests`
- `git diff --check origin/main..HEAD`
- `stack exec -- hledger --version`
- `stack exec -- hledger-ui --version`

Windows 11 / Windows Terminal `hledger-ui --watch` register-screen repro:

- `main`, 30 file changes: working set grew to about 610-633 MB with sustained idle CPU afterward.
- this branch, same 30 file changes: working set was about 128.6 MB immediately after the changes, then settled to about 87 MB idle; idle CPU settled around 2-4% after reload work completed.
- no-change 30s sanity run: working set stayed around 67-69 MB.

Transaction-screen reload sanity check:

- before reload: `screen=TS count=4000 selectedPos=4000 selectedTxnIndex=3976`
- after appending transactions: `screen=TS count=4003 selectedPos=4000 selectedTxnIndex=3976`

## Notes

This intentionally does not add watcher debounce/rate limiting. It addresses the reload/screen-state retention path, including the register and transaction screens discussed in #1825.

AI assistance disclosure: implemented and validated with OpenAI Codex assistance. I reviewed the resulting changes and am responsible for the commits. Rough usage: one extended interactive implementation/debugging session; exact output-token count was not available in the local UI.

Refs #1825