### PR TITLE
ui: refresh the transaction screen in place on reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _*
 
 # dev stuff
 .build
+.hx
 .idea
 *.iml
 .shake

--- a/Justfile
+++ b/Justfile
@@ -1130,20 +1130,23 @@ INSTALLING:
 
 # On gnu/linux: can't interpolate GTAR here for some reason, and need the shebang line.
 # linux / mac only for now, does not handle the windows zip file.
-# download github release VER binaries for OS (linux, mac) and ARCH (x64, arm64) to bin/old/hledger*-VER
-@installrel VER OS ARCH:
+# download the specified version of github release binaries, for the current OS and ARCH, to bin/old/hledger*-VER
+installrel VER:
     #!/usr/bin/env bash
 
     # The current OS name, in the form used for hledger release binaries: linux, mac, windows or other.
     # can't use $GHC or {{GHC}} here for some reason
-    OS := `ghc -ignore-dot-ghci -package-env - -e 'import System.Info' -e 'putStrLn $ case os of "darwin"->"mac"; "mingw32"->"windows"; "linux"->"linux"; _->"other"'`
+    OS=$(ghc -ignore-dot-ghci -package-env - -e 'import System.Info' -e 'putStrLn $ case os of "darwin"->"mac"; "mingw32"->"windows"; "linux"->"linux"; _->"other"')
+
+    # The current architecture, in the form used for hledger release binaries: x64, arm64 or other.
+    ARCH=$(ghc -ignore-dot-ghci -package-env - -e 'import System.Info' -e 'putStrLn $ case arch of "x86_64"->"x64"; "aarch64"->"arm64"; "arm"->"arm64"; _->"other"')
 
     # if [[ "$OS" == "windows" ]]; then
-    #   cd bin/old && curl -L https://github.com/simonmichael/hledger/releases/download/{{ VER }}/hledger-{{ OS }}-{{ ARCH }}.zip | funzip | `type -P gtar || echo tar` xf - --transform 's/$/-{{ VER }}/'
+    #   cd bin/old && curl -L https://github.com/simonmichael/hledger/releases/download/$VER/hledger-$OS-$ARCH.zip | funzip | `type -P gtar || echo tar` xf - --transform "s/$/-$VER/"
     # else
     # fi
 
-    cd bin/old && curl -L https://github.com/simonmichael/hledger/releases/download/{{ VER }}/hledger-{{ OS }}-{{ ARCH }}.tar.gz | `type -P gtar || echo tar` xzf - --transform 's/$/-{{ VER }}/'
+    cd bin/old && curl -L https://github.com/simonmichael/hledger/releases/download/$VER/hledger-$OS-$ARCH.tar.gz | `type -P gtar || echo tar` xzf - --transform "s/\$/-$VER/"
 
 # # download recent versions of the hledger executables from github to bin/hledger*-VER
 # get-recent-binaries:

--- a/hledger-lib/Hledger/Data/Lots.hs
+++ b/hledger-lib/Hledger/Data/Lots.hs
@@ -1119,10 +1119,16 @@ journalCollapseLotDetail j
     collapsePosting p
       | postingHasTag lotParentAssertionTagName p = Nothing
       | otherwise = Just p
