### PR TITLE
fix: resolve inherited tag values not overwritten issue #1950

### DIFF
--- a/hledger-lib/Hledger/Data/Posting.hs
+++ b/hledger-lib/Hledger/Data/Posting.hs
@@ -760,8 +760,14 @@ postingCommodities = map acommodity . filter (not . isMissingAmount) . amountsRa
   where isMissingAmount a = acommodity a == "AUTO"
 
 -- | Tags for this posting including any inherited from its parent transaction.
+-- Explicitly-set posting tags override inherited transaction tags with the same name.
 postingAllTags :: Posting -> [Tag]
-postingAllTags p = ptags p ++ maybe [] ttags (ptransaction p)
+postingAllTags p = postingTags ++ filteredTxnTags
+  where
+    postingTags = ptags p
+    txnTags = maybe [] ttags (ptransaction p)
+    postingTagNames = map fst postingTags
+    filteredTxnTags = filter ((`notElem` postingTagNames) . fst) txnTags
 
 -- | Tags for this transaction including any from its postings (which includes any from the postings' accounts).
 transactionAllTags :: Transaction -> [Tag]


### PR DESCRIPTION
## Summary
Fix for [BOUNTY 0] Inherited Tag Values are not Overwritten — Issue #1950

## Root cause
In `hledger-lib/Hledger/Data/Posting.hs`, the `postingAllTags` function was simply concatenating posting tags with transaction tags:

```haskell
postingAllTags p = ptags p ++ maybe [] ttags (ptransaction p)
```

This caused duplicate tag values when a tag existed at both transaction and posting levels. The posting-level tag value should **overwrite** (not append to) the transaction-level tag value.

## Fix
Modified `postingAllTags` to filter out transaction tags whose names already exist in posting tags, so higher-level (posting) tag values properly overwrite lower-level (transaction) values:

```haskell
postingAllTags p = postingTags ++ filteredTxnTags
  where
    postingTags = ptags p
    txnTags = maybe [] ttags (ptransaction p)
    postingTagNames = map fst postingTags
    filteredTxnTags = filter ((notElem postingTagNames) . fst) txnTags
```

Now when a posting has `concerns: you` it properly overwrites the inherited `concerns: me` from the transaction level, rather than creating a duplicate.

## Verification
Example from issue now works correctly:
```hledger
2022-11-17 Aldi
    ; concerns: me
    Assets               -30 €
    Costs:Food            20 €
    Loaned                10 €  ; concerns: you
```

Results in only `concerns: you` (not both `concerns: me` and `concerns: you`).

Closes #1950