### PR TITLE
fix: resolve #1950 - posting tags override inherited transaction tags

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -760,8 +760,14 @@ postingCommodities = map acommodity . filter (not . isMissingAmount) . amountsRa
   where isMissingAmount a = acommodity a == "AUTO"
 
 -- | Tags for this posting including any inherited from its parent transaction.
+-- Explicitly-set posting tags override inherited transaction tags with the same name.
 postingAllTags :: Posting -> [Tag]
-postingAllTags p = ptags p ++ maybe [] ttags (ptransaction p)
+postingAllTags p = postingTags ++ filteredTxnTags
+  where
+    postingTags = ptags p
+    txnTags = maybe [] ttags (ptransaction p)
+    postingTagNames = map fst postingTags
+    filteredTxnTags = filter ((`notElem` postingTagNames) . fst) txnTags
 
 -- | Tags for this transaction including any from its postings (which includes any from the postings' accounts).
 transactionAllTags :: Transaction -> [Tag]


### PR DESCRIPTION
## Summary
Fix for [BOUNTY 0] Inherited Tag Values are not Overwritten — Issue #1950

## Root cause
The  function in  was concatenating posting tags and transaction tags without filtering out duplicates. This caused tag values to accumulate rather than override, leading to confusing behavior when filtering or pivoting on tags.

## Fix
Modified  to filter out inherited transaction tags whose tag names already appear in the posting's explicit tags. This ensures child-level tag specifications override parent-level ones, matching the expected behavior described in the issue.

## Changes


Closes #1950