### PR TITLE
Note limitation for CSV-related matching

### DIFF
--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3836,7 +3836,7 @@ This can be confusing, so let's start with an overview:
   then its value will be automatically assigned to that hledger field.
 
 - For a CSV with the following fields:
-  accounttype, accounted, `date`,, type, payee, `amount`, for example:
+  accounttype, accountid, `date`,, type, payee, `amount`, for example:
   ```csv
   Chequing,12345-1111111,5/1/2026,,"WWW TRF DDA - 2651",,-50.00,,
   Savings,12345-2222222,5/1/2026,,"Transfer","WWW TRANSFER - 1743 ",50.00,,

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3865,7 +3865,7 @@ This can be confusing, so let's start with an overview:
   WWW TRF DDA
     account2 equity:transfers
   if HYDRO
-  account2 expenses:utilities:hydro
+    account2 expenses:utilities:hydro
   ```
 
 - CSV fields can only be read, not written to. They'll be on the right hand side, with a % prefix. Eg

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -4231,6 +4231,10 @@ they can express many matchers and field assignments in a more compact tabular f
 
 ```rules
 if,HLEDGERFIELD1,HLEDGERFIELD2,...
+TODO: /\ This is wrong if hledger is supposed to only match CSV fields
+         Alternatively, this documentation is correct, and hledger is buggy.
+         The resolution would then be to matching for a %description that is spans multiple contatenated values.
+         Alternatively hledgerfield is wrong because there is a middle-processing step where description="type string,payee string".  In this case this middle step must be noted in the documentation, becaues hledgerfield=description is what appears in the journal and what the user expects.
 MATCHERA,VALUE1,VALUE2,...
 MATCHERB && MATCHERC,VALUE1,VALUE2,...  (*since 1.42*)
 ; Comment line that explains MATCHERD

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3848,7 +3848,7 @@ This can be confusing, so let's start with an overview:
   # combine type and payee to fill hledger's description
   description %type %payee
   ```
-  the following description to payee mapping rules will fail, because hledger rules match per-CSV field:
+  the following description to payee mapping rules will fail, because hledger rules match per-CSV field and *not* the hledger %description that is printed anywhere output is supported:
   ```rules
   if
   Transfer WWW TRANSFER

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -3835,6 +3835,39 @@ This can be confusing, so let's start with an overview:
 - For simple cases, you can give a CSV field the same name as one of the hledger fields,
   then its value will be automatically assigned to that hledger field.
 
+- For a CSV with the following fields:
+  accounttype, accounted, `date`,, type, payee, `amount`, for example:
+  ```csv
+  Chequing,12345-1111111,5/1/2026,,"WWW TRF DDA - 2651",,-50.00,,
+  Savings,12345-2222222,5/1/2026,,"Transfer","WWW TRANSFER - 1743 ",50.00,,
+  Chequing,12345-1111111,5/10/2026,,"Payment","WWW PAYMENT - 1745 HYDRO ",-55.66,,
+  ```
+  with the following rules
+  ```rules
+  fields accounttype, accountid, date,, type, payee, amount
+  # combine type and payee to fill hledger's description
+  description %type %payee
+  ```
+  the following description to payee mapping rules will fail, because hledger rules match per-CSV field:
+  ```rules
+  if
+  Transfer WWW TRANSFER
+  WWW TRF DDA  # <- This one will succeed
+    account2 equity:transfers
+  if Payment HYDRO
+    account2 expenses:utilities:hydro
+
+  ```
+  rather then the above rules, the following (which are scoped to single CSV field) must be used:
+  ```rules
+  if
+  Transfer
+  WWW TRF DDA
+    account2 equity:transfers
+  if HYDRO
+  account2 expenses:utilities:hydro
+  ```
+
 - CSV fields can only be read, not written to. They'll be on the right hand side, with a % prefix. Eg
   - testing a CSV field's value: `if %CSVFIELD ...`
   - interpolating its value:     `HLEDGERFIELD %CSVFIELD`


### PR DESCRIPTION
Hi,

I'm expecting to need to rebase and will add the suggested commit message prefix then.  Meanwhile, I'm still not convinced that this is an intended hledger design decision rather than a bug.  Please let me know.
