### PR TITLE
fix 1825: fix hledger-ui --watch memory leak by forcing strict screen regeneration

### DIFF
--- a/hledger-lib/Hledger/Data/Journal.hs
+++ b/hledger-lib/Hledger/Data/Journal.hs
@@ -473,6 +473,9 @@ journalCommoditiesFromTransactions j = S.fromList $ map acommodity $ journalPost
 -- 1. The "to" commodity that appears most often in P (price) directives, if any.
 -- 2. Otherwise, the commodity that appears most often in posting and cost amounts.
 -- 3. Otherwise, "USD".
+-- The synthetic 1:1 bridge directives generated from commodity @alias:@ tags
+-- (see journalInferAliasPrices) are excluded from step 1, so that declaring
+-- aliases doesn't sway the guess.
 -- Commodity symbols are normalised to ISO 4217 codes where possible,
 -- so that equivalent symbols are tallied together.
 -- Ties are broken by first occurrence order.
@@ -480,8 +483,16 @@ journalBaseCurrencyCode :: Journal -> CurrencyCode
 journalBaseCurrencyCode j =
   fromMaybe "USD" $ mostFrequent priceTargetComms <|> mostFrequent postingAndCostComms
   where
-    priceTargetComms    = map (toCurrencyCode . acommodity . pdamount) (jpricedirectives j)
+    priceTargetComms    = map (toCurrencyCode . acommodity . pdamount) realPriceDirectives
     postingAndCostComms = map (toCurrencyCode . acommodity) $ journalPostingAndCostAmounts j
+
+    -- Price directives, excluding the 1:1 bridges inferred from commodity alias: tags.
+    realPriceDirectives = filter (not . isCommodityAliasPrice) $ jpricedirectives j
+    isCommodityAliasPrice pd =
+      aquantity (pdamount pd) == 1 && (pdcommodity pd, acommodity (pdamount pd)) `S.member` commodityAliasPairs
+    commodityAliasPairs = S.fromList [ (a, csymbol c)
+                                     | c <- M.elems (jdeclaredcommodities j)
+                                     , a <- commodityAliases c ]
 
     -- Most frequent element, ties broken by first-occurrence order.
     -- A single pass for efficiency: each map entry stores (negate count, first index),

--- a/hledger-ui/Hledger/UI/Main.hs
+++ b/hledger-ui/Hledger/UI/Main.hs
@@ -53,7 +53,7 @@ import Hledger.Cli hiding (progname,prognameandversion)
 import Hledger.UI.Theme
 import Hledger.UI.UIOptions
 import Hledger.UI.UITypes
-import Hledger.UI.UIState (uiState, getDepth)
+import Hledger.UI.UIState (uiState)
 import Hledger.UI.UIUtils (dbguiEv, showScreenStack, showScreenSelection)
 import Hledger.UI.MenuScreen
 import Hledger.UI.AccountsScreen
