### PR TITLE
ui: Fix scrolling past last item

### DIFF
--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -332,8 +332,8 @@ asHandleNormalMode ass ev = do
       else
         put' ui{aScreen=AS ass{_assList=l1}}
 
-    -- DOWN key when selection is at the last item: scroll instead of moving, until maximally scrolled
-    VtyEvent e | e `elem` moveDownEvents, isBlankItem mnextelement -> vScrollBy (viewportScroll $ l^.listNameL) 1
+    -- DOWN key when selection is at the last item: do nothing
+    VtyEvent e | e `elem` moveDownEvents, isBlankItem mnextelement -> return ()
       where mnextelement = listSelectedElement $ listMoveDown l
 
     -- Any other vty event (UP, DOWN, PGUP etc): handle with List's default handler.

--- a/hledger-ui/Hledger/UI/AccountsScreen.hs
+++ b/hledger-ui/Hledger/UI/AccountsScreen.hs
@@ -212,7 +212,7 @@ asHandleNormalMode ass ev = do
   let
     l = _assList ass
     selacct = asSelectedAccount ass
-    centerSelection = scrollSelectionToMiddle l
+    centerSelection = scrollSelectionToMiddle (asListSize l) l
     clickedAcctAt y =
       case asItemAccountName <$> listElements l !? y of
         Just t | not $ T.null t -> Just t
@@ -327,7 +327,7 @@ asHandleNormalMode ass ev = do
       if isBlankItem $ listSelectedElement l1
       then do
         let l2 = listMoveTo lastnonblankidx l1
-        scrollSelectionToMiddle l2
+        scrollSelectionToMiddle (asListSize l2) l2
         put' ui{aScreen=AS ass{_assList=l2}}
       else
         put' ui{aScreen=AS ass{_assList=l1}}

--- a/hledger-ui/Hledger/UI/MenuScreen.hs
+++ b/hledger-ui/Hledger/UI/MenuScreen.hs
@@ -195,7 +195,7 @@ msHandle sst ev = do
             VtyEvent (EvKey (KChar '/') []) -> put' $ regenerateScreens d $ showMinibuffer "filter" Nothing ui
             VtyEvent (EvKey k           []) | k `elem` [KBS, KDel] -> (put' $ regenerateScreens d $ resetFilter ui)
 
-            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle (_mssList sst) >> redraw
+            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle (msListSize $ _mssList sst) (_mssList sst) >> redraw
             VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
 
             -- RIGHT enters selected screen if there is one
@@ -238,7 +238,7 @@ msHandle sst ev = do
               if isBlankElement $ listSelectedElement l
               then do
                 let l' = listMoveTo lastnonblankidx l
-                scrollSelectionToMiddle l'
+                scrollSelectionToMiddle (msListSize l') l'
                 put' ui{aScreen=MS sst{_mssList=l'}}
               else
                 put' ui{aScreen=MS sst{_mssList=l}}

--- a/hledger-ui/Hledger/UI/MenuScreen.hs
+++ b/hledger-ui/Hledger/UI/MenuScreen.hs
@@ -221,9 +221,8 @@ msHandle sst ev = do
                 -- clickedname = maybe "" msItemScreenName item
                 mclickedscr  = msItemScreen <$> item
 
-            -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
-            VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
-              vScrollBy (viewportScroll $ (_mssList sst)^.listNameL) 1
+            -- when selection is at the last item, do nothing
+            VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> return ()
               where mnextelement = listSelectedElement $ listMoveDown (_mssList sst)
 
             -- mouse scroll wheel scrolls the viewport up or down to its maximum extent,

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -306,9 +306,8 @@ rsHandle sst@RSS{..} ev = do
               case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount _rssForceInclusive nts nt ui
               where clickeddate = maybe "" rsItemDate $ listElements _rssList !? y
 
-            -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
-            VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> do
-              vScrollBy (viewportScroll $ listName $ _rssList) 1
+            -- when selection is at the last item, do nothing
+            VtyEvent e | e `elem` moveDownEvents, isBlankElement mnextelement -> return ()
               where mnextelement = listSelectedElement $ listMoveDown _rssList
 
             -- mouse scroll wheel scrolls the viewport up or down to its maximum extent,

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -284,7 +284,7 @@ rsHandle sst@RSS{..} ev = do
             VtyEvent (EvKey (KRight)    [MShift]) -> put' $ regenerateScreens d $ nextReportPeriod journalspan ui
             VtyEvent (EvKey (KLeft)     [MShift]) -> put' $ regenerateScreens d $ previousReportPeriod journalspan ui
             VtyEvent (EvKey k           []) | k `elem` [KBS, KDel] -> (put' $ regenerateScreens d $ resetFilter ui)
-            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle _rssList >> redraw
+            VtyEvent (EvKey (KChar 'l') [MCtrl]) -> scrollSelectionToMiddle (rsListSize _rssList) _rssList >> redraw
             VtyEvent (EvKey (KChar 'z') [MCtrl]) -> suspend ui
 
             -- exit screen on LEFT
@@ -323,7 +323,7 @@ rsHandle sst@RSS{..} ev = do
               if isBlankElement $ listSelectedElement l
               then do
                 let l' = listMoveTo lastnonblankidx l
-                scrollSelectionToMiddle l'
+                scrollSelectionToMiddle (rsListSize l') l'
                 put' ui{aScreen=RS sst{_rssList=l'}}
               else
                 put' ui{aScreen=RS sst{_rssList=l}}
