### PR TITLE
fix: resolve bounty issue #1950 - posting tags now override inherited txn tags

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -760,8 +760,14 @@ postingCommodities = map acommodity . filter (not . isMissingAmount) . amountsRa
   where isMissingAmount a = acommodity a == "AUTO"
 
 -- | Tags for this posting including any inherited from its parent transaction.
+-- Explicitly-set posting tags override inherited transaction tags with the same name.
 postingAllTags :: Posting -> [Tag]
-postingAllTags p = ptags p ++ maybe [] ttags (ptransaction p)
+postingAllTags p = postingTags ++ filteredTxnTags
+  where
+    postingTags = ptags p
+    txnTags = maybe [] ttags (ptransaction p)
+    postingTagNames = map fst postingTags
+    filteredTxnTags = filter ((`notElem` postingTagNames) . fst) txnTags
 
 -- | Tags for this transaction including any from its postings (which includes any from the postings' accounts).
 transactionAllTags :: Transaction -> [Tag]


### PR DESCRIPTION
## Summary
Fix for [BOUNTY $20] Inherited Tag Values are not Overwritten — Issue #1950

## Root cause
When a posting had a tag with the same name as an inherited transaction-level tag (e.g., `concerns: me` on transaction, `concerns: you` on posting), the posting's tag value should overwrite the inherited one. However, `postingAllTags` was doing a simple concatenation: `ptags p ++ txnTags`, which meant both values were retained and matched by tag queries.

## Fix
Modified `postingAllTags` in `hledger-lib/Hledger/Data/Posting.hs` to filter out transaction-level tags whose names conflict with explicitly-set posting tags:

```haskell
postingAllTags :: Posting -> [Tag]
postingAllTags p = postingTags ++ filteredTxnTags
  where
    postingTags = ptags p
    txnTags = maybe [] ttags (ptransaction p)
    postingTagNames = map fst postingTags
    filteredTxnTags = filter ((`notElem` postingTagNames) . fst) txnTags
```

This ensures posting-level tags take precedence over inherited transaction tags with the same name, and tag queries like `tag:concerns=me` only match postings that genuinely have that effective tag value.

## Testing
The existing test case `a tag match on a posting also sees inherited tags` in `Query.hs` continues to pass (inherited tags without conflicts are still visible), and the fix properly handles the overwrite case.

Closes #1950