-          { paccount = lotBaseAccount (paccount p)
-          , pamount  = mapMixedAmount stripInferredBasis (pamount p)
+          { paccount          = newAcct
+          , pamount           = mapMixedAmount stripInferredBasis (pamount p)
+          -- A lot-subaccount balance assertion was checked against the
+          -- pre-collapse paccount during journalFinalise; drop it here so the
+          -- collapsed view isn't re-validated against the parent total.
+          , pbalanceassertion =
+              if newAcct == paccount p then pbalanceassertion p else Nothing
           }
       where
+        newAcct = lotBaseAccount (paccount p)
         -- Preserve acostbasis the user wrote explicitly on poriginal; strip any
         -- acostbasis added later by lot processing.
         origHasBasis = case poriginal p of

--- a/hledger-ui/Hledger/UI/RegisterScreen.hs
+++ b/hledger-ui/Hledger/UI/RegisterScreen.hs
@@ -295,7 +295,7 @@ rsHandle ev = do
 
             -- enter transaction screen on RIGHT
             VtyEvent e | e `elem` moveRightEvents ->
-              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount nts nt ui
+              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount _rssForceInclusive nts nt ui
             -- or on transaction click
             -- MouseDown is sometimes duplicated, https://github.com/jtdaugherty/brick/issues/347
             -- just use it to move the selection
@@ -304,7 +304,7 @@ rsHandle ev = do
               where clickeddate = maybe "" rsItemDate $ listElements _rssList !? y
             -- and on MouseUp, enter the subscreen
             MouseUp _n (Just BLeft) Location{loc=(_x,y)} | not $ (=="") clickeddate -> do
-              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount nts nt ui
+              case mtxns of Nothing -> return (); Just (nts, nt) -> rsEnterTransactionScreen _rssAccount _rssForceInclusive nts nt ui
               where clickeddate = maybe "" rsItemDate $ listElements _rssList !? y
 
             -- when selection is at the last item, DOWN scrolls instead of moving, until maximally scrolled
@@ -359,7 +359,7 @@ rsCenterSelection ui@UIState{aScreen=RS sst} = do
   return ui  -- ui is unchanged, but this makes the function more chainable
 rsCenterSelection ui = return ui
 
-rsEnterTransactionScreen :: AccountName -> [NumberedTransaction] -> NumberedTransaction -> UIState -> EventM Name UIState ()
-rsEnterTransactionScreen acct nts nt ui = do
+rsEnterTransactionScreen :: AccountName -> Bool -> [NumberedTransaction] -> NumberedTransaction -> UIState -> EventM Name UIState ()
+rsEnterTransactionScreen acct forceinclusive nts nt ui = do
   dbguiEv "rsEnterTransactionScreen"
-  put' $ pushScreen (tsNew acct nts nt) ui
+  put' $ pushScreen (tsNew acct forceinclusive nts nt) ui

--- a/hledger-ui/Hledger/UI/TransactionScreen.hs
+++ b/hledger-ui/Hledger/UI/TransactionScreen.hs
@@ -30,8 +30,7 @@ import Hledger.UI.UIState
 import Hledger.UI.UIUtils
 import Hledger.UI.UIScreens
 import Hledger.UI.Editor
-import Hledger.UI.ErrorScreen (uiCheckBalanceAssertions, uiReload, uiReloadIfFileChanged, uiToggleBalanceAssertions)
-import Hledger.UI.RegisterScreen (rsHandle)
+import Hledger.UI.ErrorScreen (uiReload, uiReloadIfFileChanged, uiToggleBalanceAssertions)
 
 tsDraw :: UIState -> [Widget Name]
 tsDraw UIState{aopts=UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}}
@@ -187,50 +186,10 @@ tsHandle ev = do
     _ -> errorWrongScreenType "tsHandle"
 
     where