@@ -352,7 +352,7 @@ rsSetAccount _ _ st = st
 -- No effect on other screens.
 rsCenterSelection :: UIState -> EventM Name UIState UIState
 rsCenterSelection ui@UIState{aScreen=RS sst} = do
-  scrollSelectionToMiddle $ _rssList sst
+  scrollSelectionToMiddle (rsListSize $ _rssList sst) (_rssList sst)
   return ui  -- ui is unchanged, but this makes the function more chainable
 rsCenterSelection ui = return ui
 

--- a/hledger-ui/Hledger/UI/UIUtils.hs
+++ b/hledger-ui/Hledger/UI/UIUtils.hs
@@ -384,21 +384,30 @@ withBorderAttr attr = updateAttrMap (applyAttrMappings [(attrName "border", attr
 -- | Scroll a list's viewport so that the selected item is centered in the
 -- middle of the display area. When the selected item is near the end of the
 -- list, the viewport is capped so that no blank padding is visible below the
--- last real item. numitems is the number of non-blank items in the list.
+-- last real item, and the last real items stay bottom-aligned (so recentering
+-- a near-the-end selection doesn't push those items off screen). numitems is
+-- the number of non-blank items in the list.
 scrollSelectionToMiddle :: Int -> Brick.Widgets.List.List Name item -> EventM Name UIState ()
 scrollSelectionToMiddle numitems list = do
   case list^.listSelectedL of
     Nothing -> return ()
     Just selectedrow -> do
-      Vty{outputIface} <- getVtyHandle
-      pageheight <- dbg4 "pageheight" . snd <$> liftIO (displayBounds outputIface)
+      let name = list^.listNameL
+      mvp <- lookupViewport name
+      -- Use the list viewport's actual height. Before its first render the
+      -- viewport isn't known yet, so fall back to the terminal height.
+      pageheight <- dbg4 "pageheight" <$> case mvp of
+        Just VP{_vpSize=(_,h)} -> return h
+        Nothing -> do
+          Vty{outputIface} <- getVtyHandle
+          snd <$> liftIO (displayBounds outputIface)
       let
         itemheight   = dbg4 "itemheight" $ list^.listItemHeightL
         itemsperpage = dbg4 "itemsperpage" $ pageheight `div` itemheight
         centeredtop  = selectedrow - (itemsperpage `div` 2)
         maxtop       = numitems - itemsperpage
         toprow       = dbg4 "toprow" $ max 0 (min centeredtop maxtop) -- assuming ViewportScroll's row offset is measured in list items not screen rows
-      setTop (viewportScroll $ list^.listNameL) toprow
+      setTop (viewportScroll name) toprow
 
 --                 arrow keys       vi keys               emacs keys                 enter key
 moveUpEvents    = [EvKey KUp []   , EvKey (KChar 'k') [], EvKey (KChar 'p') [MCtrl]]

--- a/hledger-ui/Hledger/UI/UIUtils.hs
+++ b/hledger-ui/Hledger/UI/UIUtils.hs
@@ -382,9 +382,11 @@ withBorderAttr attr = updateAttrMap (applyAttrMappings [(attrName "border", attr
 --  setTop (viewportScroll vpname) 0
 
 -- | Scroll a list's viewport so that the selected item is centered in the
--- middle of the display area.
-scrollSelectionToMiddle :: Brick.Widgets.List.List Name item -> EventM Name UIState ()
-scrollSelectionToMiddle list = do
+-- middle of the display area. When the selected item is near the end of the
+-- list, the viewport is capped so that no blank padding is visible below the
+-- last real item. numitems is the number of non-blank items in the list.
+scrollSelectionToMiddle :: Int -> Brick.Widgets.List.List Name item -> EventM Name UIState ()
+scrollSelectionToMiddle numitems list = do
   case list^.listSelectedL of
     Nothing -> return ()
     Just selectedrow -> do
@@ -393,7 +395,9 @@ scrollSelectionToMiddle list = do
       let
         itemheight   = dbg4 "itemheight" $ list^.listItemHeightL
         itemsperpage = dbg4 "itemsperpage" $ pageheight `div` itemheight
-        toprow       = dbg4 "toprow" $ max 0 (selectedrow - (itemsperpage `div` 2)) -- assuming ViewportScroll's row offset is measured in list items not screen rows
+        centeredtop  = selectedrow - (itemsperpage `div` 2)
+        maxtop       = numitems - itemsperpage
+        toprow       = dbg4 "toprow" $ max 0 (min centeredtop maxtop) -- assuming ViewportScroll's row offset is measured in list items not screen rows
       setTop (viewportScroll $ list^.listNameL) toprow
 
 --                 arrow keys       vi keys               emacs keys                 enter key


### PR DESCRIPTION
Finally made a fix for #2278. Now the lists don't keep scrolling when the end of the list is reached.

Also I did a small change in how the lists are initialized and centered, so there's no blank space at the bottom for lists with enough items to fill the screen.

I feel this behavior is now more familiar and matches other TUI tools with scrolling lists.

Closes #2278