### PR TITLE
feat: journal: accept _ and ' as digit group marks (#273, #1489)

### DIFF
--- a/hledger-lib/Hledger/Read/Common.hs
+++ b/hledger-lib/Hledger/Read/Common.hs
@@ -1278,6 +1278,10 @@ disambiguateNumber msuggestedStyle (AmbiguousNumber grp1 sep grp2) =
 -- Left (AmbiguousNumber "1" ',' "000")
 -- >>> parseTest rawnumberp "1 000"
 -- Right (WithSeparators ' ' ["1","000"] Nothing)
+-- >>> parseTest rawnumberp "1'000"
+-- Right (WithSeparators '\'' ["1","000"] Nothing)
+-- >>> parseTest rawnumberp "1_000"
+-- Right (WithSeparators '_' ["1","000"] Nothing)
 --
 rawnumberp :: TextParser m (Either AmbiguousNumber RawNumber)
 rawnumberp = label "number" $ do
@@ -1343,7 +1347,7 @@ rawnumberp = label "number" $ do
     pure $ NoSeparators grp1 (Just (decPt, mempty))
 
 isDigitSeparatorChar :: Char -> Bool
-isDigitSeparatorChar c = isDecimalMark c || isDigitSeparatorSpaceChar c
+isDigitSeparatorChar c = isDecimalMark c || isDigitSeparatorSpaceChar c || c == '_' || c == '\''
 
 -- | Kinds of unicode space character we accept as digit group marks.
 -- See also https://en.wikipedia.org/wiki/Decimal_separator#Digit_grouping .
@@ -1824,6 +1828,8 @@ tests_Common = testGroup "Common" [
      assertParseEq p "1"          (1, 0, Nothing, Nothing)
      assertParseEq p "1.1"        (1.1, 1, Just '.', Nothing)
      assertParseEq p "1,000.1"    (1000.1, 1, Just '.', Just $ DigitGroups ',' [3])
+     assertParseEq p "1_000.1"    (1000.1, 1, Just '.', Just $ DigitGroups '_' [3])
+     assertParseEq p "1'000.1"    (1000.1, 1, Just '.', Just $ DigitGroups '\'' [3])
      assertParseEq p "1.00.000,1" (100000.1, 1, Just ',', Just $ DigitGroups '.' [3,2])
      assertParseEq p "1,000,000"  (1000000, 0, Nothing, Just $ DigitGroups ',' [3,3])  -- could be simplified to [3]
      assertParseEq p "1."         (1, 0, Just '.', Nothing)

--- a/hledger/hledger.m4.md
+++ b/hledger/hledger.m4.md
@@ -1648,7 +1648,7 @@ hledger also accepts numbers like `10.` with no digits after the decimal mark
 
 In the integer part of the amount quantity (left of the decimal mark),
 groups of digits can optionally be separated by a *digit group mark* -
-a comma or period (whichever is not used as decimal mark), 
+a comma or period (whichever is not used as decimal mark), an underscore, an apostrophe,
 or a space (several Unicode space variants, like no-break space, are also accepted).
 <!--
 space,
@@ -1665,7 +1665,9 @@ So these are all valid amounts in a journal file:
          $1,000,000.00
       EUR 2.000.000,00
     INR 9,99,99,999.00
-          1 000 000.00   ; <- ordinary space  
+      CHF 1'000'000.00
+          1_000_000.00
+          1 000 000.00   ; <- ordinary space
           1 000 000.00   ; <- no-break space
 
 ### Commodity

--- a/hledger/test/commodities.test
+++ b/hledger/test/commodities.test
@@ -99,3 +99,32 @@ $ hledger -f - commodities --declared date:2099
 DA
 DB
 
+# ** 9. all digit group separators can be used in commodity directives
+<
+commodity 1,000.0 comma
+commodity 1.000,0 dot
+commodity 1_000.0 underscore
+commodity 1'000,0 apostrophe
+
+commodity 1 000,0 space
+commodity 1 000,0 no_break_space
+commodity 1 000,0 en_space
+commodity 1 000,0 em_space
+commodity 1 000,0 punctuation_space
+commodity 1 000,0 thin_space
+commodity 1 000,0 narrow_no_break_space
+commodity 1 000,0 medium_mathematical_space
+
+$ hledger -f - commodities
+apostrophe
+comma
+dot
+em_space
+en_space
+medium_mathematical_space
+narrow_no_break_space
+no_break_space
+punctuation_space
+space
+thin_space
+underscore

--- a/hledger/test/journal/numbers.test
+++ b/hledger/test/journal/numbers.test
@@ -237,3 +237,12 @@ commodity 1 000. A  ; narrow no-break space
 
 $ hledger bal -f - -N
              3 000 A  a
+
+# ** 23. underscores and apostrophes in numbers
+<
+2000-01-01
+  (a)  1_000. A
+  (a)  1'000. A  ;' <- this apostrophe is for syntax highlighting
+
+$ hledger bal -f - -N
+             2_000 A  a


### PR DESCRIPTION
This PR adds support for underscores and apostrophies as digit group marks. I've added tests where I deemed them relevant, please let me know if you'd like to see tests added in other places (or any other changes I should make)

Closes #273, #1489.

side note: I haven't used any AI generated code in the commit per your policy for first time contributors. I have however used Claude to review my code and have added that as AI usage to my commit message