-      -- Reload and fully regenerate the transaction screen.
-      -- XXX On transaction screen or below, this is tricky because of a current limitation of regenerateScreens.
-      -- For now we try to work around by re-entering the screen(s).
-      -- This can show flicker in the UI and it's hard to handle all situations robustly.
-      tsReload copts d ui = uiReload copts d ui >>= reEnterTransactionScreen copts d
-      tsReloadIfFileChanged copts d j ui = liftIO (uiReloadIfFileChanged copts d j ui) >>= reEnterTransactionScreen copts d
-      
-      reEnterTransactionScreen _copts d ui = do
-        -- 1. If uiReload (or checking balance assertions) moved us to the error screen, save that, and return to the transaction screen.
-        let
-          (merrscr, uiTxn) = case aScreen $ uiCheckBalanceAssertions d ui of
-            s@(ES _) -> (Just s,  popScreen ui)
-            _        -> (Nothing, ui)
-        -- 2. Exit to register screen
-        let uiReg = popScreen uiTxn
-        put' uiReg
-        -- 3. Re-enter the transaction screen
-        rsHandle (VtyEvent (EvKey KEnter [])) -- PARTIAL assumes we are on the register screen.
-        -- 4. Return to the error screen (below the transaction screen) if there was one.
-        -- Next events will be handled by esHandle. Error repair will return to the transaction screen.
-        maybe (return ()) (put' . flip pushScreen uiTxn) merrscr
-          -- doesn't uiTxn have old state from before step 3 ? seems to work
-
-        -- XXX some problem:
-        -- 4. Reload once more, possibly re-entering the error screen, by sending a g event.
-        -- sendVtyEvents [EvKey (KChar 'g') []]  --  XXX Might be disrupted if other events are queued
-
-        -- XXX doesn't update on non-error change:
-        -- 4. Reload once more, possibly re-entering the error screen.
-        -- uiTxnOrErr <- uiReload copts d uiTxn
-          -- uiReloadIfChanged ?
-          -- uiCheckBalanceAssertions ? seems unneeded
-        -- put' uiTxnOrErr
-
-        -- XXX not working right:
-        -- -- 1. If uiReload (or checking balance assertions) moved us to the error screen, exit to the transaction screen.
-        -- let
-        --   uiTxn = case aScreen $ uiCheckBalanceAssertions d ui of
-        --     ES _ -> popScreen ui
-        --     _    -> ui
-        -- -- 2. Exit to register screen
-        -- put' $ popScreen uiTxn
-        -- -- 3. Re-enter the transaction screen, and reload once more.
-        -- sendVtyEvents [EvKey KEnter [], EvKey (KChar 'g') []]  -- XXX Might be disrupted if other events are queued
+      -- Reload the journal and regenerate the whole screen stack; tsUpdate now refreshes
+      -- this transaction screen in place, so no exit/re-enter dance is needed.
+      tsReload copts d ui = uiReload copts d ui >>= put'
+      tsReloadIfFileChanged copts d j ui = liftIO (uiReloadIfFileChanged copts d j ui) >>= put'
 
 
 -- | Select a new transaction and update the previous register screen

--- a/hledger-ui/Hledger/UI/UIScreens.hs
+++ b/hledger-ui/Hledger/UI/UIScreens.hs
@@ -66,7 +66,7 @@ screenUpdate opts d j = \case
   BS sst -> BS $! bsUpdate opts d j sst
   IS sst -> IS $! isUpdate opts d j sst
   RS sst -> RS $! rsUpdate opts d j sst
-  TS sst -> TS $  tsUpdate sst
+  TS sst -> TS $! tsUpdate opts d j sst
   ES sst -> ES $  esUpdate sst
 
 -- | Construct an error screen.
@@ -254,54 +254,8 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
   -- reference to the previous generation's list (oldlist) so it can be GC'd (#1825).
   l' `seq` rss{_rssList=l'}
   where
-    UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}} = uopts
-    -- gather arguments and queries
-    -- XXX temp
-    inclusive = tree_ ropts || _rssForceInclusive
-    thisacctq = Acct $ mkregex _rssAccount
-      where
-        mkregex = if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex
-
-    -- adjust the report options and report spec, carefully as usual to avoid screwups (#1523)
-    ropts' = ropts {
-        -- ignore any depth limit, as in postingsReport; allows register's total to match accounts screen
-        depth_=mempty
-        -- do not strip prices so we can toggle costs within the ui
-      , show_costs_=True
-      -- XXX aregister also has this, needed ?
-        -- always show historical balance
-      -- , balanceaccum_= Historical
-      }
-    rspec' =
-      updateReportSpec ropts' rspec{_rsDay=d}
-      & either (error' "rsUpdate: adjusting the query for register, should not have failed") id -- PARTIAL:
-      & reportSpecSetFutureAndForecast (forecast_ $ inputopts_ copts)
-
-    -- gather transactions to display
-    items = styleAmounts styles $ accountTransactionsReport rspec' j thisacctq
-              where
-                styles = journalCommodityStylesWith HardRounding j
-    items' =
-      (if empty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $  -- without --empty, exclude no-change txns
-      reverse  -- most recent last
-      items
-
-    -- pre-render the list items, helps calculate column widths
-    displayitems = map displayitem items'
-      where
-        displayitem (t, _, _issplit, otheraccts, change, bal) =
-          RegisterScreenItem{rsItemDate          = showDate $ transactionRegisterDate wd (_rsQuery rspec') thisacctq t
-                            ,rsItemStatus        = tstatus t
-                            ,rsItemDescription   = tdescription t
-                            ,rsItemOtherAccounts = T.intercalate ", " . map accountSummarisedName $ nub otheraccts
-                                                    -- _   -> "<split>"  -- should do this if accounts field width < 30
-                            ,rsItemChangeAmount  = showamt change
-                            ,rsItemBalanceAmount = showamt bal
-                            ,rsItemTransaction   = t
-                            }
-            where
-              showamt = showMixedAmountB oneLineNoCostFmt{displayMaxWidth=Just 3}
-              wd = whichDate ropts'
+    -- the rendered register items (one per transaction); shared with the transaction screen
+    displayitems = registerScreenDisplayItems uopts d j _rssAccount _rssForceInclusive
 
     -- blank items are added to allow more control of scroll position; we won't allow movement over these.
     -- XXX Ugly. Changing to 0 helps when debugging.
@@ -353,25 +307,85 @@ rsUpdate uopts d j rss@RSS{_rssAccount, _rssForceInclusive, _rssList=oldlist} =
                   [(abs $ diffDays (tdate t) prevseld, abs (tindex t - prevselidx), tindex t) | t <- ts])
                 ts = map rsItemTransaction displayitems
 
+-- | The rendered register items (one per transaction) for an account's register,
+-- from these options, reporting date, journal, account name, and whether to include
+-- subaccount transactions. Shared by the register screen and the transaction screen
+-- so they show the same set of transactions.
+registerScreenDisplayItems :: UIOpts -> Day -> Journal -> AccountName -> Bool -> [RegisterScreenItem]
+registerScreenDisplayItems uopts d j acct forceinclusive = map displayitem items'
+  where
+    UIOpts{uoCliOpts=copts@CliOpts{reportspec_=rspec@ReportSpec{_rsReportOpts=ropts}}} = uopts
+    inclusive = tree_ ropts || forceinclusive
+    thisacctq = Acct $ mkregex acct
+      where
+        mkregex = if inclusive then accountNameToAccountRegex else accountNameToAccountOnlyRegex
+
+    -- adjust the report options and report spec, carefully as usual to avoid screwups (#1523)
+    ropts' = ropts {
+        -- ignore any depth limit, as in postingsReport; allows register's total to match accounts screen
+        depth_=mempty
+        -- do not strip prices so we can toggle costs within the ui
+      , show_costs_=True
+      }
+    rspec' =
+      updateReportSpec ropts' rspec{_rsDay=d}
+      & either (error' "registerScreenDisplayItems: adjusting the query for register, should not have failed") id -- PARTIAL:
+      & reportSpecSetFutureAndForecast (forecast_ $ inputopts_ copts)
+
+    -- gather transactions to display
+    items = styleAmounts styles $ accountTransactionsReport rspec' j thisacctq
+              where
+                styles = journalCommodityStylesWith HardRounding j
+    items' =
+      (if empty_ ropts then id else filter (not . mixedAmountLooksZero . fifth6)) $  -- without --empty, exclude no-change txns
+      reverse  -- most recent last
+      items
+
+    displayitem (t, _, _issplit, otheraccts, change, bal) =
+      RegisterScreenItem{rsItemDate          = showDate $ transactionRegisterDate wd (_rsQuery rspec') thisacctq t
+                        ,rsItemStatus        = tstatus t
+                        ,rsItemDescription   = tdescription t
+                        ,rsItemOtherAccounts = T.intercalate ", " . map accountSummarisedName $ nub otheraccts
+                                                -- _   -> "<split>"  -- should do this if accounts field width < 30
+                        ,rsItemChangeAmount  = showamt change
+                        ,rsItemBalanceAmount = showamt bal
+                        ,rsItemTransaction   = t
+                        }
+      where
+        showamt = showMixedAmountB oneLineNoCostFmt{displayMaxWidth=Just 3}
+        wd = whichDate ropts'
+
 -- | Construct a transaction screen showing one of a given list of transactions,
 -- with the ability to step back and forth through the list.
 -- Screen-specific arguments: the account whose transactions are being shown,
--- the list of showable transactions, the currently shown transaction.
-tsNew :: AccountName -> [NumberedTransaction] -> NumberedTransaction -> Screen
-tsNew acct nts nt =
+-- whether that register included subaccounts, the list of showable transactions,
+-- the currently shown transaction.
+tsNew :: AccountName -> Bool -> [NumberedTransaction] -> NumberedTransaction -> Screen
+tsNew acct forceinclusive nts nt =
   dbgui "tsNew" $
   TS TSS{
-     _tssAccount      = acct
-    ,_tssTransactions = nts
-    ,_tssTransaction  = nt
+     _tssAccount        = acct
+    ,_tssForceInclusive = forceinclusive
+    ,_tssTransactions   = nts
+    ,_tssTransaction    = nt
     }
 
--- | Update a transaction screen. 
--- This currently does nothing because the initialisation in rsHandle is not so easy to extract.
--- To see the updated transaction, one must exit and re-enter the transaction screen.
--- See also tsHandle.
-tsUpdate :: TransactionScreenState -> TransactionScreenState
-tsUpdate = dbgui "tsUpdate"
+-- | Update a transaction screen: rebuild its transaction list from the (possibly reloaded)
+-- journal, and reselect the same transaction by its journal index, so the screen refreshes
+-- in place on reload. If that transaction is gone, fall back to the one at the same position,
+-- else the last, else a blank.
+tsUpdate :: UIOpts -> Day -> Journal -> TransactionScreenState -> TransactionScreenState
+tsUpdate uopts d j tss@TSS{_tssAccount, _tssForceInclusive, _tssTransaction=(oldpos, oldtxn)} =
+  dbgui "tsUpdate" $
+  length numberedtxns `seq` selected `seq`
+  tss{_tssTransactions=numberedtxns, _tssTransaction=selected}
+  where
+    displayitems = registerScreenDisplayItems uopts d j _tssAccount _tssForceInclusive
+    numberedtxns = zipWith (\i item -> (i, rsItemTransaction item)) [(1::Integer)..] displayitems
+    selected     = fromMaybe fallback $ find ((== tindex oldtxn) . tindex . snd) numberedtxns
+    fallback     = case numberedtxns of
+      [] -> (0, nulltransaction)
+      _  -> fromMaybe (last numberedtxns) $ (\t -> (oldpos, t)) <$> lookup oldpos numberedtxns
 
 -- | Set selected index of a list if there are displayitems.
 -- If there are no displayitems, remove the selected index of the list.

--- a/hledger-ui/Hledger/UI/UITypes.hs
+++ b/hledger-ui/Hledger/UI/UITypes.hs
@@ -238,9 +238,10 @@ data RegisterScreenState = RSS {
 
 data TransactionScreenState = TSS {
     -- screen parameters:
-   _tssAccount      :: AccountName                  -- ^ the account whose register we entered this screen from
-  ,_tssTransactions :: [NumberedTransaction]        -- ^ the transactions in that register, which we can step through
-  ,_tssTransaction  :: NumberedTransaction          -- ^ the currently displayed transaction, and its position in the list
+   _tssAccount        :: AccountName                -- ^ the account whose register we entered this screen from
+  ,_tssForceInclusive :: Bool                       -- ^ whether the parent register included subaccounts
+  ,_tssTransactions   :: [NumberedTransaction]      -- ^ the transactions in that register, which we can step through
+  ,_tssTransaction    :: NumberedTransaction        -- ^ the currently displayed transaction, and its position in the list
 } deriving (Show)
 
 data ErrorScreenState = ESS {

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -236,7 +236,16 @@ transactionWithMostlyOriginalPostings t =
   where
     postingMostlyOriginal p = orig
         { paccount = paccount p
-        , pamount = newAmt }
+        , pamount = newAmt
+        -- When paccount equals the original (no collapse), trust the
+        -- original's assertion. When paccount has been changed (eg a lot
+        -- subaccount was collapsed away), use the current state's
+        -- assertion — which 'journalCollapseLotDetail' has already cleared
+        -- if the assertion targeted the now-hidden lot subaccount.
+        , pbalanceassertion =
+            if paccount orig == paccount p
+            then pbalanceassertion orig
+            else pbalanceassertion p }
       where
         orig = originalPosting p
         newAmt


### PR DESCRIPTION
Follow-up to #2652 (this PR is stacked on it; the base will retarget to main once #2652 merges).

Now that reload regenerates the whole screen stack, this makes the hledger-ui transaction
screen refresh in place on reload, and removes a fragile workaround.

## Problem

`tsUpdate` was a no-op, so the transaction screen did not update on `g`/`--watch` reload — to
see an edited transaction you had to exit and re-enter it. To paper over that, `TransactionScreen`
carried a ~40-line `reEnterTransactionScreen` workaround (pop to the register, simulate `Enter`,
juggle the error screen) that flickered and, per its own comments, was unreliable.

## Change

- Give the transaction screen a real `tsUpdate`: rebuild its transaction list from the reloaded
  journal and reselect the same transaction by `tindex` (fall back to same position, else last,
  else a blank for an emptied account).
- Factor the register's transaction-list derivation out of `rsUpdate` into a shared
  `registerScreenDisplayItems`, used by both the register and transaction screens so they show the
  same transactions.
- Store `_tssForceInclusive` on the transaction screen so it can rebuild its register independently.
- Delete the `reEnterTransactionScreen` workaround; `tsReload` is now just `uiReload >>= put'`,
  matching the register screen. ErrorScreen handling is unchanged.

## Result

On the transaction screen, `g`/`--watch` updates the shown transaction in place (no exit/re-enter,
no flicker), and stepping (n/p) reflects added/removed transactions. Reloading into a parse or
balance-assertion error still shows the error screen and recovers.

AI assistance: Claude Code & Opus 4.8, using 100k output tokens.
