### PR TITLE
imp: print: allow omitting trailing decimal marks for declared commodities

### DIFF
--- a/hledger-lib/Hledger/Data/Amount.hs
+++ b/hledger-lib/Hledger/Data/Amount.hs
@@ -253,9 +253,14 @@ data AmountFormat = AmountFormat
                                           --   Also, causes 0s to be generated for any commodities which are not present
                                           --   (important for tabular reports).
   , displayDigitGroups      :: Bool       -- ^ Whether to display digit group marks (eg thousands separators)
-  , displayForceDecimalMark :: Bool       -- ^ Whether to add a trailing decimal mark when there are no decimal digits 
-                                          --   and there are digit group marks, to disambiguate
-  , displayOneLine          :: Bool       -- ^ Whether to display on one line.
+   , displayForceDecimalMark :: Bool       -- ^ Whether to add a trailing decimal mark when there are no decimal digits
+                                           --   and there are digit group marks, to disambiguate
+   , displaySuppressDecimalMark :: S.Set CommoditySymbol
+                                           -- ^ Commodities for which the trailing disambiguating decimal mark is
+                                           --   suppressed even when 'displayForceDecimalMark' is set.
+                                           --   Only safe when the commodity's style is declared in the journal,
+                                           --   so the amount re-parses unambiguously with the declarations (#2664).
+   , displayOneLine          :: Bool       -- ^ Whether to display on one line.
   , displayMinWidth         :: Maybe Int  -- ^ Minimum width to pad to
   , displayMaxWidth         :: Maybe Int  -- ^ Maximum width to clip to
   , displayCost             :: Bool       -- ^ Whether to display Amounts' costs.
@@ -276,6 +281,7 @@ defaultFmt = AmountFormat {
   , displayCommodityOrder   = Nothing
   , displayDigitGroups      = True
   , displayForceDecimalMark = False
+  , displaySuppressDecimalMark = S.empty
   , displayOneLine          = False
   , displayMinWidth         = Just 0
   , displayMaxWidth         = Nothing
@@ -783,14 +789,14 @@ showAmountB :: AmountFormat -> Amount -> WideBuilder
 showAmountB _ Amount{acommodity="AUTO"} = mempty
 showAmountB
   afmt@AmountFormat{displayCommodity, displayZeroCommodity, displayDigitGroups
-                   ,displayForceDecimalMark, displayCost, displayCostBasis, displayColour, displayQuotes}
+                   ,displayForceDecimalMark, displaySuppressDecimalMark, displayCost, displayCostBasis, displayColour, displayQuotes}
   a@Amount{astyle=style} =
     color $ case ascommodityside style of
       L -> (if displayCommodity then wbFromText comm <> space else mempty) <> quantity' <> costbasis <> cost
       R -> quantity' <> (if displayCommodity then space <> wbFromText comm else mempty) <> costbasis <> cost
   where
     color = if displayColour && isNegativeAmount a then colorB Dull Red else id
-    quantity = showAmountQuantity displayForceDecimalMark $
+    quantity = showAmountQuantity (displayForceDecimalMark && S.notMember (acommodity a) displaySuppressDecimalMark) $
       if displayDigitGroups then a else a{astyle=(astyle a){asdigitgroups=Nothing}}
     (quantity', comm)
       | amountLooksZero a && not displayZeroCommodity = (WideBuilder (TB.singleton '0') 1, "")

--- a/hledger-lib/Hledger/Data/Transaction.hs
+++ b/hledger-lib/Hledger/Data/Transaction.hs
@@ -71,6 +71,7 @@ import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Semigroup (Endo(..))
 import Data.Text (Text)
 import Data.Map qualified as M
+import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import Data.Text.Lazy.Builder qualified as TB
@@ -172,18 +173,20 @@ are displayed as multiple similar postings, one per commodity.
 (Normally does not happen with this function).
 -}
 showTransaction :: Transaction -> Text
-showTransaction = TL.toStrict . TB.toLazyText . showTransactionHelper False defaultPostingLayout
+showTransaction = TL.toStrict . TB.toLazyText . showTransactionHelper S.empty False defaultPostingLayout
 
 -- | Like 'showTransaction', but with an explicit posting layout
 -- (e.g. to support @print --layout=hledger1@).
-showTransactionWithLayout :: PostingLayout -> Transaction -> Text
-showTransactionWithLayout layout = TL.toStrict . TB.toLazyText . showTransactionHelper False layout
+-- Takes the set of commodities whose styles are declared in the journal,
+-- so that their amounts can be shown without a trailing decimal mark (#2664).
+showTransactionWithLayout :: S.Set CommoditySymbol -> PostingLayout -> Transaction -> Text
+showTransactionWithLayout declared layout = TL.toStrict . TB.toLazyText . showTransactionHelper declared False layout
 
 -- | Like showTransaction, but explicit multi-commodity amounts
 -- are shown on one line, comma-separated. In this case the output will
 -- not be parseable journal syntax.
 showTransactionOneLineAmounts :: Transaction -> Text
-showTransactionOneLineAmounts = TL.toStrict . TB.toLazyText . showTransactionHelper True defaultPostingLayout
+showTransactionOneLineAmounts = TL.toStrict . TB.toLazyText . showTransactionHelper S.empty True defaultPostingLayout
 
 -- | Show only a transaction's first line: date, status, code, description,
 -- and same-line comment, without any comment lines or postings. Used by print --oneline.
@@ -193,11 +196,11 @@ showTransactionOneLine :: Transaction -> Text
 showTransactionOneLine t = transactionFirstLine t <> "\n"
 
 -- | Helper for showTransaction*.
-showTransactionHelper :: Bool -> PostingLayout -> Transaction -> TB.Builder
-showTransactionHelper onelineamounts layout t =
+showTransactionHelper :: S.Set CommoditySymbol -> Bool -> PostingLayout -> Transaction -> TB.Builder
+showTransactionHelper declared onelineamounts layout t =
       TB.fromText (transactionFirstLine t) <> newline
     <> foldMap ((<> newline) . TB.fromText) newlinecomments
-    <> foldMap ((<> newline) . TB.fromText) (postingsAsLinesWithLayout defaultFmt onelineamounts layout $ tpostings t)
+    <> foldMap ((<> newline) . TB.fromText) (postingsAsLinesWithLayout (defaultFmt{displaySuppressDecimalMark=declared}) onelineamounts layout $ tpostings t)
     <> newline
   where
     newlinecomments = drop 1 $ renderCommentLines (tcomment t)

--- a/hledger/Hledger/Cli/Commands/Add.hs
+++ b/hledger/Hledger/Cli/Commands/Add.hs
@@ -30,6 +30,7 @@ import Data.Either (isRight)
 import Data.Functor.Identity (Identity(..))
 import Data.List (isPrefixOf, nub)
 import Data.Maybe (fromJust, fromMaybe, isJust)
+import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
@@ -203,7 +204,7 @@ transactionWizard previnput state@AddState{..} stack@(currentStage : _) = case c
           previnput' = previnput{prevDescAndCmnt=Just descAndCommentString}
       when (isJust mbaset) . liftIO $ do
           hPutStrLn stderr "Using this similar transaction for defaults:"
-          T.hPutStr stderr $ showTransactionWithLayout (layoutFromRawOpts $ rawopts_ asOpts) (fromJust mbaset)
+          T.hPutStr stderr $ showTransactionWithLayout (S.fromList $ journalCommoditiesDeclared asJournal) (layoutFromRawOpts $ rawopts_ asOpts) (fromJust mbaset)
       transactionWizard previnput' state' ((GetPosting TxnData{txnDate=date, txnCode=code, txnDesc=desc, txnCmnt=comment} Nothing) : stack)
     Nothing ->
       transactionWizard previnput state (drop 1 stack)
@@ -288,7 +289,7 @@ transactionWizard previnput state@AddState{..} stack@(currentStage : _) = case c
     Nothing -> transactionWizard previnput state (drop 1 stack)
 
   Confirm t -> do
-    output . T.unpack $ showTransactionWithLayout (layoutFromRawOpts $ rawopts_ asOpts) t
+    output . T.unpack $ showTransactionWithLayout (S.fromList $ journalCommoditiesDeclared asJournal) (layoutFromRawOpts $ rawopts_ asOpts) t
     y <- let def = "y" in
          retryMsg "Please enter y or n." $
           parser ((fmap (\c -> if c == '<' then Nothing else Just c)) . headMay . map toLower . strip) $
@@ -536,7 +537,7 @@ postingsAreBalanced j ps = isRight $ balanceSingleTransaction bopts nulltransact
 journalAddTransaction :: Journal -> CliOpts -> Transaction -> IO Journal
 journalAddTransaction j@Journal{jtxns=ts} opts t = do
   let f = journalFilePath j
-      showtxn = showTransactionWithLayout (layoutFromRawOpts $ rawopts_ opts)
+      showtxn = showTransactionWithLayout (S.fromList $ journalCommoditiesDeclared j) (layoutFromRawOpts $ rawopts_ opts)
   appendToJournalFileOrStdout f $ showtxn t
     -- unelided shows all amounts explicitly, in case there's a price, cf #283
   when (debug_ opts > 0) $ do

--- a/hledger/Hledger/Cli/Commands/Close.hs
+++ b/hledger/Hledger/Cli/Commands/Close.hs
@@ -11,6 +11,7 @@ where
 import Data.Function (on)
 import Data.List (groupBy)
 import Data.Maybe (fromMaybe)
+import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import Data.Time.Calendar (addDays)
@@ -270,7 +271,7 @@ close CliOpts{rawopts_=rawopts, reportspec_=rspec0} j = do
   -- allow user-specified rounding with --round, like print
   let styles = amountStylesSetRoundingFromRawOpts rawopts $ journalCommodityStyles j
       postinglayout = layoutFromRawOpts rawopts
-      showtxn = showTransactionWithLayout postinglayout . styleAmounts styles
+      showtxn = showTransactionWithLayout S.empty postinglayout . styleAmounts styles
   maybe (pure ()) (T.putStr . showtxn) mclosetxn
   maybe (pure ()) (T.putStr . showtxn) mopentxn
  

--- a/hledger/Hledger/Cli/Commands/Import.hs
+++ b/hledger/Hledger/Cli/Commands/Import.hs
@@ -11,6 +11,7 @@ where
 
 import Control.Monad
 import Data.List
+import Data.Set qualified as S
 import Data.Text.IO qualified as T
 import System.Console.CmdArgs.Explicit
 import Text.Printf
@@ -94,7 +95,7 @@ importcmd opts@CliOpts{rawopts_=rawopts,inputopts_=iopts} j = do
               then do
                 -- show txns to be imported
                 hPrintf stderr "would import %d new transactions from %s:\n\n" (length newts) inputstr
-                mapM_ (T.putStr . showTransactionWithLayout postinglayout) newts
+                mapM_ (T.putStr . showTransactionWithLayout S.empty postinglayout) newts
 
                 -- then check the whole journal with them added, if in strict mode
                 when (strict_ iopts) $ strictChecks

--- a/hledger/Hledger/Cli/Commands/Print.hs
+++ b/hledger/Hledger/Cli/Commands/Print.hs
@@ -46,6 +46,7 @@ import Hledger.Cli.Anchor (setAccountAnchor)
 import Lucid qualified
 import System.IO qualified as IO
 import Data.Maybe (isJust, catMaybes, fromMaybe)
+import Data.Set qualified as S
 import Hledger.Write.Beancount (commodityToBeancount, tagsToBeancountMetadata)
 
 printmode = hledgerCommandMode
@@ -171,8 +172,27 @@ printEntries opts@CliOpts{rawopts_=rawopts, reportspec_=rspec} j =
     query = querystring_ $ _rsReportOpts rspec
     postinglayout = layoutFromRawOpts rawopts
     oneline = boolopt "oneline" rawopts
-    showtxn = if oneline then showTransactionOneLine else showTransactionWithLayout postinglayout
-    render | fmt=="txt"       = withTitle (_rsReportOpts rspec) . entriesReportAsTextHelper showtxn . styleAmounts styles . map maybeoriginalamounts
+    -- Commodities with styles declared in the journal: their amounts can be
+    -- shown without a trailing decimal mark, since the style directive
+    -- emitted below makes them unambiguous when re-parsed (#2664).
+    declaredCommodities = S.fromList $ journalCommoditiesDeclared j
+    showtxn = if oneline then showTransactionOneLine else showTransactionWithLayout declaredCommodities postinglayout
+    -- Re-emit the declared commodity style directives for commodities with
+    -- digit group marks, so that amounts shown without trailing decimal
+    -- marks (see 'declaredCommodities') can be re-parsed unambiguously (#2664).
+    -- Only commodities with digit group marks need this, since only they
+    -- have trailing decimal marks suppressed.
+    styleDirectiveHeader :: TL.Text
+    styleDirectiveHeader
+      | null headerCommodities = ""
+      | otherwise = TL.fromStrict $ T.unlines $
+          [ "commodity " <> T.pack (wbUnpack $ showAmountB defaultFmt{displayForceDecimalMark=True} $
+               nullamt{acommodity=sym, astyle=style, aquantity=1000})
+          | (sym, style) <- headerCommodities
+          ] <> [""]
+      where
+        headerCommodities = [(sym, style) | (sym, c) <- Map.toList (jdeclaredcommodities j), Just style <- [cformat c], isJust (asdigitgroups style)]
+    render | fmt=="txt"       = withTitle (_rsReportOpts rspec) . (styleDirectiveHeader <>) . entriesReportAsTextHelper showtxn . styleAmounts styles . map maybeoriginalamounts
            | fmt=="ledger"   = withTitle (_rsReportOpts rspec) . entriesReportAsTextHelper showTransactionLedger . styleAmounts styles . map maybeoriginalamounts
            | fmt=="beancount" = entriesReportAsBeancount (jdeclaredaccounttags j) styledPrices . styleAmounts styles . map fillBalanceAssignments
            | fmt=="csv"       = printCSV . entriesReportAsCsv . styleAmounts styles

--- a/hledger/Hledger/Cli/Commands/Rewrite.hs
+++ b/hledger/Hledger/Cli/Commands/Rewrite.hs
@@ -13,6 +13,7 @@ where
 
 import Data.Functor.Identity
 import Data.List (sortOn)
+import Data.Set qualified as S
 #if !MIN_VERSION_base(4,20,0)
 import Data.List (foldl')
 #endif
@@ -141,7 +142,7 @@ diffTxn postinglayout j t t' = case tsourcepos t of
         diffs = map mapDiff $ D.getDiff source changed'
         source | Just contents <- lookup fp $ jfiles j = drop (unPos line-1) . take (unPos line' - 1) $ T.lines contents
                | otherwise = []
-        changed = T.lines $ showTransactionWithLayout postinglayout t'
+        changed = T.lines $ showTransactionWithLayout S.empty postinglayout t'
         changed' | null changed = changed
                  | T.null $ last changed = init changed
                  | otherwise = changed

--- a/hledger/test/print/print-style.test
+++ b/hledger/test/print/print-style.test
@@ -288,3 +288,39 @@ $ hledger -f- print -X B
     (a)                                            0.0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789B
 
 >=
+
+# ** 14. When a commodity's style is declared with a commodity directive and
+# it uses digit group marks, print omits the trailing disambiguating decimal
+# mark, since the re-emitted commodity directive makes the amount unambiguous
+# when re-parsed (#2664).
+<
+commodity 1,000. JPY
+
+2023-01-01
+    a   1,000 JPY
+    b  -1,000 JPY
+
+$ hledger -f- print
+commodity 1,000. JPY
+
+2023-01-01
+    a                                          1,000 JPY
+    b                                         -1,000 JPY
+
+>=
+
+# ** 15. A declared commodity without digit group marks is unaffected:
+# no trailing decimal mark is added, and no commodity directive is re-emitted.
+<
+commodity A1000.00
+
+2023-01-01
+    a   1 A
+    b  -1 A
+
+$ hledger -f- print
+2023-01-01
+    a                                             A1
+    b                                            A-1
+
+>=


### PR DESCRIPTION
## Summary
- For commodities whose styles are declared in the journal (`commodity` directives), `print` and friends now omit the trailing disambiguating decimal mark, since the declarations re-emitted at the top of the output make the amounts unambiguous when re-parsed.
- Adds `displaySuppressDecimalMark` to `AmountFormat`; `print` and `add` pass the journal's declared commodity set through `showTransactionWithLayout`.
- `print` re-emits the journal's declared commodity style directives as a header so output round-trips.
- `close`, `import`, and `rewrite` keep the previous behaviour (no suppression) since they don't emit the directive header.

Closes #2664.

AI usage: Devin (GLM-5.2 High), ~10k output tokens.

#### Test plan
- [ ] `print` on a journal with a declared commodity using digit group marks (e.g. JPY) shows no trailing decimal mark
- [ ] `print` output round-trips through `hledger -f - print`
- [ ] `add`/`import` write amounts without trailing decimal marks for declared commodities
- [ ] `close`/`import --dry-run`/`rewrite` behaviour unchanged