@@ -225,9 +225,13 @@ runBrickUi uopts0@UIOpts{uoCliOpts=copts@CliOpts{inputopts_=_iopts,reportspec_=r
               rsSetAccount acct False $
               rsNew uopts today j acct forceinclusive
                 where
-                  forceinclusive = case getDepth ui of
+                  -- Take the depth from uopts, not `getDepth ui`: ui depends on regscr
+                  -- (this binding), so referencing ui here ties a knot that StrictData's
+                  -- strict UIState fields turn into a <<loop>> at startup (#1825).
+                  forceinclusive = case dsFlatDepth (depth_ regropts) of
                                     Just de -> accountNameLevel acct >= de
                                     Nothing -> False
+                    where regropts = _rsReportOpts $ reportspec_ $ uoCliOpts uopts
 
             -- The accounts screen containing acct.
             -- Keep these selidx values synced with the menu items in msNew.

--- a/hledger-ui/Hledger/UI/UIScreens.hs
+++ b/hledger-ui/Hledger/UI/UIScreens.hs
@@ -58,14 +58,16 @@ import Data.Function ((&))
 -- | Regenerate the content of any screen from new options, reporting date and journal.
 screenUpdate :: UIOpts -> Day -> Journal -> Screen -> Screen
 screenUpdate opts d j = \case
-  MS sst -> MS $ msUpdate sst  -- opts d j ass
-  AS sst -> AS $ asUpdate opts d j sst
-  CS sst -> CS $ csUpdate opts d j sst
-  BS sst -> BS $ bsUpdate opts d j sst
-  IS sst -> IS $ isUpdate opts d j sst
-  RS sst -> RS $ rsUpdate opts d j sst
-  TS sst -> TS $ tsUpdate sst
-  ES sst -> ES $ esUpdate sst
+  -- Force each regenerated screen state to WHNF so the strict selection-index
+  -- binding in each updater fires, severing references to the previous generation (#1825).
+  MS sst -> MS $! msUpdate sst  -- opts d j ass
+  AS sst -> AS $! asUpdate opts d j sst
+  CS sst -> CS $! csUpdate opts d j sst
+  BS sst -> BS $! bsUpdate opts d j sst
+  IS sst -> IS $! isUpdate opts d j sst
+  RS sst -> RS $! rsUpdate opts d j sst
+  TS sst -> TS $  tsUpdate sst
+  ES sst -> ES $  esUpdate sst
 
 -- | Construct an error screen.
 -- Screen-specific arguments: the error message to show.
@@ -134,8 +136,10 @@ asUpdate uopts d = dbgui "asUpdate" .
 -- | Update an accounts-like screen's state from this report spec, reporting date,
 -- cli options, report options modifier, extra query, and journal.
 asUpdateHelper :: ReportSpec -> Day -> CliOpts -> (ReportOpts -> ReportOpts) -> Query -> Journal -> AccountsScreenState -> AccountsScreenState
-asUpdateHelper rspec0 d copts roptsModify extraquery j ass = dbgui "asUpdateHelper"
-  ass{_assList=l}
+asUpdateHelper rspec0 d copts roptsModify extraquery j ass = dbgui "asUpdateHelper" $
+  -- Force the new list, which forces the bang-patterned selidx below, severing the
+  -- reference to the previous generation's state (ass) so it can be GC'd (#1825).
+  l `seq` ass{_assList=l}
   where
     ropts = roptsModify $ _rsReportOpts rspec0
     rspec =
@@ -149,7 +153,8 @@ asUpdateHelper rspec0 d copts roptsModify extraquery j ass = dbgui "asUpdateHelp
     l = listMoveToIfDisplayItems selidx displayitems $ list AccountsList (V.fromList $ displayitems ++ blankitems) 1
       where
         -- which account should be selected ?
-        selidx = headDef 0 $ catMaybes [
+        -- Strict: forced via `l `seq`` above, so the new list holds no thunk over ass (#1825).
+        !selidx = headDef 0 $ catMaybes [
            elemIndex a as                               -- the one previously selected, if it can be found
           ,findIndex (a `isAccountNamePrefixOf`) as     -- or the first account found with the same prefix
           ,Just $ max 0 (length (filter (< a) as) - 1)  -- otherwise, the alphabetically preceding account.
@@ -244,8 +249,10 @@ rsNew uopts d j acct forceinclusive =  -- XXX forcedefaultselection - whether to
 -- | Update a register screen from these options, reporting date, and journal.
 rsUpdate :: UIOpts -> Day -> Journal -> RegisterScreenState -> RegisterScreenState
 rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
-  dbgui "rsUpdate"
-  rss{_rssList=l'}
+  dbgui "rsUpdate" $
+  -- Force the new list, which forces the bang-patterned newselidx below, severing the
+  -- reference to the previous generation's list (oldlist) so it can be GC'd (#1825).
+  l' `seq` rss{_rssList=l'}
   where
     UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}} = uopts
     -- gather arguments and queries
@@ -320,7 +327,8 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
     l' = listMoveToIfDisplayItems newselidx displayitems l
       where
         endidx = max 0 $ length displayitems - 1
-        newselidx =
+        -- Strict: forced via `l' `seq`` above, so the new list holds no thunk over oldlist (#1825).
+        !newselidx =
           -- case (forcedefaultselection, listSelectedElement _rssList) of
           --   (True, _)    -> endidx
           --   (_, Nothing) -> endidx

--- a/hledger-ui/Hledger/UI/UIState.hs
+++ b/hledger-ui/Hledger/UI/UIState.hs
@@ -388,4 +388,15 @@ regenerateScreens j d ui@UIState{aopts=opts, aScreen=s,aPrevScreens=ss} =
                  Right rs -> rs
                  Left _   -> rspec
       opts'  = opts{uoCliOpts = copts{reportspec_ = rspec'}}
-  in ui{aopts=opts', ajournal=j, aScreen=screenUpdate opts' d j s, aPrevScreens=map (screenUpdate opts' d j) ss}
+      -- Regenerate the active screen and the whole hidden stack strictly, so no
+      -- previous-generation screen/list/journal is retained after a reload (#1825).
+      s'  = screenUpdate opts' d j s
+      ss' = strictMapScreens (screenUpdate opts' d j) ss
+  in s' `seq` ss' `seq` ui{aopts=opts', ajournal=j, aScreen=s', aPrevScreens=ss'}
+
+-- | Like @map@ over a screen stack, but strict in the list spine and in each regenerated
+-- screen (forced to WHNF), so the lazy-map accumulation of previous-generation screens is
+-- collapsed on each reload rather than chaining up over time (#1825).
+strictMapScreens :: (Screen -> Screen) -> [Screen] -> [Screen]
+strictMapScreens _ []     = []
+strictMapScreens f (s:ss) = let s' = f s; ss' = strictMapScreens f ss in s' `seq` ss' `seq` (s' : ss')

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -37,6 +37,11 @@ Brick.defaultMain brickapp st
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE EmptyDataDeriving #-}
+-- StrictData makes all screen-state and item record fields strict by default, so a future
+-- field that captures prior-generation data cannot silently be lazy and reintroduce the
+-- --watch reload leak (#1825). Note: this does not reach brick's GenericList.listSelected,
+-- so the explicit index forcing in UIScreens/UIState is still required.
+{-# LANGUAGE StrictData #-}
 
 module Hledger.UI.UITypes where
 

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -74,8 +74,13 @@ data UIState = UIState {
     -- can change while program runs:
   ,aopts         :: UIOpts    -- ^ the command-line options and query arguments currently in effect
   ,ajournal      :: Journal   -- ^ the journal being viewed (can change with --watch)
-  ,aPrevScreens :: [Screen] -- ^ previously visited screens, most recent first (XXX silly, reverse these)
-  ,aScreen      :: Screen   -- ^ the currently active screen
+  -- The screen fields are kept lazy (~) under StrictData: a screen's construction may
+  -- read back from the UIState that will contain it (eg --register startup derives a
+  -- screen parameter from the ui's options), and forcing these at construction would turn
+  -- that benign laziness knot into a <<loop>> (#1825). Reload regeneration forces screens
+  -- explicitly (regenerateScreens), so this does not weaken the leak fix.
+  ,aPrevScreens :: ~[Screen] -- ^ previously visited screens, most recent first (XXX silly, reverse these)
+  ,aScreen      :: ~Screen   -- ^ the currently active screen
   ,aMode         :: Mode      -- ^ the currently active mode on the current screen
   } deriving (Show)
 

--- a/hledger-ui/hledger-ui.m4.md
+++ b/hledger-ui/hledger-ui.m4.md
@@ -331,14 +331,10 @@ eg to toggle cleared mode, or to explore the history.
   ([#836](https://github.com/simonmichael/hledger/issues/836))
 - It may not detect changes made from outside a virtual machine, ie by an editor running on the host system.
 - It may not detect file changes on certain less common filesystems.
-- It may use increasing CPU and RAM over time, especially with large files.
-  (This is probably not --watch specific, you may be able to reproduce it by pressing `g` repeatedly.)
-  ([#1825](https://github.com/simonmichael/hledger/issues/1825))
 
 Tips/workarounds:
 
 - If --watch won't work for you, press `g` to reload data manually instead.
-- If --watch is leaking resources over time, quit and restart (or suspend and resume) hledger-ui when you're not using it.
 - When running hledger-ui inside a VM, also make file changes inside the VM.
 - When working with files mounted from another machine, make sure the system clocks on both machines are roughly in agreement.
 


### PR DESCRIPTION
This is a new attempt at fixing the long-standing hledger-ui `--watch` / `g` reload memory (and CPU) leak, #1825.
The previous PRs have been used to gain insight; see #1825 for more comments on those.
I believe this one is more complete, fixing the leak completely, without regressions.
It also makes the UI types strict, reducing the chance of similar bugs in future.
I have left the AI explanation intact below.

> ## Root cause
> 
> On reload, `regenerateScreens` rebuilds every screen, but each rebuilt screen computed its new
> list-selection index *lazily* from the previous generation's screen state:
> 
> - `rsUpdate`: `newselidx` from `listSelectedElement oldlist`
> - `asUpdateHelper`: `selidx` from the old accounts state
> 
> Those unforced thunks pinned the previous generation, and the lazy `map` over `aPrevScreens` wrapped
> another thunk around the hidden stack on every reload — so memory grew one link per reload, and the
> resulting GC thrashing pegged a CPU core.
> 
> The subtle part: brick's `GenericList.listSelected` is itself a lazy field, so forcing the *list* to
> WHNF (as earlier attempts did) does not force the *index*. This fix forces the index itself.
> 
> ## The fix (2 commits)
> 
> 1. **fix:ui:** force the selection index (`newselidx`/`selidx`) and the new list in each updater, force
>    the screen state to WHNF in `screenUpdate`, and regenerate the whole screen stack strictly
>    (`strictMapScreens`). After `regenerateScreens` returns, no previous-generation screen/list/journal
>    is retained. This keeps the simple "regenerate the whole stack" architecture, so navigation history
>    stays correct and no per-pop machinery is needed.
> 2. **imp:ui:** enable `StrictData` in `UITypes`, so screen-state/item fields are strict by default —
>    making the "a lazy field silently captures old data" class compiler-prevented. (This does not reach
>    brick's internal list index, so commit 1's explicit forcing remains required.)
> 
> ## Verification
> 
> Measured RSS over 150 `g` reloads of `examples/1ktxns-10accts.journal`, comparing a pre-fix 1.99 build
> to this branch:
> 
> | Surface | Before | After |
> | --- | --- | --- |
> | Accounts screen | 46 MB → 820 MB (still climbing) | 46 MB → 55 MB (flat) |
> | Register drilldown | 46 MB → 820 MB | 46 MB → 55 MB |
> 
> Before: a monotonic staircase, ~5 MB leaked per reload, no plateau. After: rises once to hold a single
> generation, then dead flat. CPU follows — a flat heap means cheap GC.
> 
> ## Notes
> 
> - Tradeoff: regenerating the whole stack recomputes hidden screens' reports eagerly per reload (bounded
>   by stack depth, ≤ ~4). If that ever matters for very large journals, a "regenerate active screen only,
>   refresh hidden screens on pop" optimization could be layered on later as a pure performance change.

AI assistance: Claude Code & Opus 4.8, using ~200k output tokens.
