### PR TITLE
Command aliases (custom commands)

### DIFF
--- a/hledger-lib/.date.m4
+++ b/hledger-lib/.date.m4
@@ -1,2 +1,2 @@
 m4_dnl Date to show in man pages. Updated by "Shake manuals"
-m4_define({{_monthyear_}}, {{June 2026}})m4_dnl
+m4_define({{_monthyear_}}, {{July 2026}})m4_dnl

--- a/hledger-ui/.date.m4
+++ b/hledger-ui/.date.m4
@@ -1,2 +1,2 @@
 m4_dnl Date to show in man pages. Updated by "Shake manuals"
-m4_define({{_monthyear_}}, {{June 2026}})m4_dnl
+m4_define({{_monthyear_}}, {{July 2026}})m4_dnl

--- a/hledger-ui/hledger-ui.1
+++ b/hledger-ui/hledger-ui.1
@@ -1,5 +1,5 @@
 
-.TH "HLEDGER\-UI" "1" "May 2026" "hledger-ui-1.99 " "hledger User Manuals"
+.TH "HLEDGER\-UI" "1" "June 2026" "hledger-ui-1.99 " "hledger User Manuals"
 
 
 
@@ -306,6 +306,10 @@ Cost mode takes precedence.
 \- There\(aqs not yet any visual indicator that cost or value mode is
 active, other than the amount values.
 .PP
+\f[CR]L\f[R] toggles lot detail (like the \f[CR]\-\-lots\f[R] flag),
+showing or hiding lot subaccounts (such as
+\f[CR]assets:broker:{2026\-01\-15, $50}\f[R]) and other per\-lot detail.
+.PP
 \f[CR]q\f[R] quits the application.
 .PP
 Additional screen\-specific keys are described below.
@@ -461,20 +465,11 @@ It may not detect changes made from outside a virtual machine, ie by an
 editor running on the host system.
 .IP \(bu 2
 It may not detect file changes on certain less common filesystems.
-.IP \(bu 2
-It may use increasing CPU and RAM over time, especially with large
-files.
-(This is probably not \-\-watch specific, you may be able to reproduce
-it by pressing \f[CR]g\f[R] repeatedly.)
-(#1825)
 .PP
 Tips/workarounds:
 .IP \(bu 2
 If \-\-watch won\(aqt work for you, press \f[CR]g\f[R] to reload data
 manually instead.
-.IP \(bu 2
-If \-\-watch is leaking resources over time, quit and restart (or
-suspend and resume) hledger\-ui when you\(aqre not using it.
 .IP \(bu 2
 When running hledger\-ui inside a VM, also make file changes inside the
 VM.

--- a/hledger-ui/hledger-ui.info
+++ b/hledger-ui/hledger-ui.info
@@ -305,6 +305,10 @@ but not both at once.  Cost mode takes precedence.  - There's not yet
 any visual indicator that cost or value mode is active, other than the
 amount values.
 
+   'L' toggles lot detail (like the '--lots' flag), showing or hiding
+lot subaccounts (such as 'assets:broker:{2026-01-15, $50}') and other
+per-lot detail.
+
    'q' quits the application.
 
    Additional screen-specific keys are described below.
@@ -520,16 +524,11 @@ _However._  There are limitations/unresolved bugs with '--watch':
    * It may not detect changes made from outside a virtual machine, ie
      by an editor running on the host system.
    * It may not detect file changes on certain less common filesystems.
-   * It may use increasing CPU and RAM over time, especially with large
-     files.  (This is probably not -watch specific, you may be able to
-     reproduce it by pressing 'g' repeatedly.)  (#1825)
 
    Tips/workarounds:
 
    * If -watch won't work for you, press 'g' to reload data manually
      instead.
-   * If -watch is leaking resources over time, quit and restart (or
-     suspend and resume) hledger-ui when you're not using it.
    * When running hledger-ui inside a VM, also make file changes inside
      the VM.
    * When working with files mounted from another machine, make sure the
@@ -570,19 +569,19 @@ Node: Top221
 Node: OPTIONS1867
 Node: MOUSE9508
 Node: KEYS9840
-Node: SCREENS15012
-Node: Menu screen15752
-Node: Cash accounts screen16068
-Node: Balance sheet accounts screen16429
-Node: Income statement accounts screen16765
-Node: All accounts screen17150
-Node: Register screen17513
-Node: Transaction screen19956
-Node: Error screen21136
-Node: WATCH MODE21502
-Node: --watch problems22400
-Node: ENVIRONMENT23647
-Node: BUGS23880
+Node: SCREENS15169
+Node: Menu screen15909
+Node: Cash accounts screen16225
+Node: Balance sheet accounts screen16586
+Node: Income statement accounts screen16922
+Node: All accounts screen17307
+Node: Register screen17670
+Node: Transaction screen20113
+Node: Error screen21293
+Node: WATCH MODE21659
+Node: --watch problems22557
+Node: ENVIRONMENT23475
+Node: BUGS23708
 
 End Tag Table
 

--- a/hledger-ui/hledger-ui.txt
+++ b/hledger-ui/hledger-ui.txt
@@ -266,14 +266,17 @@ KEYS
      sual indicator that cost or value mode is active,  other  than  the  amount
      values.
 
+     L  toggles  lot detail (like the --lots flag), showing or hiding lot subac-
+     counts (such as assets:broker:{2026-01-15, $50}) and other per-lot detail.
+
      q quits the application.
 
      Additional screen-specific keys are described below.
 
 SCREENS
-     At  startup,  hledger-ui shows a menu screen by default.  From here you can
-     navigate to other screens using the cursor keys: UP/DOWN to  select,  RIGHT
-     to  move to the selected screen, LEFT to return to the previous screen.  Or
+     At startup, hledger-ui shows a menu screen by default.  From here  you  can
+     navigate  to  other screens using the cursor keys: UP/DOWN to select, RIGHT
+     to move to the selected screen, LEFT to return to the previous screen.   Or
      you can use ESC to return directly to the top menu screen.
 
      You can also use a command line flag to specific a different startup screen
@@ -281,72 +284,72 @@ SCREENS
 
    Menu screen
      This is the top-most screen.  From here you can navigate to several screens
-     listing accounts of various types.  Note some of these may  not  show  any-
+     listing  accounts  of  various types.  Note some of these may not show any-
      thing until you have configured account types.
 
    Cash accounts screen
-     This  screen  shows  "cash"  (ie, liquid asset) accounts (like hledger bal-
+     This screen shows "cash" (ie, liquid asset)  accounts  (like  hledger  bal-
      ancesheet type:c).  It always shows balances (historical ending balances on
      the date shown in the title line).
 
    Balance sheet accounts screen
-     This screen shows asset, liability and equity accounts (like  hledger  bal-
+     This  screen  shows asset, liability and equity accounts (like hledger bal-
      ancesheetequity).  It always shows balances.
 
    Income statement accounts screen
-     This  screen  shows revenue and expense accounts (like hledger incomestate-
+     This screen shows revenue and expense accounts (like  hledger  incomestate-
      ment).  It always shows changes (balance changes in the period shown in the
      title line).
 
    All accounts screen
      This screen shows all accounts in your journal (unless filtered by a query;
-     like hledger balance).  It shows balances by default; you can toggle  show-
+     like  hledger balance).  It shows balances by default; you can toggle show-
      ing changes with the H key.
 
    Register screen
-     This  screen  shows  the transactions affecting a particular account.  Each
+     This screen shows the transactions affecting a  particular  account.   Each
      line represents one transaction, and shows:
 
-     * the other account(s) involved, in abbreviated form.  (If there  are  both
-       real  and  virtual  postings, it shows only the accounts affected by real
+     * the  other  account(s) involved, in abbreviated form.  (If there are both
+       real and virtual postings, it shows only the accounts  affected  by  real
        postings.)
 
-     * the overall change to the current account's balance; positive for an  in-
+     * the  overall change to the current account's balance; positive for an in-
        flow to this account, negative for an outflow.
 
-     * the  running  total after the transaction.  With the H key you can toggle
+     * the running total after the transaction.  With the H key you  can  toggle
        between
 
        * the period total, which is from just the transactions displayed
 
-       * or the historical total, which includes  any  undisplayed  transactions
+       * or  the  historical  total, which includes any undisplayed transactions
          before the start of the report period (and matching the filter query if
-         any).   This will be the running historical balance (what you would see
+         any).  This will be the running historical balance (what you would  see
          on a bank's website, eg) if not disturbed by a query.
 
-     Note, this screen combines each transaction's in-period postings to a  sin-
-     gle  line  item,  dated  with the earliest in-period transaction or posting
-     date (like hledger's aregister).  So custom posting  dates  can  cause  the
-     running  balance to be temporarily inaccurate.  (See hledger manual > areg-
+     Note,  this screen combines each transaction's in-period postings to a sin-
+     gle line item, dated with the earliest  in-period  transaction  or  posting
+     date  (like  hledger's  aregister).   So custom posting dates can cause the
+     running balance to be temporarily inaccurate.  (See hledger manual >  areg-
      ister and posting dates.)
 
-     Transactions affecting this account's subaccounts will be included  in  the
-     register  if  the  accounts screen is in tree mode, or if it's in list mode
-     but this account has subaccounts which are not shown due to a depth  limit.
-     In  other words, the register always shows the transactions contributing to
-     the balance shown on the accounts screen.  Tree mode/list mode can be  tog-
+     Transactions  affecting  this account's subaccounts will be included in the
+     register if the accounts screen is in tree mode, or if it's  in  list  mode
+     but  this account has subaccounts which are not shown due to a depth limit.
+     In other words, the register always shows the transactions contributing  to
+     the  balance shown on the accounts screen.  Tree mode/list mode can be tog-
      gled with t here also.
 
      U toggles filtering by unmarked status, showing or hiding unmarked transac-
-     tions.   Similarly,  P  toggles pending transactions, and C toggles cleared
-     transactions.  (By default, transactions with all statuses  are  shown;  if
-     you  activate one or two status filters, only those transactions are shown;
+     tions.  Similarly, P toggles pending transactions, and  C  toggles  cleared
+     transactions.   (By  default,  transactions with all statuses are shown; if
+     you activate one or two status filters, only those transactions are  shown;
      and if you activate all three, the filter is removed.)
 
      R toggles real mode, in which virtual postings are ignored.
 
      z toggles nonzero mode, in which only transactions posting a nonzero change
-     are shown (hledger-ui shows zero  items  by  default,  unlike  command-line
+     are  shown  (hledger-ui  shows  zero  items by default, unlike command-line
      hledger).
 
      Press RIGHT to view the selected transaction in detail.
@@ -355,72 +358,65 @@ SCREENS
      This screen shows a single transaction, as a general journal entry, similar
      to hledger's print command and journal format (hledger_journal(5)).
 
-     The  transaction's date(s) and any cleared flag, transaction code, descrip-
-     tion, comments, along with all of its account postings are  shown.   Simple
+     The transaction's date(s) and any cleared flag, transaction code,  descrip-
+     tion,  comments,  along with all of its account postings are shown.  Simple
      transactions have two postings, but there can be more (or in certain cases,
      fewer).
 
-     UP  and  DOWN will step through all transactions listed in the previous ac-
-     count register screen.  In the title bar, the numbers in  parentheses  show
-     your  position  within  that account register.  They will vary depending on
-     which account register you came from (remember most transactions appear  in
-     multiple  account registers).  The #N number preceding them is the transac-
-     tion's position within the complete unfiltered journal,  which  is  a  more
+     UP and DOWN will step through all transactions listed in the  previous  ac-
+     count  register  screen.  In the title bar, the numbers in parentheses show
+     your position within that account register.  They will  vary  depending  on
+     which  account register you came from (remember most transactions appear in
+     multiple account registers).  The #N number preceding them is the  transac-
+     tion's  position  within  the  complete unfiltered journal, which is a more
      stable id (at least until the next reload).
 
      On this screen (and the register screen), the E key will open your text ed-
      itor with the cursor positioned at the current transaction if possible.
 
    Error screen
-     This  screen will appear if there is a problem, such as a parse error, when
-     you press g to reload.  Once you have fixed the problem, press g  again  to
-     reload  and  resume  normal operation.  (Or, you can press escape to cancel
+     This screen will appear if there is a problem, such as a parse error,  when
+     you  press  g to reload.  Once you have fixed the problem, press g again to
+     reload and resume normal operation.  (Or, you can press  escape  to  cancel
      the reload attempt.)
 
 WATCH MODE
-     One of hledger-ui's best features is the  auto-reloading  -w/--watch  mode.
-     With  this  flag, it will update the display automatically whenever changes
+     One  of  hledger-ui's  best features is the auto-reloading -w/--watch mode.
+     With this flag, it will update the display automatically  whenever  changes
      are saved to the data files.
 
-     This is very useful when reconciling.  A good  workflow  is  to  have  your
+     This  is  very  useful  when  reconciling.  A good workflow is to have your
      bank's online register open in a browser window, for reference; the journal
-     file  open  in an editor window; and hledger-ui in watch mode in a terminal
+     file open in an editor window; and hledger-ui in watch mode in  a  terminal
      window, eg:
 
             $ hledger-ui --watch --register checking -C
 
-     As you mark things cleared in the editor, you can see  the  effect  immedi-
-     ately  without having to context switch.  This leaves more mental bandwidth
+     As  you  mark  things cleared in the editor, you can see the effect immedi-
+     ately without having to context switch.  This leaves more mental  bandwidth
      for your accounting.  Of course you can still interact with hledger-ui when
      needed, eg to toggle cleared mode, or to explore the history.
 
    --watch problems
      However. There are limitations/unresolved bugs with --watch:
 
-     * It may not work at all for you, depending on platform or system  configu-
-       ration.   On some unix systems, increasing fs.inotify.max_user_watches or
+     * It  may not work at all for you, depending on platform or system configu-
+       ration.  On some unix systems, increasing fs.inotify.max_user_watches  or
        fs.file-max parameters in /etc/sysctl.conf might help.  (#836)
 
-     * It may not detect changes made from outside a virtual machine, ie  by  an
+     * It  may  not detect changes made from outside a virtual machine, ie by an
        editor running on the host system.
 
      * It may not detect file changes on certain less common filesystems.
-
-     * It may use increasing CPU and RAM over time, especially with large files.
-       (This  is  probably not --watch specific, you may be able to reproduce it
-       by pressing g repeatedly.)  (#1825)
 
      Tips/workarounds:
 
      * If --watch won't work for you, press g to reload data manually instead.
 
-     * If --watch is leaking resources over time, quit and restart  (or  suspend
-       and resume) hledger-ui when you're not using it.
-
-     * When  running  hledger-ui  inside a VM, also make file changes inside the
+     * When running hledger-ui inside a VM, also make file  changes  inside  the
        VM.
 
-     * When working with files mounted from another machine, make sure the  sys-
+     * When  working with files mounted from another machine, make sure the sys-
        tem clocks on both machines are roughly in agreement.
 
 ENVIRONMENT
@@ -429,7 +425,7 @@ ENVIRONMENT
 
 BUGS
      We    welcome    bug    reports    in    the    hledger    issue    tracker
-     (https://bugs.hledger.org),  or  on  the  hledger   chat   or   mail   list
+     (https://bugs.hledger.org),   or   on   the   hledger  chat  or  mail  list
      (https://hledger.org/support).
 
      Some known issues:
@@ -459,4 +455,4 @@ LICENSE
 SEE ALSO
      hledger(1), hledger-ui(1), hledger-web(1), ledger(1)
 
-hledger-ui-1.99                     May 2026                       HLEDGER-UI(1)
+hledger-ui-1.99                     June 2026                      HLEDGER-UI(1)

--- a/hledger-web/.date.m4
+++ b/hledger-web/.date.m4
@@ -1,2 +1,2 @@
 m4_dnl Date to show in man pages. Updated by "Shake manuals"
-m4_define({{_monthyear_}}, {{June 2026}})m4_dnl
+m4_define({{_monthyear_}}, {{July 2026}})m4_dnl

--- a/hledger-web/hledger-web.1
+++ b/hledger-web/hledger-web.1
@@ -1,5 +1,5 @@
 
-.TH "HLEDGER\-WEB" "1" "May 2026" "hledger-web-1.99 " "hledger User Manuals"
+.TH "HLEDGER\-WEB" "1" "June 2026" "hledger-web-1.99 " "hledger User Manuals"
 
 
 

--- a/hledger-web/hledger-web.txt
+++ b/hledger-web/hledger-web.txt
@@ -483,4 +483,4 @@ LICENSE
 SEE ALSO
      hledger(1), hledger-ui(1), hledger-web(1), ledger(1)
 
-hledger-web-1.99                    May 2026                      HLEDGER-WEB(1)
+hledger-web-1.99                    June 2026                     HLEDGER-WEB(1)

--- a/hledger.conf.sample
+++ b/hledger.conf.sample
@@ -78,3 +78,22 @@
 # --source SRCACCT
 # --target DSTACCT
 # ACCT
+
+
+# 3. Command aliases: your own custom commands, which expand to a longer
+# command line, similar to git aliases. Extra options/arguments written
+# after the alias name are added at the end.
+# https://hledger.org/dev/hledger.html#command-aliases
+
+#[alias]
+#rev10 = balance type:R -2 -X$ -p 'every 10 years from 2000'
+
+# Or define one alias per section, with its command line written below,
+# possibly on multiple lines:
+#[alias rev10]
+#balance
+#type:R
+#-2
+#-X$
+#-p 'every 10 years from 2000'
+## --drop 1

--- a/hledger.conf.sample
+++ b/hledger.conf.sample
@@ -98,7 +98,6 @@
 
 # [alias forecasts]
 # run
-# --   # extra separator needed for some reason
 # -- echo bchecking: -- forecast bchecking #-e 2months
 # -- echo pchecking: -- forecast pchecking #-e 2months
 # -- echo ichecking: -- forecast ichecking #-e 2months

--- a/hledger.conf.sample
+++ b/hledger.conf.sample
@@ -88,7 +88,13 @@
 # p1    = print --oneline
 # rev10 = bal type:R -2 -X$ -p 'every 10 years from 2000'
 
-# Or define an alias in its own section, using multiple lines:
+# Aliases beginning with ! are shell commands. These will run only from
+# a trusted config file (your user config, or one specified with --conf).
+
+# commit = ! jj commit `hledger files` -m
+# gitcommit = ! git commit -p -- `hledger files`
+
+# Or you can define an alias in its own section, using multiple lines:
 
 # [alias forecast]
 # aregister --forecast -E
@@ -101,10 +107,3 @@
 # -- echo bchecking: -- forecast bchecking #-e 2months
 # -- echo pchecking: -- forecast pchecking #-e 2months
 # -- echo ichecking: -- forecast ichecking #-e 2months
-
-# An alias beginning with ! runs a shell command (only from a trusted config file:
-# one specified with --conf, or your user config file):
-
-# [alias]
-# commit = ! git commit -p -- `hledger files`
-# commit = ! jj commit `hledger files` -m

--- a/hledger.conf.sample
+++ b/hledger.conf.sample
@@ -80,20 +80,25 @@
 # ACCT
 
 
-# 3. Command aliases: your own custom commands, which expand to a longer
-# command line, similar to git aliases. Extra options/arguments written
-# after the alias name are added at the end.
+# 3. Command aliases: your own custom hledger commands, similar to git aliases.
 # https://hledger.org/dev/hledger.html#command-aliases
 
-#[alias]
-#rev10 = balance type:R -2 -X$ -p 'every 10 years from 2000'
+# [alias]
+# p = print
+# p1 = print --oneline
+# rev10 = bal type:R -2 -X$ -p 'every 10 years from 2000'
 
-# Or define one alias per section, with its command line written below,
-# possibly on multiple lines:
-#[alias rev10]
-#balance
-#type:R
-#-2
-#-X$
-#-p 'every 10 years from 2000'
-## --drop 1
+# Or define an alias in its own section, using multiple lines:
+
+# [alias forecast]
+# aregister --forecast -E
+# -p today..3months
+
+# With the run command you can build multi-command scripts:
+
+# [alias forecasts]
+# run
+# --   # extra separator needed for some reason
+# -- echo bchecking: -- forecast bchecking #-e 2months
+# -- echo pchecking: -- forecast pchecking #-e 2months
+# -- echo ichecking: -- forecast ichecking #-e 2months

--- a/hledger.conf.sample
+++ b/hledger.conf.sample
@@ -84,8 +84,8 @@
 # https://hledger.org/dev/hledger.html#command-aliases
 
 # [alias]
-# p = print
-# p1 = print --oneline
+# p     = print
+# p1    = print --oneline
 # rev10 = bal type:R -2 -X$ -p 'every 10 years from 2000'
 
 # Or define an alias in its own section, using multiple lines:
@@ -101,3 +101,10 @@
 # -- echo bchecking: -- forecast bchecking #-e 2months
 # -- echo pchecking: -- forecast pchecking #-e 2months
 # -- echo ichecking: -- forecast ichecking #-e 2months
+
+# An alias beginning with ! runs a shell command (only from a trusted config file:
+# one specified with --conf, or your user config file):
+
+# [alias]
+# commit = ! git commit -p -- `hledger files`
+# commit = ! jj commit `hledger files` -m

--- a/hledger/.date.m4
+++ b/hledger/.date.m4
@@ -1,2 +1,2 @@
 m4_dnl Date to show in man pages. Updated by "Shake manuals"
-m4_define({{_monthyear_}}, {{June 2026}})m4_dnl
+m4_define({{_monthyear_}}, {{July 2026}})m4_dnl

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -115,7 +115,7 @@ import System.Console.CmdArgs.Explicit
 import System.Console.CmdArgs.Explicit as CmdArgsWithoutName hiding (Name)
 import System.Environment
 import System.Exit
-import System.Process
+import System.Process (system)
 import Text.Megaparsec (optional, takeWhile1P, eof)
 import Text.Megaparsec.Char (char)
 import Text.Printf
@@ -268,6 +268,9 @@ main = handleExit $ withGhcDebug' $ do
     if clicmdarg=="setup"  -- the setup command checks config files, but never uses one itself
       then return (nullconf,Nothing)
       else getConf' cliconfrawopts
+  -- Whether !-prefixed shell command aliases from this config file are allowed to run
+  -- (only from a trusted config file: one given with --conf, or a user-level config file).
+  shellaliasesallowed <- confFileIsTrusted cliconfrawopts mconffile
 
   ---------------------------------------------------------------
   dbgio "\n3. Identify a command name if possible; handle version/help flags" ()
@@ -295,8 +298,10 @@ main = handleExit $ withGhcDebug' $ do
     -- If so, expand it to the real command name and the extra arguments to prepend.
     -- Command aliases never override exact builtin command names, and later definitions win.
     cmdaliases = reverse $ confAliases conf  -- reversed so that lookup finds the last definition
-    (effectivecmdarg, aliasargs) = second replaceNumericFlags $
-      expandCommandAlias (isJust . findBuiltinCommand) cmdaliases cmdarg
+    aliasexpansion = expandCommandAlias (isJust . findBuiltinCommand) cmdaliases cmdarg
+    (effectivecmdarg, aliasargs) = case aliasexpansion of
+      HledgerCommand c as -> (c, replaceNumericFlags as)
+      ShellCommand   _    -> (cmdarg, [])  -- handled separately below
     isaliascmd = effectivecmdarg /= cmdarg || not (null aliasargs)
 
     -- The argument may be an abbreviated command name, which we need to expand.
@@ -327,6 +332,22 @@ main = handleExit $ withGhcDebug' $ do
   dbgio "no command provided" nocmdprovided
   dbgio "bad command provided" badcmdprovided
   dbgio "is addon command" isaddoncmd
+
+  -- If the command is a !-prefixed shell command alias, run it now (if allowed) and exit.
+  -- This happens before the badcmdprovided check, since the alias name is not a real command.
+  case aliasexpansion of
+    ShellCommand shcmd
+      | shellaliasesallowed -> do
+          -- append any arguments written after the alias name (not hledger's own options)
+          let fullcmd = unwords $ shcmd : map quoteForCommandLine cliargsaftercmd
+          dbg1IO "running shell command alias" fullcmd
+          system fullcmd >>= exitWith
+      | otherwise -> error' $
+          "the command alias '" <> cmdarg <> "' runs a shell command (! " <> shcmd <> ")"
+          <> maybe "" (\f -> ",\ndefined in " <> f) mconffile <> ".\n"
+          <> "Shell command aliases are only allowed from your user config file (~/.hledger.conf or XDG),\n"
+          <> "or a config file given with --conf; refusing to run it from an automatically-found config file."
+    _ -> return ()
 
   -- If a bad command was provided, show that error now, before the full cmdargsParse attempt.
   when badcmdprovided $ do
@@ -451,8 +472,8 @@ main = handleExit $ withGhcDebug' $ do
           withPossibleJournal opts $ \j -> runWithExpandedCurQueries opts j cmdaction
 
         -- 6.4.4. "run" and "repl" need findBuiltinCommands passed to it to avoid circular dependency in the code
-        | cmdname == "run"  -> Hledger.Cli.Commands.Run.run Nothing findBuiltinCommand addons cmdaliases opts
-        | cmdname == "repl" -> Hledger.Cli.Commands.Run.repl findBuiltinCommand addons cmdaliases opts
+        | cmdname == "run"  -> Hledger.Cli.Commands.Run.run Nothing findBuiltinCommand addons cmdaliases shellaliasesallowed opts
+        | cmdname == "repl" -> Hledger.Cli.Commands.Run.repl findBuiltinCommand addons cmdaliases shellaliasesallowed opts
 
         -- 6.4.5. all other builtin commands - read the journal and if successful run the command with it
         | otherwise -> withJournal opts $ \j -> runWithExpandedCurQueries opts j cmdaction

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -232,7 +232,7 @@ main = handleExit $ withGhcDebug' $ do
 
   -- Naming notes:
   -- "arg" often has the most general meaning, including things like: -f, --flag, flagvalue, arg, >file, &, etc.
-  -- confcmdarg, clicmdarg = the first non-flag argument, from config file or cli = the subcommand name
+  -- clicmdarg = the first non-flag argument on the command line = the subcommand name
   -- cmdname = the full unabbreviated command name, or ""
   -- confcmdargs = arguments for the subcommand, from config file
 
@@ -275,23 +275,16 @@ main = handleExit $ withGhcDebug' $ do
   ---------------------------------------------------------------
   dbgio "\n3. Identify a command name if possible; handle version/help flags" ()
 
-  -- Try to identify the subcommand name,
-  -- from the first non-flag general argument in the config file,
-  -- or if there is none, from the first non-flag argument on the command line.
+  -- Try to identify the subcommand name, from the first non-flag argument on the command line.
 
   let
     confallgenargs = confLookup "general" conf & replaceNumericFlags
-    -- we don't try to move flags/values preceding a command argument here;
-    -- if a command name is written in the config file, it must be first
-    (confcmdarg, confothergenargs0) = case confallgenargs of
-      a:as | not $ isFlagArg a -> (a,as)
-      as                       -> ("",as)
     -- Drop any --conf/--no-conf flags found in the config file:
     -- they can't have their usual effect (which config file to use was decided before
     -- reading it), and leaving them in rawopts could confuse later config file reads.
-    confothergenargs   = dropConfFlags confothergenargs0
-    confdroppedgenargs = confothergenargs0 \\ confothergenargs
-    cmdarg = if not $ null confcmdarg then confcmdarg else clicmdarg
+    confothergenargs = dropConfFlags confallgenargs
+    confdroppedgenargs = confallgenargs \\ confothergenargs
+    cmdarg = clicmdarg
     nocmdprovided = null cmdarg
 
     -- The argument may be a command alias (a custom command) defined in the config file.
@@ -322,9 +315,6 @@ main = handleExit $ withGhcDebug' $ do
     mbuiltincmdaction = findBuiltinCommand cmdname
     effectivemode = maybe (mainmode []) fst mbuiltincmdaction
 
-  when (isJust mconffile) $ do
-    unless (null confcmdarg) $
-      dbg1IO "using command name argument from config file" confcmdarg
   dbgio "cli args with command first and no cli-specific opts" cliargswithcmdfirstwithoutclispecific
   when isaliascmd $
     dbg1IO "expanded command alias" (cmdarg, (effectivecmdarg, aliasargs))
@@ -351,11 +341,8 @@ main = handleExit $ withGhcDebug' $ do
 
   -- If a bad command was provided, show that error now, before the full cmdargsParse attempt.
   when badcmdprovided $ do
-    let (srcnote, hint) = case (not (null confcmdarg), mconffile) of
-          (True, Just f) -> (" (from config file " <> f <> ")", "")
-          _              -> ("", " Run with no command to see a list.")
-        aliasnote = if effectivecmdarg /= cmdarg then " (expanded from the " <> cmdarg <> " command alias)" else ""
-    error' $ "command " <> effectivecmdarg <> aliasnote <> srcnote <> " is not recognised." <> hint
+    let aliasnote = if effectivecmdarg /= cmdarg then " (expanded from the " <> cmdarg <> " command alias)" else ""
+    error' $ "command " <> effectivecmdarg <> aliasnote <> " is not recognised. Run with no command to see a list."
 
   ---------------------------------------------------------------
   dbgio "\n4. Get applicable options/arguments from config file" ()
@@ -393,7 +380,6 @@ main = handleExit $ withGhcDebug' $ do
         <> supportedgenargsfromconf
         <> confcmdargs
         <> aliasargs
-        <> [clicmdarg | not $ null clicmdarg, not $ null confcmdarg]
         <> cliargswithoutcmd
       & replaceNumericFlags                -- convert any -NUM opts from the config file
       & argsAddDoubleDash                  -- protect run/repl's first -- from cmdargs (also for an aliased run)

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -107,7 +107,7 @@ import Data.Either (isRight)
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.List
-import Data.Maybe (isJust, fromMaybe, fromJust)
+import Data.Maybe (isJust, isNothing, fromMaybe, fromJust)
 import Data.Text (pack, Text)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Safe
@@ -290,13 +290,29 @@ main = handleExit $ withGhcDebug' $ do
     cmdarg = if not $ null confcmdarg then confcmdarg else clicmdarg
     nocmdprovided = null cmdarg
 
+    -- The argument may be a command alias (a custom command) defined in the config file.
+    -- If so, expand it to the real command name and the extra arguments to prepend.
+    -- Command aliases never override exact builtin command names, and later definitions win.
+    cmdaliases = reverse $ confAliases conf  -- reversed so that lookup finds the last definition
+    expandAlias :: [CommandAlias] -> String -> (String, [String])
+    expandAlias seen name
+      | name `notElem` seen
+      , isNothing $ findBuiltinCommand name
+      , Just (realcmd:defargs) <- lookup name cmdaliases =
+          -- aliases can refer to other aliases; a repeated name (self-reference or cycle) stops the recursion
+          let (realcmd', defargs') = expandAlias (name:seen) realcmd
+          in (realcmd', defargs' <> defargs)
+      | otherwise = (name, [])
+    (effectivecmdarg, aliasargs) = second replaceNumericFlags $ expandAlias [] cmdarg
+    isaliascmd = effectivecmdarg /= cmdarg || not (null aliasargs)
+
     -- The argument may be an abbreviated command name, which we need to expand.
 
     -- Run cmdargs on conf + cli args to get the full command name.
-    -- If no command argument was provided, or if cmdargs fails because 
+    -- If no command argument was provided, or if cmdargs fails because
     -- the command line contains a bad flag or wrongly present/missing flag value,
     -- cmdname will be "".
-    args = [confcmdarg | not $ null confcmdarg] <> cliargswithcmdfirstwithoutclispecific
+    args = [effectivecmdarg | not $ null effectivecmdarg] <> cliargswithcmdfirstwithoutclispecific
     -- Actually, only scan the first non-flag argument, to avoid flag errors at this stage.
     possiblecmdarg = take 1 $ dropWhile isFlagArg args
     cmdname = stringopt "command" $ cmdargsParse "for command name" (mainmode addons) possiblecmdarg
@@ -312,6 +328,8 @@ main = handleExit $ withGhcDebug' $ do
     unless (null confcmdarg) $
       dbg1IO "using command name argument from config file" confcmdarg
   dbgio "cli args with command first and no cli-specific opts" cliargswithcmdfirstwithoutclispecific
+  when isaliascmd $
+    dbg1IO "expanded command alias" (cmdarg, (effectivecmdarg, aliasargs))
   dbg1IO "command found" cmdname
   dbgio "no command provided" nocmdprovided
   dbgio "bad command provided" badcmdprovided
@@ -322,7 +340,8 @@ main = handleExit $ withGhcDebug' $ do
     let (srcnote, hint) = case (not (null confcmdarg), mconffile) of
           (True, Just f) -> (" (from config file " <> f <> ")", "")
           _              -> ("", " Run with no command to see a list.")
-    error' $ "command " <> cmdarg <> srcnote <> " is not recognised." <> hint
+        aliasnote = if effectivecmdarg /= cmdarg then " (expanded from the " <> cmdarg <> " command alias)" else ""
+    error' $ "command " <> effectivecmdarg <> aliasnote <> srcnote <> " is not recognised." <> hint
 
   ---------------------------------------------------------------
   dbgio "\n4. Get applicable options/arguments from config file" ()
@@ -356,9 +375,10 @@ main = handleExit $ withGhcDebug' $ do
 
   let
     finalargs =
-      [cmdarg | not $ null cmdarg]
+      [effectivecmdarg | not $ null effectivecmdarg]
         <> supportedgenargsfromconf
         <> confcmdargs
+        <> aliasargs
         <> [clicmdarg | not $ null clicmdarg, not $ null confcmdarg]
         <> cliargswithoutcmd
       & replaceNumericFlags                -- convert any -NUM opts from the config file
@@ -455,7 +475,7 @@ main = handleExit $ withGhcDebug' $ do
     -- are not passed since we can't be sure they're supported.
     | isaddoncmd -> do
         let
-          addonargs0 = filter (/="--") $ supportedgenargsfromconf <> confcmdargs <> cliargswithoutcmd
+          addonargs0 = filter (/="--") $ supportedgenargsfromconf <> confcmdargs <> aliasargs <> cliargswithoutcmd
           addonargs = dropCliSpecificOpts addonargs0
           shellcmd = printf "%s-%s %s" progname cmdname (unwords $ map quoteForCommandLine addonargs) :: String
         dbgio "addon command selected" cmdname

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -240,7 +240,8 @@ main = handleExit $ withGhcDebug' $ do
   cliargs <- getArgs
     >>= expandArgsAt         -- interpolate @ARGFILEs
     <&> replaceNumericFlags  -- convert -NUM to --depth=NUM
-    <&> argsAddDoubleDash    -- repeat the first -- arg, as a cmdargs workaround
+    -- the -- cmdargs workaround (argsAddDoubleDash) is applied later, to finalargs,
+    -- so that a -- introduced by a command alias is also protected
   let
     (clicmdarg, cliargswithoutcmd, cliargswithcmdfirst) = moveFlagsAfterCommand cliargs
     cliargswithcmdfirstwithoutclispecific = dropCliSpecificOpts cliargswithcmdfirst
@@ -374,6 +375,7 @@ main = handleExit $ withGhcDebug' $ do
         <> [clicmdarg | not $ null clicmdarg, not $ null confcmdarg]
         <> cliargswithoutcmd
       & replaceNumericFlags                -- convert any -NUM opts from the config file
+      & argsAddDoubleDash                  -- protect run/repl's first -- from cmdargs (also for an aliased run)
 
   -- finalargs' <- expandArgsAt finalargs  -- expand @ARGFILEs in the config file ? don't bother
   dbg1IO "final args" finalargs

--- a/hledger/Hledger/Cli.hs
+++ b/hledger/Hledger/Cli.hs
@@ -107,7 +107,7 @@ import Data.Either (isRight)
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.List
-import Data.Maybe (isJust, isNothing, fromMaybe, fromJust)
+import Data.Maybe (isJust, fromMaybe, fromJust)
 import Data.Text (pack, Text)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Safe
@@ -294,16 +294,8 @@ main = handleExit $ withGhcDebug' $ do
     -- If so, expand it to the real command name and the extra arguments to prepend.
     -- Command aliases never override exact builtin command names, and later definitions win.
     cmdaliases = reverse $ confAliases conf  -- reversed so that lookup finds the last definition
-    expandAlias :: [CommandAlias] -> String -> (String, [String])
-    expandAlias seen name
-      | name `notElem` seen
-      , isNothing $ findBuiltinCommand name
-      , Just (realcmd:defargs) <- lookup name cmdaliases =
-          -- aliases can refer to other aliases; a repeated name (self-reference or cycle) stops the recursion
-          let (realcmd', defargs') = expandAlias (name:seen) realcmd
-          in (realcmd', defargs' <> defargs)
-      | otherwise = (name, [])
-    (effectivecmdarg, aliasargs) = second replaceNumericFlags $ expandAlias [] cmdarg
+    (effectivecmdarg, aliasargs) = second replaceNumericFlags $
+      expandCommandAlias (isJust . findBuiltinCommand) cmdaliases cmdarg
     isaliascmd = effectivecmdarg /= cmdarg || not (null aliasargs)
 
     -- The argument may be an abbreviated command name, which we need to expand.
@@ -457,8 +449,8 @@ main = handleExit $ withGhcDebug' $ do
           withPossibleJournal opts $ \j -> runWithExpandedCurQueries opts j cmdaction
 
         -- 6.4.4. "run" and "repl" need findBuiltinCommands passed to it to avoid circular dependency in the code
-        | cmdname == "run"  -> Hledger.Cli.Commands.Run.run Nothing findBuiltinCommand addons opts
-        | cmdname == "repl" -> Hledger.Cli.Commands.Run.repl findBuiltinCommand addons opts
+        | cmdname == "run"  -> Hledger.Cli.Commands.Run.run Nothing findBuiltinCommand addons cmdaliases opts
+        | cmdname == "repl" -> Hledger.Cli.Commands.Run.repl findBuiltinCommand addons cmdaliases opts
 
         -- 6.4.5. all other builtin commands - read the journal and if successful run the command with it
         | otherwise -> withJournal opts $ \j -> runWithExpandedCurQueries opts j cmdaction

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -336,9 +336,10 @@ commandsList progversion builtin othercmds cmdaliases =
   ]
   ++ map (' ':) (lines $ multicol 79 othercmds)
   ++ (if null cmdaliases then [] else
-      "" :
-      bold' "ALIASES" :
-      [" " <> padright 24 a <> " = " <> def | (a,def) <- cmdaliases])
+      let aliasw = maximum (map (length.fst) cmdaliases)
+      in  "" :
+          bold' "ALIASES" :
+          [" " <> padright aliasw a <> " = " <> def | (a,def) <- cmdaliases])
   ++ [""]
   where
     padright w s = s <> replicate (w - length s) ' '

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -332,8 +332,8 @@ commandsList progversion builtin othercmds cmdaliases =
   ," test                     run some self tests"
   ,""
     -----------------------------------------80-------------------------------------
-  ,bold' "OTHER ADDONS"
   ]
+  ++ [bold' "OTHER ADDONS" | not builtin]
   ++ map (' ':) (lines $ multicol 79 othercmds)
   ++ (if null cmdaliases then [] else
       let aliasw = maximum (map (length.fst) cmdaliases)

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -59,7 +59,7 @@ where
 import Data.Char (isAlphaNum, isSpace, toLower)
 import Data.Either (isRight)
 import Data.List
-import Data.List.Extra (groupSortOn, nubSort)
+import Data.List.Extra (groupSortOn, nubOrdOn, nubSort)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time.Calendar
@@ -74,6 +74,7 @@ import Text.Megaparsec.Char
 
 import Hledger
 import Hledger.Cli.CliOptions
+import Hledger.Cli.Conf (CommandAlias, CommandLine, confAliases, getConf')
 import Hledger.Cli.Commands.Accounts
 import Hledger.Cli.Commands.Activity
 import Hledger.Cli.Commands.Add
@@ -228,10 +229,13 @@ gradientStr intensity h w row col0 s
 -- OTHER is replaced with additional command lines (without descriptions)
 -- for any unknown addon commands found in $PATH at runtime.
 --
+-- cmdaliases are the command aliases defined in the config file, if any;
+-- they are shown in a ALIASES group at the end.
+--
 -- TODO: generate more of this automatically.
--- 
-commandsList :: String -> Bool -> [String] -> [String]
-commandsList progversion builtin othercmds =
+--
+commandsList :: String -> Bool -> [String] -> [(CommandAlias,CommandLine)] -> [String]
+commandsList progversion builtin othercmds cmdaliases =
   bannerWithVersion ++   -- XXX not showing bold, why ?
   -- Keep the following synced with:
   --  commands.m4
@@ -331,8 +335,13 @@ commandsList progversion builtin othercmds =
   ,bold' "OTHER ADDONS"
   ]
   ++ map (' ':) (lines $ multicol 79 othercmds)
+  ++ (if null cmdaliases then [] else
+      "" :
+      bold' "ALIASES" :
+      [" " <> padright 24 a <> " = " <> def | (a,def) <- cmdaliases])
   ++ [""]
   where
+    padright w s = s <> replicate (w - length s) ' '
     version = unwords $ drop 1 $ words progversion
     rightmargin = 79  -- the width of the separator line / the right margin
     -- The diagonal gradient spans a grid of the banner rows plus the separator
@@ -369,7 +378,7 @@ commandsmode =
     [flagNone ["builtin"] (setboolopt "builtin")  "show only builtin commands, not addons"
     ]
     [(helpflagstitle, helpflags)]
-    []
+    hiddenflags  -- accept --conf/--no-conf, to show/hide command aliases defined in a config file
     -- flagReq  ["debug"]    (\s opts -> Right $ setopt "debug" s opts) "[N]" "show debug output (levels 1-9, default: 1)"
 
     ([], Nothing)
@@ -379,16 +388,24 @@ commands :: CliOpts -> Journal -> IO ()
 commands opts _ = do
   let builtin = boolopt "builtin" (rawopts_ opts)
   addons <- if builtin then return [] else addonCommandNames
-  printCommandsList prognameandversion builtin addons
+  cmdaliases <-
+    if builtin then return []
+    else do
+      (conf,_) <- getConf' $ rawopts_ opts
+      -- show each alias's effective (last) definition
+      return $ reverse $ nubOrdOn fst $ reverse
+        [(a, unwords args) | (a,args) <- confAliases conf]
+  printCommandsList prognameandversion builtin addons cmdaliases
 
 {- | Print the commands list, with a pager if appropriate, customising the
-commandsList template above with the given version string and the installed addons.
+commandsList template above with the given version string, the installed addons,
+and any command aliases defined in the config file.
 Uninstalled known addons will be removed from the list,
 installed known addons will have the + prefix removed,
 and installed unknown addons will be added under Misc.
 -}
-printCommandsList :: String -> Bool -> [String] -> IO ()
-printCommandsList progversion builtin installedaddons =
+printCommandsList :: String -> Bool -> [String] -> [(CommandAlias,CommandLine)] -> IO ()
+printCommandsList progversion builtin installedaddons cmdaliases =
   seq (length $ dbg8 "uninstalledknownaddons" uninstalledknownaddons) $ -- for debug output
     seq (length $ dbg8 "installedknownaddons" installedknownaddons) $
       seq (length $ dbg8 "installedunknownaddons" installedunknownaddons) $
@@ -396,7 +413,7 @@ printCommandsList progversion builtin installedaddons =
           unlines $
             map unplus $
               filter (not . isuninstalledaddon) $
-                commandsList progversion builtin installedunknownaddons
+                commandsList progversion builtin installedunknownaddons cmdaliases
  where
   knownaddons = knownAddonCommandNames
   uninstalledknownaddons = knownaddons \\ installedaddons
@@ -417,7 +434,7 @@ printCommandsList progversion builtin installedaddons =
 -- | Canonical names of all commands which have a slot in the commands list, in alphabetical order.
 -- These include the builtin commands and the known addon commands.
 knownCommands :: [String]
-knownCommands = nubSort . commandsListExtractCommands False $ commandsList progname False []
+knownCommands = nubSort . commandsListExtractCommands False $ commandsList progname False [] []
 
 -- | All names and aliases of the builtin commands.
 builtinCommandNames :: [String]
@@ -431,7 +448,7 @@ findBuiltinCommand cmdname = find (elem cmdname . modeNames . fst) builtinComman
 in alphabetical order.
 -}
 knownAddonCommandNames :: [String]
-knownAddonCommandNames = nubSort . commandsListExtractCommands True $ commandsList progname False []
+knownAddonCommandNames = nubSort . commandsListExtractCommands True $ commandsList progname False [] []
 
 -- Search PATH for names of addon commands, that aren't shadowed by builtin commands.
 addonCommandNames :: IO [String]

--- a/hledger/Hledger/Cli/Commands.hs
+++ b/hledger/Hledger/Cli/Commands.hs
@@ -393,8 +393,7 @@ commands opts _ = do
     else do
       (conf,_) <- getConf' $ rawopts_ opts
       -- show each alias's effective (last) definition
-      return $ reverse $ nubOrdOn fst $ reverse
-        [(a, unwords args) | (a,args) <- confAliases conf]
+      return $ reverse $ nubOrdOn fst $ reverse $ confAliases conf
   printCommandsList prognameandversion builtin addons cmdaliases
 
 {- | Print the commands list, with a pager if appropriate, customising the

--- a/hledger/Hledger/Cli/Commands/Print.txt
+++ b/hledger/Hledger/Cli/Commands/Print.txt
@@ -3,6 +3,7 @@ print
 Show full journal entries, representing transactions.
 
 Flags:
+     --oneline              show transaction dates and descriptions only
   -a --all                  show all details (--explicit --lots
                             --verbose-tags)
   -x --explicit             show all inferred info explicitly
@@ -187,6 +188,10 @@ shown and the program exit code will be non-zero.
 
 With --locations, print adds the source file and line number to every
 transaction, as a tag.
+
+With --oneline, print shows only each transaction's first line (the
+date, status, code, description, and any same-line comment), This gives
+a compact overview. It affects the default txt output only.
 
 print output format
 

--- a/hledger/Hledger/Cli/Commands/Repl.md
+++ b/hledger/Hledger/Cli/Commands/Repl.md
@@ -40,6 +40,7 @@ While it is running, the REPL remembers your command history, and you can naviga
 Generally `repl` command lines should feel much like the normal hledger CLI, but you may find differences.
 `repl` is a little stricter;
 eg it requires full command names or official abbreviations (as seen in the commands list).
+Command aliases defined in a config file can also be used.
 
 The `commands` and `help` commands, and the command help flags
 (`CMD --tldr`, `CMD -h/--help`, `CMD --info`, `CMD --man`), can be useful.

--- a/hledger/Hledger/Cli/Commands/Repl.txt
+++ b/hledger/Hledger/Cli/Commands/Repl.txt
@@ -20,6 +20,11 @@ temporarily by specifying an -f option in particular commands. But note
 that commands will not see any changes made to input files (eg by add)
 until you exit and restart the REPL.
 
+Any other general flags given to repl - input, reporting, or display
+flags such as -I, --strict, --alias, -b/-e, --depth, --cost, --value,
+--color - are also applied to every command you run. A command can still
+override them by specifying its own flags.
+
 The command syntax is the same as with run:
 
 - enter one hledger command at a time, without the usual hledger first
@@ -39,7 +44,8 @@ can navigate in the usual ways:
 Generally repl command lines should feel much like the normal hledger
 CLI, but you may find differences. repl is a little stricter; eg it
 requires full command names or official abbreviations (as seen in the
-commands list).
+commands list). Command aliases defined in a config file can also be
+used.
 
 The commands and help commands, and the command help flags (CMD --tldr,
 CMD -h/--help, CMD --info, CMD --man), can be useful.

--- a/hledger/Hledger/Cli/Commands/Run.hs
+++ b/hledger/Hledger/Cli/Commands/Run.hs
@@ -25,6 +25,7 @@ import Data.Text.IO qualified as T
 import System.Console.CmdArgs.Explicit as C ( Mode )
 import Hledger
 import Hledger.Cli.CliOptions
+import Hledger.Cli.Conf (CommandAlias, expandCommandAlias)
 
 import Control.Exception
 import Control.Concurrent.MVar
@@ -38,6 +39,7 @@ import System.IO (stdin, hIsTerminalDevice, hIsOpen)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Console.Haskeline
 
+import Data.Maybe (isJust)
 import Safe (headMay)
 import Hledger.Cli.DocFiles (runTldrForPage, runInfoForTopic, runManForTopic)
 import Hledger.Cli.Utils (journalTransform)
@@ -78,8 +80,8 @@ runOrReplStub _opts _j = return ()
 newtype DefaultRunJournal = DefaultRunJournal (NE.NonEmpty String) deriving (Show)
 
 -- | The actual run command.
-run :: Maybe DefaultRunJournal -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> CliOpts -> IO ()
-run defaultJournalOverride findBuiltinCommand addons cliopts@CliOpts{rawopts_=rawopts} = do
+run :: Maybe DefaultRunJournal -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> CliOpts -> IO ()
+run defaultJournalOverride findBuiltinCommand addons cmdaliases cliopts@CliOpts{rawopts_=rawopts} = do
   jpaths <- DefaultRunJournal <$> journalFilePathFromOptsOrDefault defaultJournalOverride cliopts
   let
     args = dbg1 "args" $ listofstringopt "args" rawopts
@@ -91,37 +93,37 @@ run defaultJournalOverride findBuiltinCommand addons cliopts@CliOpts{rawopts_=ra
       let journalFromStdin = any (== "-") $ map (snd . splitReaderPrefix) $ NE.toList inputFiles
       if journalFromStdin
       then error' "'run' can't read commands from stdin, as one of the input files was stdin as well"
-      else runREPL jpaths rungeneralopts findBuiltinCommand addons
+      else runREPL jpaths rungeneralopts findBuiltinCommand addons cmdaliases
     else do
       -- Check if arguments start with "--".
       -- If not, assume that they are files with commands
         case args of
-          "--":_ -> runFromArgs  jpaths rungeneralopts findBuiltinCommand addons args
-          _      -> runFromFiles jpaths rungeneralopts findBuiltinCommand addons args
+          "--":_ -> runFromArgs  jpaths rungeneralopts findBuiltinCommand addons cmdaliases args
+          _      -> runFromFiles jpaths rungeneralopts findBuiltinCommand addons cmdaliases args
 
 -- | The actual repl command.
-repl :: (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> CliOpts -> IO ()
-repl findBuiltinCommand addons cliopts = do
+repl :: (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> CliOpts -> IO ()
+repl findBuiltinCommand addons cmdaliases cliopts = do
   jpaths <- DefaultRunJournal <$> journalFilePathFromOptsOrDefault Nothing cliopts
-  runREPL jpaths (generalRawOpts $ rawopts_ cliopts) findBuiltinCommand addons
+  runREPL jpaths (generalRawOpts $ rawopts_ cliopts) findBuiltinCommand addons cmdaliases
 
 -- | Run commands from files given to "run".
-runFromFiles :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [String] -> IO ()
-runFromFiles defaultJournalOverride rungeneralopts findBuiltinCommand addons inputfiles = do
+runFromFiles :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> [String] -> IO ()
+runFromFiles defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases inputfiles = do
   dbg1IO "inputfiles" inputfiles
   -- read commands from all the inputfiles
   commands <- (flip concatMapM) inputfiles $ \f -> do
     dbg1IO "reading commands" f
     lines . T.unpack <$> T.readFile f
 
-  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons . parseCommand)
+  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases . parseCommand)
 
 -- | Run commands from command line arguments given to "run".
-runFromArgs :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [String] -> IO ()
-runFromArgs defaultJournalOverride rungeneralopts findBuiltinCommand addons args = do
+runFromArgs :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> [String] -> IO ()
+runFromArgs defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases args = do
   -- read commands from all the inputfiles
   let commands = dbg1 "commands from args" $ splitAtElement "--" args
-  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons)
+  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases)
 
 -- When commands are passed on the command line, shell will parse them for us
 -- When commands are read from file, we need to split the line into command and arguments
@@ -131,12 +133,19 @@ parseCommand line =
   takeWhile (not. ((Just '#')==) . headMay) $  words' (strip line)
 
 -- | Take a single command line (from file, or REPL, or "--"-surrounded block of the args), and run it.
-runCommand :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [String] -> IO ()
-runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdline = do
+runCommand :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> [String] -> IO ()
+runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases cmdline = do
   dbg1IO "runCommand for" cmdline
   case cmdline of
     "echo":args -> putStrLn $ unwords $ args
-    cmdname:args ->
+    cmdname0:args0 ->
+      -- The command may be a command alias defined in the config file; expand it,
+      -- with the alias's arguments preceding this command line's own arguments.
+      let
+        (cmdname, defargs) = expandCommandAlias (isJust . findBuiltinCommand) cmdaliases cmdname0
+        args = defargs <> args0
+        aliasnote = if cmdname /= cmdname0 then " (expanded from the " ++ cmdname0 ++ " command alias)" else ""
+      in
       case findBuiltinCommand cmdname of
         Just (cmdmode,cmdaction) -> do
               -- Even though expandArgsAt is done by the Cli.hs, it stops at the first '--', so we need
@@ -160,17 +169,17 @@ runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdli
                 | otherwise -> do
                   withJournalCached (Just defaultJournalOverride) opts $ \(j,jpaths) -> do
                     if cmdname == "run" -- allow "run" to call "run"
-                      then run (Just jpaths) findBuiltinCommand addons opts
+                      then run (Just jpaths) findBuiltinCommand addons cmdaliases opts
                       else cmdaction opts j
         Nothing | cmdname `elem` addons ->
           system (printf "%s-%s %s" progname cmdname (unwords $ map quoteForCommandLine args)) >>= exitWith
         Nothing ->
-          error' $ "Unrecognized command: " ++ unwords (cmdname:args)
+          error' $ "Unrecognized command" ++ aliasnote ++ ": " ++ unwords (cmdname:args)
     [] -> return ()
 
 -- | Run an interactive REPL.
-runREPL :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> IO ()
-runREPL defaultJournalOverride rungeneralopts findBuiltinCommand addons = do
+runREPL :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> IO ()
+runREPL defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases = do
   isTerminal <- isStdinTerminal
   if not isTerminal
     then runInputT defaultSettings (loop False "")
@@ -186,7 +195,7 @@ runREPL defaultJournalOverride rungeneralopts findBuiltinCommand addons = do
       Just "quit" -> return ()
       Just "exit" -> return ()
       Just input -> do
-        let cmd = runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons $ argsAddDoubleDash $ parseCommand input
+        let cmd = runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases $ argsAddDoubleDash $ parseCommand input
         liftIO $ if interactive
           then cmd `catches`
                   [Handler (\(e::ErrorCall) -> putStrLn $ rstrip $ show e)

--- a/hledger/Hledger/Cli/Commands/Run.hs
+++ b/hledger/Hledger/Cli/Commands/Run.hs
@@ -25,7 +25,7 @@ import Data.Text.IO qualified as T
 import System.Console.CmdArgs.Explicit as C ( Mode )
 import Hledger
 import Hledger.Cli.CliOptions
-import Hledger.Cli.Conf (CommandAlias, expandCommandAlias)
+import Hledger.Cli.Conf (CommandAlias, CommandLine, ResolvedCommand(..), expandCommandAlias)
 
 import Control.Exception
 import Control.Concurrent.MVar
@@ -80,8 +80,8 @@ runOrReplStub _opts _j = return ()
 newtype DefaultRunJournal = DefaultRunJournal (NE.NonEmpty String) deriving (Show)
 
 -- | The actual run command.
-run :: Maybe DefaultRunJournal -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> CliOpts -> IO ()
-run defaultJournalOverride findBuiltinCommand addons cmdaliases cliopts@CliOpts{rawopts_=rawopts} = do
+run :: Maybe DefaultRunJournal -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,CommandLine)] -> Bool -> CliOpts -> IO ()
+run defaultJournalOverride findBuiltinCommand addons cmdaliases shellaliasesallowed cliopts@CliOpts{rawopts_=rawopts} = do
   jpaths <- DefaultRunJournal <$> journalFilePathFromOptsOrDefault defaultJournalOverride cliopts
   let
     args = dbg1 "args" $ listofstringopt "args" rawopts
@@ -93,37 +93,37 @@ run defaultJournalOverride findBuiltinCommand addons cmdaliases cliopts@CliOpts{
       let journalFromStdin = any (== "-") $ map (snd . splitReaderPrefix) $ NE.toList inputFiles
       if journalFromStdin
       then error' "'run' can't read commands from stdin, as one of the input files was stdin as well"
-      else runREPL jpaths rungeneralopts findBuiltinCommand addons cmdaliases
+      else runREPL jpaths rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed
     else do
       -- Check if arguments start with "--".
       -- If not, assume that they are files with commands
         case args of
-          "--":_ -> runFromArgs  jpaths rungeneralopts findBuiltinCommand addons cmdaliases args
-          _      -> runFromFiles jpaths rungeneralopts findBuiltinCommand addons cmdaliases args
+          "--":_ -> runFromArgs  jpaths rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed args
+          _      -> runFromFiles jpaths rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed args
 
 -- | The actual repl command.
-repl :: (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> CliOpts -> IO ()
-repl findBuiltinCommand addons cmdaliases cliopts = do
+repl :: (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,CommandLine)] -> Bool -> CliOpts -> IO ()
+repl findBuiltinCommand addons cmdaliases shellaliasesallowed cliopts = do
   jpaths <- DefaultRunJournal <$> journalFilePathFromOptsOrDefault Nothing cliopts
-  runREPL jpaths (generalRawOpts $ rawopts_ cliopts) findBuiltinCommand addons cmdaliases
+  runREPL jpaths (generalRawOpts $ rawopts_ cliopts) findBuiltinCommand addons cmdaliases shellaliasesallowed
 
 -- | Run commands from files given to "run".
-runFromFiles :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> [String] -> IO ()
-runFromFiles defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases inputfiles = do
+runFromFiles :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,CommandLine)] -> Bool -> [String] -> IO ()
+runFromFiles defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed inputfiles = do
   dbg1IO "inputfiles" inputfiles
   -- read commands from all the inputfiles
   commands <- (flip concatMapM) inputfiles $ \f -> do
     dbg1IO "reading commands" f
     lines . T.unpack <$> T.readFile f
 
-  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases . parseCommand)
+  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed . parseCommand)
 
 -- | Run commands from command line arguments given to "run".
-runFromArgs :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> [String] -> IO ()
-runFromArgs defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases args = do
+runFromArgs :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,CommandLine)] -> Bool -> [String] -> IO ()
+runFromArgs defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed args = do
   -- read commands from all the inputfiles
   let commands = dbg1 "commands from args" $ splitAtElement "--" args
-  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases)
+  forM_ commands (runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed)
 
 -- When commands are passed on the command line, shell will parse them for us
 -- When commands are read from file, we need to split the line into command and arguments
@@ -133,20 +133,26 @@ parseCommand line =
   takeWhile (not. ((Just '#')==) . headMay) $  words' (strip line)
 
 -- | Take a single command line (from file, or REPL, or "--"-surrounded block of the args), and run it.
-runCommand :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> [String] -> IO ()
-runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases cmdline = do
+runCommand :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,CommandLine)] -> Bool -> [String] -> IO ()
+runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed cmdline = do
   dbg1IO "runCommand for" cmdline
   case cmdline of
     "echo":args -> putStrLn $ unwords $ args
     cmdname0:args0 ->
-      -- The command may be a command alias defined in the config file; expand it,
-      -- with the alias's arguments preceding this command line's own arguments.
-      let
-        (cmdname, defargs) = expandCommandAlias (isJust . findBuiltinCommand) cmdaliases cmdname0
-        args = defargs <> args0
-        aliasnote = if cmdname /= cmdname0 then " (expanded from the " ++ cmdname0 ++ " command alias)" else ""
-      in
-      case findBuiltinCommand cmdname of
+      -- The command may be a command alias defined in the config file; expand it.
+      case expandCommandAlias (isJust . findBuiltinCommand) cmdaliases cmdname0 of
+       -- A !-prefixed shell command alias: run it (if allowed), with any arguments appended.
+       ShellCommand shcmd
+         | shellaliasesallowed -> system (unwords $ shcmd : map quoteForCommandLine args0) >>= exitWith
+         | otherwise -> error' $ "the command alias '" ++ cmdname0
+             ++ "' runs a shell command, which is only allowed from your user config file or a --conf file"
+       -- Otherwise an hledger command, with the alias's arguments preceding this line's own arguments.
+       HledgerCommand cmdname defargs ->
+        let
+          args = defargs <> args0
+          aliasnote = if cmdname /= cmdname0 then " (expanded from the " ++ cmdname0 ++ " command alias)" else ""
+        in
+        case findBuiltinCommand cmdname of
         Just (cmdmode,cmdaction) -> do
               -- Even though expandArgsAt is done by the Cli.hs, it stops at the first '--', so we need
               -- to do it here as well to make sure that each command can use @ARGFILEs
@@ -169,7 +175,7 @@ runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdal
                 | otherwise -> do
                   withJournalCached (Just defaultJournalOverride) opts $ \(j,jpaths) -> do
                     if cmdname == "run" -- allow "run" to call "run"
-                      then run (Just jpaths) findBuiltinCommand addons cmdaliases opts
+                      then run (Just jpaths) findBuiltinCommand addons cmdaliases shellaliasesallowed opts
                       else cmdaction opts j
         Nothing | cmdname `elem` addons ->
           system (printf "%s-%s %s" progname cmdname (unwords $ map quoteForCommandLine args)) >>= exitWith
@@ -178,8 +184,8 @@ runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdal
     [] -> return ()
 
 -- | Run an interactive REPL.
-runREPL :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,[String])] -> IO ()
-runREPL defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases = do
+runREPL :: DefaultRunJournal -> [(String,String)] -> (String -> Maybe (Mode RawOpts, CliOpts -> Journal -> IO ())) -> [String] -> [(CommandAlias,CommandLine)] -> Bool -> IO ()
+runREPL defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed = do
   isTerminal <- isStdinTerminal
   if not isTerminal
     then runInputT defaultSettings (loop False "")
@@ -195,7 +201,7 @@ runREPL defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdalias
       Just "quit" -> return ()
       Just "exit" -> return ()
       Just input -> do
-        let cmd = runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases $ argsAddDoubleDash $ parseCommand input
+        let cmd = runCommand defaultJournalOverride rungeneralopts findBuiltinCommand addons cmdaliases shellaliasesallowed $ argsAddDoubleDash $ parseCommand input
         liftIO $ if interactive
           then cmd `catches`
                   [Handler (\(e::ErrorCall) -> putStrLn $ rstrip $ show e)

--- a/hledger/Hledger/Cli/Commands/Run.md
+++ b/hledger/Hledger/Cli/Commands/Run.md
@@ -43,6 +43,8 @@ If that gives an error, use `#!/usr/bin/env -S hledger run`.
 
 It's ok to use the `run` command recursively within a command script.
 
+Command aliases defined in a config file can also be used in command scripts.
+
 You may find some differences in behaviour between `run` command lines and normal hledger command lines.
 `run` is a little stricter;
 eg it requires full command names or official abbreviations (as seen in the commands list),

--- a/hledger/Hledger/Cli/Commands/Run.txt
+++ b/hledger/Hledger/Cli/Commands/Run.txt
@@ -22,6 +22,11 @@ the same input data. But if you want a particular command to use
 different input, you can specify an -f option within that command. This
 will override (not add to) the default input, just for that command.
 
+Any other general flags given to run - input, reporting, or display
+flags such as -I, --strict, --alias, -b/-e, --depth, --cost, --value,
+--color - are also applied to every command it runs. A command can still
+override them by specifying its own flags.
+
 Each input file (more precisely, each combination of input file and
 input options) is parsed only once. This means that commands will not
 see any changes made to these files, until the next run. But the
@@ -45,6 +50,9 @@ of a command file to make it a runnable script. If that gives an error,
 use #!/usr/bin/env -S hledger run.
 
 It's ok to use the run command recursively within a command script.
+
+Command aliases defined in a config file can also be used in command
+scripts.
 
 You may find some differences in behaviour between run command lines and
 normal hledger command lines. run is a little stricter; eg it requires

--- a/hledger/Hledger/Cli/Commands/Stats.md
+++ b/hledger/Hledger/Cli/Commands/Stats.md
@@ -4,7 +4,7 @@ Show journal and performance statistics.
 
 ```flags
 Flags:
-  -1                        show a single line of output
+     --oneline              show a single line of output
   -v --verbose              show more detailed output
   -o --output-file=FILE     write output to FILE.
 ```

--- a/hledger/Hledger/Cli/Commands/Stats.txt
+++ b/hledger/Hledger/Cli/Commands/Stats.txt
@@ -3,7 +3,7 @@ stats
 Show journal and performance statistics.
 
 Flags:
-  -1                        show a single line of output
+     --oneline              show a single line of output
   -v --verbose              show more detailed output
   -o --output-file=FILE     write output to FILE.
 

--- a/hledger/Hledger/Cli/Conf.hs
+++ b/hledger/Hledger/Cli/Conf.hs
@@ -16,6 +16,7 @@ module Hledger.Cli.Conf (
   ,nullconf
   ,confLookup
   ,confAliases
+  ,expandCommandAlias
   ,activeConfFile
   ,activeLocalConfFile
   ,activeUserConfFile
@@ -126,6 +127,23 @@ confAliases Conf{confFile, confSections} = concatMap sectionaliases confSections
       _ -> error' $ "in config file " <> confFile
            <> ",\nan [alias] section line should look like: NAME = COMMAND [ARGS..]"
            <> "\nbut is: " <> l
+
+-- | Expand a command name which may be a command alias, giving the real command name
+-- and any arguments to prepend. Aliases can refer to other aliases; a name that is an
+-- exact builtin command name (per the given predicate), or already seen during this
+-- expansion (a self-reference or cycle), stops the recursion. If a name is defined
+-- more than once, the first definition in the given list wins (callers wanting the
+-- config file's last-definition-wins behaviour should pass @reverse (confAliases conf)@).
+expandCommandAlias :: (String -> Bool) -> [(CommandAlias,[Arg])] -> String -> (String,[Arg])
+expandCommandAlias isbuiltincmd cmdaliases = go []
+  where
+    go seen name
+      | name `notElem` seen
+      , not $ isbuiltincmd name
+      , Just (realcmd:defargs) <- lookup name cmdaliases =
+          let (realcmd', defargs') = go (name:seen) realcmd
+          in (realcmd', defargs' <> defargs)
+      | otherwise = (name, [])
 
 -- | Try to read a hledger config from a config file specified by --conf,
 -- or the first config file found in any of several default file paths.

--- a/hledger/Hledger/Cli/Conf.hs
+++ b/hledger/Hledger/Cli/Conf.hs
@@ -9,10 +9,13 @@ Read extra CLI arguments from a hledger config file.
 module Hledger.Cli.Conf (
    Conf
   ,SectionName
+  ,CommandAlias
+  ,CommandLine
   ,getConf
   ,getConf'
   ,nullconf
   ,confLookup
+  ,confAliases
   ,activeConfFile
   ,activeLocalConfFile
   ,activeUserConfFile
@@ -26,6 +29,7 @@ import Control.Exception (handle)
 import Control.Monad (void, forM)
 import Control.Monad.Identity (Identity)
 import Data.Functor ((<&>))
+import Data.List (stripPrefix)
 import Data.Map qualified as M
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
@@ -65,6 +69,13 @@ type SectionName = String
 -- If it contains spaces, those are treated as part of a single argument, as with CMD a "b c".
 type Arg = String
 
+-- | The name of a command alias (a custom command) defined in a config file.
+type CommandAlias = String
+
+-- | A command line (a command name followed by arguments), as a single string.
+-- Eg the command line which a command alias expands to.
+type CommandLine = String
+
 nullconf = Conf {
    confFile = ""
   ,confFormat = 1
@@ -96,6 +107,25 @@ confLookup cmd Conf{confSections} =
   maybe [] (concatMap words') $  -- XXX PARTIAL
   M.lookup cmd $
   M.fromList [(csName,csArgs) | ConfSection{csName,csArgs} <- confSections]
+
+-- | Get the command aliases (custom commands) defined in this config file,
+-- in order of definition. They are defined git-style by lines in an @[alias]@
+-- section, like @NAME = CMDLINE@; or by @[alias NAME]@ sections, whose lines
+-- are joined to form the command line. If a name is defined more than once,
+-- the last definition should win (callers can rely on the ordering here).
+-- An [alias] section line without an @=@ raises a usage error.
+confAliases :: Conf -> [(CommandAlias, [Arg])]
+confAliases Conf{confFile, confSections} = concatMap sectionaliases confSections
+  where
+    sectionaliases ConfSection{csName, csArgs}
+      | csName == "alias" = map aliasline csArgs
+      | Just name <- stripPrefix "alias " csName = [(strip name, concatMap words' csArgs)]
+      | otherwise = []
+    aliasline l = case break (=='=') l of
+      (name, '=':cmdline) | not $ null $ strip name -> (strip name, words' $ strip cmdline)
+      _ -> error' $ "in config file " <> confFile
+           <> ",\nan [alias] section line should look like: NAME = COMMAND [ARGS..]"
+           <> "\nbut is: " <> l
 
 -- | Try to read a hledger config from a config file specified by --conf,
 -- or the first config file found in any of several default file paths.
@@ -130,13 +160,14 @@ readConfFile f = handle (\(e::IOError) -> return $ Left $ show e) $ do
       ecs <- readFile f <&> parseConf f . T.pack
       case ecs of
         Left err -> return $ Left $ errorBundlePretty err -- customErrorBundlePretty err
-        Right cs -> return $ Right (nullconf{
-          confFile     = f
-          ,confFormat   = 1
-          ,confSections = cs
-          },
-          Just f
-          )
+        Right cs -> do
+          let conf = nullconf{
+                 confFile     = f
+                ,confFormat   = 1
+                ,confSections = cs
+                }
+          -- validate any command alias definitions now, so a bad one is reported promptly
+          return $ foldr seq (Right (conf, Just f)) (confAliases conf)
 
 -- -- | Like readConf, but throw an error on failure.
 -- readConfFile' :: FilePath -> IO (Conf, Maybe FilePath)

--- a/hledger/Hledger/Cli/Conf.hs
+++ b/hledger/Hledger/Cli/Conf.hs
@@ -16,7 +16,9 @@ module Hledger.Cli.Conf (
   ,nullconf
   ,confLookup
   ,confAliases
+  ,ResolvedCommand(..)
   ,expandCommandAlias
+  ,confFileIsTrusted
   ,activeConfFile
   ,activeLocalConfFile
   ,activeUserConfFile
@@ -115,35 +117,59 @@ confLookup cmd Conf{confSections} =
 -- are joined to form the command line. If a name is defined more than once,
 -- the last definition should win (callers can rely on the ordering here).
 -- An [alias] section line without an @=@ raises a usage error.
-confAliases :: Conf -> [(CommandAlias, [Arg])]
+confAliases :: Conf -> [(CommandAlias, CommandLine)]
 confAliases Conf{confFile, confSections} = concatMap sectionaliases confSections
   where
     sectionaliases ConfSection{csName, csArgs}
       | csName == "alias" = map aliasline csArgs
-      | Just name <- stripPrefix "alias " csName = [(strip name, concatMap words' csArgs)]
+      | Just name <- stripPrefix "alias " csName = [(strip name, unwords csArgs)]
       | otherwise = []
     aliasline l = case break (=='=') l of
-      (name, '=':cmdline) | not $ null $ strip name -> (strip name, words' $ strip cmdline)
+      (name, '=':cmdline) | not $ null $ strip name -> (strip name, strip cmdline)
       _ -> error' $ "in config file " <> confFile
            <> ",\nan [alias] section line should look like: NAME = COMMAND [ARGS..]"
            <> "\nbut is: " <> l
 
--- | Expand a command name which may be a command alias, giving the real command name
--- and any arguments to prepend. Aliases can refer to other aliases; a name that is an
--- exact builtin command name (per the given predicate), or already seen during this
--- expansion (a self-reference or cycle), stops the recursion. If a name is defined
--- more than once, the first definition in the given list wins (callers wanting the
--- config file's last-definition-wins behaviour should pass @reverse (confAliases conf)@).
-expandCommandAlias :: (String -> Bool) -> [(CommandAlias,[Arg])] -> String -> (String,[Arg])
+-- | The result of resolving a command name that may be a command alias.
+data ResolvedCommand
+  = HledgerCommand String [Arg]  -- ^ a resolved hledger command name, and arguments to prepend
+  | ShellCommand String          -- ^ a shell command line (from a !-prefixed alias, ! stripped)
+  deriving (Eq,Show)
+
+-- | Resolve a command name which may be a command alias, to either a real hledger command
+-- (with any arguments to prepend) or a shell command line (for a @!@-prefixed alias).
+-- Aliases can refer to other aliases; a name that is an exact builtin command name (per the
+-- given predicate), or already seen during this expansion (a self-reference or cycle), stops
+-- the recursion. If a name is defined more than once, the first definition in the given list
+-- wins (callers wanting the config file's last-definition-wins behaviour should pass
+-- @reverse (confAliases conf)@). This does not enforce the shell-alias trust policy; callers do.
+expandCommandAlias :: (String -> Bool) -> [(CommandAlias, CommandLine)] -> String -> ResolvedCommand
 expandCommandAlias isbuiltincmd cmdaliases = go []
   where
     go seen name
       | name `notElem` seen
       , not $ isbuiltincmd name
-      , Just (realcmd:defargs) <- lookup name cmdaliases =
-          let (realcmd', defargs') = go (name:seen) realcmd
-          in (realcmd', defargs' <> defargs)
-      | otherwise = (name, [])
+      , Just cmdline <- lookup name cmdaliases =
+          case strip cmdline of
+            '!':shellcmd -> ShellCommand (strip shellcmd)
+            hledgercmd   -> case words' hledgercmd of
+              (realcmd:defargs) -> case go (name:seen) realcmd of
+                HledgerCommand realcmd' defargs' -> HledgerCommand realcmd' (defargs' <> defargs)
+                ShellCommand shellcmd            -> ShellCommand (unwords $ shellcmd : defargs)
+              [] -> HledgerCommand name []
+      | otherwise = HledgerCommand name []
+
+-- | Is the active config file trusted enough to run its @!@-prefixed shell command aliases?
+-- True if the config file was given explicitly with --conf, or is a user-level config file
+-- (~/.hledger.conf or the XDG hledger.conf). False for a config file found automatically in the
+-- current directory or a parent (which could come from an untrusted downloaded/shared directory),
+-- or when there is no config file.
+confFileIsTrusted :: RawOpts -> Maybe FilePath -> IO Bool
+confFileIsTrusted _ Nothing = return False
+confFileIsTrusted rawopts (Just f) =
+  case confFileSpecFromRawOpts rawopts of
+    SomeConfFile _ -> return True
+    _              -> (f `elem`) <$> userConfFiles
 
 -- | Try to read a hledger config from a config file specified by --conf,
 -- or the first config file found in any of several default file paths.

--- a/hledger/hledger.1
+++ b/hledger/hledger.1
@@ -1,6 +1,6 @@
 .\"t
 
-.TH "HLEDGER" "1" "May 2026" "hledger-1.99 " "hledger User Manuals"
+.TH "HLEDGER" "1" "June 2026" "hledger-1.99 " "hledger User Manuals"
 
 
 
@@ -821,95 +821,157 @@ cur:\(rs$
 $ hledger bal \(atcash.args
 .EE
 .SS Config files
-With hledger 1.40+, you can save extra command line options and
-arguments in a more featureful hledger config file.
+You can configure default command line options and arguments
+conveniently in a hledger config file.
+(Since 1.40.)
+Config file options will be inserted near the start of your command
+line, so you can override them with command line options.
+.PP
+You can specify a config file with the \f[CR]\-\-conf\f[R] option.
+Otherwise, hledger will search for a default config file, in this order:
+.IP \(bu 2
+\f[CR]hledger.conf\f[R] in the current directory or above
+.IP \(bu 2
+\f[CR].hledger.conf\f[R] in your home directory
+.IP \(bu 2
+\f[CR]hledger.conf\f[R] in your XDG config
+(\f[CR]\(ti/.config/hledger/hledger.conf\f[R]).
+.PP
+Only one config file is used.
 Here\(aqs a small example:
 .IP
 .EX
-\f[I]# General options are listed first, and used with hledger commands that support them.\f[R]
+\f[I]# General options, used with all hledger commands that support them.\f[R]
 \-\-pretty
 
-\f[I]# Options following a \(ga[COMMAND]\(ga heading are used with that hledger command only.\f[R]
+\f[I]# Command\-specific options.\f[R]
 \f[B][print]\f[R]
 \-\-explicit \-\-infer\-costs
 .EE
 .PP
-To use a config file, specify it with the \f[CR]\-\-conf\f[R] option.
-Its options will be inserted near the start of your command line, so you
-can override them with command line options if needed.
-.PP
-Or, you can set up an automatic config file that is used whenever you
-run hledger, by creating \f[CR]hledger.conf\f[R] in the current
-directory or above, or \f[CR].hledger.conf\f[R] in your home directory
-(\f[CR]\(ti/.hledger.conf\f[R]), or \f[CR]hledger.conf\f[R] in your XDG
-config directory (\f[CR]\(ti/.config/hledger/hledger.conf\f[R]).
-.PP
-Here is another example config you could start with:
+And here is a commented starter config file:
 https://github.com/simonmichael/hledger/blob/main/hledger.conf.sample
 .PP
 You can put not only options, but also arguments in a config file.
-If the first word in a config file\(aqs top (general) section does not
-begin with a dash (eg: \f[CR]print\f[R]), it is treated as the command
-argument (overriding any argument on the command line).
 .PP
-On unix machines, you can add a shebang line at the top of a config
-file, set executable permission on the file, and use it like a script.
-Eg (the \f[CR]\-S\f[R] is needed on some operating systems):
-.IP
-.EX
-#!/usr/bin/env \-S hledger \-\-conf
-.EE
-.PP
-You can ignore config files by adding the
+You can ignore all config files by adding the
 \f[CR]\-n\f[R]/\f[CR]\-\-no\-conf\f[R] flag to the command line.
-This is useful when using hledger in scripts, or when troubleshooting.
+This is recommended when using hledger in scripts.
 When both \f[CR]\-\-conf\f[R] and \f[CR]\-\-no\-conf\f[R] options are
 used, the right\-most wins.
+.SS Command aliases
+In a config file you can also define command aliases: your own custom
+commands, which expand to a longer command line (similar to git\(aqs
+aliases).
+(Since 1.99.4.)
+Eg:
+.IP
+.EX
+\f[B][alias]\f[R]
+p     = print
+p1    = print \-\-oneline
+rev10 = balance type\f[B]:\f[R]R \-2 \-X\f[B]$\f[R] \-p \(aqevery 10 years from 2000\(aq
+.EE
 .PP
-To inspect the processing of config files, use \f[CR]\-\-debug\f[R] or
-\f[CR]\-\-debug=8\f[R].
-Or, run the \f[CR]setup\f[R] command, which will display any active
-config files.
-(\f[CR]setup\f[R] is not affected by config files itself, unlike other
-commands.)
+With this in your config file, you\(aqll see a \f[CR]rev10\f[R] command
+in the \f[CR]hledger commands\f[R] list, and \f[CR]hledger rev10\f[R]
+will run the balance command above.
+Options or arguments written at the command line will be added at the
+end, usually overriding those in the alias; eg
+\f[CR]hledger rev10 \-X €\f[R] will convert to \f[CR]€\f[R] instead of
+\f[CR]$\f[R].
+Command aliases can also be used in \f[CR]run\f[R] command scripts and
+at the \f[CR]repl\f[R] prompt.
 .PP
-\f[B]Warning!\f[R]
+Each line in an \f[CR][alias]\f[R] section should look like
+\f[CR]NAME = COMMAND [ARGS..]\f[R].
+Or, you can define a single alias with an \f[CR][alias NAME]\f[R]
+section, writing its command line below it, on one or more lines.
+This form can be easier to read, and lets you comment out individual
+lines.
+Eg:
+.IP
+.EX
+\f[B][alias\f[R] \f[B]rev10]\f[R]
+balance
+type\f[B]:\f[R]R
+\-2
+\-X\f[B]$\f[R]
+\-p \(aqevery 10 years from 2000\(aq
+\f[I]# \-\-drop 1\f[R]
+.EE
 .PP
+Command aliases override addon commands with the same name, but they
+can\(aqt override builtin command names or abbreviations like
+\f[CR]balance\f[R] or \f[CR]bal\f[R].
+If the same alias name is defined more than once, the last definition
+wins.
+.PP
+An alias\(aqs command can be a hledger builtin command, addon command,
+or another alias.
+If there\(aqs a \f[CR][COMMAND]\f[R] options section for an alias\(aqs
+resolved builtin command, that will also be applied.
+.PP
+Or if an alias\(aqs command line begins with \f[CR]!\f[R], the rest is
+run as a shell command (with any extra command line arguments appended).
+Eg:
+.IP
+.EX
+\f[B][alias]\f[R]
+git\-commit = \f[B]!\f[R] git commit \-p
+jj\-commit  = \f[B]!\f[R] jj commit \-i
+.EE
+.PP
+For safety, shell command aliases run only if defined in a trusted
+config file: one you gave explicitly with \f[CR]\-\-conf\f[R], or your
+user config file (\f[CR]\(ti/.hledger.conf\f[R] or the XDG
+\f[CR]hledger.conf\f[R]).
+Shell commands in a nearby automatically\-found \f[CR]hledger.conf\f[R],
+in the current directory or a parent directory, will not run \- this
+prevents a config file from an untrusted downloaded or shared directory
+from running arbitrary shell commands.
+.SS Config file troubleshooting
 There aren\(aqt many hledger features that need a warning, but this is
-one!
+one !
+.PD 0
+.P
+.PD
+A default config file (the kind that hledger runs automatically, without
+needing a \-\-conf option) is very convenient.
+But, it complicates command line processing and can surprise you \- eg
+quietly changing report output, or breaking your hledger\-using
+scripts/applications, which you might not notice until much later.
 .PP
-Automatic config files, while convenient, also make hledger less
-predictable and dependable.
-It\(aqs easy to make a config file that changes a report\(aqs behaviour,
-or breaks your hledger\-using scripts/applications, in ways that will
-surprise you later.
-.PP
-If you don\(aqt want this,
+This mainly arises when you are first using config files.
+And once you discover this kind of problem, it will be easy to fix.
+Here are some tips:
 .IP "1." 3
-Just don\(aqt create a hledger.conf file on your machine.
+Be mindful about what you put in your config file; consider the effect
+on all your reports.
 .IP "2." 3
-Also be alert to downloaded directories which may contain a hledger.conf
-file.
+If a hledger command isn\(aqt doing what you expect, try it again with
+\f[CR]\-n\f[R], to see if a config file is to blame.
 .IP "3." 3
-Also if you are sharing scripts or examples or support, consider that
-others may have a hledger.conf file.
-.PP
-Conversely, once you decide to use this feature, try to remember:
-.IP "1." 3
-Whenever a hledger command does not work as expected, try it again with
-\f[CR]\-n\f[R] (\f[CR]\-\-no\-conf\f[R]) to see if a config file was to
-blame.
-.IP "2." 3
-Whenever you call hledger from a script, consider whether that call
-should use \f[CR]\-n\f[R] or not.
-.IP "3." 3
-Be conservative about what you put in your config file; try to consider
-the effect on all your reports.
+Run \f[CR]hledger setup\f[R] to list the currently active config file.
+(\f[CR]setup\f[R] is not affected by config files.)
 .IP "4." 3
-To troubleshoot the effect of config files, run with
-\f[CR]\-\-debug\f[R] or \f[CR]\-\-debug 8\f[R].
+Add \f[CR]\-\-debug\f[R] or \f[CR]\-\-debug=8\f[R] to any command to see
+config/command line debug output.
 .PP
-The config file feature was added in hledger 1.40.
+When you are writing scripts, or sharing examples with other people,
+keep in mind that there could be a config file changing hledger\(aqs
+behaviour, so you might want to add \f[CR]\-n\f[R] to make your hledger
+commands more robust.
+.PP
+If you prefer to just avoid this feature:
+.IP \(bu 2
+Don\(aqt use a default config file.
+.IP \(bu 2
+If you download hledger data from elsewhere, watch out for directories
+containing a hledger.conf file.
+.IP \(bu 2
+If you\(aqre feeling paranoid, use the \f[CR]\-n/\-\-no\-conf\f[R] flag
+always, eg by running hledger via a script or alias.
 .SS Shell completions
 If you use the bash or zsh shells, you can optionally set up
 context\-sensitive autocompletion for hledger command lines.
@@ -918,7 +980,7 @@ hledger commands) or \f[CR]hledger reg acct:<TAB><TAB>\f[R] (should list
 your top\-level account names).
 If completions aren\(aqt working, or for more details, see Install >
 Shell completions.
-.SH Output
+˜ # Output
 .SS Output destination
 hledger commands send their output to the terminal by default.
 You can of course redirect this, eg into a file, using standard shell
@@ -1163,7 +1225,7 @@ You can override this by setting the \f[CR]NO_COLOR\f[R] environment
 variable to disable it, or by using the \f[CR]\-\-color/\-\-colour\f[R]
 option, perhaps in your config file, with a \f[CR]y\f[R]/\f[CR]yes\f[R]
 or \f[CR]n\f[R]/\f[CR]no\f[R] value to force it on or off.
-.SS Paging
+.SS Paging˜
 In unix\-like environments, when displaying large output (in any output
 format) in the terminal, hledger tries to use a pager when appropriate.
 (You can disable this with the \f[CR]\-\-pager=no\f[R] option, perhaps
@@ -1203,7 +1265,9 @@ and when colour output is enabled:
 You can prevent this by setting your preferred options in the
 \f[CR]HLEDGER_LESS\f[R] variable, which will be used instead of
 \f[CR]LESS\f[R].
-.SS HTML output
+.PP
+˜ ### HTML output˜˜
+.PP
 HTML output can be styled by an optional \f[CR]hledger.css\f[R] file in
 the same directory.
 .PP
@@ -2064,17 +2128,11 @@ separators), this means that a number like \f[CR]1,000\f[R] or
 In such cases, hledger by default assumes it is a decimal mark, and will
 parse both of those as 1.
 .PP
-To help hledger parse such ambiguous numbers more accurately, if you use
+To help hledger parse such ambiguous numbers accurately, if you use
 digit group marks, we recommend declaring the decimal mark explicitly.
-The best way is to add a \f[CR]decimal\-mark\f[R] directive at the top
-of each data file, like this:
-.IP
-.EX
-decimal\-mark .
-.EE
-.PP
-Or you can declare it per commodity with \f[CR]commodity\f[R]
-directives, described below.
+You can declare it per commodity with \f[CR]commodity\f[R] directives,
+or per file with a \f[CR]decimal\-mark\f[R] directive at the top of each
+journal file (described below).
 .PP
 hledger also accepts numbers like \f[CR]10.\f[R] with no digits after
 the decimal mark (and will sometimes display numbers that way to
@@ -2436,6 +2494,23 @@ assertions\f[R]\(dq by adding a star after the equals (\f[CR]=*\f[R] or
   assets:savings   $10
   assets            $0 ==* $20  ; assets + subaccounts contains $20 and nothing else
 .EE
+.SS Assertions and lot subaccounts
+Lot subaccounts (a special kind of subaccount for tracking lots,
+discussed in \(dqLot reporting\(dq below) have only limited support for
+balance assertions: the assertions will be checked correctly only if all
+postings to that lot mention the subaccount name explicitly.
+.PP
+Since it\(aqs common practice to leave lot subaccounts implicit,
+generally you should avoid writing balance assertions on individual
+lots.
+(\f[CR]close \-\-lots\f[R] also follows this rule.)
+If you forget, the balance assertion failure message will remind you.
+If you really need a balance assertion, you can usually write it on the
+parent account instead.
+.PP
+(The restriction is because transaction balancing amounts, balance
+assignments, and balance assertions must be calculated and checked
+before lot movements are known.)
 .SS Assertions and status
 Balance assertions always consider postings of all statuses (unmarked,
 pending, or cleared); they are not affected by the
@@ -2763,7 +2838,7 @@ them at the start of the main file, before any \f[CR]include\f[R]s.
 .PP
 .TS
 tab(@);
-lw(6.8n) lw(58.5n) lw(4.8n).
+lw(5.6n) lw(60.0n) lw(4.4n).
 T{
 directive
 T}@T{
@@ -2782,7 +2857,6 @@ T{
 T}@T{
 Rewrites account names, in following entries until
 \f[CR]end aliases\f[R] or file end.
-Command line equivalent: \f[CR]\-\-alias\f[R]
 T}@T{
 Y
 T}
@@ -2806,7 +2880,6 @@ T{
 \f[B]\f[CB]include\f[B]\f[R]
 T}@T{
 Includes entries from another file, as if they were written inline.
-Command line alternative: multiple \f[CR]\-f/\-\-file\f[R]
 T}@T{
 T}
 T{
@@ -2831,9 +2904,8 @@ the commodity\(aqs display style 3.
 optional commodity aliases and lotfulness, and 4.
 the decimal mark for parsing this commodity, until file end (overridden
 by \f[CR]decimal\-mark\f[R]).
-Command line equivalent: \f[CR]\-c/\-\-commodity\-style\f[R]
 T}@T{
-N N N Y
+N N N N
 T}
 T{
 \f[B]\f[CB]payee\f[B]\f[R]
@@ -2895,12 +2967,12 @@ T}
 T{
 \f[CR]D\f[R]
 T}@T{
-Sets 1.a default commodity to use for no\-symbol amounts in this file
-and subfiles, and 2.
-its parsing decimal mark and display style (overridden by
+Sets 1.a default commodity to use for no\-symbol amounts 2.
+the decimal mark for parsing it 3.
+the display style for showing it (these are overridden by
 \f[CR]commodity\f[R] or \f[CR]decimal\-mark\f[R]).
 T}@T{
-Y, Y, N
+Y, N, N
 T}
 T{
 \f[CR]Y\f[R]
@@ -3439,48 +3511,31 @@ be ignored, until an end comment directive or file end.
 A line containing just \f[CR]end comment\f[R] ends the effect of a
 preceding comment directive.
 .SS \f[CR]commodity\f[R] directive
-The \f[CR]commodity\f[R] directive performs several functions:
-.IP "1." 3
-It declares which commodity symbols may be used in the journal, enabling
-useful error checking with strict mode or the check command.
-See Commodity error checking below.
-.IP "2." 3
-It declares how all amounts in this commodity should be displayed, eg
-how many decimals to show.
-See Commodity display style above.
-.IP "3." 3
-(If no \f[CR]decimal\-mark\f[R] directive is in effect:) It sets the
-decimal mark to expect (period or comma) when parsing amounts in this
-commodity, in this file and files it includes, from the directive until
-end of current file.
-See Decimal marks above.
-.IP "4." 3
-It declares the precision with which this commodity\(aqs amounts should
-be compared when checking for balanced transactions, anywhere in this
-file and files it includes, until end of current file.
+\f[CR]commodity\f[R] directives declare commodity symbols (for error
+checking) and their preferred display style (digit group marks, decimal
+digits, and symbol position).
+Eg:
+.IP
+.EX
+commodity $1,000.00
+commodity 1000,00 EUR
+commodity ₹ 1,00,00,000.00
+commodity 1000.   ; the no\-symbol commodity
+.EE
 .PP
-Declaring commodities solves several common parsing/display problems, so
-we recommend it.
-.PP
-Note that effects 3 and 4 above end at the end of the directive\(aqs
-file, and will not affect sibling or parent files.
-So if you are relying on them (especially 4) and using multiple files,
-placing your commodity directives in a top\-level parent file might be
-important.
-Or, keep your decimal marks unambiguous and your entries well balanced
-and precise.
-.PP
-Omitting the commodity symbol will set the display style for just the
-no\-symbol commodity, not all commodities.
-.PP
-Commodity styles can be overridden by the
-\f[CR]\-c/\-\-commodity\-style\f[R] command line option.
-.PP
-(Related: #793)
+The sample amount must include a decimal mark (even if there are no
+decimal digits after it).
+This tells the parser which decimal mark (period or comma) is used for
+this commodity in the journal file, which can be useful in case of
+ambiguous digit group marks.
+This effect lasts until the end of the current file tree (from a single
+\f[CR]\-f\f[R] or \f[CR]LEDGER_FILE\f[R]), and it can be overridden by
+by a \f[CR]decimal\-mark\f[R] directive.
 .SS Commodity directive syntax
+In more detail.
 A commodity directive is normally the word \f[CR]commodity\f[R] followed
-by a sample amount, and optionally a comment.
-Only the amount\(aqs symbol and the number\(aqs format is significant.
+by a sample amount (only its format is significant), and optionally a
+comment.
 Eg:
 .IP
 .EX
@@ -3489,9 +3544,8 @@ commodity 1.000,00 EUR
 commodity 1 000 000.0000   ; the no\-symbol commodity
 .EE
 .PP
-A commodity directive\(aqs sample amount must always include a period or
-comma decimal mark (this rule helps disambiguate decimal marks and digit
-group marks).
+A commodity directive\(aqs sample amount must always include a decimal
+mark (period or comma).
 If you don\(aqt want to show any decimal digits, write the decimal mark
 at the end:
 .IP
@@ -3573,10 +3627,13 @@ an undeclared commodity symbol is used.
 commodity symbol.)
 It works like account error checking (described above).
 .SS \f[CR]decimal\-mark\f[R] directive
-You can use a \f[CR]decimal\-mark\f[R] directive \- usually one per
-file, at the top of the file \- to declare which character represents a
-decimal mark when parsing amounts in this file.
-It can look like
+You can use a \f[CR]decimal\-mark\f[R] directive to declare
+unambiguously which character (period or comma) represents a decimal
+mark, for all subsequent amounts until the end of the current file.
+This helps when parsing ambiguous numbers (like \f[CR]1.000\f[R] or
+\f[CR]1,000\f[R] where you mean one thousand, not one).
+.PP
+Eg, at the top of each journal file:
 .IP
 .EX
 decimal\-mark .
@@ -3588,9 +3645,10 @@ or
 decimal\-mark ,
 .EE
 .PP
-This prevents any ambiguity when parsing numbers in the file, so we
-recommend it, especially if the file contains digit group marks (eg
-thousands separators).
+This directive only affects parsing, and it takes precedence over
+\f[CR]commodity\f[R] directives.
+So you can declare preferred decimal marks for display, which may be
+different from the decimal mark(s) used in the data files.
 .SS \f[CR]include\f[R] directive
 You can pull in the content of additional files by writing an include
 directive, like this:
@@ -4592,7 +4650,7 @@ command output in an \f[CR]archive/\f[R] subdirectory of the
 The archive file name will be based on the rules file and the data
 file\(aqs modification date and extension (or for a data\-generating
 command, the current date and the \(dq.csv\(dq extension).
-The original data file, if any, will be removed.
+The original data file, once archived, will be removed.
 .PP
 Also, in this mode \f[CR]import\f[R] will prefer the oldest file matched
 by the \f[CR]source\f[R] rule\(aqs glob pattern, not the newest.
@@ -6734,7 +6792,7 @@ report at the end of february (overriding the requested end date).
 \f[CR]hledger register \-\-monthly \-\-begin 1/5 \-\-end 2/14\f[R] will
 end the report on march 4th [1].
 .PP
-[1] Since hledger 1.29.
+[1] Since 1.29.
 .SS Period expressions
 The \f[CR]\-p/\-\-period\f[R] option specifies a period expression,
 which is a compact way of expressing a start date, end date, and/or
@@ -8053,9 +8111,8 @@ $ hledger print
     (a)        $1,000.
 .EE
 .PP
-If this is a problem (eg when exporting to Ledger), you can avoid it by
-disabling digit group marks, eg with \-c/\-\-commodity (for each
-affected commodity):
+You can avoid this by disabling digit group marks, eg temporarily with
+\-c/\-\-commodity:
 .IP
 .EX
 $ hledger print \-c \(aq$1000.00\(aq
@@ -8063,7 +8120,7 @@ $ hledger print \-c \(aq$1000.00\(aq
     (a)          $1000
 .EE
 .PP
-or by forcing print to always show decimal digits, with \-\-round:
+or by forcing print to show some decimal digits, with \-\-round:
 .IP
 .EX
 $ hledger print \-c \(aq$1,000.00\(aq \-\-round=soft
@@ -8514,7 +8571,7 @@ To be safe, specify the valuation commmodity, eg:
 \f[CR]\-\-value=then \-\-infer\-market\-prices\f[R]
 .PP
 Signed costs and market prices can be confusing.
-For reference, here is the current behaviour, since hledger 1.25.
+For reference, here is the current behaviour (since 1.25).
 (If you think it should work differently, see #1870.)
 .IP
 .EX
@@ -10137,6 +10194,13 @@ in particular commands.
 But note that commands will not see any changes made to input files (eg
 by \f[CR]add\f[R]) until you exit and restart the REPL.
 .PP
+Any other general flags given to \f[CR]repl\f[R] \- input, reporting, or
+display flags such as \f[CR]\-I\f[R], \f[CR]\-\-strict\f[R],
+\f[CR]\-\-alias\f[R], \f[CR]\-b\f[R]/\f[CR]\-e\f[R],
+\f[CR]\-\-depth\f[R], \f[CR]\-\-cost\f[R], \f[CR]\-\-value\f[R],
+\f[CR]\-\-color\f[R] \- are also applied to every command you run.
+A command can still override them by specifying its own flags.
+.PP
 The command syntax is the same as with \f[CR]run\f[R]:
 .IP \(bu 2
 enter one hledger command at a time, without the usual
@@ -10164,6 +10228,7 @@ Generally \f[CR]repl\f[R] command lines should feel much like the normal
 hledger CLI, but you may find differences.
 \f[CR]repl\f[R] is a little stricter; eg it requires full command names
 or official abbreviations (as seen in the commands list).
+Command aliases defined in a config file can also be used.
 .PP
 The \f[CR]commands\f[R] and \f[CR]help\f[R] commands, and the command
 help flags (\f[CR]CMD \-\-tldr\f[R], \f[CR]CMD \-h/\-\-help\f[R],
@@ -10234,6 +10299,13 @@ specify an \f[CR]\-f\f[R] option within that command.
 This will override (not add to) the default input, just for that
 command.
 .PP
+Any other general flags given to \f[CR]run\f[R] \- input, reporting, or
+display flags such as \f[CR]\-I\f[R], \f[CR]\-\-strict\f[R],
+\f[CR]\-\-alias\f[R], \f[CR]\-b\f[R]/\f[CR]\-e\f[R],
+\f[CR]\-\-depth\f[R], \f[CR]\-\-cost\f[R], \f[CR]\-\-value\f[R],
+\f[CR]\-\-color\f[R] \- are also applied to every command it runs.
+A command can still override them by specifying its own flags.
+.PP
 Each input file (more precisely, each combination of input file and
 input options) is parsed only once.
 This means that commands will not see any changes made to these files,
@@ -10263,6 +10335,9 @@ If that gives an error, use \f[CR]#!/usr/bin/env \-S hledger run\f[R].
 .PP
 It\(aqs ok to use the \f[CR]run\f[R] command recursively within a
 command script.
+.PP
+Command aliases defined in a config file can also be used in command
+scripts.
 .PP
 You may find some differences in behaviour between \f[CR]run\f[R]
 command lines and normal hledger command lines.
@@ -11127,7 +11202,7 @@ Show journal and performance statistics.
 .IP
 .EX
 Flags:
-  \-1                        show a single line of output
+     \-\-oneline              show a single line of output
   \-v \-\-verbose              show more detailed output
   \-o \-\-output\-file=FILE     write output to FILE.
 .EE
@@ -11231,6 +11306,7 @@ Show full journal entries, representing transactions.
 .IP
 .EX
 Flags:
+     \-\-oneline              show transaction dates and descriptions only
   \-a \-\-all                  show all details (\-\-explicit \-\-lots
                             \-\-verbose\-tags)
   \-x \-\-explicit             show all inferred info explicitly
@@ -11438,6 +11514,11 @@ the program exit code will be non\-zero.
 .PP
 With \f[CR]\-\-locations\f[R], print adds the source file and line
 number to every transaction, as a tag.
+.PP
+With \f[CR]\-\-oneline\f[R], print shows only each transaction\(aqs
+first line (the date, status, code, description, and any same\-line
+comment), This gives a compact overview.
+It affects the default \f[CR]txt\f[R] output only.
 .SS print output format
 This command also supports the output destination and output format
 options The output formats supported are \f[CR]txt\f[R],

--- a/hledger/hledger.info
+++ b/hledger/hledger.info
@@ -89,7 +89,6 @@ file" and "Setting opening balances" sections in PART 5: COMMON TASKS.
 * Input::
 * Commands::
 * Options::
-* Output::
 * Environment::
 * PART 2 DATA FORMATS::
 * Journal::
@@ -345,7 +344,7 @@ set custom options for the addon there.  (Before hledger 1.50, an '--'
 argument was needed before addon options, but not any more.)
 
 
-File: hledger.info,  Node: Options,  Next: Output,  Prev: Commands,  Up: Top
+File: hledger.info,  Node: Options,  Next: Environment,  Prev: Commands,  Up: Top
 
 4 Options
 *********
@@ -486,6 +485,10 @@ to skip these until you need them.
 * Argument files::
 * Config files::
 * Shell completions::
+* Output destination::
+* Output format::
+* Commodity styles::
+* Debug output::
 
 
 File: hledger.info,  Node: Special characters,  Next: Unicode characters,  Up: Options
@@ -809,84 +812,145 @@ File: hledger.info,  Node: Config files,  Next: Shell completions,  Prev: Argume
 4.5 Config files
 ================
 
-With hledger 1.40+, you can save extra command line options and
-arguments in a more featureful hledger config file.  Here's a small
-example:
+You can configure default command line options and arguments
+conveniently in a hledger config file.  (Since 1.40.)  Config file
+options will be inserted near the start of your command line, so you can
+override them with command line options.
 
-# General options are listed first, and used with hledger commands that support them.
+   You can specify a config file with the '--conf' option.  Otherwise,
+hledger will search for a default config file, in this order:
+
+   * 'hledger.conf' in the current directory or above
+   * '.hledger.conf' in your home directory
+   * 'hledger.conf' in your XDG config
+     ('~/.config/hledger/hledger.conf').
+
+   Only one config file is used.  Here's a small example:
+
+# General options, used with all hledger commands that support them.
 --pretty
 
-# Options following a `[COMMAND]` heading are used with that hledger command only.
+# Command-specific options.
 [print]
 --explicit --infer-costs
 
-   To use a config file, specify it with the '--conf' option.  Its
-options will be inserted near the start of your command line, so you can
-override them with command line options if needed.
-
-   Or, you can set up an automatic config file that is used whenever you
-run hledger, by creating 'hledger.conf' in the current directory or
-above, or '.hledger.conf' in your home directory ('~/.hledger.conf'), or
-'hledger.conf' in your XDG config directory
-('~/.config/hledger/hledger.conf').
-
-   Here is another example config you could start with:
+   And here is a commented starter config file:
 https://github.com/simonmichael/hledger/blob/main/hledger.conf.sample
 
    You can put not only options, but also arguments in a config file.
-If the first word in a config file's top (general) section does not
-begin with a dash (eg: 'print'), it is treated as the command argument
-(overriding any argument on the command line).
 
-   On unix machines, you can add a shebang line at the top of a config
-file, set executable permission on the file, and use it like a script.
-Eg (the '-S' is needed on some operating systems):
+   You can ignore all config files by adding the '-n'/'--no-conf' flag
+to the command line.  This is recommended when using hledger in scripts.
+When both '--conf' and '--no-conf' options are used, the right-most
+wins.
 
-#!/usr/bin/env -S hledger --conf
+* Menu:
 
-   You can ignore config files by adding the '-n'/'--no-conf' flag to
-the command line.  This is useful when using hledger in scripts, or when
-troubleshooting.  When both '--conf' and '--no-conf' options are used,
-the right-most wins.
-
-   To inspect the processing of config files, use '--debug' or
-'--debug=8'.  Or, run the 'setup' command, which will display any active
-config files.  ('setup' is not affected by config files itself, unlike
-other commands.)
-
-   *Warning!*
-
-   There aren't many hledger features that need a warning, but this is
-one!
-
-   Automatic config files, while convenient, also make hledger less
-predictable and dependable.  It's easy to make a config file that
-changes a report's behaviour, or breaks your hledger-using
-scripts/applications, in ways that will surprise you later.
-
-   If you don't want this,
-
-  1. Just don't create a hledger.conf file on your machine.
-  2. Also be alert to downloaded directories which may contain a
-     hledger.conf file.
-  3. Also if you are sharing scripts or examples or support, consider
-     that others may have a hledger.conf file.
-
-   Conversely, once you decide to use this feature, try to remember:
-
-  1. Whenever a hledger command does not work as expected, try it again
-     with '-n' ('--no-conf') to see if a config file was to blame.
-  2. Whenever you call hledger from a script, consider whether that call
-     should use '-n' or not.
-  3. Be conservative about what you put in your config file; try to
-     consider the effect on all your reports.
-  4. To troubleshoot the effect of config files, run with '--debug' or
-     '--debug 8'.
-
-   The config file feature was added in hledger 1.40.
+* Command aliases::
+* Config file troubleshooting::
 
 
-File: hledger.info,  Node: Shell completions,  Prev: Config files,  Up: Options
+File: hledger.info,  Node: Command aliases,  Next: Config file troubleshooting,  Up: Config files
+
+4.5.1 Command aliases
+---------------------
+
+In a config file you can also define command aliases: your own custom
+commands, which expand to a longer command line (similar to git's
+aliases).  (Since 1.99.4.)  Eg:
+
+[alias]
+p     = print
+p1    = print --oneline
+rev10 = balance type:R -2 -X$ -p 'every 10 years from 2000'
+
+   With this in your config file, you'll see a 'rev10' command in the
+'hledger commands' list, and 'hledger rev10' will run the balance
+command above.  Options or arguments written at the command line will be
+added at the end, usually overriding those in the alias; eg 'hledger
+rev10 -X €' will convert to '€' instead of '$'.  Command aliases can
+also be used in 'run' command scripts and at the 'repl' prompt.
+
+   Each line in an '[alias]' section should look like 'NAME = COMMAND
+[ARGS..]'.  Or, you can define a single alias with an '[alias NAME]'
+section, writing its command line below it, on one or more lines.  This
+form can be easier to read, and lets you comment out individual lines.
+Eg:
+
+[alias rev10]
+balance
+type:R
+-2
+-X$
+-p 'every 10 years from 2000'
+# --drop 1
+
+   Command aliases override addon commands with the same name, but they
+can't override builtin command names or abbreviations like 'balance' or
+'bal'.  If the same alias name is defined more than once, the last
+definition wins.
+
+   An alias's command can be a hledger builtin command, addon command,
+or another alias.  If there's a '[COMMAND]' options section for an
+alias's resolved builtin command, that will also be applied.
+
+   Or if an alias's command line begins with '!', the rest is run as a
+shell command (with any extra command line arguments appended).  Eg:
+
+[alias]
+git-commit = ! git commit -p
+jj-commit  = ! jj commit -i
+
+   For safety, shell command aliases run only if defined in a trusted
+config file: one you gave explicitly with '--conf', or your user config
+file ('~/.hledger.conf' or the XDG 'hledger.conf').  Shell commands in a
+nearby automatically-found 'hledger.conf', in the current directory or a
+parent directory, will not run - this prevents a config file from an
+untrusted downloaded or shared directory from running arbitrary shell
+commands.
+
+
+File: hledger.info,  Node: Config file troubleshooting,  Prev: Command aliases,  Up: Config files
+
+4.5.2 Config file troubleshooting
+---------------------------------
+
+There aren't many hledger features that need a warning, but this is one
+!
+A default config file (the kind that hledger runs automatically, without
+needing a -conf option) is very convenient.  But, it complicates command
+line processing and can surprise you - eg quietly changing report
+output, or breaking your hledger-using scripts/applications, which you
+might not notice until much later.
+
+   This mainly arises when you are first using config files.  And once
+you discover this kind of problem, it will be easy to fix.  Here are
+some tips:
+
+  1. Be mindful about what you put in your config file; consider the
+     effect on all your reports.
+  2. If a hledger command isn't doing what you expect, try it again with
+     '-n', to see if a config file is to blame.
+  3. Run 'hledger setup' to list the currently active config file.
+     ('setup' is not affected by config files.)
+  4. Add '--debug' or '--debug=8' to any command to see config/command
+     line debug output.
+
+   When you are writing scripts, or sharing examples with other people,
+keep in mind that there could be a config file changing hledger's
+behaviour, so you might want to add '-n' to make your hledger commands
+more robust.
+
+   If you prefer to just avoid this feature:
+
+   * Don't use a default config file.
+   * If you download hledger data from elsewhere, watch out for
+     directories containing a hledger.conf file.
+   * If you're feeling paranoid, use the '-n/--no-conf' flag always, eg
+     by running hledger via a script or alias.
+
+
+File: hledger.info,  Node: Shell completions,  Next: Output destination,  Prev: Config files,  Up: Options
 
 4.6 Shell completions
 =====================
@@ -896,25 +960,12 @@ context-sensitive autocompletion for hledger command lines.  Try
 pressing 'hledger<SPACE><TAB><TAB>' (should list all hledger commands)
 or 'hledger reg acct:<TAB><TAB>' (should list your top-level account
 names).  If completions aren't working, or for more details, see Install
-> Shell completions.
+> Shell completions.  ˜ # Output
 
 
-File: hledger.info,  Node: Output,  Next: Environment,  Prev: Options,  Up: Top
+File: hledger.info,  Node: Output destination,  Next: Output format,  Prev: Shell completions,  Up: Options
 
-5 Output
-********
-
-* Menu:
-
-* Output destination::
-* Output format::
-* Commodity styles::
-* Debug output::
-
-
-File: hledger.info,  Node: Output destination,  Next: Output format,  Up: Output
-
-5.1 Output destination
+4.7 Output destination
 ======================
 
 hledger commands send their output to the terminal by default.  You can
@@ -930,9 +981,9 @@ $ hledger print -o foo.txt
 $ hledger print -o -        # write to stdout (the default)
 
 
-File: hledger.info,  Node: Output format,  Next: Commodity styles,  Prev: Output destination,  Up: Output
+File: hledger.info,  Node: Output format,  Next: Commodity styles,  Prev: Output destination,  Up: Options
 
-5.2 Output format
+4.8 Output format
 =================
 
 Some commands offer other kinds of output, not just text on the
@@ -971,7 +1022,6 @@ $ hledger balancesheet -o foo.txt -O csv    # write CSV to foo.txt
 * Menu:
 
 * Text output::
-* HTML output::
 * CSV / TSV output::
 * FODS output::
 * Ledger output::
@@ -980,9 +1030,9 @@ $ hledger balancesheet -o foo.txt -O csv    # write CSV to foo.txt
 * JSON output::
 
 
-File: hledger.info,  Node: Text output,  Next: HTML output,  Up: Output format
+File: hledger.info,  Node: Text output,  Next: CSV / TSV output,  Up: Output format
 
-5.2.1 Text output
+4.8.1 Text output
 -----------------
 
 This is the default: human readable, plain text report output, suitable
@@ -1005,12 +1055,12 @@ output, etc.
 
 * Box-drawing characters::
 * Colour::
-* Paging::
+* Paging˜::
 
 
 File: hledger.info,  Node: Box-drawing characters,  Next: Colour,  Up: Text output
 
-5.2.1.1 Box-drawing characters
+4.8.1.1 Box-drawing characters
 ..............................
 
 hledger draws simple table borders by default, to minimise the risk of
@@ -1022,9 +1072,9 @@ using the '--pretty' flag to show prettier tables in the terminal.  This
 is a good flag to add to your hledger config file.
 
 
-File: hledger.info,  Node: Colour,  Next: Paging,  Prev: Box-drawing characters,  Up: Text output
+File: hledger.info,  Node: Colour,  Next: Paging˜,  Prev: Box-drawing characters,  Up: Text output
 
-5.2.1.2 Colour
+4.8.1.2 Colour
 ..............
 
 hledger tries to automatically detect ANSI colour and text styling
@@ -1038,10 +1088,10 @@ your config file, with a 'y'/'yes' or 'n'/'no' value to force it on or
 off.
 
 
-File: hledger.info,  Node: Paging,  Prev: Colour,  Up: Text output
+File: hledger.info,  Node: Paging˜,  Prev: Colour,  Up: Text output
 
-5.2.1.3 Paging
-..............
+4.8.1.3 Paging˜
+...............
 
 In unix-like environments, when displaying large output (in any output
 format) in the terminal, hledger tries to use a pager when appropriate.
@@ -1077,23 +1127,19 @@ added to your 'LESS' environment variable:
    You can prevent this by setting your preferred options in the
 'HLEDGER_LESS' variable, which will be used instead of 'LESS'.
 
-
-File: hledger.info,  Node: HTML output,  Next: CSV / TSV output,  Prev: Text output,  Up: Output format
+   ˜ ### HTML output˜˜
 
-5.2.2 HTML output
------------------
-
-HTML output can be styled by an optional 'hledger.css' file in the same
-directory.
+   HTML output can be styled by an optional 'hledger.css' file in the
+same directory.
 
    HTML output will be a HTML fragment, not a complete HTML document.
 Like other hledger output, for non-ascii characters it will use the
 system locale's text encoding (see Text encoding).
 
 
-File: hledger.info,  Node: CSV / TSV output,  Next: FODS output,  Prev: HTML output,  Up: Output format
+File: hledger.info,  Node: CSV / TSV output,  Next: FODS output,  Prev: Text output,  Up: Output format
 
-5.2.3 CSV / TSV output
+4.8.2 CSV / TSV output
 ----------------------
 
 In CSV or TSV output, digit group marks (such as thousands separators)
@@ -1102,7 +1148,7 @@ are disabled automatically.
 
 File: hledger.info,  Node: FODS output,  Next: Ledger output,  Prev: CSV / TSV output,  Up: Output format
 
-5.2.4 FODS output
+4.8.3 FODS output
 -----------------
 
 FODS is the OpenDocument Spreadsheet format as plain XML, as accepted by
@@ -1124,7 +1170,7 @@ digit groups.
 
 File: hledger.info,  Node: Ledger output,  Next: Beancount output,  Prev: FODS output,  Up: Output format
 
-5.2.5 Ledger output
+4.8.4 Ledger output
 -------------------
 
 This is a Ledger-specific journal format supported by the 'print'
@@ -1135,7 +1181,7 @@ except that cost basis annotations will use Ledger's syntax, ('{COST}
 
 File: hledger.info,  Node: Beancount output,  Next: SQL output,  Prev: Ledger output,  Up: Output format
 
-5.2.6 Beancount output
+4.8.5 Beancount output
 ----------------------
 
 This is Beancount's journal format, supported by the 'print' command.
@@ -1175,7 +1221,7 @@ aliases, or this hledger2beancount.conf file).
 
 File: hledger.info,  Node: Beancount account names,  Next: Beancount commodity names,  Up: Beancount output
 
-5.2.6.1 Beancount account names
+4.8.5.1 Beancount account names
 ...............................
 
 Aside from the top-level names, hledger will adjust your account names
@@ -1188,7 +1234,7 @@ only one part.
 
 File: hledger.info,  Node: Beancount commodity names,  Next: Beancount balance assignments,  Prev: Beancount account names,  Up: Beancount output
 
-5.2.6.2 Beancount commodity names
+4.8.5.2 Beancount commodity names
 .................................
 
 hledger will adjust your commodity names to make valid Beancount
@@ -1206,7 +1252,7 @@ in hledger but all become 'CC' in beancount.)
 
 File: hledger.info,  Node: Beancount balance assignments,  Next: Beancount virtual postings,  Prev: Beancount commodity names,  Up: Beancount output
 
-5.2.6.3 Beancount balance assignments
+4.8.5.3 Beancount balance assignments
 .....................................
 
 Beancount doesn't support those; any balance assignments will be
@@ -1215,7 +1261,7 @@ converted to explicit amounts.
 
 File: hledger.info,  Node: Beancount virtual postings,  Next: Beancount metadata,  Prev: Beancount balance assignments,  Up: Beancount output
 
-5.2.6.4 Beancount virtual postings
+4.8.5.4 Beancount virtual postings
 ..................................
 
 Beancount doesn't allow virtual postings; if you have any, they will be
@@ -1224,7 +1270,7 @@ omitted from beancount output.
 
 File: hledger.info,  Node: Beancount metadata,  Next: Beancount costs,  Prev: Beancount virtual postings,  Up: Beancount output
 
-5.2.6.5 Beancount metadata
+4.8.5.5 Beancount metadata
 ..........................
 
 hledger tags will be converted to Beancount metadata (except for tags
@@ -1241,7 +1287,7 @@ the values combined, comma separated.  Eg: 'type: "Asset, Cash"'.
 
 File: hledger.info,  Node: Beancount costs,  Next: Beancount tolerance,  Prev: Beancount metadata,  Up: Beancount output
 
-5.2.6.6 Beancount costs
+4.8.5.6 Beancount costs
 .......................
 
 Beancount doesn't allow redundant costs and conversion postings as
@@ -1252,7 +1298,7 @@ group per transaction.
 
 File: hledger.info,  Node: Beancount tolerance,  Next: Beancount operating currency,  Prev: Beancount costs,  Up: Beancount output
 
-5.2.6.7 Beancount tolerance
+4.8.5.7 Beancount tolerance
 ...........................
 
 A sample 'inferred_tolerance_default' option is provided (commented
@@ -1262,7 +1308,7 @@ an easy way to work around it.
 
 File: hledger.info,  Node: Beancount operating currency,  Prev: Beancount tolerance,  Up: Beancount output
 
-5.2.6.8 Beancount operating currency
+4.8.5.8 Beancount operating currency
 ....................................
 
 Declaring an operating currency (or several) improves Beancount and Fava
@@ -1275,7 +1321,7 @@ option "operating_currency" "USD"
 
 File: hledger.info,  Node: SQL output,  Next: JSON output,  Prev: Beancount output,  Up: Output format
 
-5.2.7 SQL output
+4.8.6 SQL output
 ----------------
 
 SQL output is expected to work at least with SQLite, MySQL and Postgres.
@@ -1296,7 +1342,7 @@ $ hledger print -O sql | sed 's/id serial/id INTEGER PRIMARY KEY AUTOINCREMENT N
 
 File: hledger.info,  Node: JSON output,  Prev: SQL output,  Up: Output format
 
-5.2.8 JSON output
+4.8.7 JSON output
 -----------------
 
 Our JSON is rather large and verbose, since it is a faithful
@@ -1314,9 +1360,9 @@ know.  Related: #1195
    This is not yet much used; feedback is welcome.
 
 
-File: hledger.info,  Node: Commodity styles,  Next: Debug output,  Prev: Output format,  Up: Output
+File: hledger.info,  Node: Commodity styles,  Next: Debug output,  Prev: Output format,  Up: Options
 
-5.3 Commodity styles
+4.9 Commodity styles
 ====================
 
 When displaying amounts, hledger infers a standard display style for
@@ -1338,10 +1384,10 @@ style for just the no-symbol commodity, not all commodities.
 parseability (such as adding trailing decimal marks when needed).
 
 
-File: hledger.info,  Node: Debug output,  Prev: Commodity styles,  Up: Output
+File: hledger.info,  Node: Debug output,  Prev: Commodity styles,  Up: Options
 
-5.4 Debug output
-================
+4.10 Debug output
+=================
 
 We intend hledger to be relatively easy to troubleshoot, introspect and
 develop.  You can add '--debug[=N]' to any hledger command line to see
@@ -1358,9 +1404,9 @@ hledger bal --debug=3 2>hledger.log
    (This option doesn't work in a config file yet.)
 
 
-File: hledger.info,  Node: Environment,  Next: PART 2 DATA FORMATS,  Prev: Output,  Up: Top
+File: hledger.info,  Node: Environment,  Next: PART 2 DATA FORMATS,  Prev: Options,  Up: Top
 
-6 Environment
+5 Environment
 *************
 
 These environment variables affect hledger:
@@ -1391,13 +1437,13 @@ option.
 
 File: hledger.info,  Node: PART 2 DATA FORMATS,  Next: Journal,  Prev: Environment,  Up: Top
 
-7 PART 2: DATA FORMATS
+6 PART 2: DATA FORMATS
 **********************
 
 
 File: hledger.info,  Node: Journal,  Next: CSV,  Prev: PART 2 DATA FORMATS,  Up: Top
 
-8 Journal
+7 Journal
 *********
 
 hledger's usual data source is a plain text file containing journal
@@ -1471,7 +1517,7 @@ part.
 
 File: hledger.info,  Node: Journal cheatsheet,  Next: Comments,  Up: Journal
 
-8.1 Journal cheatsheet
+7.1 Journal cheatsheet
 ======================
 
 # Here is the main syntax of hledger's journal format
@@ -1606,7 +1652,7 @@ include other.journal   ; Include another journal file here.
 
 File: hledger.info,  Node: Comments,  Next: Transactions,  Prev: Journal cheatsheet,  Up: Journal
 
-8.2 Comments
+7.2 Comments
 ============
 
 Lines in the journal will be ignored if they begin with a hash ('#') or
@@ -1637,7 +1683,7 @@ comments, and Account comments below.
 
 File: hledger.info,  Node: Transactions,  Next: Dates,  Prev: Comments,  Up: Journal
 
-8.3 Transactions
+7.3 Transactions
 ================
 
 Transactions are the main unit of information in a journal file.  They
@@ -1666,7 +1712,7 @@ optional fields, separated by spaces:
 
 File: hledger.info,  Node: Dates,  Next: Status,  Prev: Transactions,  Up: Journal
 
-8.4 Dates
+7.4 Dates
 =========
 
 * Menu:
@@ -1677,7 +1723,7 @@ File: hledger.info,  Node: Dates,  Next: Status,  Prev: Transactions,  Up: Journ
 
 File: hledger.info,  Node: Simple dates,  Next: Posting dates,  Up: Dates
 
-8.4.1 Simple dates
+7.4.1 Simple dates
 ------------------
 
 Dates in the journal file use _simple dates_ format: 'YYYY-MM-DD' or
@@ -1693,7 +1739,7 @@ dates documented in the hledger manual.)
 
 File: hledger.info,  Node: Posting dates,  Prev: Simple dates,  Up: Dates
 
-8.4.2 Posting dates
+7.4.2 Posting dates
 -------------------
 
 You can give individual postings a different date from their parent
@@ -1724,7 +1770,7 @@ a 'date:' tag with no value is not allowed.
 
 File: hledger.info,  Node: Status,  Next: Code,  Prev: Dates,  Up: Journal
 
-8.5 Status
+7.5 Status
 ==========
 
 Transactions (or individual postings within a transaction) can have a
@@ -1772,7 +1818,7 @@ your finances.
 
 File: hledger.info,  Node: Code,  Next: Description,  Prev: Status,  Up: Journal
 
-8.6 Code
+7.6 Code
 ========
 
 After the status mark, but before the description, you can optionally
@@ -1789,7 +1835,7 @@ instead.
 
 File: hledger.info,  Node: Description,  Next: Transaction comments,  Prev: Code,  Up: Journal
 
-8.7 Description
+7.7 Description
 ===============
 
 After the date, status mark and/or code fields, the rest of the line (or
@@ -1811,7 +1857,7 @@ description with '--pivot desc'.
 
 File: hledger.info,  Node: Payee and note,  Up: Description
 
-8.7.1 Payee and note
+7.7.1 Payee and note
 --------------------
 
 Sometimes people want a dedicated payee/payer field that can be queried
@@ -1837,7 +1883,7 @@ checkable payee name, even if it's empty.)
 
 File: hledger.info,  Node: Transaction comments,  Next: Postings,  Prev: Description,  Up: Journal
 
-8.8 Transaction comments
+7.8 Transaction comments
 ========================
 
 Text following ';', after a transaction description, and/or on indented
@@ -1853,7 +1899,7 @@ tags, which are not ignored.
 
 File: hledger.info,  Node: Postings,  Next: Account names,  Prev: Transaction comments,  Up: Journal
 
-8.9 Postings
+7.9 Postings
 ============
 
 A posting is an addition of some amount to, or removal of some amount
@@ -1889,7 +1935,7 @@ save typing.
 
 File: hledger.info,  Node: Debits and credits,  Up: Postings
 
-8.9.1 Debits and credits
+7.9.1 Debits and credits
 ------------------------
 
 The traditional accounting concepts of debit and credit of course exist
@@ -1906,7 +1952,7 @@ _'credit / minus / right / longer words'_
 
 File: hledger.info,  Node: Account names,  Next: Amounts,  Prev: Postings,  Up: Journal
 
-8.10 Account names
+7.10 Account names
 ==================
 
 Accounts are the main way of categorising things in hledger.  As in
@@ -1935,7 +1981,7 @@ you may see them referred to as A, L, E, R, X for short.
 
 File: hledger.info,  Node: Two space delimiter,  Next: Account hierarchy,  Up: Account names
 
-8.10.1 Two space delimiter
+7.10.1 Two space delimiter
 --------------------------
 
 Note the *two or more spaces* delimiter that's sometimes required after
@@ -1966,7 +2012,7 @@ syntax light.
 
 File: hledger.info,  Node: Account hierarchy,  Next: Other account name features,  Prev: Two space delimiter,  Up: Account names
 
-8.10.2 Account hierarchy
+7.10.2 Account hierarchy
 ------------------------
 
 For more precise reporting, we usually divide accounts into more
@@ -1998,7 +2044,7 @@ less work.
 
 File: hledger.info,  Node: Other account name features,  Prev: Account hierarchy,  Up: Account names
 
-8.10.3 Other account name features
+7.10.3 Other account name features
 ----------------------------------
 
 Enclosing the account name in parentheses or brackets, like
@@ -2011,7 +2057,7 @@ permanently, by account aliases.
 
 File: hledger.info,  Node: Amounts,  Next: Costs,  Prev: Account names,  Up: Journal
 
-8.11 Amounts
+7.11 Amounts
 ============
 
 After the account name, there is usually an amount.  (Remember: between
@@ -2058,7 +2104,7 @@ EUR 1E3
 
 File: hledger.info,  Node: Decimal marks,  Next: Digit group marks,  Up: Amounts
 
-8.11.1 Decimal marks
+7.11.1 Decimal marks
 --------------------
 
 A _decimal mark_ can be written as a period or a comma:
@@ -2073,15 +2119,11 @@ like '1,000' or '1.000' containing just one period or comma is
 ambiguous.  In such cases, hledger by default assumes it is a decimal
 mark, and will parse both of those as 1.
 
-   To help hledger parse such ambiguous numbers more accurately, if you
-use digit group marks, we recommend declaring the decimal mark
-explicitly.  The best way is to add a 'decimal-mark' directive at the
-top of each data file, like this:
-
-decimal-mark .
-
-   Or you can declare it per commodity with 'commodity' directives,
-described below.
+   To help hledger parse such ambiguous numbers accurately, if you use
+digit group marks, we recommend declaring the decimal mark explicitly.
+You can declare it per commodity with 'commodity' directives, or per
+file with a 'decimal-mark' directive at the top of each journal file
+(described below).
 
    hledger also accepts numbers like '10.' with no digits after the
 decimal mark (and will sometimes display numbers that way to
@@ -2090,7 +2132,7 @@ disambiguate them - see Trailing decimal marks).
 
 File: hledger.info,  Node: Digit group marks,  Next: Commodity,  Prev: Decimal marks,  Up: Amounts
 
-8.11.2 Digit group marks
+7.11.2 Digit group marks
 ------------------------
 
 In the integer part of the amount quantity (left of the decimal mark),
@@ -2108,7 +2150,7 @@ INR 9,99,99,999.00
 
 File: hledger.info,  Node: Commodity,  Prev: Digit group marks,  Up: Amounts
 
-8.11.3 Commodity
+7.11.3 Commodity
 ----------------
 
 Amounts in hledger have both a "quantity", which is a signed decimal
@@ -2135,7 +2177,7 @@ style below.
 
 File: hledger.info,  Node: Costs,  Next: Cost basis,  Prev: Amounts,  Up: Journal
 
-8.12 Costs
+7.12 Costs
 ==========
 
 In traditional double entry bookkeeping, to record a transaction where
@@ -2240,7 +2282,7 @@ advantages of both.
 
 File: hledger.info,  Node: Cost basis,  Next: Balance assertions,  Prev: Costs,  Up: Journal
 
-8.13 Cost basis
+7.13 Cost basis
 ===============
 
 This section briefly describes the '{}' cost basis syntax, used to
@@ -2284,7 +2326,7 @@ be stripped ('("foo")' is read as label 'foo').
 
 File: hledger.info,  Node: Balance assertions,  Next: Posting comments,  Prev: Cost basis,  Up: Journal
 
-8.14 Balance assertions
+7.14 Balance assertions
 =======================
 
 hledger supports Ledger-style balance assertions in journal files.
@@ -2315,6 +2357,7 @@ does not disable balance assignments, described below).
 * Assertions and costs::
 * Assertions and commodities::
 * Assertions and subaccounts::
+* Assertions and lot subaccounts::
 * Assertions and status::
 * Assertions and virtual postings::
 * Assertions and auto postings::
@@ -2324,7 +2367,7 @@ does not disable balance assignments, described below).
 
 File: hledger.info,  Node: Assertions and ordering,  Next: Assertions and multiple files,  Up: Balance assertions
 
-8.14.1 Assertions and ordering
+7.14.1 Assertions and ordering
 ------------------------------
 
 hledger calculates and checks an account's balance assertions in date
@@ -2341,7 +2384,7 @@ updating.
 
 File: hledger.info,  Node: Assertions and multiple files,  Next: Assertions and costs,  Prev: Assertions and ordering,  Up: Balance assertions
 
-8.14.2 Assertions and multiple files
+7.14.2 Assertions and multiple files
 ------------------------------------
 
 If an account has transactions appearing in multiple files, balance
@@ -2367,7 +2410,7 @@ order.  (Discussion welcome.)
 
 File: hledger.info,  Node: Assertions and costs,  Next: Assertions and commodities,  Prev: Assertions and multiple files,  Up: Balance assertions
 
-8.14.3 Assertions and costs
+7.14.3 Assertions and costs
 ---------------------------
 
 Balance assertions ignore costs, and should normally be written without
@@ -2385,7 +2428,7 @@ costs), and because balance _assignments_ do use costs (see below).
 
 File: hledger.info,  Node: Assertions and commodities,  Next: Assertions and subaccounts,  Prev: Assertions and costs,  Up: Balance assertions
 
-8.14.4 Assertions and commodities
+7.14.4 Assertions and commodities
 ---------------------------------
 
 The balance assertions described so far are "*single commodity balance
@@ -2432,9 +2475,9 @@ specified commodities and no others.  It can be done by
   both:eur   €1 == €1  ; a euro there
 
 
-File: hledger.info,  Node: Assertions and subaccounts,  Next: Assertions and status,  Prev: Assertions and commodities,  Up: Balance assertions
+File: hledger.info,  Node: Assertions and subaccounts,  Next: Assertions and lot subaccounts,  Prev: Assertions and commodities,  Up: Balance assertions
 
-8.14.5 Assertions and subaccounts
+7.14.5 Assertions and subaccounts
 ---------------------------------
 
 All of the balance assertions above (both '=' and '==') are
@@ -2451,9 +2494,31 @@ by adding a star after the equals ('=*' or '==*'):
   assets            $0 ==* $20  ; assets + subaccounts contains $20 and nothing else
 
 
-File: hledger.info,  Node: Assertions and status,  Next: Assertions and virtual postings,  Prev: Assertions and subaccounts,  Up: Balance assertions
+File: hledger.info,  Node: Assertions and lot subaccounts,  Next: Assertions and status,  Prev: Assertions and subaccounts,  Up: Balance assertions
 
-8.14.6 Assertions and status
+7.14.6 Assertions and lot subaccounts
+-------------------------------------
+
+Lot subaccounts (a special kind of subaccount for tracking lots,
+discussed in "Lot reporting" below) have only limited support for
+balance assertions: the assertions will be checked correctly only if all
+postings to that lot mention the subaccount name explicitly.
+
+   Since it's common practice to leave lot subaccounts implicit,
+generally you should avoid writing balance assertions on individual
+lots.  ('close --lots' also follows this rule.)  If you forget, the
+balance assertion failure message will remind you.  If you really need a
+balance assertion, you can usually write it on the parent account
+instead.
+
+   (The restriction is because transaction balancing amounts, balance
+assignments, and balance assertions must be calculated and checked
+before lot movements are known.)
+
+
+File: hledger.info,  Node: Assertions and status,  Next: Assertions and virtual postings,  Prev: Assertions and lot subaccounts,  Up: Balance assertions
+
+7.14.7 Assertions and status
 ----------------------------
 
 Balance assertions always consider postings of all statuses (unmarked,
@@ -2463,7 +2528,7 @@ pending, or cleared); they are not affected by the '-U'/'--unmarked' /
 
 File: hledger.info,  Node: Assertions and virtual postings,  Next: Assertions and auto postings,  Prev: Assertions and status,  Up: Balance assertions
 
-8.14.7 Assertions and virtual postings
+7.14.8 Assertions and virtual postings
 --------------------------------------
 
 Balance assertions always consider both real and virtual postings; they
@@ -2472,7 +2537,7 @@ are not affected by the '--real/-R' flag or 'real:' query.
 
 File: hledger.info,  Node: Assertions and auto postings,  Next: Assertions and precision,  Prev: Assertions and virtual postings,  Up: Balance assertions
 
-8.14.8 Assertions and auto postings
+7.14.9 Assertions and auto postings
 -----------------------------------
 
 Balance assertions _are_ affected by the '--auto' flag, which generates
@@ -2491,8 +2556,8 @@ these.  So to avoid making fragile assertions, either:
 
 File: hledger.info,  Node: Assertions and precision,  Next: Assertions and hledger add,  Prev: Assertions and auto postings,  Up: Balance assertions
 
-8.14.9 Assertions and precision
--------------------------------
+7.14.10 Assertions and precision
+--------------------------------
 
 Balance assertions compare the exactly calculated amounts, which are not
 always what is shown by reports.  Eg a commodity directive may limit the
@@ -2502,7 +2567,7 @@ assertion failure messages show exact amounts.
 
 File: hledger.info,  Node: Assertions and hledger add,  Prev: Assertions and precision,  Up: Balance assertions
 
-8.14.10 Assertions and hledger add
+7.14.11 Assertions and hledger add
 ----------------------------------
 
 Balance assertions can be included in the amounts given in 'add'.  All
@@ -2522,7 +2587,7 @@ with '-I'.
 
 File: hledger.info,  Node: Posting comments,  Next: Transaction balancing,  Prev: Balance assertions,  Up: Journal
 
-8.15 Posting comments
+7.15 Posting comments
 =====================
 
 Text following ';', at the end of a posting line, and/or on indented
@@ -2539,7 +2604,7 @@ tags, which are not ignored.
 
 File: hledger.info,  Node: Transaction balancing,  Next: Tags,  Prev: Posting comments,  Up: Journal
 
-8.16 Transaction balancing
+7.16 Transaction balancing
 ==========================
 
 How exactly does hledger decide when a transaction is balanced ?
@@ -2585,7 +2650,7 @@ hit this problem, it's easy to fix:
 
 File: hledger.info,  Node: Tags,  Next: Directives,  Prev: Transaction balancing,  Up: Journal
 
-8.17 Tags
+7.17 Tags
 =========
 
 Tags are a way to add extra labels or data fields to transactions,
@@ -2643,7 +2708,7 @@ account assets:checking    ; acct-number: 123-45-6789
 
 File: hledger.info,  Node: Tag propagation,  Next: Displaying tags,  Up: Tags
 
-8.17.1 Tag propagation
+7.17.1 Tag propagation
 ----------------------
 
 In addition to what they are attached to, tags also affect related data
@@ -2682,7 +2747,7 @@ transaction    p2tag, atag    posting, p2tag and atag from second
 
 File: hledger.info,  Node: Displaying tags,  Next: When to use tags ?,  Prev: Tag propagation,  Up: Tags
 
-8.17.2 Displaying tags
+7.17.2 Displaying tags
 ----------------------
 
 You can use the 'tags' command to list tag names or values.
@@ -2695,7 +2760,7 @@ ways (eg appended to account names, like pseudo subaccounts).
 
 File: hledger.info,  Node: When to use tags ?,  Next: Tag names,  Prev: Displaying tags,  Up: Tags
 
-8.17.3 When to use tags ?
+7.17.3 When to use tags ?
 -------------------------
 
 Tags provide more dimensions of categorisation, complementing accounts
@@ -2710,7 +2775,7 @@ your usual account categories.
 
 File: hledger.info,  Node: Tag names,  Next: Tag values,  Prev: When to use tags ?,  Up: Tags
 
-8.17.4 Tag names
+7.17.4 Tag names
 ----------------
 
 What is allowed in a tag name ?  Any sequence of non-whitespace
@@ -2750,7 +2815,7 @@ be useful for troubleshooting.
 
 File: hledger.info,  Node: Tag values,  Prev: Tag names,  Up: Tags
 
-8.17.5 Tag values
+7.17.5 Tag values
 -----------------
 
 What is allowed in a tag value ?  Any sequence of non-comma non-newline
@@ -2762,7 +2827,7 @@ foo:a, foo:b'.
 
 File: hledger.info,  Node: Directives,  Next: account directive,  Prev: Tags,  Up: Journal
 
-8.18 Directives
+7.18 Directives
 ===============
 
 You can add directives to a 'journal' file, to add error checking,
@@ -2778,66 +2843,62 @@ there are usually workarounds.  Eg, to have 'alias' directives affect
 all of your files, put them at the start of the main file, before any
 'include's.
 
-directivewhat it does                                                ends
-                                                                     at
-                                                                     file
-                                                                     end?
+directivewhat it does                                                 ends
+                                                                      at
+                                                                      file
+                                                                      end?
 ---------------------------------------------------------------------------
 *Affects
 file
 reading:*
-*'alias'*Rewrites account names, in following entries until 'end     Y
-        aliases' or file end.  Command line equivalent: '--alias'
-*'comment'*Ignores following entries, until 'end comment' or file    Y
-        end.
-*'decimal-mark'*Declares the decimal mark, for parsing amounts of allY
-        commodities in following entries until next 'decimal-mark'
-        or file end.  Subfiles can override.
-*'include'*Includes entries from another file, as if they were
-        written inline.  Command line alternative: multiple
-        '-f/--file'
+*'alias'*Rewrites account names, in following entries until 'end      Y
+       aliases' or file end.
+*'comment'*Ignores following entries, until 'end comment' or file end.Y
+*'decimal-mark'*Declares the decimal mark, for parsing amounts of all Y
+       commodities in following entries until next 'decimal-mark'
+       or file end.  Subfiles can override.
+*'include'*Includes entries from another file, as if they were written
+       inline.
 *Declares
 data:*
-*'account'*Declares an account, for checking all entries in all      N
-        files, and its display order, and optionally its type and
-        lotfulness.
-*'commodity'*Declares 1.  a commodity symbol, for checking all amountsN N
-        in all files 2.  the commodity's display style 3.            N Y
-        optional commodity aliases and lotfulness, and 4.  the
-        decimal mark for parsing this commodity, until file end
-        (overridden by 'decimal-mark').  Command line equivalent:
-        '-c/--commodity-style'
-*'payee'*Declares a payee name, for checking all entries in all      N
-        files.
-*'tag'* Declares a tag name, for checking all entries in all         N
-        files.
-*'P'*   Declares a commodity's market price on some date, for
-        value and gain reports.
+*'account'*Declares an account, for checking all entries in all files,N
+       and its display order, and optionally its type and
+       lotfulness.
+*'commodity'*Declares 1.  a commodity symbol, for checking all amounts inN
+       all files 2.  the commodity's display style 3.  optional       N
+       commodity aliases and lotfulness, and 4.  the decimal mark     N
+       for parsing this commodity, until file end (overridden by      N
+       'decimal-mark').
+*'payee'*Declares a payee name, for checking all entries in all       N
+       files.
+*'tag'*Declares a tag name, for checking all entries in all files.    N
+*'P'*  Declares a commodity's market price on some date, for value
+       and gain reports.
 *Generates
 data:*
-*'='*   Declares an auto posting rule that generates extra           partly
-        postings with '--auto', in current/parent/subfiles (but
-        not sibling files, see #1212).
-*'~'*   Declares a periodic transaction rule that generates 1.       N
-        future transactions with '--forecast', and 2.  budget
-        goals with 'balance --budget'.
+*'='*  Declares an auto posting rule that generates extra postings    partly
+       with '--auto', in current/parent/subfiles (but not sibling
+       files, see #1212).
+*'~'*  Declares a periodic transaction rule that generates 1.         N
+       future transactions with '--forecast', and 2.  budget goals
+       with 'balance --budget'.
 *File
 reading
 (legacy/deprecated):*
-'apply  Prepends a common parent account to all account names, in    Y
+'apply Prepends a common parent account to all account names, in      Y
 account'following entries until 'end apply account' or file end.
-'D'     Sets 1.a default commodity to use for no-symbol amounts in   Y,
-        this file and subfiles, and 2.  its parsing decimal mark     Y,
-        and display style (overridden by 'commodity' or              N
-        'decimal-mark').
-'Y'     Sets a default year to use for any yearless dates, in        Y
-        following entries until file end.
-other   These other Ledger directives are accepted but ignored.
+'D'    Sets 1.a default commodity to use for no-symbol amounts 2.     Y,
+       the decimal mark for parsing it 3.  the display style for      N,
+       showing it (these are overridden by 'commodity' or             N
+       'decimal-mark').
+'Y'    Sets a default year to use for any yearless dates, in          Y
+       following entries until file end.
+other  These other Ledger directives are accepted but ignored.
 
 
 File: hledger.info,  Node: account directive,  Next: alias directive,  Prev: Directives,  Up: Journal
 
-8.19 'account' directive
+7.19 'account' directive
 ========================
 
 'account' directives can be used to declare accounts (ie, the places
@@ -2876,7 +2937,7 @@ account assets:bank:checking
 
 File: hledger.info,  Node: Account comments,  Next: Account tags,  Up: account directive
 
-8.19.1 Account comments
+7.19.1 Account comments
 -----------------------
 
 Text following *two or more spaces* and ';' at the end of an account
@@ -2893,7 +2954,7 @@ account assets:bank:checking    ; same-line comment, at least 2 spaces before th
 
 File: hledger.info,  Node: Account tags,  Next: Account error checking,  Prev: Account comments,  Up: account directive
 
-8.19.2 Account tags
+7.19.2 Account tags
 -------------------
 
 An account directive's comment may contain tags.  These will be
@@ -2905,7 +2966,7 @@ output, even with -verbose-tags.
 
 File: hledger.info,  Node: Account error checking,  Next: Account display order,  Prev: Account tags,  Up: account directive
 
-8.19.3 Account error checking
+7.19.3 Account error checking
 -----------------------------
 
 By default, accounts need not be declared; they come into existence when
@@ -2939,7 +3000,7 @@ account directive.  Some notes:
 
 File: hledger.info,  Node: Account display order,  Next: Account types,  Prev: Account error checking,  Up: account directive
 
-8.19.4 Account display order
+7.19.4 Account display order
 ----------------------------
 
 Account directives also cause hledger to display accounts in a
@@ -2981,7 +3042,7 @@ the other.
 
 File: hledger.info,  Node: Account types,  Prev: Account display order,  Up: account directive
 
-8.19.5 Account types
+7.19.5 Account types
 --------------------
 
 hledger knows that in accounting there are three main account types:
@@ -3078,7 +3139,7 @@ incomestatement reports, and querying by type:.
 
 File: hledger.info,  Node: alias directive,  Next: comment directive,  Prev: account directive,  Up: Journal
 
-8.20 'alias' directive
+7.20 'alias' directive
 ======================
 
 You can define account alias rules which rewrite your account names, or
@@ -3115,7 +3176,7 @@ more on this below.
 
 File: hledger.info,  Node: Basic aliases,  Next: Regex aliases,  Up: alias directive
 
-8.20.1 Basic aliases
+7.20.1 Basic aliases
 --------------------
 
 To set an account alias, use the 'alias' directive in your journal file.
@@ -3139,7 +3200,7 @@ alias checking = assets:bank:wells fargo:checking
 
 File: hledger.info,  Node: Regex aliases,  Next: Combining aliases,  Prev: Basic aliases,  Up: alias directive
 
-8.20.2 Regex aliases
+7.20.2 Regex aliases
 --------------------
 
 There is also a more powerful variant that uses a regular expression,
@@ -3173,7 +3234,7 @@ of option argument), so it can contain trailing whitespace.
 
 File: hledger.info,  Node: Combining aliases,  Next: Aliases and multiple files,  Prev: Regex aliases,  Up: alias directive
 
-8.20.3 Combining aliases
+7.20.3 Combining aliases
 ------------------------
 
 You can define as many aliases as you like, using journal directives
@@ -3210,7 +3271,7 @@ which aliases are being applied when.
 
 File: hledger.info,  Node: Aliases and multiple files,  Next: end aliases directive,  Prev: Combining aliases,  Up: alias directive
 
-8.20.4 Aliases and multiple files
+7.20.4 Aliases and multiple files
 ---------------------------------
 
 As explained at Directives, 'alias' directives do not affect parent or
@@ -3242,7 +3303,7 @@ include c.journal  ; also affected
 
 File: hledger.info,  Node: end aliases directive,  Next: Aliases can generate bad account names,  Prev: Aliases and multiple files,  Up: alias directive
 
-8.20.5 'end aliases' directive
+7.20.5 'end aliases' directive
 ------------------------------
 
 You can clear (forget) all currently defined aliases (seen in the
@@ -3253,7 +3314,7 @@ end aliases
 
 File: hledger.info,  Node: Aliases can generate bad account names,  Next: Aliases and account types,  Prev: end aliases directive,  Up: alias directive
 
-8.20.6 Aliases can generate bad account names
+7.20.6 Aliases can generate bad account names
 ---------------------------------------------
 
 Be aware that account aliases can produce malformed account names, which
@@ -3284,7 +3345,7 @@ $ hledger print --alias old="new  USD" | hledger -f- print
 
 File: hledger.info,  Node: Aliases and account types,  Prev: Aliases can generate bad account names,  Up: alias directive
 
-8.20.7 Aliases and account types
+7.20.7 Aliases and account types
 --------------------------------
 
 If an account with a type declaration (see Declaring accounts > Account
@@ -3308,7 +3369,7 @@ $ hledger accounts --types -1 --alias assets=bassetts
 
 File: hledger.info,  Node: comment directive,  Next: commodity directive,  Prev: alias directive,  Up: Journal
 
-8.21 'comment' directive
+7.21 'comment' directive
 ========================
 
 A line containing just 'comment' causes all following lines to be
@@ -3321,7 +3382,7 @@ ignored, until an end comment directive or file end.
 
 File: hledger.info,  Node: end comment directive,  Up: comment directive
 
-8.21.1 'end comment' directive
+7.21.1 'end comment' directive
 ------------------------------
 
 A line containing just 'end comment' ends the effect of a preceding
@@ -3330,45 +3391,25 @@ comment directive.
 
 File: hledger.info,  Node: commodity directive,  Next: decimal-mark directive,  Prev: comment directive,  Up: Journal
 
-8.22 'commodity' directive
+7.22 'commodity' directive
 ==========================
 
-The 'commodity' directive performs several functions:
+'commodity' directives declare commodity symbols (for error checking)
+and their preferred display style (digit group marks, decimal digits,
+and symbol position).  Eg:
 
-  1. It declares which commodity symbols may be used in the journal,
-     enabling useful error checking with strict mode or the check
-     command.  See Commodity error checking below.
+commodity $1,000.00
+commodity 1000,00 EUR
+commodity ₹ 1,00,00,000.00
+commodity 1000.   ; the no-symbol commodity
 
-  2. It declares how all amounts in this commodity should be displayed,
-     eg how many decimals to show.  See Commodity display style above.
-
-  3. (If no 'decimal-mark' directive is in effect:) It sets the decimal
-     mark to expect (period or comma) when parsing amounts in this
-     commodity, in this file and files it includes, from the directive
-     until end of current file.  See Decimal marks above.
-
-  4. It declares the precision with which this commodity's amounts
-     should be compared when checking for balanced transactions,
-     anywhere in this file and files it includes, until end of current
-     file.
-
-   Declaring commodities solves several common parsing/display problems,
-so we recommend it.
-
-   Note that effects 3 and 4 above end at the end of the directive's
-file, and will not affect sibling or parent files.  So if you are
-relying on them (especially 4) and using multiple files, placing your
-commodity directives in a top-level parent file might be important.  Or,
-keep your decimal marks unambiguous and your entries well balanced and
-precise.
-
-   Omitting the commodity symbol will set the display style for just the
-no-symbol commodity, not all commodities.
-
-   Commodity styles can be overridden by the '-c/--commodity-style'
-command line option.
-
-   (Related: #793)
+   The sample amount must include a decimal mark (even if there are no
+decimal digits after it).  This tells the parser which decimal mark
+(period or comma) is used for this commodity in the journal file, which
+can be useful in case of ambiguous digit group marks.  This effect lasts
+until the end of the current file tree (from a single '-f' or
+'LEDGER_FILE'), and it can be overridden by by a 'decimal-mark'
+directive.
 
 * Menu:
 
@@ -3380,21 +3421,20 @@ command line option.
 
 File: hledger.info,  Node: Commodity directive syntax,  Next: Commodity tags,  Up: commodity directive
 
-8.22.1 Commodity directive syntax
+7.22.1 Commodity directive syntax
 ---------------------------------
 
-A commodity directive is normally the word 'commodity' followed by a
-sample amount, and optionally a comment.  Only the amount's symbol and
-the number's format is significant.  Eg:
+In more detail.  A commodity directive is normally the word 'commodity'
+followed by a sample amount (only its format is significant), and
+optionally a comment.  Eg:
 
 commodity $1000.00
 commodity 1.000,00 EUR
 commodity 1 000 000.0000   ; the no-symbol commodity
 
-   A commodity directive's sample amount must always include a period or
-comma decimal mark (this rule helps disambiguate decimal marks and digit
-group marks).  If you don't want to show any decimal digits, write the
-decimal mark at the end:
+   A commodity directive's sample amount must always include a decimal
+mark (period or comma).  If you don't want to show any decimal digits,
+write the decimal mark at the end:
 
 commodity 1000. AAAA       ; show AAAA with no decimals
 
@@ -3425,7 +3465,7 @@ commodity INR
 
 File: hledger.info,  Node: Commodity tags,  Next: Commodity aliases,  Prev: Commodity directive syntax,  Up: commodity directive
 
-8.22.2 Commodity tags
+7.22.2 Commodity tags
 ---------------------
 
 A commodity directive's comment may contain tags.  These will be
@@ -3438,7 +3478,7 @@ be queryable but won't be shown in 'print' output, even with
 
 File: hledger.info,  Node: Commodity aliases,  Next: Commodity error checking,  Prev: Commodity tags,  Up: commodity directive
 
-8.22.3 Commodity aliases
+7.22.3 Commodity aliases
 ------------------------
 
 An 'alias:' tag on a commodity directive declares one or more aliases
@@ -3466,7 +3506,7 @@ reports an error.
 
 File: hledger.info,  Node: Commodity error checking,  Prev: Commodity aliases,  Up: commodity directive
 
-8.22.4 Commodity error checking
+7.22.4 Commodity error checking
 -------------------------------
 
 In strict mode ('-s'/'--strict') (or when you run 'hledger check
@@ -3478,12 +3518,16 @@ have no commodity symbol.)  It works like account error checking
 
 File: hledger.info,  Node: decimal-mark directive,  Next: include directive,  Prev: commodity directive,  Up: Journal
 
-8.23 'decimal-mark' directive
+7.23 'decimal-mark' directive
 =============================
 
-You can use a 'decimal-mark' directive - usually one per file, at the
-top of the file - to declare which character represents a decimal mark
-when parsing amounts in this file.  It can look like
+You can use a 'decimal-mark' directive to declare unambiguously which
+character (period or comma) represents a decimal mark, for all
+subsequent amounts until the end of the current file.  This helps when
+parsing ambiguous numbers (like '1.000' or '1,000' where you mean one
+thousand, not one).
+
+   Eg, at the top of each journal file:
 
 decimal-mark .
 
@@ -3491,14 +3535,15 @@ decimal-mark .
 
 decimal-mark ,
 
-   This prevents any ambiguity when parsing numbers in the file, so we
-recommend it, especially if the file contains digit group marks (eg
-thousands separators).
+   This directive only affects parsing, and it takes precedence over
+'commodity' directives.  So you can declare preferred decimal marks for
+display, which may be different from the decimal mark(s) used in the
+data files.
 
 
 File: hledger.info,  Node: include directive,  Next: P directive,  Prev: decimal-mark directive,  Up: Journal
 
-8.24 'include' directive
+7.24 'include' directive
 ========================
 
 You can pull in the content of additional files by writing an include
@@ -3552,7 +3597,7 @@ error that's hard to pinpoint: a good troubleshooting command is
 
 File: hledger.info,  Node: P directive,  Next: payee directive,  Prev: include directive,  Up: Journal
 
-8.25 'P' directive
+7.25 'P' directive
 ==================
 
 The 'P' directive declares a market price, which is a conversion rate
@@ -3582,7 +3627,7 @@ amount values in another commodity.  See Value reporting.
 
 File: hledger.info,  Node: payee directive,  Next: tag directive,  Prev: P directive,  Up: Journal
 
-8.26 'payee' directive
+7.26 'payee' directive
 ======================
 
      payee PAYEE NAME
@@ -3605,7 +3650,7 @@ payee ""
 
 File: hledger.info,  Node: tag directive,  Next: Periodic transactions,  Prev: payee directive,  Up: Journal
 
-8.27 'tag' directive
+7.27 'tag' directive
 ====================
 
      tag TAGNAME
@@ -3625,7 +3670,7 @@ check your tags .
 
 File: hledger.info,  Node: Periodic transactions,  Next: Auto postings,  Prev: tag directive,  Up: Journal
 
-8.28 Periodic transactions
+7.28 Periodic transactions
 ==========================
 
 The '~' directive declares a "periodic rule" which generates temporary
@@ -3672,7 +3717,7 @@ this whole section, or at least the following tips:
 
 File: hledger.info,  Node: Periodic rule syntax,  Next: Periodic rules and relative dates,  Up: Periodic transactions
 
-8.28.1 Periodic rule syntax
+7.28.1 Periodic rule syntax
 ---------------------------
 
 A periodic transaction rule looks like a normal journal entry, with the
@@ -3697,7 +3742,7 @@ dates).
 
 File: hledger.info,  Node: Periodic rules and relative dates,  Next: Two spaces between period expression and description!,  Prev: Periodic rule syntax,  Up: Periodic transactions
 
-8.28.2 Periodic rules and relative dates
+7.28.2 Periodic rules and relative dates
 ----------------------------------------
 
 Partial or relative dates (like '12/31', '25', 'tomorrow', 'last week',
@@ -3716,7 +3761,7 @@ dates.
 
 File: hledger.info,  Node: Two spaces between period expression and description!,  Prev: Periodic rules and relative dates,  Up: Periodic transactions
 
-8.28.3 Two spaces between period expression and description!
+7.28.3 Two spaces between period expression and description!
 ------------------------------------------------------------
 
 If the period expression is followed by a transaction description, these
@@ -3741,7 +3786,7 @@ accidentally alter their meaning, as in this example:
 
 File: hledger.info,  Node: Auto postings,  Next: Other syntax,  Prev: Periodic transactions,  Up: Journal
 
-8.29 Auto postings
+7.29 Auto postings
 ==================
 
 The '=' directive declares an "auto posting rule", which adds extra
@@ -3838,7 +3883,7 @@ output into the journal file to make it permanent.
 
 File: hledger.info,  Node: Auto postings and multiple files,  Next: Auto postings and dates,  Up: Auto postings
 
-8.29.1 Auto postings and multiple files
+7.29.1 Auto postings and multiple files
 ---------------------------------------
 
 An auto posting rule can affect any transaction in the current file, or
@@ -3848,7 +3893,7 @@ sibling files (when multiple '-f'/'--file' are used - see #1212).
 
 File: hledger.info,  Node: Auto postings and dates,  Next: Auto postings and transaction balancing / inferred amounts / balance assertions,  Prev: Auto postings and multiple files,  Up: Auto postings
 
-8.29.2 Auto postings and dates
+7.29.2 Auto postings and dates
 ------------------------------
 
 A posting date (or secondary date) in the matched posting, or (taking
@@ -3858,7 +3903,7 @@ used in the generated posting.
 
 File: hledger.info,  Node: Auto postings and transaction balancing / inferred amounts / balance assertions,  Next: Auto posting tags,  Prev: Auto postings and dates,  Up: Auto postings
 
-8.29.3 Auto postings and transaction balancing / inferred amounts /
+7.29.3 Auto postings and transaction balancing / inferred amounts /
 -------------------------------------------------------------------
 
 balance assertions Currently, auto postings are added:
@@ -3878,7 +3923,7 @@ infer amounts.
 
 File: hledger.info,  Node: Auto posting tags,  Next: Auto postings on forecast transactions only,  Prev: Auto postings and transaction balancing / inferred amounts / balance assertions,  Up: Auto postings
 
-8.29.4 Auto posting tags
+7.29.4 Auto posting tags
 ------------------------
 
 Automated postings will have some extra tags:
@@ -3900,7 +3945,7 @@ will have these tags added:
 
 File: hledger.info,  Node: Auto postings on forecast transactions only,  Prev: Auto posting tags,  Up: Auto postings
 
-8.29.5 Auto postings on forecast transactions only
+7.29.5 Auto postings on forecast transactions only
 --------------------------------------------------
 
 Tip: you can can make auto postings that will apply to forecast
@@ -3911,7 +3956,7 @@ generating new journal entries to be saved in the journal.
 
 File: hledger.info,  Node: Other syntax,  Prev: Auto postings,  Up: Journal
 
-8.30 Other syntax
+7.30 Other syntax
 =================
 
 hledger journal format supports quite a few other features, mainly to
@@ -3939,7 +3984,7 @@ you decide if you want to use them.
 
 File: hledger.info,  Node: Balance assignments,  Next: Bracketed posting dates,  Up: Other syntax
 
-8.30.1 Balance assignments
+7.30.1 Balance assignments
 --------------------------
 
 Ledger-style balance assignments are also supported.  These are like
@@ -3982,7 +4027,7 @@ trustworthy in an audit.
 
 File: hledger.info,  Node: Balance assignments and costs,  Next: Balance assignments and multiple files,  Up: Balance assignments
 
-8.30.1.1 Balance assignments and costs
+7.30.1.1 Balance assignments and costs
 ......................................
 
 A cost in a balance assignment will cause the calculated amount to have
@@ -3998,7 +4043,7 @@ $ hledger print --explicit
 
 File: hledger.info,  Node: Balance assignments and multiple files,  Prev: Balance assignments and costs,  Up: Balance assignments
 
-8.30.1.2 Balance assignments and multiple files
+7.30.1.2 Balance assignments and multiple files
 ...............................................
 
 Balance assignments handle multiple files like balance assertions.  They
@@ -4008,7 +4053,7 @@ but not from previous sibling or parent files.
 
 File: hledger.info,  Node: Bracketed posting dates,  Next: D directive,  Prev: Balance assignments,  Up: Other syntax
 
-8.30.2 Bracketed posting dates
+7.30.2 Bracketed posting dates
 ------------------------------
 
 For setting posting dates and secondary posting dates, Ledger's
@@ -4025,7 +4070,7 @@ syntax.
 
 File: hledger.info,  Node: D directive,  Next: apply account directive,  Prev: Bracketed posting dates,  Up: Other syntax
 
-8.30.3 'D' directive
+7.30.3 'D' directive
 --------------------
 
      D AMOUNT
@@ -4071,7 +4116,7 @@ Ledger's 'D'.
 
 File: hledger.info,  Node: apply account directive,  Next: Y directive,  Prev: D directive,  Up: Other syntax
 
-8.30.4 'apply account' directive
+7.30.4 'apply account' directive
 --------------------------------
 
 This directive sets a default parent account, which will be prepended to
@@ -4107,7 +4152,7 @@ portable, and less trustworthy in an audit.
 
 File: hledger.info,  Node: Y directive,  Next: Secondary dates,  Prev: apply account directive,  Up: Other syntax
 
-8.30.5 'Y' directive
+7.30.5 'Y' directive
 --------------------
 
      Y YEAR
@@ -4145,7 +4190,7 @@ date.
 
 File: hledger.info,  Node: Secondary dates,  Next: Star comments,  Prev: Y directive,  Up: Other syntax
 
-8.30.6 Secondary dates
+7.30.6 Secondary dates
 ----------------------
 
 A secondary date is written after the primary date, following an equals
@@ -4181,7 +4226,7 @@ instead.
 
 File: hledger.info,  Node: Star comments,  Next: Valuation expressions,  Prev: Secondary dates,  Up: Other syntax
 
-8.30.7 Star comments
+7.30.7 Star comments
 --------------------
 
 Lines beginning with '*' (star/asterisk) are also comment lines.  This
@@ -4198,7 +4243,7 @@ losing ledger mode's features.
 
 File: hledger.info,  Node: Valuation expressions,  Next: Virtual postings,  Prev: Star comments,  Up: Other syntax
 
-8.30.8 Valuation expressions
+7.30.8 Valuation expressions
 ----------------------------
 
 Ledger allows a valuation function or value to be written in double
@@ -4207,7 +4252,7 @@ parentheses after an amount.  hledger ignores these.
 
 File: hledger.info,  Node: Virtual postings,  Next: Other Ledger directives,  Prev: Valuation expressions,  Up: Other syntax
 
-8.30.9 Virtual postings
+7.30.9 Virtual postings
 -----------------------
 
 A posting with parentheses around the account name, like '(some:account)
@@ -4239,7 +4284,7 @@ from reports with the '-R/--real' flag or a 'real:1' query.
 
 File: hledger.info,  Node: Other Ledger directives,  Next: Ledger virtual costs,  Prev: Virtual postings,  Up: Other syntax
 
-8.30.10 Other Ledger directives
+7.30.10 Other Ledger directives
 -------------------------------
 
 These other Ledger directives are currently accepted but ignored.  This
@@ -4270,7 +4315,7 @@ hledger/Ledger syntax comparison.
 
 File: hledger.info,  Node: Ledger virtual costs,  Next: Ledger cost basis,  Prev: Other Ledger directives,  Up: Other syntax
 
-8.30.11 Ledger virtual costs
+7.30.11 Ledger virtual costs
 ----------------------------
 
 In Ledger, '(@) UNITCOST' and '(@@) TOTALCOST' are virtual costs, which
@@ -4280,7 +4325,7 @@ and '@@'.
 
 File: hledger.info,  Node: Ledger cost basis,  Prev: Ledger virtual costs,  Up: Other syntax
 
-8.30.12 Ledger cost basis
+7.30.12 Ledger cost basis
 -------------------------
 
 In Ledger, these annotations after an amount help specify or select a
@@ -4320,7 +4365,7 @@ own cost basis syntax).
 
 File: hledger.info,  Node: CSV,  Next: Timeclock,  Prev: Journal,  Up: Top
 
-9 CSV
+8 CSV
 *****
 
 hledger can read transactions from CSV (comma-separated values) files.
@@ -4392,7 +4437,7 @@ https://github.com/simonmichael/hledger/tree/main/examples/csv.
 
 File: hledger.info,  Node: CSV rules cheatsheet,  Next: source,  Up: CSV
 
-9.1 CSV rules cheatsheet
+8.1 CSV rules cheatsheet
 ========================
 
 The following kinds of rule can appear in the rules file, in any order.
@@ -4439,7 +4484,7 @@ evaluated.
 
 File: hledger.info,  Node: source,  Next: archive,  Prev: CSV rules cheatsheet,  Up: CSV
 
-9.2 'source'
+8.2 'source'
 ============
 
 If you tell hledger to read a csv file with '-f foo.csv', it will look
@@ -4490,7 +4535,7 @@ CSV files, then run 'hledger import rules/*'.
 
 File: hledger.info,  Node: Data cleaning / data generating commands,  Up: source
 
-9.2.1 Data cleaning / data generating commands
+8.2.1 Data cleaning / data generating commands
 ----------------------------------------------
 
 After 'source''s file pattern, you can write '|' (pipe) and a data
@@ -4534,7 +4579,7 @@ message.
 
 File: hledger.info,  Node: archive,  Next: encoding,  Prev: source,  Up: CSV
 
-9.3 'archive'
+8.3 'archive'
 =============
 
 With 'archive' added to a rules file, the 'import' command will archive
@@ -4543,7 +4588,7 @@ each successfully processed data file or data command output in an
 journal file.  The archive file name will be based on the rules file and
 the data file's modification date and extension (or for a
 data-generating command, the current date and the ".csv" extension).
-The original data file, if any, will be removed.
+The original data file, once archived, will be removed.
 
    Also, in this mode 'import' will prefer the oldest file matched by
 the 'source' rule's glob pattern, not the newest.  (So if there are
@@ -4558,7 +4603,7 @@ variations in your bank's CSV, etc.
 
 File: hledger.info,  Node: encoding,  Next: separator,  Prev: archive,  Up: CSV
 
-9.4 'encoding'
+8.4 'encoding'
 ==============
 
 encoding ENCODING
@@ -4585,7 +4630,7 @@ rules.  Eg: 'encoding iso-8859-1'.
 
 File: hledger.info,  Node: separator,  Next: skip,  Prev: encoding,  Up: CSV
 
-9.5 'separator'
+8.5 'separator'
 ===============
 
 You can use the 'separator' rule to read other kinds of
@@ -4610,7 +4655,7 @@ inferred automatically, and you won't need this rule.
 
 File: hledger.info,  Node: skip,  Next: date-format,  Prev: separator,  Up: CSV
 
-9.6 'skip'
+8.6 'skip'
 ==========
 
 skip N
@@ -4629,7 +4674,7 @@ required to be valid CSV.
 
 File: hledger.info,  Node: date-format,  Next: timezone,  Prev: skip,  Up: CSV
 
-9.7 'date-format'
+8.7 'date-format'
 =================
 
 date-format DATEFMT
@@ -4661,7 +4706,7 @@ setting LC_TIME won't help.
 
 File: hledger.info,  Node: timezone,  Next: newest-first,  Prev: date-format,  Up: CSV
 
-9.8 'timezone'
+8.8 'timezone'
 ==============
 
 timezone TIMEZONE
@@ -4690,7 +4735,7 @@ For others, use numeric format: +HHMM or -HHMM.
 
 File: hledger.info,  Node: newest-first,  Next: intra-day-reversed,  Prev: timezone,  Up: CSV
 
-9.9 'newest-first'
+8.9 'newest-first'
 ==================
 
 hledger tries to ensure that the generated transactions will be ordered
@@ -4713,7 +4758,7 @@ newest-first
 
 File: hledger.info,  Node: intra-day-reversed,  Next: decimal-mark,  Prev: newest-first,  Up: CSV
 
-9.10 'intra-day-reversed'
+8.10 'intra-day-reversed'
 =========================
 
 If CSV records within a single day are ordered opposite to the overall
@@ -4732,7 +4777,7 @@ intra-day-reversed
 
 File: hledger.info,  Node: decimal-mark,  Next: CSV fields vs hledger fields,  Prev: intra-day-reversed,  Up: CSV
 
-9.11 'decimal-mark'
+8.11 'decimal-mark'
 ===================
 
 decimal-mark .
@@ -4750,7 +4795,7 @@ misparsed numbers.
 
 File: hledger.info,  Node: CSV fields vs hledger fields,  Next: fields list,  Prev: decimal-mark,  Up: CSV
 
-9.12 CSV fields vs hledger fields
+8.12 CSV fields vs hledger fields
 =================================
 
 The main task of CSV rules is to convert *CSV fields* to *hledger
@@ -4792,7 +4837,7 @@ if %date 2026
 
 File: hledger.info,  Node: fields list,  Next: Field assignment,  Prev: CSV fields vs hledger fields,  Up: CSV
 
-9.13 'fields' list
+8.13 'fields' list
 ==================
 
 fields FIELDNAME1, FIELDNAME2, ...
@@ -4837,7 +4882,7 @@ field (and generating a balance assertion).
 
 File: hledger.info,  Node: Field assignment,  Next: hledger field names,  Prev: fields list,  Up: CSV
 
-9.14 Field assignment
+8.14 Field assignment
 =====================
 
 HLEDGERFIELD FIELDVALUE
@@ -4876,7 +4921,7 @@ account1 assets:%(type)checking
 
 File: hledger.info,  Node: hledger field names,  Next: if,  Prev: Field assignment,  Up: CSV
 
-9.15 hledger field names
+8.15 hledger field names
 ========================
 
 Here are all the hledger fields you can assign to.  They correspond to
@@ -4899,7 +4944,7 @@ have a special effect.
 
 File: hledger.info,  Node: date field,  Next: date2 field,  Up: hledger field names
 
-9.15.1 date field
+8.15.1 date field
 -----------------
 
 Assigning to 'date' sets the transaction date.  This is required.
@@ -4907,7 +4952,7 @@ Assigning to 'date' sets the transaction date.  This is required.
 
 File: hledger.info,  Node: date2 field,  Next: status field,  Prev: date field,  Up: hledger field names
 
-9.15.2 date2 field
+8.15.2 date2 field
 ------------------
 
 'date2' sets the transaction's secondary date, if any.
@@ -4915,7 +4960,7 @@ File: hledger.info,  Node: date2 field,  Next: status field,  Prev: date field, 
 
 File: hledger.info,  Node: status field,  Next: code field,  Prev: date2 field,  Up: hledger field names
 
-9.15.3 status field
+8.15.3 status field
 -------------------
 
 'status' sets the transaction's status, if any.
@@ -4923,7 +4968,7 @@ File: hledger.info,  Node: status field,  Next: code field,  Prev: date2 field, 
 
 File: hledger.info,  Node: code field,  Next: description field,  Prev: status field,  Up: hledger field names
 
-9.15.4 code field
+8.15.4 code field
 -----------------
 
 'code' sets the transaction's code, if any.
@@ -4931,7 +4976,7 @@ File: hledger.info,  Node: code field,  Next: description field,  Prev: status f
 
 File: hledger.info,  Node: description field,  Next: comment field,  Prev: code field,  Up: hledger field names
 
-9.15.5 description field
+8.15.5 description field
 ------------------------
 
 'description' sets the transaction's description, if any.
@@ -4939,7 +4984,7 @@ File: hledger.info,  Node: description field,  Next: comment field,  Prev: code 
 
 File: hledger.info,  Node: comment field,  Next: account field,  Prev: description field,  Up: hledger field names
 
-9.15.6 comment field
+8.15.6 comment field
 --------------------
 
 'comment' sets the transaction's comment, if any.
@@ -4957,7 +5002,7 @@ or a year-less date, will be ignored.
 
 File: hledger.info,  Node: account field,  Next: amount field,  Prev: comment field,  Up: hledger field names
 
-9.15.7 account field
+8.15.7 account field
 --------------------
 
 Assigning to 'accountN', where N is 1 to 99, sets the account name of
@@ -4975,7 +5020,7 @@ account name will be set to 'expenses:unknown' or 'income:unknown'
 
 File: hledger.info,  Node: amount field,  Next: currency field,  Prev: account field,  Up: hledger field names
 
-9.15.8 amount field
+8.15.8 amount field
 -------------------
 
 There are several ways to set posting amounts from CSV, useful in
@@ -5033,7 +5078,7 @@ different situations.
 
 File: hledger.info,  Node: currency field,  Next: balance field,  Prev: amount field,  Up: hledger field names
 
-9.15.9 currency field
+8.15.9 currency field
 ---------------------
 
 'currency' sets a currency symbol, to be prepended to all postings'
@@ -5046,7 +5091,7 @@ amount.
 
 File: hledger.info,  Node: balance field,  Prev: currency field,  Up: hledger field names
 
-9.15.10 balance field
+8.15.10 balance field
 ---------------------
 
 'balanceN' sets a balance assertion amount (or if the posting amount is
@@ -5064,7 +5109,7 @@ and currency.
 
 File: hledger.info,  Node: if,  Next: Matchers,  Prev: hledger field names,  Up: CSV
 
-9.16 'if'
+8.16 'if'
 =========
 
 Rules can be applied conditionally, depending on patterns in the CSV
@@ -5116,7 +5161,7 @@ if ,,,,
 
 File: hledger.info,  Node: Matchers,  Next: if table,  Prev: if,  Up: CSV
 
-9.17 Matchers
+8.17 Matchers
 =============
 
 There are two kinds of matcher:
@@ -5166,7 +5211,7 @@ expressions in CSV rules below.
 
 File: hledger.info,  Node: Multiple matchers,  Next: Match groups,  Up: Matchers
 
-9.17.1 Multiple matchers
+8.17.1 Multiple matchers
 ------------------------
 
 When an if block has multiple matchers, each on its own line,
@@ -5185,7 +5230,7 @@ and the date field contains "2025-01-01".  _Added in 1.42._
 
 File: hledger.info,  Node: Match groups,  Prev: Multiple matchers,  Up: Matchers
 
-9.17.2 Match groups
+8.17.2 Match groups
 -------------------
 
 _Added in 1.32_
@@ -5213,7 +5258,7 @@ if %account1 liabilities:family:(expenses:.*)
 
 File: hledger.info,  Node: if table,  Next: balance-type,  Prev: Matchers,  Up: CSV
 
-9.18 'if' table
+8.18 'if' table
 ===============
 
 "if tables" are another way of writing if rules, in a more compact
@@ -5277,7 +5322,7 @@ Plumbing LLC       | expenses:home      |
 
 File: hledger.info,  Node: balance-type,  Next: include,  Prev: if table,  Up: CSV
 
-9.19 'balance-type'
+8.19 'balance-type'
 ===================
 
 Balance assertions generated by assigning to balanceN are of the simple
@@ -5300,7 +5345,7 @@ balance-type ==*
 
 File: hledger.info,  Node: include,  Next: Working with CSV,  Prev: balance-type,  Up: CSV
 
-9.20 'include'
+8.20 'include'
 ==============
 
 include RULESFILE
@@ -5323,7 +5368,7 @@ include categorisation.rules
 
 File: hledger.info,  Node: Working with CSV,  Next: CSV rules examples,  Prev: include,  Up: CSV
 
-9.21 Working with CSV
+8.21 Working with CSV
 =====================
 
 Some tips:
@@ -5350,7 +5395,7 @@ Some tips:
 
 File: hledger.info,  Node: Rapid feedback,  Next: Valid CSV,  Up: Working with CSV
 
-9.21.1 Rapid feedback
+8.21.1 Rapid feedback
 ---------------------
 
 It's a good idea to get rapid feedback while creating/troubleshooting
@@ -5366,7 +5411,7 @@ output.
 
 File: hledger.info,  Node: Valid CSV,  Next: File Extension,  Prev: Rapid feedback,  Up: Working with CSV
 
-9.21.2 Valid CSV
+8.21.2 Valid CSV
 ----------------
 
 Note that hledger will only accept valid CSV conforming to RFC 4180, and
@@ -5387,7 +5432,7 @@ permissive CSV parser like python's csv lib.
 
 File: hledger.info,  Node: File Extension,  Next: Reading CSV from standard input,  Prev: Valid CSV,  Up: Working with CSV
 
-9.21.3 File Extension
+8.21.3 File Extension
 ---------------------
 
 To help hledger choose the CSV file reader and show the right error
@@ -5407,7 +5452,7 @@ rule if needed.
 
 File: hledger.info,  Node: Reading CSV from standard input,  Next: Reading multiple CSV files,  Prev: File Extension,  Up: Working with CSV
 
-9.21.4 Reading CSV from standard input
+8.21.4 Reading CSV from standard input
 --------------------------------------
 
 You'll need the file format prefix when reading CSV from stdin also,
@@ -5418,7 +5463,7 @@ $ cat foo.dat | hledger -f ssv:- print
 
 File: hledger.info,  Node: Reading multiple CSV files,  Next: Reading files specified by rule,  Prev: Reading CSV from standard input,  Up: Working with CSV
 
-9.21.5 Reading multiple CSV files
+8.21.5 Reading multiple CSV files
 ---------------------------------
 
 If you use multiple '-f' options to read multiple CSV files at once,
@@ -5429,7 +5474,7 @@ will be used for all the CSV files.
 
 File: hledger.info,  Node: Reading files specified by rule,  Next: Valid transactions,  Prev: Reading multiple CSV files,  Up: Working with CSV
 
-9.21.6 Reading files specified by rule
+8.21.6 Reading files specified by rule
 --------------------------------------
 
 Instead of specifying a CSV file in the command line, you can specify a
@@ -5458,7 +5503,7 @@ most recent.
 
 File: hledger.info,  Node: Valid transactions,  Next: Deduplicating importing,  Prev: Reading files specified by rule,  Up: Working with CSV
 
-9.21.7 Valid transactions
+8.21.7 Valid transactions
 -------------------------
 
 After reading a CSV file, hledger post-processes and validates the
@@ -5477,7 +5522,7 @@ $ hledger -f file.csv print | hledger -f- print
 
 File: hledger.info,  Node: Deduplicating importing,  Next: Regular expressions in CSV rules,  Prev: Valid transactions,  Up: Working with CSV
 
-9.21.8 Deduplicating, importing
+8.21.8 Deduplicating, importing
 -------------------------------
 
 When you download a CSV file periodically, eg to get your latest bank
@@ -5507,7 +5552,7 @@ CSV data.  See:
 
 File: hledger.info,  Node: Regular expressions in CSV rules,  Next: Setting amounts,  Prev: Deduplicating importing,  Up: Working with CSV
 
-9.21.9 Regular expressions in CSV rules
+8.21.9 Regular expressions in CSV rules
 ---------------------------------------
 
 Regular expressions in 'if' conditions (AKA matchers) are POSIX extended
@@ -5543,7 +5588,7 @@ good idea to make them defensive and robust if you can.
 
 File: hledger.info,  Node: Setting amounts,  Next: Amount signs,  Prev: Regular expressions in CSV rules,  Up: Working with CSV
 
-9.21.10 Setting amounts
+8.21.10 Setting amounts
 -----------------------
 
 Continuing from amount field above, here are more tips for
@@ -5610,7 +5655,7 @@ amount-setting:
 
 File: hledger.info,  Node: Amount signs,  Next: Setting currency/commodity,  Prev: Setting amounts,  Up: Working with CSV
 
-9.21.11 Amount signs
+8.21.11 Amount signs
 --------------------
 
 There is some special handling making it easier to parse and to reverse
@@ -5640,7 +5685,7 @@ its absolute value, ie discard its sign.
 
 File: hledger.info,  Node: Setting currency/commodity,  Next: Amount decimal places,  Prev: Amount signs,  Up: Working with CSV
 
-9.21.12 Setting currency/commodity
+8.21.12 Setting currency/commodity
 ----------------------------------
 
 If the currency/commodity symbol is included in the CSV's amount
@@ -5688,7 +5733,7 @@ that would trigger the prepending effect, which we don't want here.
 
 File: hledger.info,  Node: Amount decimal places,  Next: Referencing other fields,  Prev: Setting currency/commodity,  Up: Working with CSV
 
-9.21.13 Amount decimal places
+8.21.13 Amount decimal places
 -----------------------------
 
 When you are reading CSV data, eg with a command like 'hledger -f
@@ -5717,7 +5762,7 @@ want, add a 'commodity' directive to specify them.
 
 File: hledger.info,  Node: Referencing other fields,  Next: How CSV rules are evaluated,  Prev: Amount decimal places,  Up: Working with CSV
 
-9.21.14 Referencing other fields
+8.21.14 Referencing other fields
 --------------------------------
 
 In field assignments, you can interpolate only CSV fields, not hledger
@@ -5754,7 +5799,7 @@ if something
 
 File: hledger.info,  Node: How CSV rules are evaluated,  Next: Well factored rules,  Prev: Referencing other fields,  Up: Working with CSV
 
-9.21.15 How CSV rules are evaluated
+8.21.15 How CSV rules are evaluated
 -----------------------------------
 
 Here's how to think of CSV rules being evaluated.  If you get a
@@ -5814,7 +5859,7 @@ hledger command the user specified.
 
 File: hledger.info,  Node: Well factored rules,  Prev: How CSV rules are evaluated,  Up: Working with CSV
 
-9.21.16 Well factored rules
+8.21.16 Well factored rules
 ---------------------------
 
 Some things than can help reduce duplication and complexity in rules
@@ -5830,7 +5875,7 @@ files:
 
 File: hledger.info,  Node: CSV rules examples,  Prev: Working with CSV,  Up: CSV
 
-9.22 CSV rules examples
+8.22 CSV rules examples
 =======================
 
 * Menu:
@@ -5843,7 +5888,7 @@ File: hledger.info,  Node: CSV rules examples,  Prev: Working with CSV,  Up: CSV
 
 File: hledger.info,  Node: Bank of Ireland,  Next: Coinbase,  Up: CSV rules examples
 
-9.22.1 Bank of Ireland
+8.22.1 Bank of Ireland
 ----------------------
 
 Here's a CSV with two amount fields (Debit and Credit), and a balance
@@ -5896,7 +5941,7 @@ imported into a journal file.
 
 File: hledger.info,  Node: Coinbase,  Next: Amazon,  Prev: Bank of Ireland,  Up: CSV rules examples
 
-9.22.2 Coinbase
+8.22.2 Coinbase
 ---------------
 
 A simple example with some CSV from Coinbase.  The spot price is
@@ -5923,7 +5968,7 @@ $ hledger print -f coinbase.csv
 
 File: hledger.info,  Node: Amazon,  Next: Paypal,  Prev: Coinbase,  Up: CSV rules examples
 
-9.22.3 Amazon
+8.22.3 Amazon
 -------------
 
 Here we convert amazon.com order history, and use an if block to
@@ -5981,7 +6026,7 @@ $ hledger -f amazon-orders.csv print
 
 File: hledger.info,  Node: Paypal,  Prev: Amazon,  Up: CSV rules examples
 
-9.22.4 Paypal
+8.22.4 Paypal
 -------------
 
 Here's a real-world rules file for (customised) Paypal CSV, with some
@@ -6135,8 +6180,8 @@ $ hledger -f paypal-custom.csv  print
 
 File: hledger.info,  Node: Timeclock,  Next: Timedot,  Prev: CSV,  Up: Top
 
-10 Timeclock
-************
+9 Timeclock
+***********
 
 hledger can read time logs in the timeclock time logging format of
 timeclock.el.  As with Ledger, hledger's timeclock format is a
@@ -6245,7 +6290,7 @@ $ hledger -f sample.timeclock register -p weekly --depth 1 --empty  # time summa
 
 File: hledger.info,  Node: Timedot,  Next: PART 3 REPORTING CONCEPTS,  Prev: Timeclock,  Up: Top
 
-11 Timedot
+10 Timedot
 **********
 
 'timedot' format is hledger's human-friendly time logging format.
@@ -6340,7 +6385,7 @@ directives, and then includes the timedot file ('include time.timedot').
 
 File: hledger.info,  Node: Timedot examples,  Up: Timedot
 
-11.1 Timedot examples
+10.1 Timedot examples
 =====================
 
 Numbers:
@@ -6440,13 +6485,13 @@ $ hledger -f a.timedot --alias '/\./=:' bal -t
 
 File: hledger.info,  Node: PART 3 REPORTING CONCEPTS,  Next: Time periods,  Prev: Timedot,  Up: Top
 
-12 PART 3: REPORTING CONCEPTS
+11 PART 3: REPORTING CONCEPTS
 *****************************
 
 
 File: hledger.info,  Node: Time periods,  Next: Report titles,  Prev: PART 3 REPORTING CONCEPTS,  Up: Top
 
-13 Time periods
+12 Time periods
 ***************
 
 * Menu:
@@ -6460,7 +6505,7 @@ File: hledger.info,  Node: Time periods,  Next: Report titles,  Prev: PART 3 REP
 
 File: hledger.info,  Node: Report start & end date,  Next: Smart dates,  Up: Time periods
 
-13.1 Report start & end date
+12.1 Report start & end date
 ============================
 
 Most hledger reports will by default show the full time period
@@ -6509,7 +6554,7 @@ during January 2020 (the smallest common period, with the -p overriding
 
 File: hledger.info,  Node: Smart dates,  Next: Report intervals,  Prev: Report start & end date,  Up: Time periods
 
-13.2 Smart dates
+12.2 Smart dates
 ================
 
 In hledger's user interfaces (though not in the journal file), you can
@@ -6591,7 +6636,7 @@ affected by '--today'.)
 
 File: hledger.info,  Node: Report intervals,  Next: Date adjustments,  Prev: Smart dates,  Up: Time periods
 
-13.3 Report intervals
+12.3 Report intervals
 =====================
 
 A report interval can be specified so that reports like register,
@@ -6613,7 +6658,7 @@ described below.
 
 File: hledger.info,  Node: Date adjustments,  Next: Period expressions,  Prev: Report intervals,  Up: Time periods
 
-13.4 Date adjustments
+12.4 Date adjustments
 =====================
 
 * Menu:
@@ -6624,7 +6669,7 @@ File: hledger.info,  Node: Date adjustments,  Next: Period expressions,  Prev: R
 
 File: hledger.info,  Node: Start date adjustment,  Next: End date adjustment,  Up: Date adjustments
 
-13.4.1 Start date adjustment
+12.4.1 Start date adjustment
 ----------------------------
 
 If you let hledger infer a report's start date, it will adjust the date
@@ -6647,7 +6692,7 @@ certain situations).
 
 File: hledger.info,  Node: End date adjustment,  Prev: Start date adjustment,  Up: Date adjustments
 
-13.4.2 End date adjustment
+12.4.2 End date adjustment
 --------------------------
 
 A report's end date is always adjusted to include a whole number of
@@ -6663,12 +6708,12 @@ intervals, so that the last subperiod has the same length as the others.
    * 'hledger register --monthly --begin 1/5 --end 2/14' will end the
      report on march 4th [1].
 
-   [1] Since hledger 1.29.
+   [1] Since 1.29.
 
 
 File: hledger.info,  Node: Period expressions,  Prev: Date adjustments,  Up: Time periods
 
-13.5 Period expressions
+12.5 Period expressions
 =======================
 
 The '-p/--period' option specifies a period expression, which is a
@@ -6728,7 +6773,7 @@ date:
 
 File: hledger.info,  Node: Period expressions with a report interval,  Next: More complex report intervals,  Up: Period expressions
 
-13.5.1 Period expressions with a report interval
+12.5.1 Period expressions with a report interval
 ------------------------------------------------
 
 A period expression can also begin with a report interval, separated
@@ -6741,7 +6786,7 @@ from the start/end dates (if any) by a space or the word 'in':
 
 File: hledger.info,  Node: More complex report intervals,  Next: Multiple weekday intervals,  Prev: Period expressions with a report interval,  Up: Period expressions
 
-13.5.2 More complex report intervals
+12.5.2 More complex report intervals
 ------------------------------------
 
 Some more complex intervals can be specified within period expressions,
@@ -6805,7 +6850,7 @@ $ hledger register checking -p "every 3rd day of week"
 
 File: hledger.info,  Node: Multiple weekday intervals,  Prev: More complex report intervals,  Up: Period expressions
 
-13.5.3 Multiple weekday intervals
+12.5.3 Multiple weekday intervals
 ---------------------------------
 
 This special form is also supported:
@@ -6833,7 +6878,7 @@ weekendday"'
 
 File: hledger.info,  Node: Report titles,  Next: Depth,  Prev: Time periods,  Up: Top
 
-14 Report titles
+13 Report titles
 ****************
 
 Some reports ('balancesheet', 'balancesheetequity', 'cashflow',
@@ -6859,7 +6904,7 @@ periods will always be described as 'STARTDATE..ENDDATE'.
 
 File: hledger.info,  Node: Depth,  Next: Queries,  Prev: Report titles,  Up: Top
 
-15 Depth
+14 Depth
 ********
 
 With the '--depth NUM' option (short form, usually preferred: '-NUM'),
@@ -6885,7 +6930,7 @@ quotes in the usual way.  Eg: '--depth 'credit card=2''
 
 File: hledger.info,  Node: Combining depth options,  Up: Depth
 
-15.1 Combining depth options
+14.1 Combining depth options
 ============================
 
 If a command line contains multiple general depth options, the last one
@@ -6909,7 +6954,7 @@ with a later option, the later option must use the same REGEX.
 
 File: hledger.info,  Node: Queries,  Next: Pivoting,  Prev: Depth,  Up: Top
 
-16 Queries
+15 Queries
 **********
 
 Many hledger commands accept query arguments, which restrict their scope
@@ -6995,7 +7040,7 @@ here's the gist of it:
 
 File: hledger.info,  Node: Query types,  Next: Negative queries,  Up: Queries
 
-16.1 Query types
+15.1 Query types
 ================
 
 Here are the query types available:
@@ -7021,7 +7066,7 @@ Here are the query types available:
 
 File: hledger.info,  Node: acct query,  Next: amt query,  Up: Query types
 
-16.1.1 acct: query
+15.1.1 acct: query
 ------------------
 
 *'acct:REGEX'*, or just *'REGEX'*
@@ -7032,7 +7077,7 @@ This is the default query type, so we usually don't bother writing the
 
 File: hledger.info,  Node: amt query,  Next: code query,  Prev: acct query,  Up: Query types
 
-16.1.2 amt: query
+15.1.2 amt: query
 -----------------
 
 *'amt:N, amt:'<N', amt:'<=N', amt:'>N', amt:'>=N''*
@@ -7051,7 +7096,7 @@ balances.
 
 File: hledger.info,  Node: code query,  Next: cur query,  Prev: amt query,  Up: Query types
 
-16.1.3 code: query
+15.1.3 code: query
 ------------------
 
 *'code:REGEX'*
@@ -7060,7 +7105,7 @@ Match by transaction code (eg check number).
 
 File: hledger.info,  Node: cur query,  Next: sym query,  Prev: code query,  Up: Query types
 
-16.1.4 cur: query
+15.1.4 cur: query
 -----------------
 
 *'cur:FULLREGEX'*
@@ -7084,7 +7129,7 @@ _(experimental)_
 
 File: hledger.info,  Node: sym query,  Next: desc query,  Prev: cur query,  Up: Query types
 
-16.1.5 sym: query
+15.1.5 sym: query
 -----------------
 
 *'sym:FULLREGEX'*
@@ -7096,7 +7141,7 @@ _(experimental)_
 
 File: hledger.info,  Node: desc query,  Next: date query,  Prev: sym query,  Up: Query types
 
-16.1.6 desc: query
+15.1.6 desc: query
 ------------------
 
 *'desc:REGEX'*
@@ -7105,7 +7150,7 @@ Match transaction descriptions.
 
 File: hledger.info,  Node: date query,  Next: date2 query,  Prev: desc query,  Up: Query types
 
-16.1.7 date: query
+15.1.7 date: query
 ------------------
 
 *'date:PERIODEXPR'*
@@ -7122,7 +7167,7 @@ report interval may be ignored.
 
 File: hledger.info,  Node: date2 query,  Next: depth query,  Prev: date query,  Up: Query types
 
-16.1.8 date2: query
+15.1.8 date2: query
 -------------------
 
 *'date2:PERIODEXPR'*
@@ -7133,7 +7178,7 @@ interval in PERIODEXPR will be ignored.
 
 File: hledger.info,  Node: depth query,  Next: note query,  Prev: date2 query,  Up: Query types
 
-16.1.9 depth: query
+15.1.9 depth: query
 -------------------
 
 *'depth:[REGEXP=]N'*
@@ -7144,7 +7189,7 @@ expression.  See Depth for detailed rules.
 
 File: hledger.info,  Node: note query,  Next: payee query,  Prev: depth query,  Up: Query types
 
-16.1.10 note: query
+15.1.10 note: query
 -------------------
 
 *'note:REGEX'*
@@ -7154,7 +7199,7 @@ the whole description if there's no '|').
 
 File: hledger.info,  Node: payee query,  Next: real query,  Prev: note query,  Up: Query types
 
-16.1.11 payee: query
+15.1.11 payee: query
 --------------------
 
 *'payee:REGEX'*
@@ -7164,7 +7209,7 @@ Match transaction payee/payer names (the part of the description left of
 
 File: hledger.info,  Node: real query,  Next: status query,  Prev: payee query,  Up: Query types
 
-16.1.12 real: query
+15.1.12 real: query
 -------------------
 
 *'real:, real:0'*
@@ -7173,7 +7218,7 @@ Match real or virtual postings respectively.
 
 File: hledger.info,  Node: status query,  Next: type query,  Prev: real query,  Up: Query types
 
-16.1.13 status: query
+15.1.13 status: query
 ---------------------
 
 *'status:, status:!, status:*'*
@@ -7182,7 +7227,7 @@ Match unmarked, pending, or cleared transactions respectively.
 
 File: hledger.info,  Node: type query,  Next: tag query,  Prev: status query,  Up: Query types
 
-16.1.14 type: query
+15.1.14 type: query
 -------------------
 
 *'type:TYPECODES'*
@@ -7196,7 +7241,7 @@ types, see Rewriting accounts > Aliases and account types.
 
 File: hledger.info,  Node: tag query,  Prev: type query,  Up: Query types
 
-16.1.15 tag: query
+15.1.15 tag: query
 ------------------
 
 *'tag:NAMEREGEX[=VALREGEX]'*
@@ -7214,7 +7259,7 @@ Match by tag name, and optionally also by tag value.  Note:
 
 File: hledger.info,  Node: Negative queries,  Next: Space-separated queries,  Prev: Query types,  Up: Queries
 
-16.2 Negative queries
+15.2 Negative queries
 =====================
 
 * Menu:
@@ -7224,7 +7269,7 @@ File: hledger.info,  Node: Negative queries,  Next: Space-separated queries,  Pr
 
 File: hledger.info,  Node: not query,  Up: Negative queries
 
-16.2.1 not: query
+15.2.1 not: query
 -----------------
 
 *'not:QUERY'*
@@ -7236,7 +7281,7 @@ conveniently.)
 
 File: hledger.info,  Node: Space-separated queries,  Next: Boolean queries,  Prev: Negative queries,  Up: Queries
 
-16.3 Space-separated queries
+15.3 Space-separated queries
 ============================
 
 When given multiple space-separated query terms, most commands select
@@ -7257,7 +7302,7 @@ things which match:
 
 File: hledger.info,  Node: Boolean queries,  Next: Queries and command options,  Prev: Space-separated queries,  Up: Queries
 
-16.4 Boolean queries
+15.4 Boolean queries
 ====================
 
 You can write more complicated "boolean" query expressions, enclosed in
@@ -7295,7 +7340,7 @@ use, and 'any:' and 'all:' variants which can be useful with 'print'.
 
 File: hledger.info,  Node: expr query,  Next: any query,  Up: Boolean queries
 
-16.4.1 expr: query
+15.4.1 expr: query
 ------------------
 
 *'expr:'QUERYEXPR''*
@@ -7313,7 +7358,7 @@ posting with a positive amount)".
 
 File: hledger.info,  Node: any query,  Next: all query,  Prev: expr query,  Up: Boolean queries
 
-16.4.2 any: query
+15.4.2 any: query
 -----------------
 
 *'any:'QUERYEXPR''*
@@ -7326,7 +7371,7 @@ at least one posting posts a positive amount to a cash account".
 
 File: hledger.info,  Node: all query,  Prev: any query,  Up: Boolean queries
 
-16.4.3 all: query
+15.4.3 all: query
 -----------------
 
 *'all:'QUERYEXPR''*
@@ -7341,7 +7386,7 @@ which touch only cash and/or checking accounts".
 
 File: hledger.info,  Node: Queries and command options,  Next: Queries and account aliases,  Prev: Boolean queries,  Up: Queries
 
-16.5 Queries and command options
+15.5 Queries and command options
 ================================
 
 Some queries can also be expressed as command-line options: 'depth:2' is
@@ -7352,7 +7397,7 @@ resulting query is their intersection.
 
 File: hledger.info,  Node: Queries and account aliases,  Next: Queries and valuation,  Prev: Queries and command options,  Up: Queries
 
-16.6 Queries and account aliases
+15.6 Queries and account aliases
 ================================
 
 When account names are rewritten with '--alias' or 'alias', 'acct:' will
@@ -7361,7 +7406,7 @@ match either the old or the new account name.
 
 File: hledger.info,  Node: Queries and valuation,  Prev: Queries and account aliases,  Up: Queries
 
-16.7 Queries and valuation
+15.7 Queries and valuation
 ==========================
 
 When amounts are converted to other commodities in cost or value
@@ -7371,7 +7416,7 @@ amount quantity, not the new ones.  (Except in hledger 1.22, #1625.)
 
 File: hledger.info,  Node: Pivoting,  Next: Generating data,  Prev: Queries,  Up: Top
 
-17 Pivoting
+16 Pivoting
 ***********
 
 Normally, hledger groups amounts and displays their totals by account
@@ -7444,7 +7489,7 @@ $ hledger balance Income:Dues --pivot kind:member
 
 File: hledger.info,  Node: Generating data,  Next: Detecting special postings,  Prev: Pivoting,  Up: Top
 
-18 Generating data
+17 Generating data
 ******************
 
 hledger can enrich the data provided to it, or generate new data, in a
@@ -7485,7 +7530,7 @@ shows the hidden tags which hledger uses for classifying things.
 
 File: hledger.info,  Node: Detecting special postings,  Next: Forecasting,  Prev: Generating data,  Up: Top
 
-19 Detecting special postings
+18 Detecting special postings
 *****************************
 
 hledger detects certain kinds of postings, both generated and
@@ -7541,7 +7586,7 @@ Tag    Detected pattern                          Effect
 
 File: hledger.info,  Node: Forecasting,  Next: Budgeting,  Prev: Detecting special postings,  Up: Top
 
-20 Forecasting
+19 Forecasting
 **************
 
 Forecasting, or speculative future reporting, can be useful for
@@ -7564,7 +7609,7 @@ when you want to see them.
 
 File: hledger.info,  Node: --forecast,  Next: Inspecting forecast transactions,  Up: Forecasting
 
-20.1 -forecast
+19.1 -forecast
 ==============
 
 There is another way: with the '--forecast' option, hledger can generate
@@ -7588,7 +7633,7 @@ that the '=' is required.
 
 File: hledger.info,  Node: Inspecting forecast transactions,  Next: Forecast reports,  Prev: --forecast,  Up: Forecasting
 
-20.2 Inspecting forecast transactions
+19.2 Inspecting forecast transactions
 =====================================
 
 'print' is the best command for inspecting and troubleshooting forecast
@@ -7632,7 +7677,7 @@ reproducible.)
 
 File: hledger.info,  Node: Forecast reports,  Next: Forecast tags,  Prev: Inspecting forecast transactions,  Up: Forecasting
 
-20.3 Forecast reports
+19.3 Forecast reports
 =====================
 
 Forecast transactions affect all reports, as you would expect.  Eg:
@@ -7657,7 +7702,7 @@ Balance changes in 2023-05-01..2023-09-30:
 
 File: hledger.info,  Node: Forecast tags,  Next: Forecast period in detail,  Prev: Forecast reports,  Up: Forecasting
 
-20.4 Forecast tags
+19.4 Forecast tags
 ==================
 
 Forecast transactions generated by -forecast have a hidden tag,
@@ -7673,7 +7718,7 @@ rule was responsible.
 
 File: hledger.info,  Node: Forecast period in detail,  Next: Forecast troubleshooting,  Prev: Forecast tags,  Up: Forecasting
 
-20.5 Forecast period, in detail
+19.5 Forecast period, in detail
 ===============================
 
 Forecast start/end dates are chosen so as to do something useful by
@@ -7704,7 +7749,7 @@ default in almost all situations, while also being flexible.  Here are
 
 File: hledger.info,  Node: Forecast troubleshooting,  Prev: Forecast period in detail,  Up: Forecasting
 
-20.6 Forecast troubleshooting
+19.6 Forecast troubleshooting
 =============================
 
 When -forecast is not doing what you expect, one of these tips should
@@ -7732,7 +7777,7 @@ help:
 
 File: hledger.info,  Node: Budgeting,  Next: Amount formatting,  Prev: Forecasting,  Up: Top
 
-21 Budgeting
+20 Budgeting
 ************
 
 With the balance command's '--budget' report, each periodic transaction
@@ -7749,7 +7794,7 @@ bal -M --budget --forecast ...'
 
 File: hledger.info,  Node: Amount formatting,  Next: Cost reporting,  Prev: Budgeting,  Up: Top
 
-22 Amount formatting
+21 Amount formatting
 ********************
 
 * Menu:
@@ -7762,7 +7807,7 @@ File: hledger.info,  Node: Amount formatting,  Next: Cost reporting,  Prev: Budg
 
 File: hledger.info,  Node: Commodity display style,  Next: Rounding,  Up: Amount formatting
 
-22.1 Commodity display style
+21.1 Commodity display style
 ============================
 
 For the amounts in each commodity, hledger chooses a consistent display
@@ -7805,7 +7850,7 @@ as decimal mark, and two decimal digits).
 
 File: hledger.info,  Node: Rounding,  Next: Trailing decimal marks,  Prev: Commodity display style,  Up: Amount formatting
 
-22.2 Rounding
+21.2 Rounding
 =============
 
 Amounts are stored internally as decimal numbers with up to 255 decimal
@@ -7819,7 +7864,7 @@ decimal digits appears as "0".
 
 File: hledger.info,  Node: Trailing decimal marks,  Next: Amount parseability,  Prev: Rounding,  Up: Amount formatting
 
-22.3 Trailing decimal marks
+21.3 Trailing decimal marks
 ===========================
 
 If you're wondering why your 'print' report sometimes shows trailing
@@ -7836,15 +7881,14 @@ $ hledger print
 2023-01-02
     (a)        $1,000.
 
-   If this is a problem (eg when exporting to Ledger), you can avoid it
-by disabling digit group marks, eg with -c/-commodity (for each affected
-commodity):
+   You can avoid this by disabling digit group marks, eg temporarily
+with -c/-commodity:
 
 $ hledger print -c '$1000.00'
 2023-01-02
     (a)          $1000
 
-   or by forcing print to always show decimal digits, with -round:
+   or by forcing print to show some decimal digits, with -round:
 
 $ hledger print -c '$1,000.00' --round=soft
 2023-01-02
@@ -7853,7 +7897,7 @@ $ hledger print -c '$1,000.00' --round=soft
 
 File: hledger.info,  Node: Amount parseability,  Prev: Trailing decimal marks,  Up: Amount formatting
 
-22.4 Amount parseability
+21.4 Amount parseability
 ========================
 
 More generally, hledger output falls into three rough categories, which
@@ -7892,7 +7936,7 @@ by humans)*
 
 File: hledger.info,  Node: Cost reporting,  Next: Value reporting,  Prev: Amount formatting,  Up: Top
 
-23 Cost reporting
+22 Cost reporting
 *****************
 
 In some transactions - for example a currency conversion, or a purchase
@@ -7915,7 +7959,7 @@ can show amounts "at cost", converted to the cost's commodity.
 
 File: hledger.info,  Node: Recording costs,  Next: Reporting at cost,  Up: Cost reporting
 
-23.1 Recording costs
+22.1 Recording costs
 ====================
 
 We'll explore several ways of recording transactions involving costs.
@@ -7969,7 +8013,7 @@ sure you have none of these by using '-s' (strict mode), or by running
 
 File: hledger.info,  Node: Reporting at cost,  Next: Equity conversion postings,  Prev: Recording costs,  Up: Cost reporting
 
-23.2 Reporting at cost
+22.2 Reporting at cost
 ======================
 
 Now when you add the '-B'/'--cost' flag to reports ("B" is from Ledger's
@@ -7989,7 +8033,7 @@ they will be displayed "at cost" or "at sale price".
 
 File: hledger.info,  Node: Equity conversion postings,  Next: Inferring equity conversion postings,  Prev: Reporting at cost,  Up: Cost reporting
 
-23.3 Equity conversion postings
+22.3 Equity conversion postings
 ===============================
 
 There is a problem with the entries above - they are not conventional
@@ -8045,7 +8089,7 @@ $ hledger bal --infer-costs -B
 
 File: hledger.info,  Node: Inferring equity conversion postings,  Next: Combining costs and equity conversion postings,  Prev: Equity conversion postings,  Up: Cost reporting
 
-23.4 Inferring equity conversion postings
+22.4 Inferring equity conversion postings
 =========================================
 
 Can we go in the other direction ?  Yes, if you have transactions
@@ -8076,7 +8120,7 @@ account declarations.)
 
 File: hledger.info,  Node: Combining costs and equity conversion postings,  Next: Requirements for detecting equity conversion postings,  Prev: Inferring equity conversion postings,  Up: Cost reporting
 
-23.5 Combining costs and equity conversion postings
+22.5 Combining costs and equity conversion postings
 ===================================================
 
 Finally, you can use both the @/@@ cost notation and equity postings at
@@ -8110,7 +8154,7 @@ $ hledger print -x --infer-costs --infer-equity
 
 File: hledger.info,  Node: Requirements for detecting equity conversion postings,  Next: Infer cost and equity by default ?,  Prev: Combining costs and equity conversion postings,  Up: Cost reporting
 
-23.6 Requirements for detecting equity conversion postings
+22.6 Requirements for detecting equity conversion postings
 ==========================================================
 
 '--infer-costs' has certain requirements (unlike '--infer-equity', which
@@ -8142,7 +8186,7 @@ fails, hledger raises an "unbalanced transaction" error.
 
 File: hledger.info,  Node: Infer cost and equity by default ?,  Prev: Requirements for detecting equity conversion postings,  Up: Cost reporting
 
-23.7 Infer cost and equity by default ?
+22.7 Infer cost and equity by default ?
 =======================================
 
 Should '--infer-costs' and '--infer-equity' be enabled by default ?  Try
@@ -8155,7 +8199,7 @@ alias h="hledger --infer-equity --infer-costs"
 
 File: hledger.info,  Node: Value reporting,  Next: Lot reporting,  Prev: Cost reporting,  Up: Top
 
-24 Value reporting
+23 Value reporting
 ******************
 
 hledger can also show amounts "at market value", converted to some other
@@ -8183,7 +8227,7 @@ transactions, by using the '--infer-market-prices' flag.
 
 File: hledger.info,  Node: -X Value in specified commodity,  Next: -V Value in default commoditys,  Up: Value reporting
 
-24.1 -X: Value in specified commodity
+23.1 -X: Value in specified commodity
 =====================================
 
 The '-X COMM' (or '--exchange=COMM') option converts amounts to their
@@ -8206,7 +8250,7 @@ special shell characters, if needed.  Some examples:
 
 File: hledger.info,  Node: -V Value in default commoditys,  Next: Valuation date,  Prev: -X Value in specified commodity,  Up: Value reporting
 
-24.2 -V: Value in default commodity(s)
+23.2 -V: Value in default commodity(s)
 ======================================
 
 The '-V/--market' flag is a variant of '-X' where you don't have to
@@ -8222,7 +8266,7 @@ better to use '-X', unless you're sure '-V' is doing what you want.
 
 File: hledger.info,  Node: Valuation date,  Next: Finding market price,  Prev: -V Value in default commoditys,  Up: Value reporting
 
-24.3 Valuation date
+23.3 Valuation date
 ===================
 
 Market prices can change from day to day.  hledger will use the prices
@@ -8243,7 +8287,7 @@ can select either "then", "end", "now", or "custom" dates.
 
 File: hledger.info,  Node: Finding market price,  Next: --infer-market-prices market prices from transactions,  Prev: Valuation date,  Up: Value reporting
 
-24.4 Finding market price
+23.4 Finding market price
 =========================
 
 To convert a commodity A to its market value in another commodity B,
@@ -8277,7 +8321,7 @@ converted.
 
 File: hledger.info,  Node: --infer-market-prices market prices from transactions,  Next: Valuation commodity,  Prev: Finding market price,  Up: Value reporting
 
-24.5 -infer-market-prices: market prices from transactions
+23.5 -infer-market-prices: market prices from transactions
 ==========================================================
 
 Normally, market value in hledger is fully controlled by, and requires,
@@ -8319,8 +8363,8 @@ commmodity, eg:
      --infer-market-prices'
 
    Signed costs and market prices can be confusing.  For reference, here
-is the current behaviour, since hledger 1.25.  (If you think it should
-work differently, see #1870.)
+is the current behaviour (since 1.25).  (If you think it should work
+differently, see #1870.)
 
 2022-01-01 Positive Unit prices
     a        A 1
@@ -8363,7 +8407,7 @@ P 2022-01-03 B A -1.0
 
 File: hledger.info,  Node: Valuation commodity,  Next: --value Flexible valuation,  Prev: --infer-market-prices market prices from transactions,  Up: Value reporting
 
-24.6 Valuation commodity
+23.6 Valuation commodity
 ========================
 
 *When you specify a valuation commodity ('-X COMM' or '--value
@@ -8402,7 +8446,7 @@ converted.
 
 File: hledger.info,  Node: --value Flexible valuation,  Next: Valuation examples,  Prev: Valuation commodity,  Up: Value reporting
 
-24.7 -value: Flexible valuation
+23.7 -value: Flexible valuation
 ===============================
 
 '-V' and '-X' are special cases of the more general '--value' option:
@@ -8444,7 +8488,7 @@ this commodity, deducing market prices as described above.
 
 File: hledger.info,  Node: Valuation examples,  Next: Interaction of valuation and queries,  Prev: --value Flexible valuation,  Up: Value reporting
 
-24.8 Valuation examples
+23.8 Valuation examples
 =======================
 
 Here are some quick examples of '-V':
@@ -8555,7 +8599,7 @@ $ hledger -f- print --value=2000-01-15
 
 File: hledger.info,  Node: Interaction of valuation and queries,  Next: Effect of valuation on reports,  Prev: Valuation examples,  Up: Value reporting
 
-24.9 Interaction of valuation and queries
+23.9 Interaction of valuation and queries
 =========================================
 
 When matching postings based on queries in the presence of valuation,
@@ -8576,7 +8620,7 @@ the following happens:
 
 File: hledger.info,  Node: Effect of valuation on reports,  Prev: Interaction of valuation and queries,  Up: Value reporting
 
-24.10 Effect of valuation on reports
+23.10 Effect of valuation on reports
 ====================================
 
 Here is a reference for how valuation is supposed to affect each part of
@@ -8724,7 +8768,7 @@ a zero starting balance.
 
 File: hledger.info,  Node: Lot reporting,  Next: PART 4 COMMANDS,  Prev: Value reporting,  Up: Top
 
-25 Lot reporting
+24 Lot reporting
 ****************
 
 (Since 1.99.1)
@@ -8774,7 +8818,7 @@ better.
 
 File: hledger.info,  Node: How to enable or disable lot tracking,  Next: First lots example,  Up: Lot reporting
 
-25.1 How to enable or disable lot tracking
+24.1 How to enable or disable lot tracking
 ==========================================
 
 hledger will enable lots/gains tracking if it sees any of these three
@@ -8794,7 +8838,7 @@ command.  For this, use the '--ignore-lots' flag, or just '-I'.
 
 File: hledger.info,  Node: First lots example,  Next: Lot concepts,  Prev: How to enable or disable lot tracking,  Up: Lot reporting
 
-25.2 First lots example
+24.2 First lots example
 =======================
 
 To get a feel for what lot tracking looks like, here is a minimal buy
@@ -8868,7 +8912,7 @@ other notation styles.
 
 File: hledger.info,  Node: Lot concepts,  Next: Lot movements,  Prev: First lots example,  Up: Lot reporting
 
-25.3 Lot concepts
+24.3 Lot concepts
 =================
 
 * Menu:
@@ -8882,7 +8926,7 @@ File: hledger.info,  Node: Lot concepts,  Next: Lot movements,  Prev: First lots
 
 File: hledger.info,  Node: Cost basis annotations,  Next: Lotful commodities and accounts,  Up: Lot concepts
 
-25.3.1 Cost basis annotations
+24.3.1 Cost basis annotations
 -----------------------------
 
 Each acquisition of an investment creates a _lot_, with a _cost basis_.
@@ -8909,7 +8953,7 @@ the cost.  Here are some examples:
 
 File: hledger.info,  Node: Lotful commodities and accounts,  Next: Lot subaccounts,  Prev: Cost basis annotations,  Up: Lot concepts
 
-25.3.2 Lotful commodities and accounts
+24.3.2 Lotful commodities and accounts
 --------------------------------------
 
 A more convenient way to record lot transactions, is to declare
@@ -8926,7 +8970,7 @@ automatically, and you won't need to write them in the journal.
 
 File: hledger.info,  Node: Lot subaccounts,  Next: Lot ids,  Prev: Lotful commodities and accounts,  Up: Lot concepts
 
-25.3.3 Lot subaccounts
+24.3.3 Lot subaccounts
 ----------------------
 
 Internally, hledger tracks each lot in a subaccount, named like the cost
@@ -8980,7 +9024,7 @@ lot subaccounts.
 
 File: hledger.info,  Node: Lot ids,  Next: Cost basis vs transacted cost,  Prev: Lot subaccounts,  Up: Lot concepts
 
-25.3.4 Lot ids
+24.3.4 Lot ids
 --------------
 
 A lot id is a unique identifier for that lot, used internally by
@@ -9004,7 +9048,7 @@ lot ids:
 
 File: hledger.info,  Node: Cost basis vs transacted cost,  Prev: Lot ids,  Up: Lot concepts
 
-25.3.5 Cost basis vs transacted cost
+24.3.5 Cost basis vs transacted cost
 ------------------------------------
 
 In acquisition transactions, hledger allows the cost basis ('{}', call
@@ -9038,7 +9082,7 @@ below shows an example.
 
 File: hledger.info,  Node: Lot movements,  Next: Gain postings,  Prev: Lot concepts,  Up: Lot reporting
 
-25.4 Lot movements
+24.4 Lot movements
 ==================
 
 hledger understands three kinds of event involving lots.  Other
@@ -9055,7 +9099,7 @@ these.
 
 File: hledger.info,  Node: Acquire,  Next: Transfer,  Up: Lot movements
 
-25.4.1 Acquire
+24.4.1 Acquire
 --------------
 
 A positive lot posting in an asset account creates a new lot.
@@ -9093,7 +9137,7 @@ more capital gain, $4000 more in total).
 
 File: hledger.info,  Node: Transfer,  Next: Dispose,  Prev: Acquire,  Up: Lot movements
 
-25.4.2 Transfer
+24.4.2 Transfer
 ---------------
 
 A matching pair of negative/positive lotful postings moves one or more
@@ -9117,7 +9161,7 @@ explicitly, so the output round-trips correctly.
 
 File: hledger.info,  Node: Dispose,  Next: Cost basis methods,  Prev: Transfer,  Up: Lot movements
 
-25.4.3 Dispose
+24.4.3 Dispose
 --------------
 
 A negative lot posting sells from one or more existing lots.
@@ -9139,7 +9183,7 @@ rejected at load time anyway, see Acquire above).
 
 File: hledger.info,  Node: Cost basis methods,  Prev: Dispose,  Up: Lot movements
 
-25.4.4 Cost basis methods
+24.4.4 Cost basis methods
 -------------------------
 
 If a lot transfer or a lot disposal doesn't specifically identify the
@@ -9224,7 +9268,7 @@ lots in every other account too.
 
 File: hledger.info,  Node: Gain postings,  Next: Recording gains,  Prev: Lot movements,  Up: Lot reporting
 
-25.5 Gain postings
+24.5 Gain postings
 ==================
 
 Each disposal transaction will have a balanced pair of postings
@@ -9259,7 +9303,7 @@ hledger fills in missing amounts, but not in gain postings.)
 
 File: hledger.info,  Node: Gain and UnrealisedGain accounts,  Up: Gain postings
 
-25.5.1 Gain and UnrealisedGain accounts
+24.5.1 Gain and UnrealisedGain accounts
 ---------------------------------------
 
 The *'Gain'* (*'G'*) and *'UnrealisedGain'* (*'U'*) account types are
@@ -9290,7 +9334,7 @@ the sign keeps things correct.
 
 File: hledger.info,  Node: Recording gains,  Next: Lot postings and balance assertions,  Prev: Gain postings,  Up: Lot reporting
 
-25.6 Recording gains
+24.6 Recording gains
 ====================
 
 In the journal, you can write disposal transactions in four main styles,
@@ -9321,7 +9365,7 @@ compare it with what you wrote, potentially catching more errors.
 
 File: hledger.info,  Node: Style 1 No gain postings,  Next: Style 2 rgain posting non-G account,  Up: Recording gains
 
-25.6.1 Style 1: No gain postings
+24.6.1 Style 1: No gain postings
 --------------------------------
 
 2026-02-01 sell
@@ -9331,7 +9375,7 @@ File: hledger.info,  Node: Style 1 No gain postings,  Next: Style 2 rgain postin
 
 File: hledger.info,  Node: Style 2 rgain posting non-G account,  Next: Style 3 rgain posting G account,  Prev: Style 1 No gain postings,  Up: Recording gains
 
-25.6.2 Style 2: rgain posting, non-G account
+24.6.2 Style 2: rgain posting, non-G account
 --------------------------------------------
 
 2026-02-01 sell
@@ -9369,7 +9413,7 @@ for simple entries.
 
 File: hledger.info,  Node: Style 3 rgain posting G account,  Next: Style 4 rgain and ugain postings G and U accounts,  Prev: Style 2 rgain posting non-G account,  Up: Recording gains
 
-25.6.3 Style 3: rgain posting, G account
+24.6.3 Style 3: rgain posting, G account
 ----------------------------------------
 
 account revenues:gain  ; type:G
@@ -9382,7 +9426,7 @@ account revenues:gain  ; type:G
 
 File: hledger.info,  Node: Style 4 rgain and ugain postings G and U accounts,  Prev: Style 3 rgain posting G account,  Up: Recording gains
 
-25.6.4 Style 4: rgain and ugain postings, G and U accounts
+24.6.4 Style 4: rgain and ugain postings, G and U accounts
 ----------------------------------------------------------
 
 account revenues:gain           ; type:G
@@ -9397,7 +9441,7 @@ account equity:unrealised-gain  ; type:U
 
 File: hledger.info,  Node: Lot postings and balance assertions,  Next: Lot reporting example,  Prev: Recording gains,  Up: Lot reporting
 
-25.7 Lot postings and balance assertions
+24.7 Lot postings and balance assertions
 ========================================
 
 On a dispose or transfer posting without an explicit lot subaccount, a
@@ -9418,7 +9462,7 @@ print --lots -x | hledger -f- check assertions' will still pass.)
 
 File: hledger.info,  Node: Lot reporting example,  Prev: Lot postings and balance assertions,  Up: Lot reporting
 
-25.8 Lot reporting example
+24.8 Lot reporting example
 ==========================
 
 A simple scenario: two acquisitions and a disposal.
@@ -9500,7 +9544,7 @@ $ hledger print desc:sell -a
 
 File: hledger.info,  Node: PART 4 COMMANDS,  Next: Help commands,  Prev: Lot reporting,  Up: Top
 
-26 PART 4: COMMANDS
+25 PART 4: COMMANDS
 *******************
 
 Here are hledger's standard subcommands.  You can list these by running
@@ -9583,7 +9627,7 @@ can list all of a command's options by running 'hledger CMD -h'.
 
 File: hledger.info,  Node: Help commands,  Next: User interface commands,  Prev: PART 4 COMMANDS,  Up: Top
 
-27 Help commands
+26 Help commands
 ****************
 
 * Menu:
@@ -9595,7 +9639,7 @@ File: hledger.info,  Node: Help commands,  Next: User interface commands,  Prev:
 
 File: hledger.info,  Node: commands,  Next: demo,  Up: Help commands
 
-27.1 commands
+26.1 commands
 =============
 
 Show the hledger commands list.
@@ -9606,7 +9650,7 @@ Flags:
 
 File: hledger.info,  Node: demo,  Next: help,  Prev: commands,  Up: Help commands
 
-27.2 demo
+26.2 demo
 =========
 
 Play demos of hledger usage in the terminal, if asciinema is installed.
@@ -9638,7 +9682,7 @@ $ hledger demo install -s4   # play the "install" demo at 4x speed
 
 File: hledger.info,  Node: help,  Prev: demo,  Up: Help commands
 
-27.3 help
+26.3 help
 =========
 
 Show the hledger user manual with 'info', 'man', or a pager.  With a
@@ -9680,7 +9724,7 @@ $ hledger help 'time periods' -m  # use man, even if info is installed
 
 File: hledger.info,  Node: User interface commands,  Next: Data entry commands,  Prev: Help commands,  Up: Top
 
-28 User interface commands
+27 User interface commands
 **************************
 
 * Menu:
@@ -9693,7 +9737,7 @@ File: hledger.info,  Node: User interface commands,  Next: Data entry commands, 
 
 File: hledger.info,  Node: repl,  Next: run,  Up: User interface commands
 
-28.1 repl
+27.1 repl
 =========
 
 Start an interactive prompt, where you can run any of hledger's
@@ -9716,6 +9760,11 @@ override this temporarily by specifying an '-f' option in particular
 commands.  But note that commands will not see any changes made to input
 files (eg by 'add') until you exit and restart the REPL.
 
+   Any other general flags given to 'repl' - input, reporting, or
+display flags such as '-I', '--strict', '--alias', '-b'/'-e', '--depth',
+'--cost', '--value', '--color' - are also applied to every command you
+run.  A command can still override them by specifying its own flags.
+
    The command syntax is the same as with 'run':
 
    * enter one hledger command at a time, without the usual 'hledger'
@@ -9735,7 +9784,8 @@ can navigate in the usual ways:
    Generally 'repl' command lines should feel much like the normal
 hledger CLI, but you may find differences.  'repl' is a little stricter;
 eg it requires full command names or official abbreviations (as seen in
-the commands list).
+the commands list).  Command aliases defined in a config file can also
+be used.
 
    The 'commands' and 'help' commands, and the command help flags ('CMD
 --tldr', 'CMD -h/--help', 'CMD --info', 'CMD --man'), can be useful.
@@ -9753,7 +9803,7 @@ shell (and then 'fg' to return to the REPL).
 
 File: hledger.info,  Node: Examples,  Up: repl
 
-28.1.1 Examples
+27.1.1 Examples
 ---------------
 
 Start the REPL and enter some commands:
@@ -9784,7 +9834,7 @@ Enter hledger commands. To exit, enter 'quit' or 'exit', or send EOF.
 
 File: hledger.info,  Node: run,  Next: ui,  Prev: repl,  Up: User interface commands
 
-28.2 run
+27.2 run
 ========
 
 Run a sequence of hledger commands, provided as files or command line
@@ -9811,6 +9861,11 @@ different input, you can specify an '-f' option within that command.
 This will override (not add to) the default input, just for that
 command.
 
+   Any other general flags given to 'run' - input, reporting, or display
+flags such as '-I', '--strict', '--alias', '-b'/'-e', '--depth',
+'--cost', '--value', '--color' - are also applied to every command it
+runs.  A command can still override them by specifying its own flags.
+
    Each input file (more precisely, each combination of input file and
 input options) is parsed only once.  This means that commands will not
 see any changes made to these files, until the next run.  But the
@@ -9835,6 +9890,9 @@ error, use '#!/usr/bin/env -S hledger run'.
 
    It's ok to use the 'run' command recursively within a command script.
 
+   Command aliases defined in a config file can also be used in command
+scripts.
+
    You may find some differences in behaviour between 'run' command
 lines and normal hledger command lines.  'run' is a little stricter; eg
 it requires full command names or official abbreviations (as seen in the
@@ -9848,7 +9906,7 @@ name.
 
 File: hledger.info,  Node: Examples 2,  Up: run
 
-28.2.1 Examples
+27.2.1 Examples
 ---------------
 
 Run commands from the command line:
@@ -9888,7 +9946,7 @@ List of accounts in some.journal
 
 File: hledger.info,  Node: ui,  Next: web,  Prev: run,  Up: User interface commands
 
-28.3 ui
+27.3 ui
 =======
 
 Runs hledger-ui (if installed).
@@ -9896,7 +9954,7 @@ Runs hledger-ui (if installed).
 
 File: hledger.info,  Node: web,  Prev: ui,  Up: User interface commands
 
-28.4 web
+27.4 web
 ========
 
 Runs hledger-web (if installed).
@@ -9904,7 +9962,7 @@ Runs hledger-web (if installed).
 
 File: hledger.info,  Node: Data entry commands,  Next: Basic report commands,  Prev: User interface commands,  Up: Top
 
-29 Data entry commands
+28 Data entry commands
 **********************
 
 * Menu:
@@ -9917,7 +9975,7 @@ File: hledger.info,  Node: Data entry commands,  Next: Basic report commands,  P
 
 File: hledger.info,  Node: add,  Next: add and balance assertions,  Up: Data entry commands
 
-29.1 add
+28.1 add
 ========
 
 Add new transactions to a journal file, with interactive prompting.
@@ -9993,7 +10051,7 @@ or press control-d or control-c to exit.
 
 File: hledger.info,  Node: add and balance assertions,  Next: add and balance assignments,  Prev: add,  Up: Data entry commands
 
-29.2 add and balance assertions
+28.2 add and balance assertions
 ===============================
 
 Since hledger 1.43, you can add a balance assertion by writing 'AMOUNT =
@@ -10007,7 +10065,7 @@ to disable balance assertion checking.
 
 File: hledger.info,  Node: add and balance assignments,  Next: import,  Prev: add and balance assertions,  Up: Data entry commands
 
-29.3 add and balance assignments
+28.3 add and balance assignments
 ================================
 
 *Adding a new balance assignment*
@@ -10026,7 +10084,7 @@ with balance assertions ignored: 'hledger add -I'.
 
 File: hledger.info,  Node: import,  Prev: add and balance assignments,  Up: Data entry commands
 
-29.4 import
+28.4 import
 ===========
 
 Import new transactions from one or more data files to the main journal.
@@ -10073,7 +10131,7 @@ $ hledger import *.csv
 
 File: hledger.info,  Node: Default import sources,  Next: Fetching new data first,  Up: import
 
-29.4.1 Default import sources
+28.4.1 Default import sources
 -----------------------------
 
 If 'import' is run with no file arguments, it looks in the journal's
@@ -10100,7 +10158,7 @@ other rules files and not meant to be read directly.
 
 File: hledger.info,  Node: Fetching new data first,  Next: Import dry run,  Prev: Default import sources,  Up: import
 
-29.4.2 Fetching new data first
+28.4.2 Fetching new data first
 ------------------------------
 
 With '-g/--get', 'import' runs the 'get' command first, which runs your
@@ -10112,7 +10170,7 @@ rules.
 
 File: hledger.info,  Node: Import dry run,  Next: Overlap detection,  Prev: Fetching new data first,  Up: import
 
-29.4.3 Import dry run
+28.4.3 Import dry run
 ---------------------
 
 It's useful to preview the import by running first with '--dry-run', to
@@ -10141,7 +10199,7 @@ $ hledger import bank.csv
 
 File: hledger.info,  Node: Overlap detection,  Next: First import,  Prev: Import dry run,  Up: import
 
-29.4.4 Overlap detection
+28.4.4 Overlap detection
 ------------------------
 
 Reading CSV files is built in to hledger, and not specific to 'import';
@@ -10207,7 +10265,7 @@ works:
 
 File: hledger.info,  Node: First import,  Next: Importing balance assignments,  Prev: Overlap detection,  Up: import
 
-29.4.5 First import
+28.4.5 First import
 -------------------
 
 The first time you import from a file, when no corresponding .latest
@@ -10240,7 +10298,7 @@ newer records.
 
 File: hledger.info,  Node: Importing balance assignments,  Next: Import and commodity styles,  Prev: First import,  Up: import
 
-29.4.6 Importing balance assignments
+28.4.6 Importing balance assignments
 ------------------------------------
 
 Journal entries added by import will have all posting amounts made
@@ -10266,7 +10324,7 @@ that and send a pull request.)
 
 File: hledger.info,  Node: Import and commodity styles,  Next: Import archiving,  Prev: Importing balance assignments,  Up: import
 
-29.4.7 Import and commodity styles
+28.4.7 Import and commodity styles
 ----------------------------------
 
 Amounts in entries added by import will be formatted according to the
@@ -10278,7 +10336,7 @@ directives or inferred from the journal's amounts.
 
 File: hledger.info,  Node: Import archiving,  Next: Import special cases,  Prev: Import and commodity styles,  Up: import
 
-29.4.8 Import archiving
+28.4.8 Import archiving
 -----------------------
 
 When importing from a CSV rules file ('hledger import bank.rules'), you
@@ -10301,7 +10359,7 @@ pick the oldest, not the newest.
 
 File: hledger.info,  Node: Import special cases,  Prev: Import archiving,  Up: import
 
-29.4.9 Import special cases
+28.4.9 Import special cases
 ---------------------------
 
 * Menu:
@@ -10315,7 +10373,7 @@ File: hledger.info,  Node: Import special cases,  Prev: Import archiving,  Up: i
 
 File: hledger.info,  Node: Multiple journals in the same directory,  Next: Import configurations to avoid,  Up: Import special cases
 
-29.4.9.1 Multiple journals in the same directory
+28.4.9.1 Multiple journals in the same directory
 ................................................
 
 You might want to keep each journal you are importing to in its own
@@ -10331,7 +10389,7 @@ see below:
 
 File: hledger.info,  Node: Import configurations to avoid,  Next: Deduplication,  Prev: Multiple journals in the same directory,  Up: Import special cases
 
-29.4.9.2 Import configurations to avoid
+28.4.9.2 Import configurations to avoid
 .......................................
 
 A few unusual workflows which you should generally avoid:
@@ -10354,7 +10412,7 @@ A few unusual workflows which you should generally avoid:
 
 File: hledger.info,  Node: Deduplication,  Next: Varying file name,  Prev: Import configurations to avoid,  Up: Import special cases
 
-29.4.9.3 Deduplication
+28.4.9.3 Deduplication
 ......................
 
 Here are two kinds of "deduplication" which 'import' does not handle
@@ -10369,7 +10427,7 @@ data):
 
 File: hledger.info,  Node: Varying file name,  Next: Multiple versions,  Prev: Deduplication,  Up: Import special cases
 
-29.4.9.4 Varying file name
+28.4.9.4 Varying file name
 ..........................
 
 If you have a download whose file name varies, you could rename it to a
@@ -10379,7 +10437,7 @@ with a suitable glob pattern, and import from the .rules file.
 
 File: hledger.info,  Node: Multiple versions,  Prev: Varying file name,  Up: Import special cases
 
-29.4.9.5 Multiple versions
+28.4.9.5 Multiple versions
 ..........................
 
 Say you download 'bank.csv', import it, but forget to delete it from
@@ -10402,7 +10460,7 @@ import bank.rules' will import and archive first 'bank.csv', then 'bank
 
 File: hledger.info,  Node: Basic report commands,  Next: Standard report commands,  Prev: Data entry commands,  Up: Top
 
-30 Basic report commands
+29 Basic report commands
 ************************
 
 * Menu:
@@ -10421,7 +10479,7 @@ File: hledger.info,  Node: Basic report commands,  Next: Standard report command
 
 File: hledger.info,  Node: accounts,  Next: codes,  Up: Basic report commands
 
-30.1 accounts
+29.1 accounts
 =============
 
 List the account names used or declared in the journal.
@@ -10486,7 +10544,7 @@ $ hledger check accounts
 
 File: hledger.info,  Node: codes,  Next: commodities,  Prev: accounts,  Up: Basic report commands
 
-30.2 codes
+29.2 codes
 ==========
 
 List the codes seen in transactions, in the order parsed.
@@ -10537,7 +10595,7 @@ $ hledger codes -E
 
 File: hledger.info,  Node: commodities,  Next: descriptions,  Prev: codes,  Up: Basic report commands
 
-30.3 commodities
+29.3 commodities
 ================
 
 List the commodity symbols used or declared in the journal.
@@ -10577,7 +10635,7 @@ Flag        No date query                 With a date query
 
 File: hledger.info,  Node: descriptions,  Next: files,  Prev: commodities,  Up: Basic report commands
 
-30.4 descriptions
+29.4 descriptions
 =================
 
 List the unique descriptions used in transactions.
@@ -10599,7 +10657,7 @@ Person A
 
 File: hledger.info,  Node: files,  Next: notes,  Prev: descriptions,  Up: Basic report commands
 
-30.5 files
+29.5 files
 ==========
 
 List all files included in the journal.  With a REGEX argument, only
@@ -10611,7 +10669,7 @@ no command-specific flags
 
 File: hledger.info,  Node: notes,  Next: payees,  Prev: files,  Up: Basic report commands
 
-30.6 notes
+29.6 notes
 ==========
 
 List the unique notes that appear in transactions.
@@ -10633,7 +10691,7 @@ Snacks
 
 File: hledger.info,  Node: payees,  Next: prices,  Prev: notes,  Up: Basic report commands
 
-30.7 payees
+29.7 payees
 ===========
 
 List the payee/payer names used or declared in the journal.
@@ -10668,7 +10726,7 @@ Person A
 
 File: hledger.info,  Node: prices,  Next: stats,  Prev: payees,  Up: Basic report commands
 
-30.8 prices
+29.8 prices
 ===========
 
 Print the market prices declared with P directives.  With
@@ -10706,7 +10764,7 @@ running the value report with -debug=2.
 
 File: hledger.info,  Node: prices summary,  Up: prices
 
-30.8.1 prices summary
+29.8.1 prices summary
 ---------------------
 
 With '--summary', instead of listing individual prices, 'prices' prints
@@ -10732,13 +10790,13 @@ that are summarised.
 
 File: hledger.info,  Node: stats,  Next: tags,  Prev: prices,  Up: Basic report commands
 
-30.9 stats
+29.9 stats
 ==========
 
 Show journal and performance statistics.
 
 Flags:
-  -1                        show a single line of output
+     --oneline              show a single line of output
   -v --verbose              show more detailed output
   -o --output-file=FILE     write output to FILE.
 
@@ -10791,7 +10849,7 @@ $ hledger stats -1 -f examples/10ktxns-1kaccts.journal
 
 File: hledger.info,  Node: tags,  Prev: stats,  Up: Basic report commands
 
-30.10 tags
+29.10 tags
 ==========
 
 List the tag names used or declared in the journal, or their values.
@@ -10835,7 +10893,7 @@ also acquire tags from their postings.
 
 File: hledger.info,  Node: Standard report commands,  Next: Advanced report commands,  Prev: Basic report commands,  Up: Top
 
-31 Standard report commands
+30 Standard report commands
 ***************************
 
 * Menu:
@@ -10851,12 +10909,13 @@ File: hledger.info,  Node: Standard report commands,  Next: Advanced report comm
 
 File: hledger.info,  Node: print,  Next: aregister,  Up: Standard report commands
 
-31.1 print
+30.1 print
 ==========
 
 Show full journal entries, representing transactions.
 
 Flags:
+     --oneline              show transaction dates and descriptions only
   -a --all                  show all details (--explicit --lots
                             --verbose-tags)
   -x --explicit             show all inferred info explicitly
@@ -10926,7 +10985,7 @@ $ hledger print -f examples/sample.journal date:200806
 
 File: hledger.info,  Node: print explicitness,  Next: print layout,  Up: print
 
-31.1.1 print explicitness
+30.1.1 print explicitness
 -------------------------
 
 Normally, whether posting amounts are implicit or explicit is preserved.
@@ -10952,7 +11011,7 @@ classify things -- use '-a'/'--all', which is equivalent to '--explicit
 
 File: hledger.info,  Node: print layout,  Next: print amount style,  Prev: print explicitness,  Up: print
 
-31.1.2 print layout
+30.1.2 print layout
 -------------------
 
 By default, 'print' aligns posting amounts so that their decimal mark is
@@ -10982,7 +11041,7 @@ be aligned by their decimal marks.
 
 File: hledger.info,  Node: print amount style,  Next: print parseability,  Prev: print layout,  Up: print
 
-31.1.3 print amount style
+30.1.3 print amount style
 -------------------------
 
 Amounts will be displayed mostly in their commodity's display style,
@@ -11010,7 +11069,7 @@ entries, perhaps requiring manual fixup.
 
 File: hledger.info,  Node: print parseability,  Next: print other features,  Prev: print amount style,  Up: print
 
-31.1.4 print parseability
+30.1.4 print parseability
 -------------------------
 
 Usually, print's output is a valid hledger journal, which you can pipe
@@ -11050,7 +11109,7 @@ these, we often use the '-I' flag (short for '--ignore-assertions
 
 File: hledger.info,  Node: print other features,  Next: print output format,  Prev: print parseability,  Up: print
 
-31.1.5 print, other features
+30.1.5 print, other features
 ----------------------------
 
 With '-B'/'--cost', amounts with costs are shown converted to cost.
@@ -11071,10 +11130,14 @@ will be shown and the program exit code will be non-zero.
    With '--locations', print adds the source file and line number to
 every transaction, as a tag.
 
+   With '--oneline', print shows only each transaction's first line (the
+date, status, code, description, and any same-line comment), This gives
+a compact overview.  It affects the default 'txt' output only.
+
 
 File: hledger.info,  Node: print output format,  Prev: print other features,  Up: print
 
-31.1.6 print output format
+30.1.6 print output format
 --------------------------
 
 This command also supports the output destination and output format
@@ -11143,7 +11206,7 @@ $ hledger print -Ocsv
 
 File: hledger.info,  Node: aregister,  Next: register,  Prev: print,  Up: Standard report commands
 
-31.2 aregister
+30.2 aregister
 ==============
 
 (areg)
@@ -11245,7 +11308,7 @@ in 1.32_), 'html', 'fods' (_Added in 1.41_) and 'json'.
 
 File: hledger.info,  Node: aregister and posting dates,  Up: aregister
 
-31.2.1 aregister and posting dates
+30.2.1 aregister and posting dates
 ----------------------------------
 
 aregister always shows one line (and date and amount) per transaction.
@@ -11265,7 +11328,7 @@ inaccurate running balance.
 
 File: hledger.info,  Node: register,  Next: balancesheet,  Prev: aregister,  Up: Standard report commands
 
-31.3 register
+30.3 register
 =============
 
 (reg)
@@ -11419,7 +11482,7 @@ no posting will be shown and the program exit code will be non-zero.
 
 File: hledger.info,  Node: Custom register output,  Up: register
 
-31.3.1 Custom register output
+30.3.1 Custom register output
 -----------------------------
 
 register normally uses the full terminal width (or 80 columns if it
@@ -11448,7 +11511,7 @@ options The output formats supported are 'txt', 'csv', 'tsv' (_Added in
 
 File: hledger.info,  Node: balancesheet,  Next: balancesheetequity,  Prev: register,  Up: Standard report commands
 
-31.4 balancesheet
+30.4 balancesheet
 =================
 
 (bs)
@@ -11549,7 +11612,7 @@ options The output formats supported are 'txt', 'csv', 'tsv' (_Added in
 
 File: hledger.info,  Node: balancesheetequity,  Next: cashflow,  Prev: balancesheet,  Up: Standard report commands
 
-31.5 balancesheetequity
+30.5 balancesheetequity
 =======================
 
 (bse)
@@ -11657,7 +11720,7 @@ and 'json'.
 
 File: hledger.info,  Node: cashflow,  Next: incomestatement,  Prev: balancesheetequity,  Up: Standard report commands
 
-31.6 cashflow
+30.6 cashflow
 =============
 
 (cf)
@@ -11757,7 +11820,7 @@ options The output formats supported are 'txt', 'csv', 'tsv' (_Added in
 
 File: hledger.info,  Node: incomestatement,  Prev: cashflow,  Up: Standard report commands
 
-31.7 incomestatement
+30.7 incomestatement
 ====================
 
 (is)
@@ -11859,7 +11922,7 @@ options The output formats supported are 'txt', 'csv', 'tsv' (_Added in
 
 File: hledger.info,  Node: Advanced report commands,  Next: Chart commands,  Prev: Standard report commands,  Up: Top
 
-32 Advanced report commands
+31 Advanced report commands
 ***************************
 
 * Menu:
@@ -11870,7 +11933,7 @@ File: hledger.info,  Node: Advanced report commands,  Next: Chart commands,  Pre
 
 File: hledger.info,  Node: balance,  Next: roi,  Up: Advanced report commands
 
-32.1 balance
+31.1 balance
 ============
 
 (bal)
@@ -11976,7 +12039,7 @@ more control, then use 'balance'.
 
 File: hledger.info,  Node: balance features,  Next: Simple balance report,  Up: balance
 
-32.1.1 balance features
+31.1.1 balance features
 -----------------------
 
 Here's a quick overview of the 'balance' command's features, followed by
@@ -12038,7 +12101,7 @@ amounts are shown in red.
 
 File: hledger.info,  Node: Simple balance report,  Next: Balance report line format,  Prev: balance features,  Up: balance
 
-32.1.2 Simple balance report
+31.1.2 Simple balance report
 ----------------------------
 
 With no arguments, 'balance' shows a list of all accounts and their
@@ -12087,7 +12150,7 @@ $ hledger -f examples/sample.journal bal  -E
 
 File: hledger.info,  Node: Balance report line format,  Next: Filtered balance report,  Prev: Simple balance report,  Up: balance
 
-32.1.3 Balance report line format
+31.1.3 Balance report line format
 ---------------------------------
 
 For single-period balance reports displayed in the terminal (only), you
@@ -12152,7 +12215,7 @@ may be needed to get pleasing results.
 
 File: hledger.info,  Node: Filtered balance report,  Next: List or tree mode,  Prev: Balance report line format,  Up: balance
 
-32.1.4 Filtered balance report
+31.1.4 Filtered balance report
 ------------------------------
 
 You can show fewer accounts, a different time period, totals from
@@ -12167,7 +12230,7 @@ $ hledger -f examples/sample.journal bal --cleared assets date:200806
 
 File: hledger.info,  Node: List or tree mode,  Next: Depth limiting,  Prev: Filtered balance report,  Up: balance
 
-32.1.5 List or tree mode
+31.1.5 List or tree mode
 ------------------------
 
 By default, or with '-l/--flat', accounts are shown as a flat list with
@@ -12210,7 +12273,7 @@ $ hledger -f examples/sample.journal balance
 
 File: hledger.info,  Node: Depth limiting,  Next: Dropping top-level accounts,  Prev: List or tree mode,  Up: balance
 
-32.1.6 Depth limiting
+31.1.6 Depth limiting
 ---------------------
 
 With a 'depth:NUM' query, or '--depth NUM' option, or just '-NUM' (eg:
@@ -12232,7 +12295,7 @@ $ hledger -f examples/sample.journal balance -1
 
 File: hledger.info,  Node: Dropping top-level accounts,  Next: Showing declared accounts,  Prev: Depth limiting,  Up: balance
 
-32.1.7 Dropping top-level accounts
+31.1.7 Dropping top-level accounts
 ----------------------------------
 
 You can also hide one or more top-level account name parts, using
@@ -12248,7 +12311,7 @@ $ hledger -f examples/sample.journal bal expenses --drop 1
 
 File: hledger.info,  Node: Showing declared accounts,  Next: Sorting by amount,  Prev: Dropping top-level accounts,  Up: balance
 
-32.1.8 Showing declared accounts
+31.1.8 Showing declared accounts
 --------------------------------
 
 With '--declared', accounts which have been declared with an account
@@ -12266,7 +12329,7 @@ accounts yet.
 
 File: hledger.info,  Node: Sorting by amount,  Next: Percentages,  Prev: Showing declared accounts,  Up: balance
 
-32.1.9 Sorting by amount
+31.1.9 Sorting by amount
 ------------------------
 
 With '-S/--sort-amount', accounts with the largest (most positive)
@@ -12285,7 +12348,7 @@ balance reports ('bs', 'is'..), which flip the sign automatically (eg:
 
 File: hledger.info,  Node: Percentages,  Next: Multi-period balance report,  Prev: Sorting by amount,  Up: balance
 
-32.1.10 Percentages
+31.1.10 Percentages
 -------------------
 
 With '-%/--percent', balance reports show each account's value expressed
@@ -12308,7 +12371,7 @@ $ hledger bal -% cur:€
 
 File: hledger.info,  Node: Multi-period balance report,  Next: Balance change end balance,  Prev: Percentages,  Up: balance
 
-32.1.11 Multi-period balance report
+31.1.11 Multi-period balance report
 -----------------------------------
 
 With a report interval (set by the '-D/--daily', '-W/--weekly',
@@ -12368,7 +12431,7 @@ viewing in the terminal.  Here are some ways to handle that:
 
 File: hledger.info,  Node: Balance change end balance,  Next: Balance report modes,  Prev: Multi-period balance report,  Up: balance
 
-32.1.12 Balance change, end balance
+31.1.12 Balance change, end balance
 -----------------------------------
 
 It's important to be clear on the meaning of the numbers shown in
@@ -12405,7 +12468,7 @@ historical end balances:
 
 File: hledger.info,  Node: Balance report modes,  Next: Budget report,  Prev: Balance change end balance,  Up: balance
 
-32.1.13 Balance report modes
+31.1.13 Balance report modes
 ----------------------------
 
 The balance command is quite flexible; here is the full detail on how to
@@ -12427,7 +12490,7 @@ experimentation to get familiar with all the report modes.
 
 File: hledger.info,  Node: Calculation mode,  Next: Accumulation mode,  Up: Balance report modes
 
-32.1.13.1 Calculation mode
+31.1.13.1 Calculation mode
 ..........................
 
 The basic calculation to perform for each table cell.  It is one of:
@@ -12451,7 +12514,7 @@ The basic calculation to perform for each table cell.  It is one of:
 
 File: hledger.info,  Node: Accumulation mode,  Next: Valuation mode,  Prev: Calculation mode,  Up: Balance report modes
 
-32.1.13.2 Accumulation mode
+31.1.13.2 Accumulation mode
 ...........................
 
 How amounts should accumulate across a report's subperiods/columns.
@@ -12477,7 +12540,7 @@ each cell's calculation.  It is one of:
 
 File: hledger.info,  Node: Valuation mode,  Next: Combining balance report modes,  Prev: Accumulation mode,  Up: Balance report modes
 
-32.1.13.3 Valuation mode
+31.1.13.3 Valuation mode
 ........................
 
 Which kind of value or cost conversion should be applied, if any, before
@@ -12513,7 +12576,7 @@ together.
 
 File: hledger.info,  Node: Combining balance report modes,  Prev: Valuation mode,  Up: Balance report modes
 
-32.1.13.4 Combining balance report modes
+31.1.13.4 Combining balance report modes
 ........................................
 
 Most combinations of these modes should produce reasonable reports, but
@@ -12552,7 +12615,7 @@ Accumulation:v                                                YYYY-MM-DD
 
 File: hledger.info,  Node: Budget report,  Next: Balance report layout,  Prev: Balance report modes,  Up: balance
 
-32.1.14 Budget report
+31.1.14 Budget report
 ---------------------
 
 The 'balance --budget' report is like a regular balance report, but with
@@ -12623,7 +12686,7 @@ https://plaintextaccounting.org/Budgeting has more on this topic.
 
 File: hledger.info,  Node: Using the budget report,  Next: Budget date surprises,  Up: Budget report
 
-32.1.14.1 Using the budget report
+31.1.14.1 Using the budget report
 .................................
 
 Historically this report has been confusing and fragile.  hledger's
@@ -12679,7 +12742,7 @@ troubleshooting.
 
 File: hledger.info,  Node: Budget date surprises,  Next: Selecting budget goals,  Prev: Using the budget report,  Up: Budget report
 
-32.1.14.2 Budget date surprises
+31.1.14.2 Budget date surprises
 ...............................
 
 With small data, or when starting out, some of the generated budget goal
@@ -12718,7 +12781,7 @@ the trick.
 
 File: hledger.info,  Node: Selecting budget goals,  Next: Budgeting vs forecasting,  Prev: Budget date surprises,  Up: Budget report
 
-32.1.14.3 Selecting budget goals
+31.1.14.3 Selecting budget goals
 ................................
 
 By default, the budget report uses all available periodic transaction
@@ -12738,7 +12801,7 @@ defined in your journal.
 
 File: hledger.info,  Node: Budgeting vs forecasting,  Prev: Selecting budget goals,  Up: Budget report
 
-32.1.14.4 Budgeting vs forecasting
+31.1.14.4 Budgeting vs forecasting
 ..................................
 
 '--forecast' and '--budget' both use the periodic transaction rules in
@@ -12770,7 +12833,7 @@ uses all periodic rules                  uses all periodic rules; or
 
 File: hledger.info,  Node: Balance report layout,  Next: Balance report output,  Prev: Budget report,  Up: balance
 
-32.1.15 Balance report layout
+31.1.15 Balance report layout
 -----------------------------
 
 The '--layout' option affects how 'balance' and the other balance-like
@@ -12809,7 +12872,7 @@ tidy         Y
 
 File: hledger.info,  Node: Wide layout,  Next: Tall layout,  Up: Balance report layout
 
-32.1.15.1 Wide layout
+31.1.15.1 Wide layout
 .....................
 
 With many commodities, reports can be very wide:
@@ -12837,7 +12900,7 @@ Balance changes in 2012-01-01..2014-12-31:
 
 File: hledger.info,  Node: Tall layout,  Next: Bare layout,  Prev: Wide layout,  Up: Balance report layout
 
-32.1.15.2 Tall layout
+31.1.15.2 Tall layout
 .....................
 
 Each commodity gets a new line (may be different in each column), and
@@ -12863,7 +12926,7 @@ Balance changes in 2012-01-01..2014-12-31:
 
 File: hledger.info,  Node: Bare layout,  Next: Tidy layout,  Prev: Tall layout,  Up: Balance report layout
 
-32.1.15.3 Bare layout
+31.1.15.3 Bare layout
 .....................
 
 Commodity symbols are kept in one column, each commodity has its own
@@ -12910,7 +12973,7 @@ commodity-less, usually).  This can break 'hledger-bar' confusingly
 
 File: hledger.info,  Node: Tidy layout,  Prev: Bare layout,  Up: Balance report layout
 
-32.1.15.4 Tidy layout
+31.1.15.4 Tidy layout
 .....................
 
 This produces normalised "tidy data" (see
@@ -12940,7 +13003,7 @@ $ hledger -f examples/bcexample.journal bal assets:us:etrade -3 -Y -O csv --layo
 
 File: hledger.info,  Node: Balance report output,  Next: Some useful balance reports,  Prev: Balance report layout,  Up: balance
 
-32.1.16 Balance report output
+31.1.16 Balance report output
 -----------------------------
 
 As noted in Output format, if you choose HTML output (by using '-O html'
@@ -12957,7 +13020,7 @@ links, like '--base-url="some/path"' or '--base-url=""'.)
 
 File: hledger.info,  Node: Some useful balance reports,  Prev: Balance report output,  Up: balance
 
-32.1.17 Some useful balance reports
+31.1.17 Some useful balance reports
 -----------------------------------
 
 Some frequently used 'balance' options/reports are:
@@ -12997,7 +13060,7 @@ Some frequently used 'balance' options/reports are:
 
 File: hledger.info,  Node: roi,  Prev: balance,  Up: Advanced report commands
 
-32.2 roi
+31.2 roi
 ========
 
 Shows the money-weighted (IRR) and time-weighted (TWR) rate of return on
@@ -13057,7 +13120,7 @@ annual rate.
 
 File: hledger.info,  Node: Spaces and special characters in --inv and --pnl,  Next: Semantics of --inv and --pnl,  Up: roi
 
-32.2.1 Spaces and special characters in '--inv' and
+31.2.1 Spaces and special characters in '--inv' and
 ---------------------------------------------------
 
 '--pnl' Note that '--inv' and '--pnl''s argument is a query, and queries
@@ -13076,7 +13139,7 @@ $ hledger roi --inv="'Assets:Test 1'" --pnl="'Equity:Unrealized Profit and Loss'
 
 File: hledger.info,  Node: Semantics of --inv and --pnl,  Next: IRR and TWR explained,  Prev: Spaces and special characters in --inv and --pnl,  Up: roi
 
-32.2.2 Semantics of '--inv' and '--pnl'
+31.2.2 Semantics of '--inv' and '--pnl'
 ---------------------------------------
 
 Query supplied to '--inv' has to match all transactions that are related
@@ -13130,7 +13193,7 @@ postings in the example below would be classifed as:
 
 File: hledger.info,  Node: IRR and TWR explained,  Prev: Semantics of --inv and --pnl,  Up: roi
 
-32.2.3 IRR and TWR explained
+31.2.3 IRR and TWR explained
 ----------------------------
 
 "ROI" stands for "return on investment".  Traditionally this was
@@ -13210,7 +13273,7 @@ removes the distortion caused by investor cash flows.
 
 File: hledger.info,  Node: Chart commands,  Next: Data generation commands,  Prev: Advanced report commands,  Up: Top
 
-33 Chart commands
+32 Chart commands
 *****************
 
 * Menu:
@@ -13220,7 +13283,7 @@ File: hledger.info,  Node: Chart commands,  Next: Data generation commands,  Pre
 
 File: hledger.info,  Node: activity,  Up: Chart commands
 
-33.1 activity
+32.1 activity
 =============
 
 Show an ascii barchart of posting counts per interval.
@@ -13243,7 +13306,7 @@ $ hledger activity --quarterly
 
 File: hledger.info,  Node: Data generation commands,  Next: Maintenance commands,  Prev: Chart commands,  Up: Top
 
-34 Data generation commands
+33 Data generation commands
 ***************************
 
 * Menu:
@@ -13255,7 +13318,7 @@ File: hledger.info,  Node: Data generation commands,  Next: Maintenance commands
 
 File: hledger.info,  Node: close,  Next: get,  Up: Data generation commands
 
-34.1 close
+33.1 close
 ==========
 
 (equity)
@@ -13327,7 +13390,7 @@ value by providing an argument to the mode flag.  Eg '--close=foo' or
 
 File: hledger.info,  Node: close --clopen,  Next: close --close,  Up: close
 
-34.1.1 close -clopen
+33.1.1 close -clopen
 --------------------
 
 This is useful if migrating balances to a new journal file at the start
@@ -13368,7 +13431,7 @@ the closed/opened accounts.
 
 File: hledger.info,  Node: close --close,  Next: close --open,  Prev: close --clopen,  Up: close
 
-34.1.2 close -close
+33.1.2 close -close
 -------------------
 
 This prints just the closing balances transaction of '--clopen'.  It is
@@ -13382,7 +13445,7 @@ to move just a portion of the balance, see hledger-move.)
 
 File: hledger.info,  Node: close --open,  Next: close --assert,  Prev: close --close,  Up: close
 
-34.1.3 close -open
+33.1.3 close -open
 ------------------
 
 This prints just the opening balances transaction of '--clopen'.  (It is
@@ -13391,7 +13454,7 @@ similar to Ledger's equity command.)
 
 File: hledger.info,  Node: close --assert,  Next: close --assign,  Prev: close --open,  Up: close
 
-34.1.4 close -assert
+33.1.4 close -assert
 --------------------
 
 This prints a transaction that asserts the account balances as they are
@@ -13401,7 +13464,7 @@ documention and to guard against changes.
 
 File: hledger.info,  Node: close --assign,  Next: close --retain,  Prev: close --assert,  Up: close
 
-34.1.5 close -assign
+33.1.5 close -assign
 --------------------
 
 This prints a transaction that assigns the account balances as they are
@@ -13418,7 +13481,7 @@ usually recommended.
 
 File: hledger.info,  Node: close --retain,  Next: close customisation,  Prev: close --assign,  Up: close
 
-34.1.6 close -retain
+33.1.6 close -retain
 --------------------
 
 This is like '--close', but it closes Revenue and Expense account
@@ -13438,7 +13501,7 @@ report show a zero total, demonstrating that the accounting equation
 
 File: hledger.info,  Node: close customisation,  Next: close and balance assertions,  Prev: close --retain,  Up: close
 
-34.1.7 close customisation
+33.1.7 close customisation
 --------------------------
 
 In all modes, the following things can be overridden:
@@ -13476,7 +13539,7 @@ hledger.  (To move or dispose of lots, see the more capable
 
 File: hledger.info,  Node: close and balance assertions,  Next: close examples,  Prev: close customisation,  Up: close
 
-34.1.8 close and balance assertions
+33.1.8 close and balance assertions
 -----------------------------------
 
 'close' adds balance assertions verifying that the accounts have been
@@ -13522,7 +13585,7 @@ transactions:
 
 File: hledger.info,  Node: close examples,  Prev: close and balance assertions,  Up: close
 
-34.1.9 close examples
+33.1.9 close examples
 ---------------------
 
 * Menu:
@@ -13534,7 +13597,7 @@ File: hledger.info,  Node: close examples,  Prev: close and balance assertions, 
 
 File: hledger.info,  Node: Retain earnings,  Next: Migrate balances to a new file,  Up: close examples
 
-34.1.9.1 Retain earnings
+33.1.9.1 Retain earnings
 ........................
 
 Record 2022's revenues/expenses as retained earnings on 2022-12-31,
@@ -13550,7 +13613,7 @@ $ hledger -f 2022.journal is not:desc:'retain earnings'
 
 File: hledger.info,  Node: Migrate balances to a new file,  Next: More detailed close examples,  Prev: Retain earnings,  Up: close examples
 
-34.1.9.2 Migrate balances to a new file
+33.1.9.2 Migrate balances to a new file
 .......................................
 
 Close assets/liabilities on 2022-12-31 and re-open them on 2023-01-01:
@@ -13579,7 +13642,7 @@ $ hledger bs -Y -f 2023.j                     # unclosed file, no query needed
 
 File: hledger.info,  Node: More detailed close examples,  Prev: Migrate balances to a new file,  Up: close examples
 
-34.1.9.3 More detailed close examples
+33.1.9.3 More detailed close examples
 .....................................
 
 See examples/multi-year.
@@ -13587,7 +13650,7 @@ See examples/multi-year.
 
 File: hledger.info,  Node: get,  Next: rewrite,  Prev: close,  Up: Data generation commands
 
-34.2 get
+33.2 get
 ========
 
 Fetch data for the journal: transactions and market prices, by running
@@ -13610,7 +13673,7 @@ Flags:
 
 File: hledger.info,  Node: Phase 1 transactions data,  Next: Phase 2 prices,  Up: get
 
-34.2.1 Phase 1: transactions data
+33.2.1 Phase 1: transactions data
 ---------------------------------
 
   1. Creates a 'data/' directory next to the main journal file, if it
@@ -13622,7 +13685,7 @@ File: hledger.info,  Node: Phase 1 transactions data,  Next: Phase 2 prices,  Up
 
 File: hledger.info,  Node: Phase 2 prices,  Next: Merging new prices,  Prev: Phase 1 transactions data,  Up: get
 
-34.2.2 Phase 2: prices
+33.2.2 Phase 2: prices
 ----------------------
 
   1. Creates a 'prices/' directory next to the main journal file, if it
@@ -13643,7 +13706,7 @@ With '--dry-run', you can preview the commands without running them.
 
 File: hledger.info,  Node: Merging new prices,  Next: get's helper scripts,  Prev: Phase 2 prices,  Up: get
 
-34.2.3 Merging new prices
+33.2.3 Merging new prices
 -------------------------
 
 Complete historical price data can be hard to get, so the prices phase
@@ -13661,7 +13724,7 @@ newly fetched prices will be merged as follows:
 
 File: hledger.info,  Node: get's helper scripts,  Prev: Merging new prices,  Up: get
 
-34.2.4 get's helper scripts
+33.2.4 get's helper scripts
 ---------------------------
 
 Data downloading varies for everyone, and needs to be easily
@@ -13675,7 +13738,7 @@ customisable, so it is done via helper scripts:
 
 File: hledger.info,  Node: getdata,  Next: getprices,  Up: get's helper scripts
 
-34.2.4.1 getdata
+33.2.4.1 getdata
 ................
 
 If you want 'get' to download transaction data for you, make your own
@@ -13689,7 +13752,7 @@ files, but could be anything that your hledger rules files can read.
 
 File: hledger.info,  Node: getprices,  Prev: getdata,  Up: get's helper scripts
 
-34.2.4.2 getprices
+33.2.4.2 getprices
 ..................
 
 If you want 'get' to download historical market prices (useful for
@@ -13714,7 +13777,7 @@ arguments:
 
 File: hledger.info,  Node: rewrite,  Prev: get,  Up: Data generation commands
 
-34.3 rewrite
+33.3 rewrite
 ============
 
 Print all transactions, rewriting the postings of matched transactions.
@@ -13784,7 +13847,7 @@ commodity.
 
 File: hledger.info,  Node: Re-write rules in a file,  Next: Diff output format,  Up: rewrite
 
-34.3.1 Re-write rules in a file
+33.3.1 Re-write rules in a file
 -------------------------------
 
 During the run this tool will execute so called "Automated Transactions"
@@ -13822,7 +13885,7 @@ postings.
 
 File: hledger.info,  Node: Diff output format,  Next: rewrite vs print --auto,  Prev: Re-write rules in a file,  Up: rewrite
 
-34.3.2 Diff output format
+33.3.2 Diff output format
 -------------------------
 
 To use this tool for batch modification of your journal files you may
@@ -13863,7 +13926,7 @@ output from 'hledger print'.
 
 File: hledger.info,  Node: rewrite vs print --auto,  Prev: Diff output format,  Up: rewrite
 
-34.3.3 rewrite vs. print -auto
+33.3.3 rewrite vs. print -auto
 ------------------------------
 
 This command predates print -auto, and currently does much the same
@@ -13883,7 +13946,7 @@ thing, but with these differences:
 
 File: hledger.info,  Node: Maintenance commands,  Next: PART 5 COMMON TASKS,  Prev: Data generation commands,  Up: Top
 
-35 Maintenance commands
+34 Maintenance commands
 ***********************
 
 * Menu:
@@ -13896,7 +13959,7 @@ File: hledger.info,  Node: Maintenance commands,  Next: PART 5 COMMON TASKS,  Pr
 
 File: hledger.info,  Node: check,  Next: diff,  Up: Maintenance commands
 
-35.1 check
+34.1 check
 ==========
 
 Check for various kinds of errors in your data.
@@ -13931,7 +13994,7 @@ reported.
 
 File: hledger.info,  Node: Basic checks,  Next: Strict checks,  Up: check
 
-35.1.1 Basic checks
+34.1.1 Basic checks
 -------------------
 
 These important checks are performed by default, by almost all hledger
@@ -13964,7 +14027,7 @@ commands:
 
 File: hledger.info,  Node: Strict checks,  Next: Other checks,  Prev: Basic checks,  Up: check
 
-35.1.2 Strict checks
+34.1.2 Strict checks
 --------------------
 
 When the '-s'/'--strict' flag is used (AKA strict mode), all commands
@@ -13990,7 +14053,7 @@ error-catching power to help you keep your data clean and correct:
 
 File: hledger.info,  Node: Other checks,  Next: Custom checks,  Prev: Strict checks,  Up: check
 
-35.1.3 Other checks
+34.1.3 Other checks
 -------------------
 
 These are not wanted by everyone, but can be run using the 'check'
@@ -14036,7 +14099,7 @@ command:
 
 File: hledger.info,  Node: Custom checks,  Prev: Other checks,  Up: check
 
-35.1.4 Custom checks
+34.1.4 Custom checks
 --------------------
 
 You can build your own custom checks with add-on command scripts.  See
@@ -14051,7 +14114,7 @@ also Cookbook > Scripting.  Here are some examples from hledger/bin/:
 
 File: hledger.info,  Node: diff,  Next: setup,  Prev: check,  Up: Maintenance commands
 
-35.2 diff
+34.2 diff
 =========
 
 Compares a particular account's transactions in two input files.  It
@@ -14090,7 +14153,7 @@ These transactions are in the second file only:
 
 File: hledger.info,  Node: setup,  Next: test,  Prev: diff,  Up: Maintenance commands
 
-35.3 setup
+34.3 setup
 ==========
 
 Check the status of the hledger installation.
@@ -14156,7 +14219,7 @@ journal
 
 File: hledger.info,  Node: test,  Prev: setup,  Up: Maintenance commands
 
-35.4 test
+34.4 test
 =========
 
 Run built-in unit tests.
@@ -14186,7 +14249,7 @@ $ hledger test -- -h         # show tasty's options
 
 File: hledger.info,  Node: PART 5 COMMON TASKS,  Next: BUGS,  Prev: Maintenance commands,  Up: Top
 
-36 PART 5: COMMON TASKS
+35 PART 5: COMMON TASKS
 ***********************
 
 Here are some quick examples of how to do some basic tasks with hledger.
@@ -14206,7 +14269,7 @@ Here are some quick examples of how to do some basic tasks with hledger.
 
 File: hledger.info,  Node: Getting help,  Next: Constructing command lines,  Up: PART 5 COMMON TASKS
 
-36.1 Getting help
+35.1 Getting help
 =================
 
 Here's how to list commands and view options and command docs:
@@ -14229,7 +14292,7 @@ can be found at https://hledger.org/support.
 
 File: hledger.info,  Node: Constructing command lines,  Next: Starting a journal file,  Prev: Getting help,  Up: PART 5 COMMON TASKS
 
-36.2 Constructing command lines
+35.2 Constructing command lines
 ===============================
 
 hledger has a flexible command line interface.  We strive to keep it
@@ -14249,7 +14312,7 @@ described in OPTIONS, here are some tips that might help:
 
 File: hledger.info,  Node: Starting a journal file,  Next: Setting LEDGER_FILE,  Prev: Constructing command lines,  Up: PART 5 COMMON TASKS
 
-36.3 Starting a journal file
+35.3 Starting a journal file
 ============================
 
 hledger looks for your accounting data in a journal file,
@@ -14288,7 +14351,7 @@ Market prices            : 0 ()
 
 File: hledger.info,  Node: Setting LEDGER_FILE,  Next: Setting opening balances,  Prev: Starting a journal file,  Up: PART 5 COMMON TASKS
 
-36.4 Setting LEDGER_FILE
+35.4 Setting LEDGER_FILE
 ========================
 
 * Menu:
@@ -14300,7 +14363,7 @@ File: hledger.info,  Node: Setting LEDGER_FILE,  Next: Setting opening balances,
 
 File: hledger.info,  Node: Set LEDGER_FILE on unix,  Next: Set LEDGER_FILE on mac,  Up: Setting LEDGER_FILE
 
-36.4.1 Set LEDGER_FILE on unix
+35.4.1 Set LEDGER_FILE on unix
 ------------------------------
 
 It depends on your shell, but running these commands in the terminal
@@ -14317,7 +14380,7 @@ $ source ~/.profile
 
 File: hledger.info,  Node: Set LEDGER_FILE on mac,  Next: Set LEDGER_FILE on Windows,  Prev: Set LEDGER_FILE on unix,  Up: Setting LEDGER_FILE
 
-36.4.2 Set LEDGER_FILE on mac
+35.4.2 Set LEDGER_FILE on mac
 -----------------------------
 
 In a terminal window, follow the unix procedure above.
@@ -14341,7 +14404,7 @@ In a terminal window, follow the unix procedure above.
 
 File: hledger.info,  Node: Set LEDGER_FILE on Windows,  Prev: Set LEDGER_FILE on mac,  Up: Setting LEDGER_FILE
 
-36.4.3 Set LEDGER_FILE on Windows
+35.4.3 Set LEDGER_FILE on Windows
 ---------------------------------
 
 It can be easier to create a default file at
@@ -14392,7 +14455,7 @@ other methods you may find online:
 
 File: hledger.info,  Node: Setting opening balances,  Next: Recording transactions,  Prev: Setting LEDGER_FILE,  Up: PART 5 COMMON TASKS
 
-36.5 Setting opening balances
+35.5 Setting opening balances
 =============================
 
 Pick a starting date for which you can look up the balances of some
@@ -14475,7 +14538,7 @@ $ git commit -m 'initial balances' 2023.journal
 
 File: hledger.info,  Node: Recording transactions,  Next: Reconciling,  Prev: Setting opening balances,  Up: PART 5 COMMON TASKS
 
-36.6 Recording transactions
+35.6 Recording transactions
 ===========================
 
 As you spend or receive money, you can record these transactions using
@@ -14501,7 +14564,7 @@ and hledger.org for more ideas:
 
 File: hledger.info,  Node: Reconciling,  Next: Reporting,  Prev: Recording transactions,  Up: PART 5 COMMON TASKS
 
-36.7 Reconciling
+35.7 Reconciling
 ================
 
 Periodically you should reconcile - compare your hledger-reported
@@ -14556,7 +14619,7 @@ $ git commit -m 'txns' 2023.journal
 
 File: hledger.info,  Node: Reporting,  Next: Migrating to a new file,  Prev: Reconciling,  Up: PART 5 COMMON TASKS
 
-36.8 Reporting
+35.8 Reporting
 ==============
 
 Here are some basic reports.
@@ -14704,7 +14767,7 @@ $ hledger activity -W
 
 File: hledger.info,  Node: Migrating to a new file,  Prev: Reporting,  Up: PART 5 COMMON TASKS
 
-36.9 Migrating to a new file
+35.9 Migrating to a new file
 ============================
 
 At the end of the year, you may want to continue your journal in a new
@@ -14717,7 +14780,7 @@ close command.
 
 File: hledger.info,  Node: BUGS,  Prev: PART 5 COMMON TASKS,  Up: Top
 
-37 BUGS
+36 BUGS
 *******
 
 We welcome bug reports in the hledger issue tracker
@@ -14746,7 +14809,7 @@ Ledger.
 
 File: hledger.info,  Node: Troubleshooting,  Up: BUGS
 
-37.1 Troubleshooting
+36.1 Troubleshooting
 ====================
 
 Here are some common issues you might encounter when you run hledger,
@@ -14784,451 +14847,452 @@ See hledger and Ledger for full details.
 
 Tag Table:
 Node: Top208
-Node: PART 1 USER INTERFACE4157
-Node: Input4296
-Node: Text encoding5388
-Node: Data formats6137
-Node: Standard input7871
-Node: Multiple files8260
-Node: Strict mode8997
-Node: Commands9831
-Node: Add-on commands11113
-Node: Options12164
-Node: Special characters20071
-Node: Escaping shell special characters21061
-Node: Escaping regular expression special characters22420
-Node: Escaping in other situations23935
-Node: Unicode characters25083
-Node: Regular expressions26504
-Node: hledger's regular expressions29853
-Node: Argument files31524
-Node: Config files32421
-Node: Shell completions35688
-Node: Output36177
-Node: Output destination36368
-Node: Output format36926
-Node: Text output38780
-Node: Box-drawing characters39764
-Node: Colour40264
-Node: Paging40850
-Node: HTML output42391
-Node: CSV / TSV output42809
-Node: FODS output43063
-Node: Ledger output44094
-Node: Beancount output44511
-Node: Beancount account names45968
-Node: Beancount commodity names46509
-Node: Beancount balance assignments47453
-Node: Beancount virtual postings47779
-Node: Beancount metadata48099
-Node: Beancount costs48879
-Node: Beancount tolerance49286
-Node: Beancount operating currency49650
-Node: SQL output50104
-Node: JSON output50895
-Node: Commodity styles51710
-Node: Debug output52720
-Node: Environment53552
-Node: PART 2 DATA FORMATS54721
-Node: Journal54864
-Node: Journal cheatsheet57376
-Node: Comments63627
-Node: Transactions64570
-Node: Dates65707
-Node: Simple dates65859
-Node: Posting dates66475
-Node: Status67648
-Node: Code69414
-Node: Description70033
-Node: Payee and note70720
-Node: Transaction comments71811
-Node: Postings72327
-Node: Debits and credits73643
-Node: Account names74202
-Node: Two space delimiter75159
-Node: Account hierarchy76564
-Node: Other account name features77447
-Node: Amounts77865
-Node: Decimal marks78871
-Node: Digit group marks79975
-Node: Commodity80610
-Node: Costs81713
-Node: Cost basis85430
-Node: Balance assertions86794
-Node: Assertions and ordering88050
-Node: Assertions and multiple files88769
-Node: Assertions and costs89937
-Node: Assertions and commodities90584
-Node: Assertions and subaccounts92243
-Node: Assertions and status92903
-Node: Assertions and virtual postings93323
-Node: Assertions and auto postings93688
-Node: Assertions and precision94563
-Node: Assertions and hledger add95047
-Node: Posting comments95795
-Node: Transaction balancing96335
-Node: Tags98543
-Node: Tag propagation100077
-Node: Displaying tags101576
-Node: When to use tags ?101969
-Node: Tag names102633
-Node: Tag values104673
-Node: Directives104989
-Node: account directive108534
-Node: Account comments109900
-Node: Account tags110487
-Node: Account error checking110963
-Node: Account display order112669
-Node: Account types113867
-Node: alias directive118051
-Node: Basic aliases119260
-Node: Regex aliases120135
-Node: Combining aliases121182
-Node: Aliases and multiple files122636
-Node: end aliases directive123400
-Node: Aliases can generate bad account names123768
-Node: Aliases and account types124601
-Node: comment directive125493
-Node: end comment directive125814
-Node: commodity directive126041
-Node: Commodity directive syntax127877
-Node: Commodity tags129413
-Node: Commodity aliases129945
-Node: Commodity error checking130979
-Node: decimal-mark directive131445
-Node: include directive132024
-Node: P directive134247
-Node: payee directive135281
-Node: tag directive135896
-Node: Periodic transactions136501
-Node: Periodic rule syntax138619
-Node: Periodic rules and relative dates139442
-Node: Two spaces between period expression and description!140219
-Node: Auto postings141180
-Node: Auto postings and multiple files144466
-Node: Auto postings and dates144871
-Node: Auto postings and transaction balancing / inferred amounts / balance assertions145312
-Node: Auto posting tags146158
-Node: Auto postings on forecast transactions only147053
-Node: Other syntax147523
-Node: Balance assignments148313
-Node: Balance assignments and costs149841
-Node: Balance assignments and multiple files150263
-Node: Bracketed posting dates150686
-Node: D directive151384
-Node: apply account directive153160
-Node: Y directive154027
-Node: Secondary dates155018
-Node: Star comments156503
-Node: Valuation expressions157195
-Node: Virtual postings157494
-Node: Other Ledger directives159118
-Node: Ledger virtual costs159876
-Node: Ledger cost basis160218
-Node: CSV161823
-Node: CSV rules cheatsheet164022
-Node: source166320
-Node: Data cleaning / data generating commands168134
-Node: archive170033
-Node: encoding171016
-Node: separator172059
-Node: skip172712
-Node: date-format173362
-Node: timezone174307
-Node: newest-first175433
-Node: intra-day-reversed176146
-Node: decimal-mark176748
-Node: CSV fields vs hledger fields177245
-Node: fields list178761
-Node: Field assignment180585
-Node: hledger field names182021
-Node: date field182520
-Node: date2 field182711
-Node: status field182914
-Node: code field183112
-Node: description field183308
-Node: comment field183533
-Node: account field184098
-Node: amount field184832
-Node: currency field187679
-Node: balance field188095
-Node: if188626
-Node: Matchers189957
-Node: Multiple matchers191829
-Node: Match groups192637
-Node: if table193530
-Node: balance-type195475
-Node: include196302
-Node: Working with CSV196871
-Node: Rapid feedback197460
-Node: Valid CSV198043
-Node: File Extension198919
-Node: Reading CSV from standard input199654
-Node: Reading multiple CSV files200040
-Node: Reading files specified by rule200516
-Node: Valid transactions201913
-Node: Deduplicating importing202738
-Node: Regular expressions in CSV rules203984
-Node: Setting amounts205476
-Node: Amount signs208014
-Node: Setting currency/commodity209079
-Node: Amount decimal places210455
-Node: Referencing other fields211712
-Node: How CSV rules are evaluated212820
-Node: Well factored rules215537
-Node: CSV rules examples216027
-Node: Bank of Ireland216225
-Node: Coinbase217822
-Node: Amazon219005
-Node: Paypal220847
-Node: Timeclock228597
-Node: Timedot232650
-Node: Timedot examples236684
-Node: PART 3 REPORTING CONCEPTS238764
-Node: Time periods238928
-Node: Report start & end date239189
-Node: Smart dates240665
-Node: Report intervals243036
-Node: Date adjustments243610
-Node: Start date adjustment243833
-Node: End date adjustment244736
-Node: Period expressions245517
-Node: Period expressions with a report interval247423
-Node: More complex report intervals247871
-Node: Multiple weekday intervals249987
-Node: Report titles250998
-Node: Depth252111
-Node: Combining depth options253098
-Node: Queries254048
-Node: Query types256750
-Node: acct query257139
-Node: amt query257450
-Node: code query258147
-Node: cur query258342
-Node: sym query259277
-Node: desc query259622
-Node: date query259805
-Node: date2 query260419
-Node: depth query260760
-Node: note query261096
-Node: payee query261364
-Node: real query261645
-Node: status query261850
-Node: type query262090
-Node: tag query262648
-Node: Negative queries263277
-Node: not query263459
-Node: Space-separated queries263746
-Node: Boolean queries264434
-Node: expr query265752
-Node: any query266432
-Node: all query266885
-Node: Queries and command options267467
-Node: Queries and account aliases267915
-Node: Queries and valuation268240
-Node: Pivoting268602
-Node: Generating data270909
-Node: Detecting special postings272740
-Node: Forecasting275797
-Node: --forecast276464
-Node: Inspecting forecast transactions277565
-Node: Forecast reports278898
-Node: Forecast tags280007
-Node: Forecast period in detail280627
-Node: Forecast troubleshooting281715
-Node: Budgeting282786
-Node: Amount formatting283346
-Node: Commodity display style283590
-Node: Rounding285431
-Node: Trailing decimal marks286036
-Node: Amount parseability286969
-Node: Cost reporting288578
-Node: Recording costs289409
-Node: Reporting at cost291136
-Node: Equity conversion postings291901
-Node: Inferring equity conversion postings294546
-Node: Combining costs and equity conversion postings295792
-Node: Requirements for detecting equity conversion postings297017
-Node: Infer cost and equity by default ?298584
-Node: Value reporting299021
-Node: -X Value in specified commodity299977
-Node: -V Value in default commoditys300837
-Node: Valuation date301574
-Node: Finding market price302406
-Node: --infer-market-prices market prices from transactions303786
-Node: Valuation commodity306830
-Node: --value Flexible valuation308263
-Node: Valuation examples310106
-Node: Interaction of valuation and queries312250
-Node: Effect of valuation on reports312967
-Node: Lot reporting320817
-Node: How to enable or disable lot tracking322742
-Node: First lots example323509
-Node: Lot concepts326226
-Node: Cost basis annotations326514
-Node: Lotful commodities and accounts327425
-Node: Lot subaccounts328059
-Node: Lot ids329964
-Node: Cost basis vs transacted cost330891
-Node: Lot movements332584
-Node: Acquire332940
-Node: Transfer334348
-Node: Dispose335373
-Node: Cost basis methods336271
-Node: Gain postings340145
-Node: Gain and UnrealisedGain accounts341470
-Node: Recording gains342805
-Node: Style 1 No gain postings343960
-Node: Style 2 rgain posting non-G account344229
-Node: Style 3 rgain posting G account345802
-Node: Style 4 rgain and ugain postings G and U accounts346213
-Node: Lot postings and balance assertions346722
-Node: Lot reporting example347729
-Node: PART 4 COMMANDS350593
-Node: Help commands353436
-Node: commands353622
-Node: demo353830
-Node: help354923
-Node: User interface commands356628
-Node: repl356839
-Node: Examples359103
-Node: run359661
-Node: Examples 2362076
-Node: ui363100
-Node: web363237
-Node: Data entry commands363365
-Node: add363626
-Node: add and balance assertions366830
-Node: add and balance assignments367407
-Node: import368265
-Node: Default import sources369797
-Node: Fetching new data first370797
-Node: Import dry run371274
-Node: Overlap detection372254
-Node: First import375140
-Node: Importing balance assignments376335
-Node: Import and commodity styles377390
-Node: Import archiving377824
-Node: Import special cases378864
-Node: Multiple journals in the same directory379161
-Node: Import configurations to avoid379859
-Node: Deduplication380835
-Node: Varying file name381365
-Node: Multiple versions381749
-Node: Basic report commands382856
-Node: accounts383157
-Node: codes385669
-Node: commodities386691
-Node: descriptions388471
-Node: files388931
-Node: notes389228
-Node: payees389740
-Node: prices390897
-Node: prices summary392321
-Node: stats393327
-Node: tags395411
-Node: Standard report commands397235
-Node: print397540
-Node: print explicitness400742
-Node: print layout401896
-Node: print amount style402944
-Node: print parseability404171
-Node: print other features405867
-Node: print output format406829
-Node: aregister410317
-Node: aregister and posting dates414844
-Node: register415745
-Node: Custom register output423466
-Node: balancesheet424651
-Node: balancesheetequity429616
-Node: cashflow434951
-Node: incomestatement439764
-Node: Advanced report commands444613
-Node: balance444821
-Node: balance features450331
-Node: Simple balance report452423
-Node: Balance report line format454233
-Node: Filtered balance report456729
-Node: List or tree mode457248
-Node: Depth limiting458761
-Node: Dropping top-level accounts459528
-Node: Showing declared accounts460038
-Node: Sorting by amount460768
-Node: Percentages461622
-Node: Multi-period balance report462329
-Node: Balance change end balance465081
-Node: Balance report modes466718
-Node: Calculation mode467397
-Node: Accumulation mode468469
-Node: Valuation mode469570
-Node: Combining balance report modes470914
-Node: Budget report472944
-Node: Using the budget report475252
-Node: Budget date surprises477528
-Node: Selecting budget goals478892
-Node: Budgeting vs forecasting479840
-Node: Balance report layout481517
-Node: Wide layout482722
-Node: Tall layout485127
-Node: Bare layout486433
-Node: Tidy layout488497
-Node: Balance report output490041
-Node: Some useful balance reports490815
-Node: roi492075
-Node: Spaces and special characters in --inv and --pnl494525
-Node: Semantics of --inv and --pnl495251
-Node: IRR and TWR explained497339
-Node: Chart commands500967
-Node: activity501148
-Node: Data generation commands501645
-Node: close501859
-Node: close --clopen505179
-Node: close --close507075
-Node: close --open507599
-Node: close --assert507849
-Node: close --assign508176
-Node: close --retain508855
-Node: close customisation509712
-Node: close and balance assertions511390
-Node: close examples513110
-Node: Retain earnings513347
-Node: Migrate balances to a new file513850
-Node: More detailed close examples515212
-Node: get515434
-Node: Phase 1 transactions data516040
-Node: Phase 2 prices516443
-Node: Merging new prices517447
-Node: get's helper scripts518251
-Node: getdata518542
-Node: getprices519054
-Node: rewrite520011
-Node: Re-write rules in a file523012
-Node: Diff output format524313
-Node: rewrite vs print --auto525583
-Node: Maintenance commands526297
-Node: check526516
-Node: Basic checks527599
-Node: Strict checks529067
-Node: Other checks530164
-Node: Custom checks532322
-Node: diff532761
-Node: setup533969
-Node: test536836
-Node: PART 5 COMMON TASKS537739
-Node: Getting help538188
-Node: Constructing command lines539089
-Node: Starting a journal file539954
-Node: Setting LEDGER_FILE541358
-Node: Set LEDGER_FILE on unix541646
-Node: Set LEDGER_FILE on mac542165
-Node: Set LEDGER_FILE on Windows542895
-Node: Setting opening balances544800
-Node: Recording transactions548142
-Node: Reconciling548887
-Node: Reporting551296
-Node: Migrating to a new file555430
-Node: BUGS555886
-Node: Troubleshooting556712
+Node: PART 1 USER INTERFACE4146
+Node: Input4285
+Node: Text encoding5377
+Node: Data formats6126
+Node: Standard input7860
+Node: Multiple files8249
+Node: Strict mode8986
+Node: Commands9820
+Node: Add-on commands11102
+Node: Options12153
+Node: Special characters20144
+Node: Escaping shell special characters21134
+Node: Escaping regular expression special characters22493
+Node: Escaping in other situations24008
+Node: Unicode characters25156
+Node: Regular expressions26577
+Node: hledger's regular expressions29926
+Node: Argument files31597
+Node: Config files32494
+Node: Command aliases33862
+Node: Config file troubleshooting36139
+Node: Shell completions37828
+Node: Output destination38357
+Node: Output format38942
+Node: Text output40781
+Node: Box-drawing characters41772
+Node: Colour42272
+Node: Paging˜42860
+Node: CSV / TSV output44710
+Node: FODS output44964
+Node: Ledger output45995
+Node: Beancount output46412
+Node: Beancount account names47869
+Node: Beancount commodity names48410
+Node: Beancount balance assignments49354
+Node: Beancount virtual postings49680
+Node: Beancount metadata50000
+Node: Beancount costs50780
+Node: Beancount tolerance51187
+Node: Beancount operating currency51551
+Node: SQL output52005
+Node: JSON output52796
+Node: Commodity styles53611
+Node: Debug output54622
+Node: Environment55457
+Node: PART 2 DATA FORMATS56627
+Node: Journal56770
+Node: Journal cheatsheet59282
+Node: Comments65533
+Node: Transactions66476
+Node: Dates67613
+Node: Simple dates67765
+Node: Posting dates68381
+Node: Status69554
+Node: Code71320
+Node: Description71939
+Node: Payee and note72626
+Node: Transaction comments73717
+Node: Postings74233
+Node: Debits and credits75549
+Node: Account names76108
+Node: Two space delimiter77065
+Node: Account hierarchy78470
+Node: Other account name features79353
+Node: Amounts79771
+Node: Decimal marks80777
+Node: Digit group marks81839
+Node: Commodity82474
+Node: Costs83577
+Node: Cost basis87294
+Node: Balance assertions88658
+Node: Assertions and ordering89949
+Node: Assertions and multiple files90668
+Node: Assertions and costs91836
+Node: Assertions and commodities92483
+Node: Assertions and subaccounts94142
+Node: Assertions and lot subaccounts94811
+Node: Assertions and status95826
+Node: Assertions and virtual postings96250
+Node: Assertions and auto postings96615
+Node: Assertions and precision97490
+Node: Assertions and hledger add97976
+Node: Posting comments98724
+Node: Transaction balancing99264
+Node: Tags101472
+Node: Tag propagation103006
+Node: Displaying tags104505
+Node: When to use tags ?104898
+Node: Tag names105562
+Node: Tag values107602
+Node: Directives107918
+Node: account directive111272
+Node: Account comments112638
+Node: Account tags113225
+Node: Account error checking113701
+Node: Account display order115407
+Node: Account types116605
+Node: alias directive120789
+Node: Basic aliases121998
+Node: Regex aliases122873
+Node: Combining aliases123920
+Node: Aliases and multiple files125374
+Node: end aliases directive126138
+Node: Aliases can generate bad account names126506
+Node: Aliases and account types127339
+Node: comment directive128231
+Node: end comment directive128552
+Node: commodity directive128779
+Node: Commodity directive syntax129772
+Node: Commodity tags131227
+Node: Commodity aliases131759
+Node: Commodity error checking132793
+Node: decimal-mark directive133259
+Node: include directive134039
+Node: P directive136262
+Node: payee directive137296
+Node: tag directive137911
+Node: Periodic transactions138516
+Node: Periodic rule syntax140634
+Node: Periodic rules and relative dates141457
+Node: Two spaces between period expression and description!142234
+Node: Auto postings143195
+Node: Auto postings and multiple files146481
+Node: Auto postings and dates146886
+Node: Auto postings and transaction balancing / inferred amounts / balance assertions147327
+Node: Auto posting tags148173
+Node: Auto postings on forecast transactions only149068
+Node: Other syntax149538
+Node: Balance assignments150328
+Node: Balance assignments and costs151856
+Node: Balance assignments and multiple files152278
+Node: Bracketed posting dates152701
+Node: D directive153399
+Node: apply account directive155175
+Node: Y directive156042
+Node: Secondary dates157033
+Node: Star comments158518
+Node: Valuation expressions159210
+Node: Virtual postings159509
+Node: Other Ledger directives161133
+Node: Ledger virtual costs161891
+Node: Ledger cost basis162233
+Node: CSV163838
+Node: CSV rules cheatsheet166037
+Node: source168335
+Node: Data cleaning / data generating commands170149
+Node: archive172048
+Node: encoding173038
+Node: separator174081
+Node: skip174734
+Node: date-format175384
+Node: timezone176329
+Node: newest-first177455
+Node: intra-day-reversed178168
+Node: decimal-mark178770
+Node: CSV fields vs hledger fields179267
+Node: fields list180783
+Node: Field assignment182607
+Node: hledger field names184043
+Node: date field184542
+Node: date2 field184733
+Node: status field184936
+Node: code field185134
+Node: description field185330
+Node: comment field185555
+Node: account field186120
+Node: amount field186854
+Node: currency field189701
+Node: balance field190117
+Node: if190648
+Node: Matchers191979
+Node: Multiple matchers193851
+Node: Match groups194659
+Node: if table195552
+Node: balance-type197497
+Node: include198324
+Node: Working with CSV198893
+Node: Rapid feedback199482
+Node: Valid CSV200065
+Node: File Extension200941
+Node: Reading CSV from standard input201676
+Node: Reading multiple CSV files202062
+Node: Reading files specified by rule202538
+Node: Valid transactions203935
+Node: Deduplicating importing204760
+Node: Regular expressions in CSV rules206006
+Node: Setting amounts207498
+Node: Amount signs210036
+Node: Setting currency/commodity211101
+Node: Amount decimal places212477
+Node: Referencing other fields213734
+Node: How CSV rules are evaluated214842
+Node: Well factored rules217559
+Node: CSV rules examples218049
+Node: Bank of Ireland218247
+Node: Coinbase219844
+Node: Amazon221027
+Node: Paypal222869
+Node: Timeclock230619
+Node: Timedot234670
+Node: Timedot examples238704
+Node: PART 3 REPORTING CONCEPTS240784
+Node: Time periods240948
+Node: Report start & end date241209
+Node: Smart dates242685
+Node: Report intervals245056
+Node: Date adjustments245630
+Node: Start date adjustment245853
+Node: End date adjustment246756
+Node: Period expressions247529
+Node: Period expressions with a report interval249435
+Node: More complex report intervals249883
+Node: Multiple weekday intervals251999
+Node: Report titles253010
+Node: Depth254123
+Node: Combining depth options255110
+Node: Queries256060
+Node: Query types258762
+Node: acct query259151
+Node: amt query259462
+Node: code query260159
+Node: cur query260354
+Node: sym query261289
+Node: desc query261634
+Node: date query261817
+Node: date2 query262431
+Node: depth query262772
+Node: note query263108
+Node: payee query263376
+Node: real query263657
+Node: status query263862
+Node: type query264102
+Node: tag query264660
+Node: Negative queries265289
+Node: not query265471
+Node: Space-separated queries265758
+Node: Boolean queries266446
+Node: expr query267764
+Node: any query268444
+Node: all query268897
+Node: Queries and command options269479
+Node: Queries and account aliases269927
+Node: Queries and valuation270252
+Node: Pivoting270614
+Node: Generating data272921
+Node: Detecting special postings274752
+Node: Forecasting277809
+Node: --forecast278476
+Node: Inspecting forecast transactions279577
+Node: Forecast reports280910
+Node: Forecast tags282019
+Node: Forecast period in detail282639
+Node: Forecast troubleshooting283727
+Node: Budgeting284798
+Node: Amount formatting285358
+Node: Commodity display style285602
+Node: Rounding287443
+Node: Trailing decimal marks288048
+Node: Amount parseability288911
+Node: Cost reporting290520
+Node: Recording costs291351
+Node: Reporting at cost293078
+Node: Equity conversion postings293843
+Node: Inferring equity conversion postings296488
+Node: Combining costs and equity conversion postings297734
+Node: Requirements for detecting equity conversion postings298959
+Node: Infer cost and equity by default ?300526
+Node: Value reporting300963
+Node: -X Value in specified commodity301919
+Node: -V Value in default commoditys302779
+Node: Valuation date303516
+Node: Finding market price304348
+Node: --infer-market-prices market prices from transactions305728
+Node: Valuation commodity308765
+Node: --value Flexible valuation310198
+Node: Valuation examples312041
+Node: Interaction of valuation and queries314185
+Node: Effect of valuation on reports314902
+Node: Lot reporting322752
+Node: How to enable or disable lot tracking324677
+Node: First lots example325444
+Node: Lot concepts328161
+Node: Cost basis annotations328449
+Node: Lotful commodities and accounts329360
+Node: Lot subaccounts329994
+Node: Lot ids331899
+Node: Cost basis vs transacted cost332826
+Node: Lot movements334519
+Node: Acquire334875
+Node: Transfer336283
+Node: Dispose337308
+Node: Cost basis methods338206
+Node: Gain postings342080
+Node: Gain and UnrealisedGain accounts343405
+Node: Recording gains344740
+Node: Style 1 No gain postings345895
+Node: Style 2 rgain posting non-G account346164
+Node: Style 3 rgain posting G account347737
+Node: Style 4 rgain and ugain postings G and U accounts348148
+Node: Lot postings and balance assertions348657
+Node: Lot reporting example349664
+Node: PART 4 COMMANDS352528
+Node: Help commands355371
+Node: commands355557
+Node: demo355765
+Node: help356858
+Node: User interface commands358563
+Node: repl358774
+Node: Examples361378
+Node: run361936
+Node: Examples 2364712
+Node: ui365736
+Node: web365873
+Node: Data entry commands366001
+Node: add366262
+Node: add and balance assertions369466
+Node: add and balance assignments370043
+Node: import370901
+Node: Default import sources372433
+Node: Fetching new data first373433
+Node: Import dry run373910
+Node: Overlap detection374890
+Node: First import377776
+Node: Importing balance assignments378971
+Node: Import and commodity styles380026
+Node: Import archiving380460
+Node: Import special cases381500
+Node: Multiple journals in the same directory381797
+Node: Import configurations to avoid382495
+Node: Deduplication383471
+Node: Varying file name384001
+Node: Multiple versions384385
+Node: Basic report commands385492
+Node: accounts385793
+Node: codes388305
+Node: commodities389327
+Node: descriptions391107
+Node: files391567
+Node: notes391864
+Node: payees392376
+Node: prices393533
+Node: prices summary394957
+Node: stats395963
+Node: tags398047
+Node: Standard report commands399871
+Node: print400176
+Node: print explicitness403451
+Node: print layout404605
+Node: print amount style405653
+Node: print parseability406880
+Node: print other features408576
+Node: print output format409747
+Node: aregister413235
+Node: aregister and posting dates417762
+Node: register418663
+Node: Custom register output426384
+Node: balancesheet427569
+Node: balancesheetequity432534
+Node: cashflow437869
+Node: incomestatement442682
+Node: Advanced report commands447531
+Node: balance447739
+Node: balance features453249
+Node: Simple balance report455341
+Node: Balance report line format457151
+Node: Filtered balance report459647
+Node: List or tree mode460166
+Node: Depth limiting461679
+Node: Dropping top-level accounts462446
+Node: Showing declared accounts462956
+Node: Sorting by amount463686
+Node: Percentages464540
+Node: Multi-period balance report465247
+Node: Balance change end balance467999
+Node: Balance report modes469636
+Node: Calculation mode470315
+Node: Accumulation mode471387
+Node: Valuation mode472488
+Node: Combining balance report modes473832
+Node: Budget report475862
+Node: Using the budget report478170
+Node: Budget date surprises480446
+Node: Selecting budget goals481810
+Node: Budgeting vs forecasting482758
+Node: Balance report layout484435
+Node: Wide layout485640
+Node: Tall layout488045
+Node: Bare layout489351
+Node: Tidy layout491415
+Node: Balance report output492959
+Node: Some useful balance reports493733
+Node: roi494993
+Node: Spaces and special characters in --inv and --pnl497443
+Node: Semantics of --inv and --pnl498169
+Node: IRR and TWR explained500257
+Node: Chart commands503885
+Node: activity504066
+Node: Data generation commands504563
+Node: close504777
+Node: close --clopen508097
+Node: close --close509993
+Node: close --open510517
+Node: close --assert510767
+Node: close --assign511094
+Node: close --retain511773
+Node: close customisation512630
+Node: close and balance assertions514308
+Node: close examples516028
+Node: Retain earnings516265
+Node: Migrate balances to a new file516768
+Node: More detailed close examples518130
+Node: get518352
+Node: Phase 1 transactions data518958
+Node: Phase 2 prices519361
+Node: Merging new prices520365
+Node: get's helper scripts521169
+Node: getdata521460
+Node: getprices521972
+Node: rewrite522929
+Node: Re-write rules in a file525930
+Node: Diff output format527231
+Node: rewrite vs print --auto528501
+Node: Maintenance commands529215
+Node: check529434
+Node: Basic checks530517
+Node: Strict checks531985
+Node: Other checks533082
+Node: Custom checks535240
+Node: diff535679
+Node: setup536887
+Node: test539754
+Node: PART 5 COMMON TASKS540657
+Node: Getting help541106
+Node: Constructing command lines542007
+Node: Starting a journal file542872
+Node: Setting LEDGER_FILE544276
+Node: Set LEDGER_FILE on unix544564
+Node: Set LEDGER_FILE on mac545083
+Node: Set LEDGER_FILE on Windows545813
+Node: Setting opening balances547718
+Node: Recording transactions551060
+Node: Reconciling551805
+Node: Reporting554214
+Node: Migrating to a new file558348
+Node: BUGS558804
+Node: Troubleshooting559630
 
 End Tag Table
 

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -608,6 +608,7 @@ With this in your config file, you'll see a `rev10` command in the `hledger comm
 and `hledger rev10` will run the balance command above.
 Options or arguments written at the command line will be added at the end, usually overriding those in the alias;
 eg `hledger rev10 -X €` will convert to `€` instead of `$`.
+Command aliases can also be used in `run` command scripts and at the `repl` prompt.
 
 Each line in an `[alias]` section should look like `NAME = COMMAND [ARGS..]`.
 Or, you can define a single alias with an `[alias NAME]` section,
@@ -631,11 +632,24 @@ If the same alias name is defined more than once, the last definition wins.
 An alias's command can be a hledger builtin command, addon command, or another alias.
 If there's a `[COMMAND]` options section for an alias's resolved builtin command, that will also be applied.
 
-Command aliases can also be used in `run` command scripts and at the `repl` prompt.
+Or if an alias's command line begins with `!`, the rest is run as a shell command
+(with any extra command line arguments appended). Eg:
+
+```conf
+[alias]
+git-commit = ! git commit -p
+jj-commit  = ! jj commit -i
+```
+
+For safety, shell command aliases run only if defined in a trusted config file:
+one you gave explicitly with `--conf`, or your user config file (`~/.hledger.conf`
+or the XDG `hledger.conf`). Shell commands in a nearby automatically-found `hledger.conf`,
+in the current directory or a parent directory, will not run - this prevents a config file
+from an untrusted downloaded or shared directory from running arbitrary shell commands.
 
 ### Config file troubleshooting
 
-There aren't many hledger features that need a warning, but here is one!\
+There aren't many hledger features that need a warning, but this is one !\
 A default config file (the kind that hledger runs automatically, without needing a --conf option)
 is very convenient. But, it complicates command line processing and can surprise you -
 eg quietly changing report output, or breaking your hledger-using scripts/applications,

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -576,17 +576,6 @@ And here is a commented starter config file:
 
 You can put not only options, but also arguments in a config file.
 
-As a special case, if the first word in a config file's top (general options) section
-does not begin with a dash (`-`), it is treated as the command to run,
-overriding any command argument on the command line.
-
-On unix machines, you can add a shebang line at the top of a config file, 
-make the file executable with `chmod +x FILE`, and use it like a script.
-Eg (the `-S` is needed on some operating systems):
-```
-#!/usr/bin/env -S hledger --conf
-```
-
 You can ignore all config files by adding the `-n`/`--no-conf` flag to the command line.
 This is recommended when using hledger in scripts.
 When both `--conf` and `--no-conf` options are used, the right-most wins.

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -546,76 +546,117 @@ $ hledger bal @cash.args
 ```
 
 
-
-
 ## Config files
 
-With hledger 1.40+, you can save extra command line options and arguments
-in a more featureful hledger config file. Here's a small example:
+You can configure default command line options and arguments conveniently in a hledger config file.
+(Since 1.40.)
+Config file options will be inserted near the start of your command line,
+so you can override them with command line options.
+
+You can specify a config file with the `--conf` option.
+Otherwise, hledger will search for a default config file, in this order:
+
+- `hledger.conf` in the current directory or above
+- `.hledger.conf` in your home directory
+- `hledger.conf` in your XDG config (`~/.config/hledger/hledger.conf`).
+
+Only one config file is used. Here's a small example:
 
 ```conf
-# General options are listed first, and used with hledger commands that support them.
+# General options, used with all hledger commands that support them.
 --pretty
 
-# Options following a `[COMMAND]` heading are used with that hledger command only.
+# Command-specific options.
 [print]
 --explicit --infer-costs
 ```
 
-To use a config file, specify it with the `--conf` option.
-Its options will be inserted near the start of your command line,
-so you can override them with command line options if needed.
-
-Or, you can set up an automatic config file that is used whenever you run hledger,
-by creating `hledger.conf` in the current directory or above,
-or `.hledger.conf` in your home directory (`~/.hledger.conf`),
-or `hledger.conf` in your XDG config directory (`~/.config/hledger/hledger.conf`).
-
-Here is another example config you could start with:
+And here is a commented starter config file:
 <https://github.com/simonmichael/hledger/blob/main/hledger.conf.sample>
 
 You can put not only options, but also arguments in a config file.
-If the first word in a config file's top (general) section does not begin with a dash
-(eg: `print`), it is treated as the command argument
-(overriding any argument on the command line).
 
-On unix machines, you can add a shebang line at the top of a config file, set executable permission on the file, and use it like a script.
+As a special case, if the first word in a config file's top (general options) section
+does not begin with a dash (`-`), it is treated as the command to run,
+overriding any command argument on the command line.
+
+On unix machines, you can add a shebang line at the top of a config file, 
+make the file executable with `chmod +x FILE`, and use it like a script.
 Eg (the `-S` is needed on some operating systems):
 ```
 #!/usr/bin/env -S hledger --conf
 ```
 
-You can ignore config files by adding the `-n`/`--no-conf` flag to the command line.
-This is useful when using hledger in scripts, or when troubleshooting.
+You can ignore all config files by adding the `-n`/`--no-conf` flag to the command line.
+This is recommended when using hledger in scripts.
 When both `--conf` and `--no-conf` options are used, the right-most wins.
 
-To inspect the processing of config files, use `--debug` or `--debug=8`.
-Or, run the `setup` command, which will display any active config files.
-(`setup` is not affected by config files itself, unlike other commands.)
+### Command aliases
 
-**Warning!**
+In a config file you can also define command aliases: your own custom commands,
+which expand to a longer command line (similar to git's aliases). (Since 1.99.4.)
+Eg:
 
-There aren't many hledger features that need a warning, but this is one!
+```conf
+[alias]
+p     = print
+p1    = print --oneline
+rev10 = balance type:R -2 -X$ -p 'every 10 years from 2000'
+```
 
-Automatic config files, while convenient, also make hledger less predictable and dependable.
-It's easy to make a config file that changes a report's behaviour,
-or breaks your hledger-using scripts/applications,
-in ways that will surprise you later.
+With this in your config file, you'll see a `rev10` command in the `hledger commands` list,
+and `hledger rev10` will run the balance command above.
+Options or arguments written at the command line will be added at the end, usually overriding those in the alias;
+eg `hledger rev10 -X €` will convert to `€` instead of `$`.
 
-If you don't want this,
+Each line in an `[alias]` section should look like `NAME = COMMAND [ARGS..]`.
+Or, you can define a single alias with an `[alias NAME]` section,
+writing its command line below it, on one or more lines.
+This form can be easier to read, and lets you comment out individual lines. Eg:
 
-1. Just don't create a hledger.conf file on your machine.
-2. Also be alert to downloaded directories which may contain a hledger.conf file.
-3. Also if you are sharing scripts or examples or support, consider that others may have a hledger.conf file.
+```conf
+[alias rev10]
+balance
+type:R
+-2
+-X$
+-p 'every 10 years from 2000'
+# --drop 1
+```
 
-Conversely, once you decide to use this feature, try to remember:
+Command aliases override addon commands with the same name,
+but they can't override builtin command names or abbreviations like `balance` or `bal`.
+If the same alias name is defined more than once, the last definition wins.
 
-1. Whenever a hledger command does not work as expected, try it again with `-n` (`--no-conf`) to see if a config file was to blame.
-2. Whenever you call hledger from a script, consider whether that call should use `-n` or not.
-3. Be conservative about what you put in your config file; try to consider the effect on all your reports.
-4. To troubleshoot the effect of config files, run with `--debug` or `--debug 8`.
+An alias's command can be a hledger builtin command, addon command, or another alias.
+If there's a `[COMMAND]` options section for an alias's resolved builtin command, that will also be applied.
 
-The config file feature was added in hledger 1.40.
+### Config file troubleshooting
+
+There aren't many hledger features that need a warning, but here is one!\
+A default config file (the kind that hledger runs automatically, without needing a --conf option)
+is very convenient. But, it complicates command line processing and can surprise you -
+eg quietly changing report output, or breaking your hledger-using scripts/applications,
+which you might not notice until much later.
+
+This mainly arises when you are first using config files.
+And once you discover this kind of problem, it will be easy to fix.
+Here are some tips:
+
+1. Be mindful about what you put in your config file; consider the effect on all your reports.
+2. If a hledger command isn't doing what you expect, try it again with `-n`, to see if a config file is to blame.
+3. Run `hledger setup` to list the currently active config file. (`setup` is not affected by config files.)
+4. Add `--debug` or `--debug=8` to any command to see config/command line debug output.
+
+When you are writing scripts, or sharing examples with other people,
+keep in mind that there could be a config file changing hledger's behaviour,
+so you might want to add `-n` to make your hledger commands more robust.
+
+If you prefer to just avoid this feature:
+
+- Don't use a default config file.
+- If you download hledger data from elsewhere, watch out for directories containing a hledger.conf file.
+- If you're feeling paranoid, use the `-n/--no-conf` flag always, eg by running hledger via a script or alias.
 
 ## Shell completions
 
@@ -623,7 +664,7 @@ If you use the bash or zsh shells, you can optionally set up context-sensitive a
 Try pressing `hledger<SPACE><TAB><TAB>` (should list all hledger commands)
 or `hledger reg acct:<TAB><TAB>` (should list your top-level account names).
 If completions aren't working, or for more details, see [Install > Shell completions](install.html#shell-completions).
-
+˜
 # Output
 
 ## Output destination
@@ -738,7 +779,7 @@ You can override this by setting the `NO_COLOR` environment variable to disable 
 or by using the `--color/--colour` option, perhaps in your config file,
 with a `y`/`yes` or `n`/`no` value to force it on or off.
 
-#### Paging
+#### Paging˜
 
 In unix-like environments, when displaying large output (in any output format) in the terminal,
 hledger tries to use a pager when appropriate.
@@ -773,8 +814,8 @@ and when colour output is enabled:
 
 You can prevent this by setting your preferred options in the `HLEDGER_LESS` variable, which will be used instead of `LESS`.
 
-
-### HTML output
+˜
+### HTML output˜˜
 
 HTML output can be styled by an optional `hledger.css` file in the same directory.
 
@@ -5477,7 +5518,7 @@ For example, if the journal's last transaction is on february 20th,
 - `hledger register --monthly --end 2/14` also will end the report at the end of february (overriding the requested end date).
 - `hledger register --monthly --begin 1/5 --end 2/14` will end the report on march 4th [1].
 
-[1] Since hledger 1.29.
+[1] Since 1.29.
 
 ## Period expressions
 
@@ -6676,7 +6717,7 @@ To be safe, specify the valuation commmodity, eg:
 - `--value=then,EUR --infer-market-prices`, not `--value=then --infer-market-prices`
 
 Signed costs and market prices can be confusing.
-For reference, here is the current behaviour, since hledger 1.25.
+For reference, here is the current behaviour (since 1.25).
 (If you think it should work differently, see [#1870](https://github.com/simonmichael/hledger/issues/1870).)
 
 ```journal

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -631,6 +631,8 @@ If the same alias name is defined more than once, the last definition wins.
 An alias's command can be a hledger builtin command, addon command, or another alias.
 If there's a `[COMMAND]` options section for an alias's resolved builtin command, that will also be applied.
 
+Command aliases can also be used in `run` command scripts and at the `repl` prompt.
+
 ### Config file troubleshooting
 
 There aren't many hledger features that need a warning, but here is one!\

--- a/hledger/hledger.txt
+++ b/hledger/hledger.txt
@@ -632,90 +632,135 @@ Options
             $ hledger bal @cash.args
 
    Config files
-     With hledger 1.40+, you can save extra command line options  and  arguments
-     in a more featureful hledger config file.  Here's a small example:
+     You can configure default command line options and  arguments  conveniently
+     in  a  hledger config file.  (Since 1.40.)  Config file options will be in-
+     serted near the start of your command line, so you can override  them  with
+     command line options.
 
-            # General options are listed first, and used with hledger commands that support them.
+     You  can  specify a config file with the --conf option.  Otherwise, hledger
+     will search for a default config file, in this order:
+
+     * hledger.conf in the current directory or above
+
+     * .hledger.conf in your home directory
+
+     * hledger.conf in your XDG config (~/.config/hledger/hledger.conf).
+
+     Only one config file is used.  Here's a small example:
+
+            # General options, used with all hledger commands that support them.
             --pretty
 
-            # Options following a `[COMMAND]` heading are used with that hledger command only.
+            # Command-specific options.
             [print]
             --explicit --infer-costs
 
-     To  use a config file, specify it with the --conf option.  Its options will
-     be inserted near the start of your command line, so you can  override  them
-     with command line options if needed.
+     And here is a  commented  starter  config  file:  https://github.com/simon-
+     michael/hledger/blob/main/hledger.conf.sample
 
-     Or,  you  can set up an automatic config file that is used whenever you run
-     hledger, by creating hledger.conf in the current  directory  or  above,  or
-     .hledger.conf  in your home directory (~/.hledger.conf), or hledger.conf in
-     your XDG config directory (~/.config/hledger/hledger.conf).
+     You can put not only options, but also arguments in a config file.
 
-     Here is another example config you could start with: https://github.com/si-
-     monmichael/hledger/blob/main/hledger.conf.sample
+     You can ignore all config files by adding the -n/--no-conf flag to the com-
+     mand  line.   This is recommended when using hledger in scripts.  When both
+     --conf and --no-conf options are used, the right-most wins.
 
-     You can put not only options, but also arguments in a config file.  If  the
-     first  word  in a config file's top (general) section does not begin with a
-     dash (eg: print), it is treated as the command argument (overriding any ar-
-     gument on the command line).
+   Command aliases
+     In a config file you can also define command aliases: your own custom  com-
+     mands,  which  expand  to a longer command line (similar to git's aliases).
+     (Since 1.99.4.)  Eg:
 
-     On unix machines, you can add a shebang line at the top of a  config  file,
-     set  executable  permission on the file, and use it like a script.  Eg (the
-     -S is needed on some operating systems):
+            [alias]
+            p     = print
+            p1    = print --oneline
+            rev10 = balance type:R -2 -X$ -p 'every 10 years from 2000'
 
-            #!/usr/bin/env -S hledger --conf
+     With this in your config file, you'll see a rev10 command  in  the  hledger
+     commands  list,  and hledger rev10 will run the balance command above.  Op-
+     tions or arguments written at the command line will be added  at  the  end,
+     usually  overriding  those in the alias; eg hledger rev10 -X a will convert
+     to a instead of $.  Command aliases can also be used in run command scripts
+     and at the repl prompt.
 
-     You can ignore config files by adding the -n/--no-conf flag to the  command
-     line.   This is useful when using hledger in scripts, or when troubleshoot-
-     ing.  When both --conf and --no-conf options are used, the right-most wins.
+     Each line in an [alias] section should look like NAME =  COMMAND  [ARGS..].
+     Or, you can define a single alias with an [alias NAME] section, writing its
+     command  line  below  it, on one or more lines.  This form can be easier to
+     read, and lets you comment out individual lines.  Eg:
 
-     To inspect the processing of config files, use --debug or  --debug=8.   Or,
-     run  the setup command, which will display any active config files.  (setup
-     is not affected by config files itself, unlike other commands.)
+            [alias rev10]
+            balance
+            type:R
+            -2
+            -X$
+            -p 'every 10 years from 2000'
+            # --drop 1
 
-     Warning!
+     Command aliases override addon commands with the same name, but they  can't
+     override  builtin  command  names or abbreviations like balance or bal.  If
+     the same alias name is defined more than once, the last definition wins.
 
-     There aren't many hledger features that need a warning, but this is one!
+     An alias's command can be a hledger builtin command, addon command, or  an-
+     other  alias.   If  there's  a [COMMAND] options section for an alias's re-
+     solved builtin command, that will also be applied.
 
-     Automatic config files, while  convenient,  also  make  hledger  less  pre-
-     dictable  and  dependable.   It's easy to make a config file that changes a
-     report's behaviour, or breaks your hledger-using  scripts/applications,  in
-     ways that will surprise you later.
+     Or if an alias's command line begins with !, the rest is  run  as  a  shell
+     command (with any extra command line arguments appended).  Eg:
 
-     If you don't want this,
+            [alias]
+            git-commit = ! git commit -p
+            jj-commit  = ! jj commit -i
 
-     1. Just don't create a hledger.conf file on your machine.
+     For  safety,  shell command aliases run only if defined in a trusted config
+     file: one you gave  explicitly  with  --conf,  or  your  user  config  file
+     (~/.hledger.conf  or the XDG hledger.conf).  Shell commands in a nearby au-
+     tomatically-found hledger.conf, in the current directory or a parent direc-
+     tory, will not run - this prevents a config file from  an  untrusted  down-
+     loaded or shared directory from running arbitrary shell commands.
 
-     2. Also be alert to downloaded directories which may contain a hledger.conf
-        file.
+   Config file troubleshooting
+     There aren't many hledger features that need a warning, but this is one !
+     A  default  config  file (the kind that hledger runs automatically, without
+     needing a --conf option) is very convenient.  But, it  complicates  command
+     line  processing  and can surprise you - eg quietly changing report output,
+     or breaking your hledger-using scripts/applications, which  you  might  not
+     notice until much later.
 
-     3. Also  if  you  are sharing scripts or examples or support, consider that
-        others may have a hledger.conf file.
+     This  mainly  arises  when  you are first using config files.  And once you
+     discover this kind of problem, it will be easy to fix.  Here are some tips:
 
-     Conversely, once you decide to use this feature, try to remember:
+     1. Be mindful about what you put in your config file; consider  the  effect
+        on all your reports.
 
-     1. Whenever a hledger command does not work as expected, try it again  with
-        -n (--no-conf) to see if a config file was to blame.
+     2. If  a hledger command isn't doing what you expect, try it again with -n,
+        to see if a config file is to blame.
 
-     2. Whenever  you  call  hledger  from  a script, consider whether that call
-        should use -n or not.
+     3. Run hledger setup to list the currently active config file.   (setup  is
+        not affected by config files.)
 
-     3. Be conservative about what you put in your config file; try to  consider
-        the effect on all your reports.
+     4. Add --debug or --debug=8 to any command to see config/command line debug
+        output.
 
-     4. To  troubleshoot the effect of config files, run with --debug or --debug
-        8.
+     When  you  are writing scripts, or sharing examples with other people, keep
+     in mind that there could be a config file changing hledger's behaviour,  so
+     you might want to add -n to make your hledger commands more robust.
 
-     The config file feature was added in hledger 1.40.
+     If you prefer to just avoid this feature:
+
+     * Don't use a default config file.
+
+     * If  you  download  hledger data from elsewhere, watch out for directories
+       containing a hledger.conf file.
+
+     * If you're feeling paranoid, use the -n/--no-conf flag always, eg by  run-
+       ning hledger via a script or alias.
 
    Shell completions
      If you use the bash or zsh shells, you can optionally set up context-sensi-
-     tive   autocompletion   for   hledger   command   lines.    Try    pressing
-     hledger<SPACE><TAB><TAB>  (should list all hledger commands) or hledger reg
+     tive    autocompletion   for   hledger   command   lines.    Try   pressing
+     hledger<SPACE><TAB><TAB> (should list all hledger commands) or hledger  reg
      acct:<TAB><TAB> (should list your top-level account names).  If completions
-     aren't working, or for more details, see Install > Shell completions.
+     aren't  working, or for more details, see Install > Shell completions.  E #
+     Output
 
-Output
    Output destination
      hledger commands send their output to the terminal by default.  You can  of
      course redirect this, eg into a file, using standard shell syntax:
@@ -798,7 +843,7 @@ Output
      able  it,  or  by using the --color/--colour option, perhaps in your config
      file, with a y/yes or n/no value to force it on or off.
 
-   Paging
+   PagingE
      In unix-like environments, when displaying large output (in any output for-
      mat) in the terminal, hledger tries to use a pager when appropriate.   (You
      can disable this with the --pager=no option, perhaps in your config file.)
@@ -831,7 +876,8 @@ Output
      You  can prevent this by setting your preferred options in the HLEDGER_LESS
      variable, which will be used instead of LESS.
 
-   HTML output
+     E ### HTML outputEE
+
      HTML output can be styled by an optional hledger.css file in the  same  di-
      rectory.
 
@@ -1550,25 +1596,20 @@ Journal
      hledger  by  default  assumes  it is a decimal mark, and will parse both of
      those as 1.
 
-     To help hledger parse such ambiguous numbers more accurately,  if  you  use
-     digit group marks, we recommend declaring the decimal mark explicitly.  The
-     best  way  is to add a decimal-mark directive at the top of each data file,
-     like this:
-
-            decimal-mark .
-
-     Or you can declare it per commodity with  commodity  directives,  described
-     below.
+     To help hledger parse such ambiguous numbers accurately, if you  use  digit
+     group  marks,  we recommend declaring the decimal mark explicitly.  You can
+     declare it per commodity with commodity directives, or per file with a dec-
+     imal-mark directive at the top of each journal file (described below).
 
      hledger also accepts numbers like 10. with no digits after the decimal mark
-     (and  will  sometimes  display  numbers that way to disambiguate them - see
+     (and will sometimes display numbers that way to  disambiguate  them  -  see
      Trailing decimal marks).
 
    Digit group marks
-     In the integer part of the amount quantity  (left  of  the  decimal  mark),
-     groups  of  digits  can  optionally  be separated by a digit group mark - a
-     comma or period (whichever is not used as decimal mark), or a  space  (sev-
-     eral  Unicode space variants, like no-break space, are also accepted).   So
+     In  the  integer  part  of  the amount quantity (left of the decimal mark),
+     groups of digits can optionally be separated by a  digit  group  mark  -  a
+     comma  or  period (whichever is not used as decimal mark), or a space (sev-
+     eral Unicode space variants, like no-break space, are also accepted).    So
      these are all valid amounts in a journal file:
 
                  $1,000,000.00
@@ -1578,30 +1619,30 @@ Journal
                   1 000 000.00   ; <- no-break space
 
    Commodity
-     Amounts in hledger have both a "quantity", which is a signed  decimal  num-
-     ber,  and  a  "commodity", which is a currency symbol, stock ticker, or any
+     Amounts  in  hledger have both a "quantity", which is a signed decimal num-
+     ber, and a "commodity", which is a currency symbol, stock  ticker,  or  any
      word or phrase describing something you are tracking.
 
-     If the commodity name contains non-letters (spaces,  numbers,  or  punctua-
-     tion),  you  must  always  write  it  inside double quotes ("green apples",
+     If  the  commodity  name contains non-letters (spaces, numbers, or punctua-
+     tion), you must always write  it  inside  double  quotes  ("green  apples",
      "ABC123").
 
-     If you write just a bare number, that too will have a commodity, with  name
+     If  you write just a bare number, that too will have a commodity, with name
      ""; we call that the "no-symbol commodity".
 
-     Actually,  hledger combines these single-commodity amounts into more power-
+     Actually, hledger combines these single-commodity amounts into more  power-
      ful multi-commodity amounts, which are what it works with most of the time.
-     A multi-commodity amount could be, eg: 1 USD, 2 EUR, 3.456 TSLA.  In  prac-
-     tice,  you  will  only see multi-commodity amounts in hledger's output; you
+     A  multi-commodity amount could be, eg: 1 USD, 2 EUR, 3.456 TSLA.  In prac-
+     tice, you will only see multi-commodity amounts in  hledger's  output;  you
      can't write them directly in the journal file.
 
-     By default, the format of amounts in the  journal  influences  how  hledger
-     displays  them in output.  This is explained in Commodity display style be-
+     By  default,  the  format  of amounts in the journal influences how hledger
+     displays them in output.  This is explained in Commodity display style  be-
      low.
 
    Costs
-     In traditional double entry bookkeeping, to record a transaction where  one
-     commodity  is  exchanged for another, you add extra equity postings to bal-
+     In  traditional double entry bookkeeping, to record a transaction where one
+     commodity is exchanged for another, you add extra equity postings  to  bal-
      ance the two commodities.  Eg:
 
             2026-01-01 buy euros
@@ -1610,10 +1651,10 @@ Journal
               equity:conversion  a-100
               assets:euros        a100
 
-     hledger offers a more convenient notation: instead of equity postings,  you
-     can  write  @  UNITPRICE or @@ TOTALPRICE after a posting amount, recording
-     the transacted price or conversion rate.  (hledger  docs  generically  call
-     this  a  "cost",  whether buying or selling, though "cost" is an overloaded
+     hledger  offers a more convenient notation: instead of equity postings, you
+     can write @ UNITPRICE or @@ TOTALPRICE after a  posting  amount,  recording
+     the  transacted  price  or conversion rate.  (hledger docs generically call
+     this a "cost", whether buying or selling, though "cost"  is  an  overloaded
      word.  "Transacted cost" or "transacted price" is more precise.)
 
      So you could write the above as:
@@ -1628,12 +1669,12 @@ Journal
               assets:dollars     $-123
               assets:euros        a100 @@ $123    ; total cost
 
-     The cost should normally be a positive amount.   Negative  costs  are  sup-
+     The  cost  should  normally  be a positive amount.  Negative costs are sup-
      ported, but can be confusing, as discussed at --infer-market-prices: market
      prices from transactions.
 
      Costs participate in transaction balancing.  Amounts are converted to their
-     cost  before checking if the transaction is balanced.  You could also write
+     cost before checking if the transaction is balanced.  You could also  write
      the above less redundantly, like so:
 
             2026-01-01 buy euros
@@ -1652,26 +1693,26 @@ Journal
               assets:euros        a100            ;  @@ $123 is inferred
               assets:dollars     $-123
 
-     This last form works for transactions involving  exactly  two  commodities,
-     with  neither cost notation nor equity postings.  If one of the postings is
+     This  last  form  works for transactions involving exactly two commodities,
+     with neither cost notation nor equity postings.  If one of the postings  is
      recognised as a lot posting, the cost will be attached to that one.  Other-
-     wise the cost will be attached to the first (top) posting - so  it  can  be
-     important  to  but the right one first.  Here we had to switch the order of
+     wise  the  cost  will be attached to the first (top) posting - so it can be
+     important to but the right one first.  Here we had to switch the  order  of
      postings, to get the same meaning as above.
 
-     This form is the easiest to make undetected errors with; so it is  rejected
+     This  form is the easiest to make undetected errors with; so it is rejected
      by hledger check balanced, and by strict mode.
 
      Advantages of cost notation:
 
      1. it's more compact and easier to read and write
 
-     2. hledger  reports can show such amounts converted to their cost, when you
+     2. hledger reports can show such amounts converted to their cost, when  you
         add the -B/--cost flag (see Cost reporting).
 
      Advantages of equity postings
 
-     1. they help to keep the accounting equation balanced (if  you  care  about
+     1. they  help  to  keep the accounting equation balanced (if you care about
         that)
 
      2. they translate easily to any other double entry accounting system.
@@ -1681,12 +1722,12 @@ Journal
      But you can always convert cost notation to equity postings by adding --in-
      fer-equity.  Eg try hledger print -x --infer-equity.
 
-     And  you  can  usually  convert  equity postings to cost notation by adding
-     --infer-costs (see Requirements for detecting equity conversion  postings).
+     And you can usually convert equity postings  to  cost  notation  by  adding
+     --infer-costs  (see Requirements for detecting equity conversion postings).
      Eg try hledger print -x --infer-costs.
 
-     Finally:  using  both equity postings and cost notation at the same time is
-     allowed, as long as the journal entry is well formed such that  the  equity
+     Finally: using both equity postings and cost notation at the same  time  is
+     allowed,  as  long as the journal entry is well formed such that the equity
      postings / cost equivalences can be detected.  (Otherwise you'll get an er-
      ror message saying that the transaction is unbalanced.):
 
@@ -1696,18 +1737,18 @@ Journal
               equity:conversion  a-100
               assets:euros        a100 @ $1.23
 
-     So  in  principle you could enable both --infer-equity and --infer-costs in
+     So in principle you could enable both --infer-equity and  --infer-costs  in
      your config file, and your reports would have the advantages of both.
 
    Cost basis
      This section briefly describes the {} cost basis syntax, used to record the
-     nominal cost of an investment being  acquired,  or  to  select  lots  being
-     transfered  or disposed.  This is described in more detail later in Lot re-
+     nominal  cost  of  an  investment  being  acquired, or to select lots being
+     transfered or disposed.  This is described in more detail later in Lot  re-
      porting.  If you're not tracking investment lots and capital gains, you can
      skip this.
 
-     hledger's cost basis annotations  look  like  Beancount's:  comma-separated
-     parts  enclosed  in curly braces, after an amount.  All parts are optional,
+     hledger's  cost  basis  annotations  look like Beancount's: comma-separated
+     parts enclosed in curly braces, after an amount.  All parts  are  optional,
      but when present they must be in this order:
 
      1. a date, in YYYY-MM-DD format
@@ -1724,25 +1765,25 @@ Journal
             {$50}
             {}
 
-     This means: selling 10 AAPL, originally purchased  at  $50  each,  for  $60
+     This  means:  selling  10  AAPL,  originally purchased at $50 each, for $60
      each:
 
             -10 AAPL {$50} @ $60
 
      Note the preferred order is to write {} before @, as shown.
 
-     hledger  can  also  read  Ledger's  cost basis syntax.  Here, the parts are
+     hledger can also read Ledger's cost basis  syntax.   Here,  the  parts  are
      written separately, in any order, with different enclosing characters:
 
             10 AAPL {$50} [2026-01-15] (12:05)
 
-     If a Ledger-style label annotation contains double  quotes,  they  will  be
+     If  a  Ledger-style  label  annotation contains double quotes, they will be
      stripped (("foo") is read as label foo).
 
    Balance assertions
-     hledger  supports  Ledger-style balance assertions in journal files.  These
+     hledger supports Ledger-style balance assertions in journal  files.   These
      look like, for example, = EXPECTEDBALANCE following a posting's amount.  Eg
-     here we assert the expected dollar balance in accounts a and b  after  each
+     here  we  assert the expected dollar balance in accounts a and b after each
      posting:
 
             2013/1/1
@@ -1754,65 +1795,65 @@ Journal
               b  $-1 = $-2
 
      After reading a journal file, hledger will check all balance assertions and
-     report  an  error  if any of them fail.  Balance assertions can protect you
-     from, eg, inadvertently disrupting reconciled balances  while  cleaning  up
-     old  entries.  You can disable them temporarily with the -I or --ignore-as-
-     sertions flag, which can be  useful  for  troubleshooting  or  for  reading
-     Ledger  files.  (Note: this flag currently does not disable balance assign-
+     report an error if any of them fail.  Balance assertions  can  protect  you
+     from,  eg,  inadvertently  disrupting reconciled balances while cleaning up
+     old entries.  You can disable them temporarily with the -I or  --ignore-as-
+     sertions  flag,  which  can  be  useful  for troubleshooting or for reading
+     Ledger files.  (Note: this flag currently does not disable balance  assign-
      ments, described below).
 
    Assertions and ordering
      hledger calculates and checks an account's balance assertions in date order
-     (and when there are multiple assertions on the same day, in  parse  order).
+     (and  when  there are multiple assertions on the same day, in parse order).
      Note this is different from Ledger, which checks assertions always in parse
      order, ignoring dates.
 
-     This  means  in  hledger  you can freely reorder transactions, postings, or
-     files, and balance assertions will usually keep working.  The exception  is
-     when  you  reorder  multiple postings on the same day, to the same account,
+     This means in hledger you can freely  reorder  transactions,  postings,  or
+     files,  and balance assertions will usually keep working.  The exception is
+     when you reorder multiple postings on the same day, to  the  same  account,
      which have balance assertions; those will likely need updating.
 
    Assertions and multiple files
-     If an account has transactions appearing in multiple files, balance  asser-
+     If  an account has transactions appearing in multiple files, balance asser-
      tions can still work - but only if those files are part of a hierarchy made
      by include directives.
 
-     If  the  same  files are specified with two -f options on the command line,
+     If the same files are specified with two -f options on  the  command  line,
      the assertions in the second will not see the balances from the first.
 
-     To work around this, arrange your files in a hierarchy with  include.   Or,
-     you  could concatenate the files temporarily, and process them like one big
+     To  work  around this, arrange your files in a hierarchy with include.  Or,
+     you could concatenate the files temporarily, and process them like one  big
      file.
 
-     Why does it work this way ?  It might be related to hledger's goal of  sta-
+     Why  does it work this way ?  It might be related to hledger's goal of sta-
      ble predictable reports.  File hierarchy is considered "permanent", part of
-     your  data,  while  the order of command line options/arguments is not.  We
-     don't want transient changes to be able to change the meaning of the  data.
-     Eg  it  would  be frustrating if tomorrow all your balance assertions broke
+     your data, while the order of command line options/arguments  is  not.   We
+     don't  want transient changes to be able to change the meaning of the data.
+     Eg it would be frustrating if tomorrow all your  balance  assertions  broke
      because you wrote command line arguments in a different order.  (Discussion
      welcome.)
 
    Assertions and costs
-     Balance assertions ignore costs, and should  normally  be  written  without
+     Balance  assertions  ignore  costs,  and should normally be written without
      one:
 
             2019/1/1
               (a)     $1 @ a1 = $1
 
-     We  do allow costs to be written in balance assertion amounts, however, and
-     print shows them, but they don't affect whether  the  assertion  passes  or
+     We do allow costs to be written in balance assertion amounts, however,  and
+     print  shows  them,  but  they don't affect whether the assertion passes or
      fails.  This is for backward compatibility (hledger's close command used to
      generate balance assertions with costs), and because balance assignments do
      use costs (see below).
 
    Assertions and commodities
-     The  balance  assertions described so far are "single commodity balance as-
+     The balance assertions described so far are "single commodity  balance  as-
      sertions": they assert and check the balance in one commodity, ignoring any
-     others that may be present.  This is how balance assertions work in  Ledger
+     others  that may be present.  This is how balance assertions work in Ledger
      also.
 
-     If  an account contains multiple commodities, you can assert their balances
-     by writing multiple postings with balance assertions, one for each  commod-
+     If an account contains multiple commodities, you can assert their  balances
+     by  writing multiple postings with balance assertions, one for each commod-
      ity:
 
             2013/1/1
@@ -1824,9 +1865,9 @@ Journal
               both    0 = $1
               both    0 = a1
 
-     In  hledger  you  can make a stronger "sole commodity balance assertion" by
-     writing two equals signs (==  EXPECTEDBALANCE).   This  also  asserts  that
-     there  are no other commodities in the account besides the asserted one (or
+     In hledger you can make a stronger "sole commodity  balance  assertion"  by
+     writing  two  equals  signs  (==  EXPECTEDBALANCE).  This also asserts that
+     there are no other commodities in the account besides the asserted one  (or
      at least, that their current balance is zero):
 
             2013/1/1
@@ -1834,13 +1875,13 @@ Journal
               eur   a-1  == a-1
               both      ;==  $1  ; this one would fail because 'both' contains $ and a
 
-     It's less easy to make a "sole commodities  balance  assertion"  (note  the
+     It's  less  easy  to  make a "sole commodities balance assertion" (note the
      plural) - ie, asserting that an account contains two or more specified com-
      modities and no others.  It can be done by
 
      1. isolating each commodity in a subaccount, and asserting those
 
-     2. and  also  asserting  there are no commodities in the parent account it-
+     2. and also asserting there are no commodities in the  parent  account  it-
         self:
 
         2013/1/1
@@ -1851,8 +1892,8 @@ Journal
           both:eur   a1 == a1  ; a euro there
 
    Assertions and subaccounts
-     All of the balance assertions above (both = and ==) are  "subaccount-exclu-
-     sive  balance  assertions";  they  ignore any balances that exist in deeper
+     All  of the balance assertions above (both = and ==) are "subaccount-exclu-
+     sive balance assertions"; they ignore any balances  that  exist  in  deeper
      subaccounts.
 
      In hledger you can make "subaccount-inclusive balance assertions" by adding
@@ -1863,6 +1904,22 @@ Journal
               assets:checking  $10
               assets:savings   $10
               assets            $0 ==* $20  ; assets + subaccounts contains $20 and nothing else
+
+   Assertions and lot subaccounts
+     Lot  subaccounts (a special kind of subaccount for tracking lots, discussed
+     in "Lot reporting" below) have only limited support for balance assertions:
+     the assertions will be checked correctly only if all postings to  that  lot
+     mention the subaccount name explicitly.
+
+     Since it's common practice to leave lot subaccounts implicit, generally you
+     should  avoid writing balance assertions on individual lots.  (close --lots
+     also follows this rule.)  If you forget, the balance assertion failure mes-
+     sage will remind you.  If you really need a balance assertion, you can usu-
+     ally write it on the parent account instead.
+
+     (The restriction is because transaction balancing amounts, balance  assign-
+     ments,  and  balance  assertions  must be calculated and checked before lot
+     movements are known.)
 
    Assertions and status
      Balance assertions always consider  postings  of  all  statuses  (unmarked,
@@ -2108,78 +2165,77 @@ Journal
      workarounds.  Eg, to have alias directives affect all of  your  files,  put
      them at the start of the main file, before any includes.
 
-     direc-     what it does                                                 ends
-     tive                                                                    at
-                                                                             file
-                                                                             end?
-     -------------------------------------------------------------------------------
+     direc-     what it does                                                   ends
+     tive                                                                      at
+                                                                               file
+                                                                               end?
+     ---------------------------------------------------------------------------------
                 Affects file reading:
-     alias      Rewrites  account  names,  in  following entries until end   Y
-                aliases or file end.  Command line equivalent: --alias
-     comment    Ignores following entries, until end comment or file end.    Y
-     deci-      Declares the decimal mark, for parsing amounts of all com-   Y
-     mal-mark   modities in following entries until next  decimal-mark  or
+     alias      Rewrites  account  names,  in  following  entries  until end   Y
+                aliases or file end.
+     com-       Ignores following entries, until end comment or file end.      Y
+     ment
+     deci-      Declares the decimal mark, for parsing amounts of  all  com-   Y
+     mal-mark   modities  in  following  entries  until next decimal-mark or
                 file end.  Subfiles can override.
-     include    Includes  entries from another file, as if they were writ-
-                ten inline.  Command line alternative: multiple -f/--file
+     include    Includes entries from another file, as if they were  written
+                inline.
                 Declares data:
-     account    Declares an account,  for  checking  all  entries  in  all   N
-                files,  and its display order, and optionally its type and
-                lotfulness.
-     commod-    Declares 1.  a commodity symbol, for checking all  amounts   N N N
-     ity        in  all  files  2.   the commodity's display style 3.  op-   Y
-                tional commodity aliases and lotfulness, and 4.  the deci-
-                mal mark for parsing this commodity, until file end (over-
-                ridden  by  decimal-mark).    Command   line   equivalent:
-                -c/--commodity-style
-     payee      Declares  a  payee  name,  for checking all entries in all   N
+     account    Declares  an account, for checking all entries in all files,   N
+                and its display order, and optionally its type  and  lotful-
+                ness.
+     commod-    Declares 1.  a commodity symbol, for checking all amounts in   N  N
+     ity        all  files  2.   the  commodity's display style 3.  optional   N N
+                commodity aliases and lotfulness, and 4.  the  decimal  mark
+                for  parsing  this  commodity, until file end (overridden by
+                decimal-mark).
+     payee      Declares  a  payee  name,  for  checking  all entries in all   N
                 files.
-     tag        Declares a tag name,  for  checking  all  entries  in  all   N
-                files.
-     P          Declares  a  commodity's  market  price  on some date, for
-                value and gain reports.
+     tag        Declares a tag name, for checking all entries in all files.    N
+     P          Declares a commodity's market price on some date, for  value
+                and gain reports.
                 Generates data:
-     =          Declares an auto posting rule that generates  extra  post-   partly
-                ings with --auto, in current/parent/subfiles (but not sib-
-                ling files, see #1212).
-     ~          Declares  a  periodic  transaction  rule that generates 1.   N
-                future transactions with --forecast, and 2.  budget  goals
-                with balance --budget.
+     =          Declares  an auto posting rule that generates extra postings   partly
+                with --auto, in  current/parent/subfiles  (but  not  sibling
+                files, see #1212).
+     ~          Declares  a periodic transaction rule that generates 1.  fu-   N
+                ture transactions with --forecast, and 2.  budget goals with
+                balance --budget.
                 File reading (legacy/deprecated):
-     apply      Prepends  a common parent account to all account names, in   Y
+     apply      Prepends a common parent account to all  account  names,  in   Y
      account    following entries until end apply account or file end.
-     D          Sets 1.a default commodity to use for no-symbol amounts in   Y,  Y,
-                this file and subfiles, and 2.  its parsing  decimal  mark   N
-                and  display  style  (overridden  by  commodity  or  deci-
+     D          Sets  1.a  default commodity to use for no-symbol amounts 2.   Y,  N,
+                the decimal mark for parsing it 3.  the  display  style  for   N
+                showing  it  (these  are  overridden  by  commodity or deci-
                 mal-mark).
-     Y          Sets a default year to use for any yearless dates, in fol-   Y
+     Y          Sets  a  default year to use for any yearless dates, in fol-   Y
                 lowing entries until file end.
      other      These other Ledger directives are accepted but ignored.
 
    account directive
-     account  directives  can  be  used to declare accounts (ie, the places that
-     amounts are transferred from and to).  Though not required, these  declara-
+     account directives can be used to declare accounts  (ie,  the  places  that
+     amounts  are transferred from and to).  Though not required, these declara-
      tions can provide several benefits:
 
      * They can document your intended chart of accounts, providing a reference.
 
-     * They  can  store  additional  account information as comments, or as tags
+     * They can store additional account information as  comments,  or  as  tags
        which can be used to filter or pivot reports.
 
-     * They can restrict which accounts may be posted to by transactions, eg  in
+     * They  can restrict which accounts may be posted to by transactions, eg in
        strict mode, which helps prevent errors.
 
-     * They  influence account display order in reports, allowing non-alphabetic
+     * They influence account display order in reports, allowing  non-alphabetic
        sorting (eg Revenues to appear above Expenses).
 
-     * They can help hledger know your accounts' types  (asset,  liability,  eq-
-       uity,  revenue, expense), enabling reports like balancesheet and incomes-
+     * They  can  help  hledger know your accounts' types (asset, liability, eq-
+       uity, revenue, expense), enabling reports like balancesheet and  incomes-
        tatement.
 
-     * They help with account name  completion  (in  hledger  add,  hledger-web,
+     * They  help  with  account  name  completion (in hledger add, hledger-web,
        hledger-iadd, ledger-mode, etc.)
 
-     They  are  written  as the word account followed by a hledger-style account
+     They are written as the word account followed by  a  hledger-style  account
      name.  Eg:
 
             account assets:bank:checking
@@ -2187,11 +2243,11 @@ Journal
      Any indented subdirectives are ignored.
 
    Account comments
-     Text following two or more spaces and ; at the end of an account  directive
-     line,  and/or following ; on indented lines immediately below it, form com-
+     Text  following two or more spaces and ; at the end of an account directive
+     line, and/or following ; on indented lines immediately below it, form  com-
      ments for that account.
 
-     Same-line account comments require two+ spaces before ; because that  char-
+     Same-line  account comments require two+ spaces before ; because that char-
      acter can appear in account names.
 
             account assets:bank:checking    ; same-line comment, at least 2 spaces before the semicolon
@@ -2199,48 +2255,48 @@ Journal
               ; some tags - type:A, acctnum:12345
 
    Account tags
-     An  account  directive's comment may contain tags.  These will be inherited
-     by all postings using that account, except where the posting already has  a
+     An account directive's comment may contain tags.  These will  be  inherited
+     by  all postings using that account, except where the posting already has a
      value for that tag.  (A posting tag overrides an account tag.)  Note, these
      tags will be queryable but won't be shown in print output, even with --ver-
      bose-tags.
 
    Account error checking
-     By  default, accounts need not be declared; they come into existence when a
-     posting references them.  This is convenient, but it  means  hledger  can't
+     By default, accounts need not be declared; they come into existence when  a
+     posting  references  them.   This is convenient, but it means hledger can't
      warn you when you mis-spell an account name in the journal.  Usually you'll
      find that error later, as an extra account in balance reports, or an incor-
      rect balance when reconciling.
 
-     In  strict mode, enabled with the -s/--strict flag, or when you run hledger
+     In strict mode, enabled with the -s/--strict flag, or when you run  hledger
      check accounts, hledger will report an error if any transaction uses an ac-
      count name that has not been declared by an account directive.  Some notes:
 
-     * The declaration is case-sensitive; transactions must use the correct  ac-
+     * The  declaration is case-sensitive; transactions must use the correct ac-
        count name capitalisation.
 
      * The account directive's scope is "whole file and below" (see directives).
        This means it affects all of the current file, and any files it includes,
-       but  not  parent  or  sibling  files.  The position of account directives
-       within the file does not matter, though it's usual to  put  them  at  the
+       but not parent or sibling files.   The  position  of  account  directives
+       within  the  file  does  not matter, though it's usual to put them at the
        top.
 
-     * Accounts  can only be declared in journal files, but will affect included
+     * Accounts can only be declared in journal files, but will affect  included
        files of all types.
 
-     * It's currently not possible to declare "all possible subaccounts" with  a
+     * It's  currently not possible to declare "all possible subaccounts" with a
        wildcard; every account posted to must be declared.
 
-     * As  an  exception:  lot  subaccounts (a final account name component like
+     * As an exception: lot subaccounts (a final  account  name  component  like
        :{2026-01-15, $50}) are always ignored by check accounts, and need not be
        declared.
 
-     * If you use the --infer-equity flag, you will also need  declarations  for
+     * If  you  use the --infer-equity flag, you will also need declarations for
        the account names it generates.
 
    Account display order
-     Account  directives  also cause hledger to display accounts in a particular
-     order, not just alphabetically.  Eg, here is a  conventional  ordering  for
+     Account directives also cause hledger to display accounts in  a  particular
+     order,  not  just  alphabetically.  Eg, here is a conventional ordering for
      the top-level accounts:
 
             account assets
@@ -2258,20 +2314,20 @@ Journal
             revenues
             expenses
 
-     If  there  are undeclared accounts, those will be displayed last, in alpha-
+     If there are undeclared accounts, those will be displayed last,  in  alpha-
      betical order.
 
      Sorting is done within each group of sibling accounts, at each level of the
-     account tree.  Eg,  a  declaration  like  account  parent:child  influences
+     account  tree.   Eg,  a  declaration  like  account parent:child influences
      child's position among its siblings.
 
-     Note,  it  does not affect parent's position; for that, you need an account
+     Note, it does not affect parent's position; for that, you need  an  account
      parent declaration.
 
-     Sibling accounts are always displayed together; hledger won't  display  x:y
+     Sibling  accounts  are always displayed together; hledger won't display x:y
      in between a:b and a:c.
 
-     An  account  directive  both declares an account as a valid posting target,
+     An account directive both declares an account as a  valid  posting  target,
      and declares its display order; you can't easily do one without the other.
 
    Account types
@@ -2285,30 +2341,30 @@ Journal
 
      and two more representing changes in these:
 
-     Revenue   R   inflows (also  known
+     Revenue   R   inflows  (also known
                    as Income)
      Expense   X   outflows
 
      hledger also uses a few subtypes:
 
-     Cash                      C                          liquid  assets (subtype
+     Cash                      C                          liquid assets  (subtype
                                                           of Asset)
      Conversion                V                          commodity   conversions
-                                                          equity  (subtype of Eq-
+                                                          equity (subtype of  Eq-
                                                           uity)
      Gain                      G                          realised        capital
                                                           gains/losses   (subtype
                                                           of Revenue)
      UnrealisedGain            U                          accumulated  unrealised
-                                                          capital  gains (subtype
+                                                          capital gains  (subtype
                                                           of Equity)
 
-     As a convenience, hledger will detect these types automatically  from  eng-
+     As  a  convenience, hledger will detect these types automatically from eng-
      lish account names.  But it's better to declare them explicitly by adding a
-     type:  tag  in  the  account directives.  The tag's value can be any of the
+     type: tag in the account directives.  The tag's value can  be  any  of  the
      types or one-letter abbreviations above.
 
-     Here is a typical set of account type declarations.  Subaccounts  will  in-
+     Here  is  a typical set of account type declarations.  Subaccounts will in-
      herit their parent's type, or can override it:
 
             account assets             ; type: A
@@ -2325,7 +2381,7 @@ Journal
 
             account revenues:gain           ; type: G
 
-     This  enables  the  easy balancesheet, balancesheetequity, cashflow and in-
+     This enables the easy balancesheet, balancesheetequity,  cashflow  and  in-
      comestatement reports, and querying by type:.
 
      Tips:
@@ -2334,12 +2390,12 @@ Journal
 
               $ hledger accounts --types [ACCTPAT] [type:TYPECODES] [-DEPTH] [--locations]
 
-     * It's a good idea to declare at least one account for each  account  type.
+     * It's  a  good idea to declare at least one account for each account type.
        Having some types declared and some inferred can disrupt certain reports.
 
-     * The  rules  for  inferring types from account names are as follows (using
+     * The rules for inferring types from account names are  as  follows  (using
        Regular expressions).
-     If they don't work for you, just ignore them and declare  your  types  with
+     If  they  don't  work for you, just ignore them and declare your types with
      type: tags.
 
               If account's name contains this case insensitive regular expression | its type is
@@ -2360,12 +2416,12 @@ Journal
 
        1. A type: declaration for this account.
 
-       2. A  type:  declaration  in the parent accounts above it, preferring the
+       2. A type: declaration in the parent accounts above  it,  preferring  the
           nearest.
 
        3. An account type inferred from this account's name.
 
-       4. An account type inferred from a parent account's name, preferring  the
+       4. An  account type inferred from a parent account's name, preferring the
           nearest parent.
 
        5. Otherwise, it will have no type.
@@ -2373,10 +2429,10 @@ Journal
      * Account aliases can disrupt account types.
 
    alias directive
-     You  can  define  account  alias rules which rewrite your account names, or
+     You can define account alias rules which rewrite  your  account  names,  or
      parts of them, before generating reports.  This can be useful for:
 
-     * expanding shorthand account names to their  full  form,  allowing  easier
+     * expanding  shorthand  account  names  to their full form, allowing easier
        data entry and a less verbose journal
 
      * adapting old journals to your current chart of accounts
@@ -2388,19 +2444,19 @@ Journal
 
      * customising reports
 
-     Account  aliases also rewrite account names in account directives.  They do
+     Account aliases also rewrite account names in account directives.  They  do
      not affect account names being entered via hledger add or hledger-web.
 
-     Account aliases are very powerful.  They are generally  easy  to  use  cor-
-     rectly,  but you can also generate invalid account names with them; more on
+     Account  aliases  are  very  powerful.  They are generally easy to use cor-
+     rectly, but you can also generate invalid account names with them; more  on
      this below.
 
      See also Rewrite account names.
 
    Basic aliases
-     To set an account alias, use the alias  directive  in  your  journal  file.
-     This  affects all subsequent journal entries in the current file or its in-
-     cluded files (but note: not sibling or parent files).   The  spaces  around
+     To  set  an  account  alias,  use the alias directive in your journal file.
+     This affects all subsequent journal entries in the current file or its  in-
+     cluded  files  (but  note: not sibling or parent files).  The spaces around
      the = are optional:
 
             alias OLD = NEW
@@ -2408,8 +2464,8 @@ Journal
      Or, you can use the --alias 'OLD=NEW' option on the command line.  This af-
      fects all entries.  It's useful for trying out aliases interactively.
 
-     OLD  and  NEW  are case sensitive full account names.  hledger will replace
-     any occurrence of the old account name with the new one.   Subaccounts  are
+     OLD and NEW are case sensitive full account names.   hledger  will  replace
+     any  occurrence  of the old account name with the new one.  Subaccounts are
      also affected.  Eg:
 
             alias checking = assets:bank:wells fargo:checking
@@ -2417,7 +2473,7 @@ Journal
 
    Regex aliases
      There is also a more powerful variant that uses a regular expression, indi-
-     cated  by wrapping the pattern in forward slashes.  (This is the only place
+     cated by wrapping the pattern in forward slashes.  (This is the only  place
      where hledger requires forward slashes around a regular expression.)
 
      Eg:
@@ -2428,12 +2484,12 @@ Journal
 
             $ hledger --alias '/REGEX/=REPLACEMENT' ...
 
-     Any part of an account name matched by REGEX will be replaced  by  REPLACE-
+     Any  part  of an account name matched by REGEX will be replaced by REPLACE-
      MENT.  REGEX is case-insensitive as usual.
 
      If you need to match a forward slash, escape it with a backslash, eg /\/=:.
 
-     If  REGEX  contains  parenthesised match groups, these can be referenced by
+     If REGEX contains parenthesised match groups, these can  be  referenced  by
      the usual backslash and number in REPLACEMENT:
 
             alias /^(.+):bank:([^:]+):(.*)/ = \1:\2 \3
@@ -2446,12 +2502,12 @@ Journal
      You can define as many aliases as you like, using journal directives and/or
      command line options.
 
-     Recursive aliases - where an account name is rewritten by one  alias,  then
-     by  another  alias, and so on - are allowed.  Each alias sees the effect of
+     Recursive  aliases  - where an account name is rewritten by one alias, then
+     by another alias, and so on - are allowed.  Each alias sees the  effect  of
      previously applied aliases.
 
-     In such cases it can be important to understand which aliases will  be  ap-
-     plied  and  in which order.  For (each account name in) each journal entry,
+     In  such  cases it can be important to understand which aliases will be ap-
+     plied and in which order.  For (each account name in) each  journal  entry,
      we apply:
 
      1. alias directives preceding the journal entry, most recently parsed first
@@ -2468,20 +2524,20 @@ Journal
 
      * aliases defined after/below the entry do not affect it.
 
-     This gives nearby aliases precedence over distant ones, and  helps  provide
-     semantic  stability - aliases will keep working the same way independent of
+     This  gives  nearby aliases precedence over distant ones, and helps provide
+     semantic stability - aliases will keep working the same way independent  of
      which files are being read and in which order.
 
-     In case of trouble, adding --debug=6 to the command line  will  show  which
+     In  case  of  trouble, adding --debug=6 to the command line will show which
      aliases are being applied when.
 
    Aliases and multiple files
-     As  explained  at Directives, alias directives do not affect parent or sib-
+     As explained at Directives, alias directives do not affect parent  or  sib-
      ling files.  Eg in this command,
 
             hledger -f a.aliases -f b.journal
 
-     account aliases defined in a.aliases will not affect b.journal.   Including
+     account  aliases defined in a.aliases will not affect b.journal.  Including
      the aliases doesn't work either:
 
             include a.aliases
@@ -2490,7 +2546,7 @@ Journal
               foo  1
               bar
 
-     This  means that account aliases should usually be declared at the start of
+     This means that account aliases should usually be declared at the start  of
      your top-most file, like this:
 
             alias foo=Foo
@@ -2503,14 +2559,14 @@ Journal
             include c.journal  ; also affected
 
    end aliases directive
-     You can clear (forget) all currently defined aliases (seen in  the  journal
+     You  can  clear (forget) all currently defined aliases (seen in the journal
      so far, or defined on the command line) with this directive:
 
             end aliases
 
    Aliases can generate bad account names
-     Be  aware  that  account aliases can produce malformed account names, which
-     could cause confusing reports or invalid print output.   For  example,  you
+     Be aware that account aliases can produce malformed  account  names,  which
+     could  cause  confusing  reports or invalid print output.  For example, you
      could erase all account names:
 
             2021-01-01
@@ -2521,8 +2577,8 @@ Journal
             2021-01-01
                                1
 
-     The  above print output is not a valid journal.  Or you could insert an il-
-     legal double space, causing print output that would give a different  jour-
+     The above print output is not a valid journal.  Or you could insert an  il-
+     legal  double space, causing print output that would give a different jour-
      nal when reparsed:
 
             2021-01-01
@@ -2535,7 +2591,7 @@ Journal
                 other
 
    Aliases and account types
-     If  an  account  with  a type declaration (see Declaring accounts > Account
+     If an account with a type declaration (see  Declaring  accounts  >  Account
      types) is renamed by an alias, normally the account type remains in effect.
 
      However, renaming in a way that reshapes the account tree (eg renaming par-
@@ -2545,69 +2601,49 @@ Journal
      Secondly, if an account's type is being inferred from its name, renaming it
      by an alias could prevent or alter that.
 
-     If you are using account aliases and the type: query is  not  matching  ac-
-     counts  as  you  expect,  try troubleshooting with the accounts command, eg
+     If  you  are  using account aliases and the type: query is not matching ac-
+     counts as you expect, try troubleshooting with  the  accounts  command,  eg
      something like:
 
             $ hledger accounts --types -1 --alias assets=bassetts
 
    comment directive
-     A line containing just comment causes all following lines  to  be  ignored,
+     A  line  containing  just comment causes all following lines to be ignored,
      until an end comment directive or file end.
 
    end comment directive
-     A  line  containing just end comment ends the effect of a preceding comment
+     A line containing just end comment ends the effect of a  preceding  comment
      directive.
 
    commodity directive
-     The commodity directive performs several functions:
+     commodity  directives  declare  commodity  symbols (for error checking) and
+     their preferred display style (digit group marks, decimal digits, and  sym-
+     bol position).  Eg:
 
-     1. It declares which commodity symbols may be used in the journal, enabling
-        useful error checking with strict mode or the check command.   See  Com-
-        modity error checking below.
+            commodity $1,000.00
+            commodity 1000,00 EUR
+            commodity a 1,00,00,000.00
+            commodity 1000.   ; the no-symbol commodity
 
-     2. It  declares  how  all amounts in this commodity should be displayed, eg
-        how many decimals to show.  See Commodity display style above.
-
-     3. (If no decimal-mark directive is in effect:) It sets the decimal mark to
-        expect (period or comma) when parsing amounts in this commodity, in this
-        file and files it includes, from the  directive  until  end  of  current
-        file.  See Decimal marks above.
-
-     4. It  declares the precision with which this commodity's amounts should be
-        compared when checking for balanced transactions, anywhere in this  file
-        and files it includes, until end of current file.
-
-     Declaring commodities solves several common parsing/display problems, so we
-     recommend it.
-
-     Note that effects 3 and 4 above end at the end of the directive's file, and
-     will  not  affect  sibling  or parent files.  So if you are relying on them
-     (especially 4) and using multiple files, placing your commodity  directives
-     in a top-level parent file might be important.  Or, keep your decimal marks
-     unambiguous and your entries well balanced and precise.
-
-     Omitting  the  commodity  symbol  will  set  the display style for just the
-     no-symbol commodity, not all commodities.
-
-     Commodity styles can be overridden by the -c/--commodity-style command line
-     option.
-
-     (Related: #793)
+     The sample amount must include a decimal mark (even if there are no decimal
+     digits  after  it).   This  tells  the parser which decimal mark (period or
+     comma) is used for this commodity in the journal file, which can be  useful
+     in case of ambiguous digit group marks.  This effect lasts until the end of
+     the  current  file  tree  (from  a single -f or LEDGER_FILE), and it can be
+     overridden by by a decimal-mark directive.
 
    Commodity directive syntax
-     A commodity directive is normally the word commodity followed by  a  sample
-     amount,  and  optionally  a comment.  Only the amount's symbol and the num-
-     ber's format is significant.  Eg:
+     In more detail.  A commodity directive is normally the word commodity  fol-
+     lowed by a sample amount (only its format is significant), and optionally a
+     comment.  Eg:
 
             commodity $1000.00
             commodity 1.000,00 EUR
             commodity 1 000 000.0000   ; the no-symbol commodity
 
-     A commodity directive's sample amount must always include a period or comma
-     decimal mark (this rule helps disambiguate decimal marks  and  digit  group
-     marks).   If  you  don't want to show any decimal digits, write the decimal
-     mark at the end:
+     A  commodity  directive's  sample amount must always include a decimal mark
+     (period or comma).  If you don't want to show any decimal digits, write the
+     decimal mark at the end:
 
             commodity 1000. AAAA       ; show AAAA with no decimals
 
@@ -2672,9 +2708,12 @@ Journal
      symbol.)  It works like account error checking (described above).
 
    decimal-mark directive
-     You  can use a decimal-mark directive - usually one per file, at the top of
-     the file - to declare which character represents a decimal mark when  pars-
-     ing amounts in this file.  It can look like
+     You can use a decimal-mark directive to declare unambiguously which charac-
+     ter (period or comma) represents a decimal mark, for all subsequent amounts
+     until  the end of the current file.  This helps when parsing ambiguous num-
+     bers (like 1.000 or 1,000 where you mean one thousand, not one).
+
+     Eg, at the top of each journal file:
 
             decimal-mark .
 
@@ -2682,9 +2721,9 @@ Journal
 
             decimal-mark ,
 
-     This  prevents any ambiguity when parsing numbers in the file, so we recom-
-     mend it, especially if the file contains digit group  marks  (eg  thousands
-     separators).
+     This directive only affects parsing, and it takes precedence over commodity
+     directives.  So you can declare preferred decimal marks for display,  which
+     may be different from the decimal mark(s) used in the data files.
 
    include directive
      You  can  pull in the content of additional files by writing an include di-
@@ -3491,8 +3530,8 @@ CSV
      directory  of  the  data/  directory  next  to  the main journal file.  The
      archive file name will be based on the rules file and the data file's modi-
      fication date and extension (or for a data-generating command, the  current
-     date  and  the  ".csv" extension).  The original data file, if any, will be
-     removed.
+     date  and  the  ".csv"  extension).  The original data file, once archived,
+     will be removed.
 
      Also, in this mode import will prefer the oldest file matched by the source
      rule's glob pattern, not the newest.  (So if there are multiple  downloads,
@@ -5226,7 +5265,7 @@ Time periods
      * hledger register --monthly --begin 1/5 --end 2/14 will end the report  on
        march 4th [1].
 
-     [1] Since hledger 1.29.
+     [1] Since 1.29.
 
    Period expressions
      The  -p/--period  option  specifies a period expression, which is a compact
@@ -6120,15 +6159,14 @@ Amount formatting
             2023-01-02
                 (a)        $1,000.
 
-     If  this  is  a  problem (eg when exporting to Ledger), you can avoid it by
-     disabling digit group marks, eg with -c/--commodity (for each affected com-
-     modity):
+     You  can  avoid  this  by  disabling digit group marks, eg temporarily with
+     -c/--commodity:
 
             $ hledger print -c '$1000.00'
             2023-01-02
                 (a)          $1000
 
-     or by forcing print to always show decimal digits, with --round:
+     or by forcing print to show some decimal digits, with --round:
 
             $ hledger print -c '$1,000.00' --round=soft
             2023-01-02
@@ -6513,8 +6551,8 @@ Value reporting
        ket-prices
 
      Signed  costs  and  market prices can be confusing.  For reference, here is
-     the current behaviour, since hledger 1.25.  (If you think  it  should  work
-     differently, see #1870.)
+     the current behaviour (since 1.25).  (If you think it should  work  differ-
+     ently, see #1870.)
 
             2022-01-01 Positive Unit prices
                 a        A 1
@@ -7680,6 +7718,11 @@ User interface commands
      commands will not see any changes made to input files (eg by add) until you
      exit and restart the REPL.
 
+     Any  other general flags given to repl - input, reporting, or display flags
+     such as -I, --strict, --alias, -b/-e, --depth, --cost, --value,  --color  -
+     are  also  applied  to every command you run.  A command can still override
+     them by specifying its own flags.
+
      The command syntax is the same as with run:
 
      * enter one hledger command at a time, without the usual hledger first word
@@ -7690,7 +7733,7 @@ User interface commands
 
      * type exit or quit or control-D to exit the REPL.
 
-     While  it  is running, the REPL remembers your command history, and you can
+     While it is running, the REPL remembers your command history, and  you  can
      navigate in the usual ways:
 
      * Keypad or Emacs navigation keys to edit the current command line
@@ -7701,18 +7744,18 @@ User interface commands
 
      * TAB to complete file paths.
 
-     Generally repl command lines should feel much like the normal hledger  CLI,
-     but  you  may  find differences.  repl is a little stricter; eg it requires
-     full command names or official  abbreviations  (as  seen  in  the  commands
-     list).
+     Generally  repl command lines should feel much like the normal hledger CLI,
+     but you may find differences.  repl is a little stricter;  eg  it  requires
+     full  command  names  or  official  abbreviations  (as seen in the commands
+     list).  Command aliases defined in a config file can also be used.
 
      The commands and help commands, and the command help flags (CMD --tldr, CMD
      -h/--help, CMD --info, CMD --man), can be useful.
 
-     You  can  type  control-C  to cancel a long-running command (but only once;
+     You can type control-C to cancel a long-running  command  (but  only  once;
      typing it a second time will exit the REPL).
 
-     And in most shells you can type control-Z to temporarily exit to the  shell
+     And  in most shells you can type control-Z to temporarily exit to the shell
      (and then fg to return to the REPL).
 
    Examples
@@ -7752,19 +7795,24 @@ User interface commands
 
      You can use run in three ways:
 
-     * hledger  run  --  CMD1  --  CMD2 -- CMD3 - read commands from the command
+     * hledger run -- CMD1 -- CMD2 -- CMD3 -  read  commands  from  the  command
        line, separated by --
 
-     * hledger run SCRIPTFILE1 SCRIPTFILE2 - read  commands  from  one  or  more
+     * hledger  run  SCRIPTFILE1  SCRIPTFILE2  -  read commands from one or more
        files
 
      * cat SCRIPTFILE1 | hledger run - read commands from standard input.
 
-     run  first  loads  the  input file(s) specified by LEDGER_FILE or by -f op-
+     run first loads the input file(s) specified by LEDGER_FILE  or  by  -f  op-
      tions, in the usual way.  Then it runs each command in turn, each using the
      same input data.  But if you want a particular command to use different in-
-     put, you can specify an -f option within that command.  This will  override
+     put,  you can specify an -f option within that command.  This will override
      (not add to) the default input, just for that command.
+
+     Any other general flags given to run - input, reporting, or  display  flags
+     such  as  -I, --strict, --alias, -b/-e, --depth, --cost, --value, --color -
+     are also applied to every command it runs.  A command  can  still  override
+     them by specifying its own flags.
 
      Each  input  file (more precisely, each combination of input file and input
      options) is parsed only once.  This means that commands will  not  see  any
@@ -7793,9 +7841,12 @@ User interface commands
 
      It's ok to use the run command recursively within a command script.
 
-     You may find some differences in behaviour between run  command  lines  and
-     normal  hledger  command  lines.   run is a little stricter; eg it requires
-     full command names or official  abbreviations  (as  seen  in  the  commands
+     Command aliases defined in a config  file  can  also  be  used  in  command
+     scripts.
+
+     You  may  find  some differences in behaviour between run command lines and
+     normal hledger command lines.  run is a little  stricter;  eg  it  requires
+     full  command  names  or  official  abbreviations  (as seen in the commands
      list), and command options must be written after the command name.
 
    Examples
@@ -7803,8 +7854,8 @@ User interface commands
 
             hledger -f some.journal run -- balance assets --depth 2 -- balance liabilities -f /some/other.journal --depth 3 --transpose -- stats
 
-     This  would load some.journal, run balance assets --depth 2 on it, then run
-     balance liabilities --depth 3 --transpose on /some/other.journal,  and  fi-
+     This would load some.journal, run balance assets --depth 2 on it, then  run
+     balance  liabilities  --depth 3 --transpose on /some/other.journal, and fi-
      nally run stats on some.journal
 
      Run commands from standard input:
@@ -7851,28 +7902,28 @@ Data entry commands
                                         (default: 53)
 
      Many hledger users edit their journals directly with a text editor, or gen-
-     erate  them  from  CSV.   For more interactive data entry, there is the add
-     command, which prompts interactively on the console for  new  transactions,
-     and  appends them to the main journal file (which should be in journal for-
-     mat).  Existing transactions are not changed.   This  is  one  of  the  few
+     erate them from CSV.  For more interactive data entry,  there  is  the  add
+     command,  which  prompts interactively on the console for new transactions,
+     and appends them to the main journal file (which should be in journal  for-
+     mat).   Existing  transactions  are  not  changed.   This is one of the few
      hledger commands that writes to the journal file (see also import).
 
-     To  use  it,  just  run hledger add and follow the prompts.  You can add as
+     To use it, just run hledger add and follow the prompts.   You  can  add  as
      many transactions as you like; when you are finished, enter . or press con-
      trol-d or control-c to exit.
 
      Features:
 
      * add tries to provide useful defaults, using the most similar (by descrip-
-       tion) and nearest-dated transaction (filtered by the query, if any) as  a
+       tion)  and nearest-dated transaction (filtered by the query, if any) as a
        template.
 
      * You can also set the initial defaults with command line arguments.
 
      * Readline-style edit keys can be used during data entry.
 
-     * The  tab  key will auto-complete whenever possible - accounts, payees/de-
-       scriptions, dates (yesterday, today, tomorrow).  If  the  input  area  is
+     * The tab key will auto-complete whenever possible -  accounts,  payees/de-
+       scriptions,  dates  (yesterday,  today,  tomorrow).  If the input area is
        empty, it will insert the default value.
 
      * A parenthesised transaction code may be entered following a date.
@@ -7881,24 +7932,24 @@ Data entry commands
 
      * If you make a mistake, enter < at any prompt to go one step backward.
 
-     * Input  prompts are displayed in a different colour when the terminal sup-
+     * Input prompts are displayed in a different colour when the terminal  sup-
        ports it.
 
      Notes:
 
-     * If you enter a number with no commodity symbol, and you have  declared  a
-       default  commodity  with  a D directive, you might expect add to add this
+     * If  you  enter a number with no commodity symbol, and you have declared a
+       default commodity with a D directive, you might expect add  to  add  this
        symbol for you.  It does not do this; we assume that if you are using a D
-       directive you prefer not to see the commodity symbol repeated on  amounts
+       directive  you prefer not to see the commodity symbol repeated on amounts
        in the journal.
 
-     * add  creates  entries  in journal format; it won't work with timeclock or
+     * add creates entries in journal format; it won't work  with  timeclock  or
        timedot files.
 
-     * There is a known issue on Windows if this hledger version is  built  from
-       stackage:  the  prompts  will  show ANSI junk instead of colours (#2410).
-       You can avoid this by using  official  hledger  release  binaries  or  by
-       building  it  with  haskeline >=0.8.4; or by running add with --color=no,
+     * There  is  a known issue on Windows if this hledger version is built from
+       stackage: the prompts will show ANSI junk  instead  of  colours  (#2410).
+       You  can  avoid  this  by  using  official hledger release binaries or by
+       building it with haskeline >=0.8.4; or by running  add  with  --color=no,
        perhaps configured in your config file.
 
      Examples:
@@ -7907,7 +7958,7 @@ Data entry commands
 
        hledger add
 
-     * Add transactions to 2024.journal, but also load 2023.journal for  comple-
+     * Add  transactions to 2024.journal, but also load 2023.journal for comple-
        tions:
 
        hledger add --file 2024.journal --file 2023.journal
@@ -7919,29 +7970,29 @@ Data entry commands
      There is a detailed tutorial at https://hledger.org/add.html.
 
    add and balance assertions
-     Since  hledger  1.43,  you  can add a balance assertion by writing AMOUNT =
+     Since hledger 1.43, you can add a balance assertion  by  writing  AMOUNT  =
      BALANCE when asked for an amount.  Eg 100 = 500.
 
-     Also, each time you enter a new amount, hledger re-checks all  balance  as-
-     sertions  in the journal and rejects the new amount if it would make any of
-     them fail.  You can run add with -I or --ignore-assertions to disable  bal-
+     Also,  each  time you enter a new amount, hledger re-checks all balance as-
+     sertions in the journal and rejects the new amount if it would make any  of
+     them  fail.  You can run add with -I or --ignore-assertions to disable bal-
      ance assertion checking.
 
    add and balance assignments
      Adding a new balance assignment
      When entering a posting amount, you can write a = BALANCEAMOUNT balance as-
-     signment  (or ==, =*, ==*) instead.  The posting amount required to produce
+     signment (or ==, =*, ==*) instead.  The posting amount required to  produce
      this balance will be calculated automatically.  (Since 1.51)
 
      Adding a posting dated before an existing balance assignment
-     add won't let you add a posting dated earlier than an existing balance  as-
-     signment  in that account.  (Because it calculates balance assignments only
-     once at startup, converting them to assertions, so adding  the  new  amount
-     causes  an  assertion  failure.)  To work around this, run add with balance
+     add  won't let you add a posting dated earlier than an existing balance as-
+     signment in that account.  (Because it calculates balance assignments  only
+     once  at  startup,  converting them to assertions, so adding the new amount
+     causes an assertion failure.)  To work around this, run  add  with  balance
      assertions ignored: hledger add -I.
 
    import
-     Import new transactions from one or more data files to  the  main  journal.
+     Import  new  transactions  from one or more data files to the main journal.
      Or with no arguments, import from the rules files in rules/.
 
             Flags:
@@ -7953,11 +8004,11 @@ Data entry commands
                                         COL      - align decimal marks at column COL
                                         (default: 53)
 
-     This  command  detects new transactions in one or more data files specified
+     This command detects new transactions in one or more data  files  specified
      as arguments, and appends them to the main journal.
 
      You can import from any input file format hledger supports, but CSV/SSV/TSV
-     files, downloaded from financial institutions, are the most  common  import
+     files,  downloaded  from financial institutions, are the most common import
      source.
 
      The import destination is the default journal file, or another specified in
@@ -7971,11 +8022,11 @@ Data entry commands
             $ hledger import *.csv
 
    Default import sources
-     If  import  is run with no file arguments, it looks in the journal's rules/
-     directory (next to the main journal file) and  imports  from  every  .rules
+     If import is run with no file arguments, it looks in the  journal's  rules/
+     directory  (next  to  the  main journal file) and imports from every .rules
      file found there, in alphabetical order.  Files whose name begins with . or
      _ are skipped: the _ prefix is for rules files that are either disabled, or
-     shared/common  rules included by other rules files and not meant to be read
+     shared/common rules included by other rules files and not meant to be  read
      directly.
 
      So a typical setup might be:
@@ -7988,52 +8039,52 @@ Data entry commands
 
      and hledger import reads bank1-checking.rules then bank1-savings.rules.
 
-     If the rules/ directory does not exist or contains no usable .rules  files,
+     If  the rules/ directory does not exist or contains no usable .rules files,
      import reports an error.
 
    Fetching new data first
      With -g/--get, import runs the get command first, which runs your data/get-
-     data  and prices/getprices scripts (if any) to download new transaction and
-     price data.  The import then proceeds normally, with  the  new  transaction
+     data and prices/getprices scripts (if any) to download new transaction  and
+     price  data.   The  import then proceeds normally, with the new transaction
      data (if any) readable by your rules files' source rules.
 
    Import dry run
-     It's  useful to preview the import by running first with --dry-run, to san-
-     ity check the range of dates being imported, and to  check  the  effect  of
+     It's useful to preview the import by running first with --dry-run, to  san-
+     ity  check  the  range  of dates being imported, and to check the effect of
      your conversion rules if converting from CSV.  Eg:
 
             $ hledger import bank.csv --dry-run
 
      The dry run output is valid journal format, so hledger can re-parse it.  If
-     the  output  is  large,  you could show just the uncategorised transactions
+     the output is large, you could show  just  the  uncategorised  transactions
      like so:
 
             $ hledger import --dry-run bank.csv | hledger -f- -I print unknown
 
-     You could also run this repeatedly to see the effect of edits to your  con-
+     You  could also run this repeatedly to see the effect of edits to your con-
      version rules:
 
             $ watchexec -- "hledger import --dry-run bank.csv | hledger -f- -I print unknown"
 
-     Once  the  conversion and dates look good enough to import to your journal,
+     Once the conversion and dates look good enough to import to  your  journal,
      perhaps with some manual fixups to follow, you would do the actual import:
 
             $ hledger import bank.csv
 
    Overlap detection
-     Reading CSV files is built in to hledger, and not specific  to  import;  so
+     Reading  CSV  files  is built in to hledger, and not specific to import; so
      you could also import by doing hledger -f bank.csv print >>$LEDGER_FILE.
 
      But import is easier and provides some advantages.  The main one is that it
-     avoids  re-importing transactions it has seen on previous runs.  This means
-     you don't have to worry about overlapping data in successive  downloads  of
-     your  bank CSV; just download and import as often as you like, and only the
+     avoids re-importing transactions it has seen on previous runs.  This  means
+     you  don't  have to worry about overlapping data in successive downloads of
+     your bank CSV; just download and import as often as you like, and only  the
      new transactions will be imported each time.
 
      We don't call this "deduplication", as it's generally not possible to reli-
-     ably detect duplicates in bank CSV.  Instead, import remembers  the  latest
-     date  processed  previously  in each CSV file (saving it in a hidden file),
-     and skips any records prior  to  that  date.   This  works  well  for  most
+     ably  detect  duplicates in bank CSV.  Instead, import remembers the latest
+     date processed previously in each CSV file (saving it in  a  hidden  file),
+     and  skips  any  records  prior  to  that  date.   This works well for most
      real-world CSV, where:
 
      1. the data file name is stable (does not change) across imports
@@ -8047,28 +8098,28 @@ Data entry commands
      (Occasional violations of 2-4 are often harmless; you can reduce the chance
      of disruption by downloading and importing more often.)
 
-     Overlap  detection  is automatic, and shouldn't require much attention from
+     Overlap detection is automatic, and shouldn't require much  attention  from
      you, except perhaps at first import (see below).  But here's how it works:
 
      * For each FILE being imported from:
 
        1. hledger reads a file named .latest.FILE file in the same directory, if
-          any.  This file contains the latest record  date  previously  imported
-          from  FILE,  in YYYY-MM-DD format.  If multiple records with that date
+          any.   This  file  contains the latest record date previously imported
+          from FILE, in YYYY-MM-DD format.  If multiple records with  that  date
           were imported, the date is repeated on N lines.
 
-       2. hledger reads records from FILE.  If a latest date was found  in  step
+       2. hledger  reads  records from FILE.  If a latest date was found in step
           1, any records before that date, and the first N records on that date,
           are skipped.
 
-     * After  a  successful  import  from  all  FILEs, without error and without
+     * After a successful import from  all  FILEs,  without  error  and  without
        --dry-run, hledger updates each FILE's .latest.FILE for next time.
 
      If this goes wrong, it's relatively easy to repair:
 
      * You'll notice it before import when you preview with import --dry-run.
 
-     * Or after import when you try to reconcile your hledger  account  balances
+     * Or  after  import when you try to reconcile your hledger account balances
        with your bank.
 
      * hledger print -f FILE.csv will show all recently downloaded transactions.
@@ -8076,27 +8127,27 @@ Data entry commands
 
      * Update your conversion rules and print again, if needed.
 
-     * You  can  manually  update  or  remove  the  .latest  file, or use import
+     * You can manually update  or  remove  the  .latest  file,  or  use  import
        --catchup FILE.
 
-     * Download and import more often, eg twice a week, at least while  you  are
-       learning.   It's  easier  to review and troubleshoot when there are fewer
+     * Download  and  import more often, eg twice a week, at least while you are
+       learning.  It's easier to review and troubleshoot when  there  are  fewer
        transactions.
 
    First import
-     The first time you import from a file, when no corresponding  .latest  file
+     The  first  time you import from a file, when no corresponding .latest file
      has been created yet, all of the records will be imported.
 
-     But  perhaps you have been entering the data manually, so you know that all
-     of these transactions are already recorded in the journal.   In  this  case
+     But perhaps you have been entering the data manually, so you know that  all
+     of  these  transactions  are already recorded in the journal.  In this case
      you can run hledger import --catchup once.  This will create a .latest file
-     containing  the  latest CSV record date, so that none of those records will
+     containing the latest CSV record date, so that none of those  records  will
      be re-imported.
 
-     Or, if you know that some but not all of the transactions are in the  jour-
-     nal,  you  can  create the .latest file yourself.  Eg, let's say you previ-
-     ously recorded foobank transactions up to 2024-10-31 in the journal.   Then
-     in  the  directory  where  you'll be saving foobank.csv, you would create a
+     Or,  if you know that some but not all of the transactions are in the jour-
+     nal, you can create the .latest file yourself.  Eg, let's  say  you  previ-
+     ously  recorded foobank transactions up to 2024-10-31 in the journal.  Then
+     in the directory where you'll be saving foobank.csv,  you  would  create  a
      .latest.foobank.csv file containing
 
             2024-10-31
@@ -8108,109 +8159,109 @@ Data entry commands
             2024-10-31
             2024-10-31
 
-     Then hledger import foobank.csv [--dry-run]  will  import  only  the  newer
+     Then  hledger  import  foobank.csv  [--dry-run]  will import only the newer
      records.
 
    Importing balance assignments
      Journal entries added by import will have all posting amounts made explicit
      (like print -x).
 
-     This  means that any balance assignments in the imported entries would need
+     This means that any balance assignments in the imported entries would  need
      to be evaluated.  But this generally isn't possible, as the main file's ac-
-     count balances are not visible during import.  So try to  avoid  generating
-     balance  assignments  with your CSV rules, or importing from a journal that
-     contains balance assignments.  (Balance assignments are best  avoided  any-
+     count  balances  are not visible during import.  So try to avoid generating
+     balance assignments with your CSV rules, or importing from a  journal  that
+     contains  balance  assignments.  (Balance assignments are best avoided any-
      way.)
 
-     But  if  you must use them, eg because your CSV includes only balances: you
-     can import with print, which leaves implicit amounts implicit.  (print  can
+     But if you must use them, eg because your CSV includes only  balances:  you
+     can  import with print, which leaves implicit amounts implicit.  (print can
      also do overlap detection like import, with the --new flag):
 
             $ hledger print --new -f bank.csv >> $LEDGER_FILE
 
-     (If  you  think  import should preserve implicit balances, please test that
+     (If you think import should preserve implicit balances,  please  test  that
      and send a pull request.)
 
    Import and commodity styles
      Amounts in entries added by import will be formatted according to the jour-
-     nal's canonical commodity styles, as declared by  commodity  directives  or
+     nal's  canonical  commodity  styles, as declared by commodity directives or
      inferred from the journal's amounts.
 
      Related: CSV > Amount decimal places.
 
    Import archiving
-     When  importing  from a CSV rules file (hledger import bank.rules), you can
+     When importing from a CSV rules file (hledger import bank.rules),  you  can
      use the archive rule to enable automatic archiving of the data file.
 
-     After a successful import, the data file specified by source will be  moved
-     (or  data  generated  by  a command will be saved) to an archive directory.
+     After  a successful import, the data file specified by source will be moved
+     (or data generated by a command will be saved)  to  an  archive  directory.
      This can be useful for troubleshooting, detecting variations in your banks'
      CSV data, regenerating entries with improved rules, etc.
 
-     The archive directory is data/archive/, next  to  the  main  journal  file,
-     auto-created.   The  archive  file  name will be similar to the rules file,
-     with a date added: the original data file's modification date,  or  today's
+     The  archive  directory  is  data/archive/,  next to the main journal file,
+     auto-created.  The archive file name will be similar  to  the  rules  file,
+     with  a  date added: the original data file's modification date, or today's
      date if the data was command-generated.
 
-     The  archive rule also causes import to handle source glob patterns differ-
-     ently: when there are multiple matched files, it will pick the oldest,  not
+     The archive rule also causes import to handle source glob patterns  differ-
+     ently:  when there are multiple matched files, it will pick the oldest, not
      the newest.
 
    Import special cases
    Multiple journals in the same directory
-     You  might want to keep each journal you are importing to in its own direc-
-     tory.  That way, each will have its own rules/,  data/,  and  data/archive/
+     You might want to keep each journal you are importing to in its own  direc-
+     tory.   That  way,  each will have its own rules/, data/, and data/archive/
      directories (if those are used).
 
-     Otherwise,  imports to the same-directory journals will potentially use the
+     Otherwise, imports to the same-directory journals will potentially use  the
      same rules/, data/ and data/archive/ directories (depending on commands and
-     rules configuration).  This is not necessarily a problem; it might even  be
+     rules  configuration).  This is not necessarily a problem; it might even be
      desirable in some cases.  But see below:
 
    Import configurations to avoid
      A few unusual workflows which you should generally avoid:
 
-     * Don't  import  from  one  input file to different journals.  The imports'
-       overlap detection would overwrite the same .latest.FILE state file.   (In
+     * Don't import from one input file to  different  journals.   The  imports'
+       overlap  detection would overwrite the same .latest.FILE state file.  (In
        effect, the journals would compete for the new records.)
 
-     * Don't  import  from multiple data files on the same day, reusing the same
-       rules file for all, with archive enabled.  The  archived  file  names  in
+     * Don't import from multiple data files on the same day, reusing  the  same
+       rules  file  for  all,  with archive enabled.  The archived file names in
        data/archive/ would clash, causing some archives to be overwritten.
 
-     * Don't  do  argument-less  hledger  import to more than one journal in the
-       same directory.  That would read from the same files  in  rules/,  poten-
+     * Don't do argument-less hledger import to more than  one  journal  in  the
+       same  directory.   That  would read from the same files in rules/, poten-
        tially disrupting both overlap detection and archiving.
 
    Deduplication
-     Here  are  two  kinds  of "deduplication" which import does not handle (and
+     Here are two kinds of "deduplication" which import  does  not  handle  (and
      should not, because these can happen legitimately in financial data):
 
-     * Two or more of the new CSV records are identical, and generate  identical
+     * Two  or more of the new CSV records are identical, and generate identical
        new journal entries.
 
      * A new CSV record generates a journal entry identical to one(s) already in
        the journal.
 
    Varying file name
-     If  you  have  a  download whose file name varies, you could rename it to a
-     fixed name after each download.  Or you could use a CSV source rule with  a
+     If you have a download whose file name varies, you could  rename  it  to  a
+     fixed  name after each download.  Or you could use a CSV source rule with a
      suitable glob pattern, and import from the .rules file.
 
    Multiple versions
-     Say  you  download  bank.csv,  import it, but forget to delete it from your
-     downloads folder.  The next time you download it,  your  web  browser  will
+     Say you download bank.csv, import it, but forget to  delete  it  from  your
+     downloads  folder.   The  next  time you download it, your web browser will
      save it as (eg) bank (2).csv.  The source rule's glob patterns are for just
-     this  situation:  instead  of  specifying  source  bank.csv, specify source
-     bank*.csv.  Then hledger -f bank.rules CMD  or  hledger  import  bank.rules
+     this situation: instead  of  specifying  source  bank.csv,  specify  source
+     bank*.csv.   Then  hledger  -f  bank.rules CMD or hledger import bank.rules
      will automatically pick the newest matched file (bank (2).csv).
 
-     Alternately,  what  if  you  download, but forget to import or delete, then
-     download again ?  Now each of bank.csv and bank (2).csv might contain  data
-     that's  not in the other, and not in your journal.  In this case, it's best
-     to import each of them in turn, oldest first (otherwise, overlap  detection
-     could  cause new records to be skipped).  Enabling import archiving ensures
-     this.  Then hledger import bank.rules; hledger import bank.rules  will  im-
+     Alternately, what if you download, but forget to  import  or  delete,  then
+     download  again ?  Now each of bank.csv and bank (2).csv might contain data
+     that's not in the other, and not in your journal.  In this case, it's  best
+     to  import each of them in turn, oldest first (otherwise, overlap detection
+     could cause new records to be skipped).  Enabling import archiving  ensures
+     this.   Then  hledger import bank.rules; hledger import bank.rules will im-
      port and archive first bank.csv, then bank (2).csv.
 
 Basic report commands
@@ -8233,27 +8284,27 @@ Basic report commands
                  --drop=N               flat mode: omit N leading account name parts
 
      This command lists account names - all of them by default, or just the ones
-     which  have been used in transactions (-u/--used), or declared with account
+     which have been used in transactions (-u/--used), or declared with  account
      directives (-d/--declared), or used but not declared (--undeclared), or de-
-     clared but not used (--unused), or just the first one matched by a  pattern
+     clared  but not used (--unused), or just the first one matched by a pattern
      (--find, returning a non-zero exit code if it fails).
 
      You can add query arguments to select a subset of transactions or accounts.
 
-     With  --directives, it shows valid account directives which could be pasted
+     With --directives, it shows valid account directives which could be  pasted
      into a journal file.  This is useful together with --undeclared when updat-
      ing your account declarations to satisfy hledger check accounts.
 
-     With --locations, it also shows the file and line number of each  account's
+     With  --locations, it also shows the file and line number of each account's
      declaration, if any, and the account's overall declaration order; these may
      be useful when troubleshooting account display order.
 
-     With  --types,  it also shows each account's type, if it's known.  (See De-
+     With --types, it also shows each account's type, if it's known.   (See  De-
      claring accounts > Account types.)
 
-     It shows a flat list by default.  With --tree, it uses indentation to  show
+     It  shows a flat list by default.  With --tree, it uses indentation to show
      the account hierarchy.  In flat mode you can add --drop N to omit the first
-     few  account  name  components.   Account  names  can be depth-clipped with
+     few account name components.   Account  names  can  be  depth-clipped  with
      depth:N or --depth N or -N.
 
      Examples:
@@ -8277,13 +8328,13 @@ Basic report commands
             Flags:
             no command-specific flags
 
-     This command prints the value of each transaction's code field, in the  or-
-     der  transactions  were  parsed.  The transaction code is an optional value
-     written in parentheses between the date  and  description,  often  used  to
+     This  command prints the value of each transaction's code field, in the or-
+     der transactions were parsed.  The transaction code is  an  optional  value
+     written  in  parentheses  between  the  date and description, often used to
      store a cheque number, order number or similar.
 
-     Transactions  aren't  required  to  have a code, and missing or empty codes
-     will not be shown by default.  With  the  -E/--empty  flag,  they  will  be
+     Transactions aren't required to have a code, and  missing  or  empty  codes
+     will  not  be  shown  by  default.   With the -E/--empty flag, they will be
      printed as blank lines.
 
      You can add a query to select a subset of transactions.
@@ -8332,21 +8383,21 @@ Basic report commands
      Most of these flags can be combined.  Some kinds of query argument are sup-
      ported: cur:, tag:, and date: (also -b/-e/-p report period options).
 
-     Providing  a date query will affect which commodities are reported, as fol-
+     Providing a date query will affect which commodities are reported, as  fol-
      lows:
 
      Flag         No date query                   With a date query
      -----------------------------------------------------------------------------
-     (none)       declared  a   transacted   a    (transacted  a  priced)  in the
+     (none)       declared   a   transacted  a    (transacted a  priced)  in  the
                   priced                          period
      --used       transacted in the journal       transacted in the period
-     --priced     appearing in any P directive    appearing in a P  directive  in
+     --priced     appearing in any P directive    appearing  in  a P directive in
                                                   the period
      --declared   declared  with  a  commodity    same
                   directive
-     --unde-      (transacted a priced) a  de-    (transacted a priced in the pe-
+     --unde-      (transacted  a priced) a de-    (transacted a priced in the pe-
      clared       clared                          riod) a declared
-     --unused     declared   a  (transacted  a    same
+     --unused     declared  a  (transacted   a    same
                   priced)
      --find       the first commodity matching    same
                   the argument
@@ -8357,7 +8408,7 @@ Basic report commands
             Flags:
             no command-specific flags
 
-     This command lists the unique descriptions that appear in transactions,  in
+     This  command lists the unique descriptions that appear in transactions, in
      alphabetic order.  You can add a query to select a subset of transactions.
 
      Example:
@@ -8368,7 +8419,7 @@ Basic report commands
             Person A
 
    files
-     List  all  files included in the journal.  With a REGEX argument, only file
+     List all files included in the journal.  With a REGEX argument,  only  file
      names matching the regular expression (case sensitive) are shown.
 
             Flags:
@@ -8380,9 +8431,9 @@ Basic report commands
             Flags:
             no command-specific flags
 
-     This command lists the unique notes that appear in transactions, in  alpha-
-     betic  order.  You can add a query to select a subset of transactions.  The
-     note is the part of the transaction description after a | character (or  if
+     This  command lists the unique notes that appear in transactions, in alpha-
+     betic order.  You can add a query to select a subset of transactions.   The
+     note  is the part of the transaction description after a | character (or if
      there is no |, the whole description).
 
      Example:
@@ -8402,13 +8453,13 @@ Basic report commands
                  --find                 list the first payee matched by the first
                                         argument (a case-insensitive infix regexp)
 
-     This  command  lists  unique payee/payer names - all of them by default, or
+     This command lists unique payee/payer names - all of them  by  default,  or
      just the ones which have been used in transaction descriptions, or declared
-     with payee directives, or used but not declared, or declared but not  used,
-     or  just  the  first  one  matched  by  a pattern (with --find, returning a
+     with  payee directives, or used but not declared, or declared but not used,
+     or just the first one matched  by  a  pattern  (with  --find,  returning  a
      non-zero exit code if it fails).
 
-     The payee/payer name is the part of the transaction description before a  |
+     The  payee/payer name is the part of the transaction description before a |
      character (or if there is no |, the whole description).
 
      You can add query arguments to select a subset of transactions or payees.
@@ -8421,9 +8472,9 @@ Basic report commands
             Person A
 
    prices
-     Print  the  market  prices  declared  with P directives.  With --infer-mar-
-     ket-prices, also show any additional  prices  inferred  from  costs.   With
-     --show-reverse,  also  show  additional  prices inferred by reversing known
+     Print the market prices declared  with  P  directives.   With  --infer-mar-
+     ket-prices,  also  show  any  additional  prices inferred from costs.  With
+     --show-reverse, also show additional prices  inferred  by  reversing  known
      prices.
 
             Flags:
@@ -8433,25 +8484,25 @@ Basic report commands
                                         of listing them
                  --locations            also show where prices where declared
 
-     With --locations, each price line gets a  trailing  ;  location:  FILE:LINE
-     comment  showing  where it came from.  Declared prices point at their P di-
+     With  --locations,  each  price  line gets a trailing ; location: FILE:LINE
+     comment showing where it came from.  Declared prices point at their  P  di-
      rective; prices inferred from costs point at the parent transaction's first
-     line.  Reversed prices keep the source position of the directive they  were
+     line.   Reversed prices keep the source position of the directive they were
      derived from.
 
-     Price  amounts  are  always displayed with their full precision, except for
+     Price amounts are always displayed with their full  precision,  except  for
      reverse prices which are limited to 8 decimal digits.
 
      Prices can be filtered by a date:, cur: or amt: query.
 
-     Generally if you run this  command  with  --infer-market-prices  --show-re-
-     verse,  it will show the same prices used internally to calculate value re-
-     ports.  But if in doubt, you can inspect  those  directly  by  running  the
+     Generally  if  you  run  this command with --infer-market-prices --show-re-
+     verse, it will show the same prices used internally to calculate value  re-
+     ports.   But  if  in  doubt,  you can inspect those directly by running the
      value report with --debug=2.
 
    prices summary
      With --summary, instead of listing individual prices, prices prints one row
-     per  commodity used in the journal (other than the base currency), with the
+     per commodity used in the journal (other than the base currency), with  the
      following columns:
 
      * Commodity -- the commodity, as an ISO 4217 code if possible.
@@ -8462,26 +8513,26 @@ Basic report commands
 
      * Period -- the duration between earliest and latest.
 
-     * Coverage -- the percentage of weekdays in that period that have  a  price
+     * Coverage  --  the percentage of weekdays in that period that have a price
        declared (or blank when fewer than two prices).
 
      Summary mode is a quick way to spot gaps in your price data, and pairs nat-
      urally with getprices.  Only prices declared with P directives are counted;
      prices inferred with --show-reverse or --infer-market-prices are ignored.
 
-     Queries  (cur:, date:, amt:) can be used to narrow the prices that are sum-
+     Queries (cur:, date:, amt:) can be used to narrow the prices that are  sum-
      marised.
 
    stats
      Show journal and performance statistics.
 
             Flags:
-              -1                        show a single line of output
+                 --oneline              show a single line of output
               -v --verbose              show more detailed output
               -o --output-file=FILE     write output to FILE.
 
-     The stats command shows summary information for the  whole  journal,  or  a
-     matched  part of it.  With a reporting interval, it shows a report for each
+     The  stats  command  shows  summary information for the whole journal, or a
+     matched part of it.  With a reporting interval, it shows a report for  each
      report period.
 
      It also shows some performance statistics:
@@ -8494,13 +8545,13 @@ Basic report commands
 
      * the peak allocated memory as seen by the program
 
-     By default, the output is reasonably discreet; it  reveals  the  main  file
+     By  default,  the  output  is reasonably discreet; it reveals the main file
      name, your activity level, and the speed of your machine.
 
      With -v/--verbose, more details are shown: the full paths of all files, and
      the names of the commodities you work with.
 
-     With  -1, only one line of output is shown, in a machine-friendly tab-sepa-
+     With -1, only one line of output is shown, in a machine-friendly  tab-sepa-
      rated format: the program version, the main journal file name, and the per-
      formance stats,
 
@@ -8543,15 +8594,15 @@ Basic report commands
                  --parsed               show them in the order they were parsed (mostly),
                                         including duplicates
 
-     This command lists tag names - all of them by default,  or  just  the  ones
-     which  have  been  used on transactions/postings/accounts, or declared with
+     This  command  lists  tag  names - all of them by default, or just the ones
+     which have been used on transactions/postings/accounts,  or  declared  with
      tag directives, or used but not declared, or declared but not used, or just
-     the first one matched by a pattern (with --find, returning a non-zero  exit
+     the  first one matched by a pattern (with --find, returning a non-zero exit
      code if it fails).
 
-     Note  this  command's non-standard first argument: it is a case-insensitive
-     infix regular expression for matching tag  names,  which  limits  the  tags
-     shown.   Any additional arguments are standard query arguments, which limit
+     Note this command's non-standard first argument: it is  a  case-insensitive
+     infix  regular  expression  for  matching  tag names, which limits the tags
+     shown.  Any additional arguments are standard query arguments, which  limit
      the transactions, postings, or accounts providing tags.
 
      With --values, the tags' unique non-empty values are listed instead.
@@ -8559,11 +8610,11 @@ Basic report commands
      With -E/--empty, blank/empty values are also shown.
 
      With --parsed, tags or values are shown in the order they were parsed, with
-     duplicates included.  (Except, tags from account  declarations  are  always
+     duplicates  included.   (Except,  tags from account declarations are always
      shown first.)
 
-     Remember  that accounts also acquire tags from their parents; postings also
-     acquire tags from their account and transaction; and transactions also  ac-
+     Remember that accounts also acquire tags from their parents; postings  also
+     acquire  tags from their account and transaction; and transactions also ac-
      quire tags from their postings.
 
 Standard report commands
@@ -8571,6 +8622,7 @@ Standard report commands
      Show full journal entries, representing transactions.
 
             Flags:
+                 --oneline              show transaction dates and descriptions only
               -a --all                  show all details (--explicit --lots
                                         --verbose-tags)
               -x --explicit             show all inferred info explicitly
@@ -8604,12 +8656,12 @@ Standard report commands
               -o --output-file=FILE     write output to FILE. A file extension matching
                                         one of the above formats selects that format.
 
-     The  print  command  displays  full journal entries (transactions) from the
+     The print command displays full journal  entries  (transactions)  from  the
      journal file, sorted by date (or with --date2, by secondary date).
 
-     Directives and inter-transaction comments are not shown,  currently.   This
-     means  the  print command is somewhat lossy, and if you are using it to re-
-     format/regenerate your journal you should take care to also copy  over  the
+     Directives  and  inter-transaction comments are not shown, currently.  This
+     means the print command is somewhat lossy, and if you are using it  to  re-
+     format/regenerate  your  journal you should take care to also copy over the
      directives and inter-transaction comments.
 
      Eg:
@@ -8629,8 +8681,8 @@ Standard report commands
                 assets:cash                 $-2
 
    print explicitness
-     Normally,  whether  posting  amounts are implicit or explicit is preserved.
-     For example, when an amount is omitted in the journal, it will  not  appear
+     Normally, whether posting amounts are implicit or  explicit  is  preserved.
+     For  example,  when an amount is omitted in the journal, it will not appear
      in the output.  Similarly, if a conversion cost is implied but not written,
      it will not appear in the output.
 
@@ -8639,22 +8691,22 @@ Standard report commands
      nal more readable and robust against data entry errors.  -x is also implied
      by using any of -B,-V,-X,--value.
 
-     The  -x/--explicit  flag  will  cause  any  postings with a multi-commodity
-     amount (which can arise when a multi-commodity transaction has an  implicit
-     amount)  to  be  split into multiple single-commodity postings, keeping the
+     The -x/--explicit flag will  cause  any  postings  with  a  multi-commodity
+     amount  (which can arise when a multi-commodity transaction has an implicit
+     amount) to be split into multiple single-commodity  postings,  keeping  the
      output parseable.
 
-     To see more details -- not just inferred amounts and costs,  but  also  lot
+     To  see  more  details -- not just inferred amounts and costs, but also lot
      subaccounts and postings, and the hidden tags that hledger adds to classify
-     things  --  use  -a/--all,  which is equivalent to --explicit --lots --ver-
+     things -- use -a/--all, which is equivalent  to  --explicit  --lots  --ver-
      bose-tags.
 
    print layout
-     By default, print aligns posting amounts so that their decimal mark  is  at
-     column  53  (or  would  be if they had a decimal mark).  If needed, it will
-     shift a transaction's amounts further to the right to  ensure  at  least  2
-     spaces  between account names and amounts.  Also, any balance assertion/as-
-     signment operators (=, =* etc.)  are aligned to the right  of  the  posting
+     By  default,  print aligns posting amounts so that their decimal mark is at
+     column 53 (or would be if they had a decimal mark).   If  needed,  it  will
+     shift  a  transaction's  amounts  further to the right to ensure at least 2
+     spaces between account names and amounts.  Also, any balance  assertion/as-
+     signment  operators  (=,  =* etc.)  are aligned to the right of the posting
      amounts; and the assertion/assignment amounts will be aligned by their dec-
      imal marks.
 
@@ -8663,47 +8715,47 @@ Standard report commands
      * --layout=COL -- sets a different target column for posting amounts' deci-
        mal mark
 
-     * --layout=hledger1  -- use hledger 1 layout (right-aligned posting amounts
+     * --layout=hledger1 -- use hledger 1 layout (right-aligned posting  amounts
        in each transaction).
 
-     If  you  want  to  change  the  default,  put  something   like   this   in
+     If   you   want   to  change  the  default,  put  something  like  this  in
      ~/.hledger.conf:
 
             [print]
             --layout=hledger1
 
-     Other  print-like commands (close, import, rewrite, add) also accept --lay-
+     Other print-like commands (close, import, rewrite, add) also accept  --lay-
      out.
 
    print amount style
-     Amounts will be displayed mostly in their commodity's display  style,  with
-     standardised  symbol  placement, decimal mark, and digit group marks.  This
+     Amounts  will  be displayed mostly in their commodity's display style, with
+     standardised symbol placement, decimal mark, and digit group  marks.   This
      does not apply to their decimal digits; print normally shows the same deci-
      mal digits that are recorded in each journal entry.
 
      You can override the decimal precisions with print's special --round option
-     (since 1.32).  --round tries to show amounts with their commodities'  stan-
+     (since  1.32).  --round tries to show amounts with their commodities' stan-
      dard decimal precisions, increasingly strongly:
 
      * --round=none show amounts with original precisions (default)
 
      * --round=soft add/remove decimal zeros in amounts (except costs)
 
-     * --round=hard  round  amounts  (except costs), possibly hiding significant
+     * --round=hard round amounts (except costs),  possibly  hiding  significant
        digits
 
      * --round=all round all amounts and costs
 
-     soft is good for non-lossy cleanup,  displaying  more  consistent  decimals
+     soft  is  good  for  non-lossy cleanup, displaying more consistent decimals
      where possible, without making entries unbalanced.
 
-     hard  or  all  can  be  good for stronger cleanup, when decimal rounding is
-     wanted.  Note rounding can produce unbalanced journal entries, perhaps  re-
+     hard or all can be good for stronger  cleanup,  when  decimal  rounding  is
+     wanted.   Note rounding can produce unbalanced journal entries, perhaps re-
      quiring manual fixup.
 
    print parseability
      Usually, print's output is a valid hledger journal, which you can pipe into
-     a  second hledger command for further processing.  This is sometimes conve-
+     a second hledger command for further processing.  This is sometimes  conve-
      nient for rewriting journal entries:
 
             # Make today's shopping entry explicit. (-f - means read from standard input.)
@@ -8714,15 +8766,15 @@ Standard report commands
             # Show running total of food expenses paid from cash.
             $ hledger print assets:cash | hledger -f- reg expenses:food
 
-     But here are some things which can  cause  print's  output  to  become  un-
+     But  here  are  some  things  which  can cause print's output to become un-
      parseable:
 
      * --round (see above) can disrupt transaction balancing.
 
-     * Account  aliases  or  pivoting  can disrupt account names, balance asser-
+     * Account aliases or pivoting can disrupt  account  names,  balance  asser-
        tions, or balance assignments.
 
-     * Value reporting also can disrupt balance assertions  or  balance  assign-
+     * Value  reporting  also  can disrupt balance assertions or balance assign-
        ments.
 
      * Auto postings can generate too many amountless postings.
@@ -8730,33 +8782,37 @@ Standard report commands
      * --infer-costs or --infer-equity can generate too-complex redundant costs.
 
      * Because print always shows transactions in date order, balance assertions
-       involving  non-date-ordered transactions (and same-day postings) could be
+       involving non-date-ordered transactions (and same-day postings) could  be
        disrupted.
 
-     Also, printing a subset of journal entries can disrupt validation  of  bal-
-     ance  assertions  or lot entries.  And print does not reproduce directives;
-     this too can break lot entries.  To suppress errors from  these,  we  often
-     use  the -I flag (short for --ignore-assertions --ignore-lots.  So any time
+     Also,  printing  a subset of journal entries can disrupt validation of bal-
+     ance assertions or lot entries.  And print does not  reproduce  directives;
+     this  too  can  break lot entries.  To suppress errors from these, we often
+     use the -I flag (short for --ignore-assertions --ignore-lots.  So any  time
      you are reading from standard input with -f-, consider adding -I also.
 
    print, other features
      With -B/--cost, amounts with costs are shown converted to cost.
 
      With --invert, posting amounts are shown with their sign flipped.  It could
-     be useful if you have accidentally  recorded  some  transactions  with  the
+     be  useful  if  you  have  accidentally recorded some transactions with the
      wrong signs.
 
-     With  --new,  print  shows  only transactions it has not seen on a previous
-     run.  This uses the same deduplication system as the import command.   (See
+     With --new, print shows only transactions it has not  seen  on  a  previous
+     run.   This uses the same deduplication system as the import command.  (See
      import's docs for details.)
 
-     With  -m  DESC/--match=DESC,  print  shows one recent transaction whose de-
-     scription is most similar to DESC.  DESC should contain at least two  char-
-     acters.   If there is no similar-enough match, no transaction will be shown
+     With -m DESC/--match=DESC, print shows one  recent  transaction  whose  de-
+     scription  is most similar to DESC.  DESC should contain at least two char-
+     acters.  If there is no similar-enough match, no transaction will be  shown
      and the program exit code will be non-zero.
 
-     With --locations, print adds the source  file  and  line  number  to  every
+     With  --locations,  print  adds  the  source  file and line number to every
      transaction, as a tag.
+
+     With --oneline, print shows only each transaction's first line  (the  date,
+     status, code, description, and any same-line comment), This gives a compact
+     overview.  It affects the default txt output only.
 
    print output format
      This command also supports the output destination and output format options
@@ -11873,4 +11929,4 @@ LICENSE
 SEE ALSO
      hledger(1), hledger-ui(1), hledger-web(1), ledger(1)
 
-hledger-1.99                        May 2026                          HLEDGER(1)
+hledger-1.99                        June 2026                         HLEDGER(1)

--- a/hledger/test/cli/cli.test
+++ b/hledger/test/cli/cli.test
@@ -158,11 +158,10 @@ $ hledger --debug -f /dev/null --conf /dev/null --no-conf >/dev/null
 $  echo '--pretty' >$$.conf; hledger -f /dev/null --conf $$.conf files; rm -f $$.conf
 /dev/null
 
-# ** 27. An initial non-flag general argument in a conf file is used as the command.
-$  echo 'files' >$$.conf; hledger stats -f /dev/null --conf $$.conf; rm -f $$.conf
-
-# ** 28. A non-flag general argument that's not first in the conf file is note used as the command.
-$  echo '--pretty files' >$$.conf; hledger stats -f /dev/null --conf $$.conf; rm -f $$.conf
+# ** 27. A non-flag argument in a config file's general section is NOT treated as the command
+# (that feature was removed); it is just passed to the command as an argument.
+# Here the command run is the one on the command line (stats), not the config's "balance".
+$  printf 'balance\n' >$$.conf; printf '2026-01-01\n  a  1\n  b\n' | hledger stats -f- --conf $$.conf; rm -f $$.conf
 > /Runtime stats/
 
 # ** 29. A required-value flag followed by another flag is rejected with a clear error.
@@ -237,13 +236,7 @@ $ hledger help -m -h
 $ hledger help -i -h
 > /Show the hledger user manual/
 
-# ** 42. When the command comes from the config file and no command is written
-# on the command line, no spurious empty argument is passed to the command.
-$  printf 'files\n' >$$.conf; hledger -f /dev/null --conf $$.conf; rm -f $$.conf
-/dev/null
-
-# ** 43. --conf/--no-conf flags inside a config file are ignored:
-# they can't affect which config file is used, since that was decided before reading the file.
-# Here the config file is still used (its command argument still applies) despite its --no-conf.
-$  printf -- 'files\n--no-conf\n' >$$.conf; hledger -f /dev/null --conf $$.conf; rm -f $$.conf
-/dev/null
+# ** 42. --conf/--no-conf flags inside a config file are ignored: which config file to use
+# was decided before reading it, so they are dropped from the config's general arguments.
+$  printf -- '--no-conf\n' >$$.conf; hledger --debug=1 files -f /dev/null --conf $$.conf 2>&1 >/dev/null | grep -o 'ignored conf-selecting flags from config file'; rm -f $$.conf
+ignored conf-selecting flags from config file

--- a/hledger/test/cli/command-aliases.test
+++ b/hledger/test/cli/command-aliases.test
@@ -84,7 +84,7 @@ $  printf '[alias]\nbadline\n' >$$.conf; hledger --conf $$.conf -f /dev/null fil
 # ** 12. Command aliases are shown in the commands list.
 $  printf '[alias]\nnetworth = bse -H --tree\n' >$$.conf; hledger --conf $$.conf commands | grep -A1 '^ALIASES'; rm -f $$.conf
 ALIASES
- networth                 = bse -H --tree
+ networth = bse -H --tree
 
 # ** 13. --no-conf disables command aliases.
 $  printf '[alias]\nlist = files\n' >$$.conf; hledger --conf $$.conf -n -f /dev/null list; s=$?; rm -f $$.conf; exit $s
@@ -162,7 +162,7 @@ $  printf '[alias]\nbad = !false\n' >$$.conf; hledger --conf $$.conf bad; s=$?; 
 # ** 24. Shell aliases are shown in the commands list, with their ! definition.
 $  printf '[alias]\nhi = !echo hello\n' >$$.conf; hledger --conf $$.conf commands | grep -A1 '^ALIASES'; rm -f $$.conf
 ALIASES
- hi                       = !echo hello
+ hi = !echo hello
 
 # ** 25. Shell aliases work in run command scripts too.
 $  printf '[alias]\nhi = !echo hello\n' >$$.conf; hledger --conf $$.conf run -f /dev/null -- hi; rm -f $$.conf

--- a/hledger/test/cli/command-aliases.test
+++ b/hledger/test/cli/command-aliases.test
@@ -141,3 +141,42 @@ $  printf '[alias]\nbadalias = nosuchcmd\n' >$$.conf; hledger --conf $$.conf run
 $  printf '[alias r3]\nrun\n-- echo ran: -- stats\n' >$$.conf; printf '2026-01-01\n  a  1\n  b\n' >$$.j; LEDGER_FILE=$$.j hledger --conf $$.conf r3 | grep -E 'ran:|Txns span'; rm -f $$.conf $$.j
 ran:
 Txns span           : 2026-01-01 to 2026-01-02 (1 days)
+
+# ** 20. An alias whose command line begins with ! runs a shell command.
+# (--conf makes this config file trusted, so the shell alias is allowed.)
+$  printf '[alias]\nhi = !echo hello\n' >$$.conf; hledger --conf $$.conf hi; rm -f $$.conf
+hello
+
+# ** 21. Arguments written after the alias name are appended to the shell command.
+$  printf '[alias]\nhi = !echo hello\n' >$$.conf; hledger --conf $$.conf hi there; rm -f $$.conf
+hello there
+
+# ** 22. A shell alias also works in the [alias NAME] section form.
+$  printf '[alias hi]\n!echo hello\n' >$$.conf; hledger --conf $$.conf hi; rm -f $$.conf
+hello
+
+# ** 23. The shell command's exit code is propagated.
+$  printf '[alias]\nbad = !false\n' >$$.conf; hledger --conf $$.conf bad; s=$?; rm -f $$.conf; exit $s
+>= 1
+
+# ** 24. Shell aliases are shown in the commands list, with their ! definition.
+$  printf '[alias]\nhi = !echo hello\n' >$$.conf; hledger --conf $$.conf commands | grep -A1 '^ALIASES'; rm -f $$.conf
+ALIASES
+ hi                       = !echo hello
+
+# ** 25. Shell aliases work in run command scripts too.
+$  printf '[alias]\nhi = !echo hello\n' >$$.conf; hledger --conf $$.conf run -f /dev/null -- hi; rm -f $$.conf
+hello
+
+# ** 26. Trust gate: a shell alias in your user config file (~/.hledger.conf) is allowed.
+# HOME/XDG are set so config discovery is contained and the dev's real config is not used.
+# We run from a subdirectory (cwd != HOME) so the user config isn't also seen as a local one.
+$  d=$(mktemp -d); mkdir $d/work; printf '[alias]\nhi = !echo hello\n' >$d/.hledger.conf; (cd $d/work && HOME=$d XDG_CONFIG_HOME=$d/.config hledger hi); rm -rf $d
+hello
+
+# ** 27. Trust gate: a shell alias in an automatically-found local hledger.conf is refused.
+# The config is in cwd, which is a subdirectory of HOME so it is treated as a local
+# (non-user) config. (If cwd == HOME, the file would be looked up as ~/.hledger.conf.)
+$  d=$(mktemp -d); mkdir $d/work; printf '[alias]\nevil = !echo pwned\n' >$d/work/hledger.conf; (cd $d/work && HOME=$d XDG_CONFIG_HOME=$d/.config hledger evil); s=$?; rm -rf $d; exit $s
+>2 /only allowed from your user config file/
+>= 1

--- a/hledger/test/cli/command-aliases.test
+++ b/hledger/test/cli/command-aliases.test
@@ -133,3 +133,11 @@ $  printf '[alias]\nmybal = balance --tree -N\n' >$$.conf; printf '2026-01-01\n 
 $  printf '[alias]\nbadalias = nosuchcmd\n' >$$.conf; hledger --conf $$.conf run -f /dev/null -- badalias; s=$?; rm -f $$.conf; exit $s
 >2 /Unrecognized command \(expanded from the badalias command alias\): nosuchcmd/
 >= 1
+
+# ** 19. An alias running "run" with inline commands needs only a single --
+# separator (the extra -- that cmdargs consumes is added automatically).
+# LEDGER_FILE points run (and its inline commands) at our test journal, so the
+# result doesn't depend on the environment's default journal.
+$  printf '[alias r3]\nrun\n-- echo ran: -- stats\n' >$$.conf; printf '2026-01-01\n  a  1\n  b\n' >$$.j; LEDGER_FILE=$$.j hledger --conf $$.conf r3 | grep -E 'ran:|Txns span'; rm -f $$.conf $$.j
+ran:
+Txns span           : 2026-01-01 to 2026-01-02 (1 days)

--- a/hledger/test/cli/command-aliases.test
+++ b/hledger/test/cli/command-aliases.test
@@ -95,3 +95,41 @@ $  printf '[alias]\nlist = files\n' >$$.conf; hledger --conf $$.conf -n -f /dev/
 # does not hide the file's aliases from the commands list.
 $  printf -- '--no-conf\n\n[alias]\nlist = files\n' >$$.conf; hledger --conf $$.conf commands | grep -c '^ALIASES'; rm -f $$.conf
 1
+
+# ** 15. Command aliases can be used in run's command line arguments.
+<
+2026-01-01
+  a:x  1
+  a:y  1
+  b   -2
+$  printf '[alias]\nmybal = balance --tree -N\n' >$$.conf; hledger --conf $$.conf run -f- -- mybal; rm -f $$.conf
+                   2  a
+                   1    x
+                   1    y
+                  -2  b
+
+# ** 16. Command aliases can be used in a run command script,
+# and extra arguments written after the alias name are added at the end.
+<
+2026-01-01
+  a:x  1
+  a:y  1
+  b   -2
+$  printf '[alias]\nmybal = balance --tree -N\n' >$$.conf; printf 'mybal --flat\n' >$$.script; hledger --conf $$.conf run -f- $$.script; rm -f $$.conf $$.script
+                   1  a:x
+                   1  a:y
+                  -2  b
+
+# ** 17. Command aliases can be used in run/repl commands read from stdin.
+<
+mybal
+$  printf '[alias]\nmybal = balance --tree -N\n' >$$.conf; printf '2026-01-01\n  a:x  1\n  a:y  1\n  b   -2\n' >$$.j; hledger --conf $$.conf run -f $$.j; rm -f $$.conf $$.j
+                   2  a
+                   1    x
+                   1    y
+                  -2  b
+
+# ** 18. In run, an alias whose command is unrecognised gives a helpful error.
+$  printf '[alias]\nbadalias = nosuchcmd\n' >$$.conf; hledger --conf $$.conf run -f /dev/null -- badalias; s=$?; rm -f $$.conf; exit $s
+>2 /Unrecognized command \(expanded from the badalias command alias\): nosuchcmd/
+>= 1

--- a/hledger/test/cli/command-aliases.test
+++ b/hledger/test/cli/command-aliases.test
@@ -1,0 +1,97 @@
+# * command aliases (custom commands) defined in config files
+# See https://hledger.org/dev/hledger.html#command-aliases
+
+# ** 1. An [alias] section line defines a custom command.
+$  printf '[alias]\nlist = files\n' >$$.conf; hledger --conf $$.conf -f /dev/null list; rm -f $$.conf
+/dev/null
+
+# ** 2. The alias's arguments are used.
+<
+2026-01-01
+  a:x  1
+  a:y  1
+  b   -2
+$  printf '[alias]\nmybal = balance --tree -N\n' >$$.conf; hledger --conf $$.conf -f- mybal; rm -f $$.conf
+                   2  a
+                   1    x
+                   1    y
+                  -2  b
+
+# ** 3. Extra options/arguments written after the alias name are added at the end,
+# so they can override the alias's arguments.
+<
+2026-01-01
+  a:x  1
+  a:y  1
+  b   -2
+$  printf '[alias]\nmybal = balance --tree -N\n' >$$.conf; hledger --conf $$.conf -f- mybal --flat; rm -f $$.conf
+                   1  a:x
+                   1  a:y
+                  -2  b
+
+# ** 4. An [alias NAME] section also defines a custom command, with its
+# command line written below, possibly on multiple lines, possibly with
+# some lines commented out.
+<
+2026-01-01
+  a:x  1
+  a:y  1
+  b   -2
+$  printf '[alias mybal]\nbalance --tree\n# --flat\n-N\n' >$$.conf; hledger --conf $$.conf -f- mybal; rm -f $$.conf
+                   2  a
+                   1    x
+                   1    y
+                  -2  b
+
+# ** 5. If the same alias name is defined more than once, the last definition wins.
+<
+2026-01-01
+  a:x  1
+  a:y  1
+  b   -2
+$  printf '[alias]\nmybal = balance --tree -N\nmybal = balance --flat -N\n' >$$.conf; hledger --conf $$.conf -f- mybal; rm -f $$.conf
+                   1  a:x
+                   1  a:y
+                  -2  b
+
+# ** 6. Command aliases can not override builtin command names.
+$  printf '[alias]\nfiles = stats\n' >$$.conf; hledger --conf $$.conf -f /dev/null files; rm -f $$.conf
+/dev/null
+
+# ** 7. Command aliases do override addon commands with the same name.
+$ mkdir -p $$d; printf '#!/bin/sh\necho ADDON RAN\n' >$$d/hledger-zzzz; chmod +x $$d/hledger-zzzz; printf '[alias]\nzzzz = files\n' >$$.conf; PATH=$$d:$PATH hledger --conf $$.conf -f /dev/null zzzz; rm -rf $$d $$.conf
+/dev/null
+
+# ** 8. An alias can refer to itself; the name is then resolved as an addon command.
+# This allows adding default options to an addon command.
+$ mkdir -p $$d; printf '#!/bin/sh\necho ADDON RAN: $@\n' >$$d/hledger-zzzz; chmod +x $$d/hledger-zzzz; printf '[alias]\nzzzz = zzzz --extra\n' >$$.conf; PATH=$$d:$PATH hledger --conf $$.conf -f /dev/null zzzz; rm -rf $$d $$.conf
+> /ADDON RAN: --extra/
+
+# ** 9. An alias can refer to another alias.
+$  printf '[alias]\nlist2 = list1\nlist1 = files\n' >$$.conf; hledger --conf $$.conf -f /dev/null list2; rm -f $$.conf
+/dev/null
+
+# ** 10. An alias whose command is unrecognised gives a helpful error.
+$  printf '[alias]\nbadalias = nosuchcmd --foo\n' >$$.conf; hledger --conf $$.conf -f /dev/null badalias; s=$?; rm -f $$.conf; exit $s
+>2 /command nosuchcmd \(expanded from the badalias command alias\) is not recognised/
+>= 1
+
+# ** 11. An [alias] section line without an equals sign gives a helpful error.
+$  printf '[alias]\nbadline\n' >$$.conf; hledger --conf $$.conf -f /dev/null files; s=$?; rm -f $$.conf; exit $s
+>2 /an \[alias\] section line should look like/
+>= 1
+
+# ** 12. Command aliases are shown in the commands list.
+$  printf '[alias]\nnetworth = bse -H --tree\n' >$$.conf; hledger --conf $$.conf commands | grep -A1 '^ALIASES'; rm -f $$.conf
+ALIASES
+ networth                 = bse -H --tree
+
+# ** 13. --no-conf disables command aliases.
+$  printf '[alias]\nlist = files\n' >$$.conf; hledger --conf $$.conf -n -f /dev/null list; s=$?; rm -f $$.conf; exit $s
+>2 /command list is not recognised/
+>= 1
+
+# ** 14. A --no-conf flag inside the config file (which is ignored, see cli.test)
+# does not hide the file's aliases from the commands list.
+$  printf -- '--no-conf\n\n[alias]\nlist = files\n' >$$.conf; hledger --conf $$.conf commands | grep -c '^ALIASES'; rm -f $$.conf
+1


### PR DESCRIPTION
This adds git-style command aliases (custom commands) that can be defined in a config file. I've had this for a day, and I can already say it is a very useful feature! 

But there's also a breaking change: to reduce the risk of unexpectedly running shell commands, I have dropped config files' ability to set the command to be run; now the command must always be specified by the command line. I could have added a restriction, but it seems simpler and clearer to drop it.

I think the changes are solid, but any testing or comments are welcome, especially about the breaking change.

1. **feat: command aliases (custom commands) can be defined in config files**
   Define aliases one per line in an `[alias]` section (`NAME = COMMAND ARGS..`), or one per `[alias NAME]` section with the command line below (possibly multi-line, with commentable lines). An alias command can be a builtin command, an addon, or another alias. Aliases can't override builtin names but do override same-named addons. Aliases show in the commands list in a new ALIASES group.

2. **imp: run,repl: command aliases can be used in run and repl**
   Aliases now also work in run command scripts and at the repl prompt.

3. **fix: command aliases: don't require an extra `--` separator in run commands**
   An alias running `run` with inline commands no longer needs an extra `--`.

4. **feat: command aliases can run shell commands with a `!` prefix**
   An alias whose command line begins with `!` runs as a shell command. Shell aliases run only from a trusted config file - one given explicitly with `--conf`, or a user-level config (`~/.hledger.conf` or XDG `hledger.conf`). A shell alias in an auto-discovered local `hledger.conf` is refused. This prevents a downloaded/shared directory's config from running arbitrary shell commands.

5. **fix!: config files can no longer specify the command to run**
   Previously a non-flag first word in a config file's general section was used as the command. Now the command must always be on the command line. This removes a risk introduced by shell aliases.